### PR TITLE
cli: use command UI in init

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -163,7 +163,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 		// TODO(mitchellh): when we support app targeting we can have more
 		// than one as long as its targeted.
 		if len(cfg.Apps) != 1 {
-			c.project.UI.Output(errAppModeSingle, terminal.WithErrorStyle())
+			c.ui.Output(errAppModeSingle, terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 


### PR DESCRIPTION
Without this you could get a panic running something like `waypoint build` in an empty directory.

```
$ waypoint build
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0x2cbd9b9]

goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.(*baseCommand).Init(0xc000342960, 0xc000b19db0, 0x3, 0x3, 0x34a5801, 0xc000285170)
	/Users/pearkes/code/hashicorp/waypoint/internal/cli/base.go:166 +0x2d9
github.com/hashicorp/waypoint/internal/cli.(*ArtifactBuildCommand).Run(0xc000285170, 0xc0004ef210, 0x0, 0x0, 0xc00035a960)
	/Users/pearkes/code/hashicorp/waypoint/internal/cli/artifact_build.go:25 +0xd6
github.com/mitchellh/cli.(*CLI).Run(0xc000501680, 0xc000501680, 0xc0004ef220, 0xc0004ccf50)
	/Users/pearkes/code/golang/pkg/mod/github.com/mitchellh/cli@v1.0.0/cli.go:255 +0x1da
github.com/hashicorp/waypoint/internal/cli.Main(0xc0004ef200, 0x2, 0x2, 0x0)
	/Users/pearkes/code/hashicorp/waypoint/internal/cli/main.go:76 +0x27e
main.main()
	/Users/pearkes/code/hashicorp/waypoint/cmd/waypoint/main.go:14 +0xa2
```