### PR TITLE
Add a number of quality of life improvements to k8

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -317,7 +317,7 @@ type Config struct {
 	// way. This might be control an image that has mulitple modes of operation,
 	// selected via environment variable. Most configuration should use the waypoint
 	// config commands.
-	StaticEnvVars map[string]string `hcl:"static_environment"`
+	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 }
 
 var (


### PR DESCRIPTION
Adds 3 configuration points that make production deployments easier:

1. The ability to specify the ImagePullSecret to use. This makes it much simpler to configure how the images are authenticated than defining some default one or webhook modifier.
2. The ability to request some scratch space (ie tmp space) for the application to use. This is common for many apps to have some place for this data and most don't need more than one directory to use.
3. A set of static environment variables. These would not be the more common configuration variables, but rather env vars that would be used to control the behavior of a multi-use image. Putting those sorts of variables here makes the settings in the `waypoint config` much more generic and focused on the runtime configuration of the application.