### PR TITLE
internal/core: add proper subtype to Any values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6
 	github.com/gliderlabs/ssh v0.2.2
 	github.com/golang/protobuf v1.3.4
-	github.com/hashicorp/go-argmapper v0.0.0-20200601005345-c13e5b41aa1f
+	github.com/hashicorp/go-argmapper v0.0.0-20200606213939-1b3495a979bb
 	github.com/hashicorp/go-hclog v0.14.0
 	github.com/hashicorp/go-memdb v1.2.0
 	github.com/hashicorp/go-multierror v1.1.0
@@ -45,7 +45,7 @@ require (
 	github.com/sebdah/goldie v1.0.0
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
-	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
+	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 	google.golang.org/api v0.20.0
 	google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0
 	google.golang.org/grpc v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplb
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-argmapper v0.0.0-20200601005345-c13e5b41aa1f h1:kk56BnUsQ2SAjLhppLSmgAI7W+XbislfNuEK5u4Dz38=
-github.com/hashicorp/go-argmapper v0.0.0-20200601005345-c13e5b41aa1f/go.mod h1:WA3PocIo+40wf4ko3dRdL3DEgxIQB4qaqp+jVccLV1I=
+github.com/hashicorp/go-argmapper v0.0.0-20200606213939-1b3495a979bb h1:tLSI9c4Q/u3wljR36YPg2N6ow0g3o715Ywk2CG4KOhE=
+github.com/hashicorp/go-argmapper v0.0.0-20200606213939-1b3495a979bb/go.mod h1:WA3PocIo+40wf4ko3dRdL3DEgxIQB4qaqp+jVccLV1I=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -809,8 +809,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
-golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -70,7 +70,7 @@ func (op *deployOperation) Do(ctx context.Context, log hclog.Logger, app *App) (
 		(*component.Deployment)(nil),
 		app.Platform,
 		app.Platform.DeployFunc(),
-		argmapper.Named("artifact", op.Push.Artifact.Artifact),
+		argNamedAny("artifact", op.Push.Artifact.Artifact),
 		argmapper.Typed(&dconfig),
 	)
 }

--- a/internal/core/app_push.go
+++ b/internal/core/app_push.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/hashicorp/go-argmapper"
 	"github.com/hashicorp/go-hclog"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
@@ -58,7 +57,7 @@ func (op *pushBuildOperation) Do(ctx context.Context, log hclog.Logger, app *App
 		(*component.Artifact)(nil),
 		app.Registry,
 		app.Registry.PushFunc(),
-		argmapper.Named("artifact", op.Build.Artifact.Artifact),
+		argNamedAny("artifact", op.Build.Artifact.Artifact),
 	)
 }
 

--- a/internal/core/arg.go
+++ b/internal/core/arg.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/hashicorp/go-argmapper"
+)
+
+// argNamedAny returns an argmapper.Arg that specifies the Any value
+// with the proper subtype.
+func argNamedAny(n string, v *any.Any) argmapper.Arg {
+	msg, err := ptypes.AnyMessageName(v)
+	if err != nil {
+		// This should never happen.
+		panic(err)
+	}
+
+	return argmapper.NamedSubtype(n, v, msg)
+}


### PR DESCRIPTION
Without this, subsequent operations such as push and deploy would get an
error of "type cannot be satisfied". We need to tag our *any.Any values
with the proper subtype otherwise argmapper doesn't know WHAT any.Any
is.

This is paired with a small bug in argmapper that was fixed as well
where named subtype values couldn't satisfy typed subtype values.

The tests for this are covered in argmapper.