### PR TITLE
internal/cli: add version command

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mitchellh/cli"
 
 	"github.com/hashicorp/waypoint/internal/pkg/signalcontext"
+	"github.com/hashicorp/waypoint/internal/version"
 )
 
 const (
@@ -186,6 +187,13 @@ func commands(ctx context.Context, log hclog.Logger, logOutput io.Writer) map[st
 
 		"plugin": func() (cli.Command, error) {
 			return &PluginCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+
+		"version": func() (cli.Command, error) {
+			return &VersionCommand{
+				VersionInfo: version.GetVersion(),
 				baseCommand: baseCommand,
 			}, nil
 		},

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"github.com/posener/complete"
+
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/version"
+)
+
+type VersionCommand struct {
+	*baseCommand
+
+	VersionInfo *version.VersionInfo
+}
+
+func (c *VersionCommand) Run(args []string) int {
+	flagSet := c.Flags()
+
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(flagSet),
+		WithNoConfig(),
+	); err != nil {
+		return 1
+	}
+	args = flagSet.Args()
+
+	out := c.VersionInfo.FullVersionNumber(true)
+	c.ui.Output(out)
+
+	return 0
+}
+
+func (c *VersionCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
+}
+
+func (c *VersionCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *VersionCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *VersionCommand) Synopsis() string {
+	return ""
+}
+
+func (c *VersionCommand) Help() string {
+	helpText := `
+Usage: waypoint version
+  Prints the version of this Waypoint CLI.
+
+  There are no arguments or flags to this command. Any additional arguments or
+  flags are ignored.
+`
+	return helpText
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,84 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+)
+
+var (
+	// The git commit that was compiled. This will be filled in by the compiler.
+	GitCommit   string
+	GitDescribe string
+
+	Version           = "0.0.1"
+	VersionPrerelease = ""
+	VersionMetadata   = ""
+)
+
+// VersionInfo
+type VersionInfo struct {
+	Revision          string
+	Version           string
+	VersionPrerelease string
+	VersionMetadata   string
+}
+
+func GetVersion() *VersionInfo {
+	ver := Version
+	rel := VersionPrerelease
+	md := VersionMetadata
+	if GitDescribe != "" {
+		ver = GitDescribe
+	}
+	if GitDescribe == "" && rel == "" && VersionPrerelease != "" {
+		rel = "dev"
+	}
+
+	return &VersionInfo{
+		Revision:          GitCommit,
+		Version:           ver,
+		VersionPrerelease: rel,
+		VersionMetadata:   md,
+	}
+}
+
+func (c *VersionInfo) VersionNumber() string {
+	if Version == "unknown" && VersionPrerelease == "unknown" {
+		return "(version unknown)"
+	}
+
+	version := fmt.Sprintf("%s", c.Version)
+
+	if c.VersionPrerelease != "" {
+		version = fmt.Sprintf("%s-%s", version, c.VersionPrerelease)
+	}
+
+	if c.VersionMetadata != "" {
+		version = fmt.Sprintf("%s+%s", version, c.VersionMetadata)
+	}
+
+	return version
+}
+
+func (c *VersionInfo) FullVersionNumber(rev bool) string {
+	var versionString bytes.Buffer
+
+	if Version == "unknown" && VersionPrerelease == "unknown" {
+		return "Waypoint (version unknown)"
+	}
+
+	fmt.Fprintf(&versionString, "Waypoint v%s", c.Version)
+	if c.VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
+	}
+
+	if c.VersionMetadata != "" {
+		fmt.Fprintf(&versionString, "+%s", c.VersionMetadata)
+	}
+
+	if rev && c.Revision != "" {
+		fmt.Fprintf(&versionString, " (%s)", c.Revision)
+	}
+
+	return versionString.String()
+}


### PR DESCRIPTION
Will require build system improvements for compile-time git variables.

I used `Init()` `WithNoConfig()` as that seemed right for this. Also writing to the base config UI. 
