### PR TITLE
Add Docker as install target and platform target

### DIFF
--- a/builtin/docker/main.go
+++ b/builtin/docker/main.go
@@ -8,6 +8,6 @@ import (
 
 // Options are the SDK options to use for instantiation.
 var Options = []sdk.Option{
-	sdk.WithComponents(&Builder{}, &Registry{}),
+	sdk.WithComponents(&Builder{}, &Registry{}, &Platform{}),
 	sdk.WithMappers(PackImageMapper),
 }

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -1,0 +1,232 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/hashicorp/go-hclog"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/hashicorp/waypoint/sdk/component"
+	"github.com/hashicorp/waypoint/sdk/terminal"
+)
+
+const (
+	labelId    = "waypoint.hashicorp.com/id"
+	labelNonce = "waypoint.hashicorp.com/nonce"
+)
+
+// Platform is the Platform implementation for Kubernetes.
+type Platform struct {
+	config PlatformConfig
+}
+
+// Config implements Configurable
+func (p *Platform) Config() (interface{}, error) {
+	return &p.config, nil
+}
+
+// DeployFunc implements component.Platform
+func (p *Platform) DeployFunc() interface{} {
+	return p.Deploy
+}
+
+// DestroyFunc implements component.Destroyer
+func (p *Platform) DestroyFunc() interface{} {
+	return p.Destroy
+}
+
+// ValidateAuthFunc implements component.Authenticator
+func (p *Platform) ValidateAuthFunc() interface{} {
+	return p.ValidateAuth
+}
+
+// AuthFunc implements component.Authenticator
+func (p *Platform) AuthFunc() interface{} {
+	return p.Auth
+}
+
+func (p *Platform) Auth() error {
+	return nil
+}
+
+func (p *Platform) ValidateAuth() error {
+	return nil
+}
+
+// Deploy deploys an image to Kubernetes.
+func (p *Platform) Deploy(
+	ctx context.Context,
+	log hclog.Logger,
+	src *component.Source,
+	img *Image,
+	deployConfig *component.DeploymentConfig,
+	ui terminal.UI,
+) (*Deployment, error) {
+	// We'll update the user in real time
+	st := ui.Status()
+	defer st.Close()
+
+	st.Update("Deploying container to docker")
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	cli.NegotiateAPIVersion(ctx)
+
+	// Create our deployment and set an initial ID
+	var result Deployment
+	id, err := component.Id()
+	if err != nil {
+		return nil, err
+	}
+	result.Id = id
+	result.Name = src.App
+
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{
+			Key:   "label",
+			Value: "app=" + src.App,
+		}),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) > 0 {
+		st.Update("Deleting existing container: " + containers[0].ID)
+		err = cli.ContainerRemove(ctx, containers[0].ID, types.ContainerRemoveOptions{
+			Force: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	port := "3000"
+
+	np, err := nat.NewPort("tcp", port)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := container.Config{
+		AttachStdout: true,
+		AttachStderr: true,
+		AttachStdin:  true,
+		OpenStdin:    true,
+		StdinOnce:    true,
+		Image:        img.Image,
+		ExposedPorts: nat.PortSet{np: struct{}{}},
+		Env:          []string{"PORT=" + port},
+	}
+
+	if p.config.Command != "" {
+		cfg.Cmd = append(cfg.Cmd, "/bin/sh", "-c", p.config.Command)
+	}
+
+	bindings := nat.PortMap{}
+	bindings[np] = []nat.PortBinding{
+		{
+			HostPort: port,
+		},
+	}
+
+	hostconfig := container.HostConfig{
+		Binds:        []string{src.App + "-scratch" + ":/input"},
+		PortBindings: bindings,
+	}
+
+	netconfig := network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			"waypoint": {},
+		},
+	}
+
+	for k, v := range p.config.StaticEnvVars {
+		cfg.Env = append(cfg.Env, k+"="+v)
+	}
+
+	for k, v := range deployConfig.Env() {
+		cfg.Env = append(cfg.Env, k+"="+v)
+	}
+
+	cfg.Labels = map[string]string{
+		labelId: result.Id,
+		"app":   src.App,
+	}
+
+	name := src.App + "-" + id
+
+	st.Update("Creating container...")
+	cr, err := cli.ContainerCreate(ctx, &cfg, &hostconfig, &netconfig, name)
+	if err != nil {
+		return nil, err
+	}
+
+	st.Update("Starting container...")
+	err = cli.ContainerStart(ctx, cr.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	st.Step(terminal.StatusOK, "App deployed as docker container: "+name)
+
+	result.Container = cr.ID
+
+	return &result, nil
+}
+
+// Destroy deletes the K8S deployment.
+func (p *Platform) Destroy(
+	ctx context.Context,
+	log hclog.Logger,
+	deployment *Deployment,
+	ui terminal.UI,
+) error {
+	// We'll update the user in real time
+	st := ui.Status()
+	defer st.Close()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+
+	cli.NegotiateAPIVersion(ctx)
+
+	st.Update("Deleting container...")
+
+	return cli.ContainerRemove(ctx, deployment.Container, types.ContainerRemoveOptions{
+		Force: true,
+	})
+}
+
+// Config is the configuration structure for the Platform.
+type PlatformConfig struct {
+	// The command to run in the container
+	Command string `hcl:"command,optional"`
+
+	// A path to a directory that will be created for the service to store
+	// temporary data.
+	ScratchSpace string `hcl:"scratch_path,optional"`
+
+	// Environment variables that are meant to configure the application in a static
+	// way. This might be control an image that has mulitple modes of operation,
+	// selected via environment variable. Most configuration should use the waypoint
+	// config commands.
+	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
+}
+
+var (
+	_ component.Platform     = (*Platform)(nil)
+	_ component.Configurable = (*Platform)(nil)
+	_ component.Destroyer    = (*Platform)(nil)
+)

--- a/builtin/docker/plugin.pb.go
+++ b/builtin/docker/plugin.pb.go
@@ -3,9 +3,11 @@
 
 package docker
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -16,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Image is the artifact type for the registry.
 type Image struct {
@@ -31,16 +33,17 @@ func (m *Image) Reset()         { *m = Image{} }
 func (m *Image) String() string { return proto.CompactTextString(m) }
 func (*Image) ProtoMessage()    {}
 func (*Image) Descriptor() ([]byte, []int) {
-	return fileDescriptor_plugin_f6d33b291aab7c0d, []int{0}
+	return fileDescriptor_22a625af4bc1cc87, []int{0}
 }
+
 func (m *Image) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Image.Unmarshal(m, b)
 }
 func (m *Image) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Image.Marshal(b, m, deterministic)
 }
-func (dst *Image) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Image.Merge(dst, src)
+func (m *Image) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Image.Merge(m, src)
 }
 func (m *Image) XXX_Size() int {
 	return xxx_messageInfo_Image.Size(m)
@@ -65,18 +68,121 @@ func (m *Image) GetTag() string {
 	return ""
 }
 
-func init() {
-	proto.RegisterType((*Image)(nil), "docker.Image")
+type Deployment struct {
+	Id                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Container            string   `protobuf:"bytes,3,opt,name=container,proto3" json:"container,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
-func init() { proto.RegisterFile("plugin.proto", fileDescriptor_plugin_f6d33b291aab7c0d) }
+func (m *Deployment) Reset()         { *m = Deployment{} }
+func (m *Deployment) String() string { return proto.CompactTextString(m) }
+func (*Deployment) ProtoMessage()    {}
+func (*Deployment) Descriptor() ([]byte, []int) {
+	return fileDescriptor_22a625af4bc1cc87, []int{1}
+}
 
-var fileDescriptor_plugin_f6d33b291aab7c0d = []byte{
-	// 88 bytes of a gzipped FileDescriptorProto
+func (m *Deployment) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Deployment.Unmarshal(m, b)
+}
+func (m *Deployment) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Deployment.Marshal(b, m, deterministic)
+}
+func (m *Deployment) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Deployment.Merge(m, src)
+}
+func (m *Deployment) XXX_Size() int {
+	return xxx_messageInfo_Deployment.Size(m)
+}
+func (m *Deployment) XXX_DiscardUnknown() {
+	xxx_messageInfo_Deployment.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Deployment proto.InternalMessageInfo
+
+func (m *Deployment) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+func (m *Deployment) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Deployment) GetContainer() string {
+	if m != nil {
+		return m.Container
+	}
+	return ""
+}
+
+type Release struct {
+	Url                  string   `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Release) Reset()         { *m = Release{} }
+func (m *Release) String() string { return proto.CompactTextString(m) }
+func (*Release) ProtoMessage()    {}
+func (*Release) Descriptor() ([]byte, []int) {
+	return fileDescriptor_22a625af4bc1cc87, []int{2}
+}
+
+func (m *Release) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Release.Unmarshal(m, b)
+}
+func (m *Release) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Release.Marshal(b, m, deterministic)
+}
+func (m *Release) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Release.Merge(m, src)
+}
+func (m *Release) XXX_Size() int {
+	return xxx_messageInfo_Release.Size(m)
+}
+func (m *Release) XXX_DiscardUnknown() {
+	xxx_messageInfo_Release.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Release proto.InternalMessageInfo
+
+func (m *Release) GetUrl() string {
+	if m != nil {
+		return m.Url
+	}
+	return ""
+}
+
+func init() {
+	proto.RegisterType((*Image)(nil), "docker.Image")
+	proto.RegisterType((*Deployment)(nil), "docker.Deployment")
+	proto.RegisterType((*Release)(nil), "docker.Release")
+}
+
+func init() {
+	proto.RegisterFile("plugin.proto", fileDescriptor_22a625af4bc1cc87)
+}
+
+var fileDescriptor_22a625af4bc1cc87 = []byte{
+	// 163 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x29, 0xc8, 0x29, 0x4d,
 	0xcf, 0xcc, 0xd3, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x4b, 0xc9, 0x4f, 0xce, 0x4e, 0x2d,
 	0x52, 0xd2, 0xe7, 0x62, 0xf5, 0xcc, 0x4d, 0x4c, 0x4f, 0x15, 0x12, 0xe1, 0x62, 0xcd, 0x04, 0x31,
 	0x24, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x20, 0x1c, 0x21, 0x01, 0x2e, 0xe6, 0x92, 0xc4, 0x74,
-	0x09, 0x26, 0xb0, 0x18, 0x88, 0x99, 0xc4, 0x06, 0xd6, 0x6f, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff,
-	0xd2, 0x37, 0x76, 0x36, 0x4f, 0x00, 0x00, 0x00,
+	0x09, 0x26, 0xb0, 0x18, 0x88, 0xa9, 0xe4, 0xc7, 0xc5, 0xe5, 0x92, 0x5a, 0x90, 0x93, 0x5f, 0x99,
+	0x9b, 0x9a, 0x57, 0x22, 0xc4, 0xc7, 0xc5, 0x94, 0x99, 0x02, 0xd5, 0xc2, 0x94, 0x99, 0x22, 0x24,
+	0xc4, 0xc5, 0x92, 0x97, 0x98, 0x9b, 0x0a, 0xd5, 0x00, 0x66, 0x0b, 0xc9, 0x70, 0x71, 0x26, 0xe7,
+	0xe7, 0x95, 0x24, 0x66, 0xe6, 0xa5, 0x16, 0x49, 0x30, 0x83, 0x25, 0x10, 0x02, 0x4a, 0xd2, 0x5c,
+	0xec, 0x41, 0xa9, 0x39, 0xa9, 0x89, 0xc5, 0x60, 0xcb, 0x4a, 0x8b, 0x72, 0xa0, 0xa6, 0x81, 0x98,
+	0x49, 0x6c, 0x60, 0xc7, 0x1a, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0xe3, 0x68, 0x00, 0xe5, 0xbc,
+	0x00, 0x00, 0x00,
 }

--- a/builtin/docker/plugin.proto
+++ b/builtin/docker/plugin.proto
@@ -7,3 +7,13 @@ message Image {
   string image = 1;
   string tag = 2;
 }
+
+message Deployment {
+  string id = 1;
+  string name = 2;
+  string container = 3;
+}
+
+message Release {
+  string url = 1;
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dustin/go-humanize v1.0.0

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -49,6 +49,7 @@ func init() {
 	Platforms.Register("lambda", BuiltinFactory("lambda", component.PlatformType))
 	Platforms.Register("azure-aci", BuiltinFactory("azure-aci", component.PlatformType))
 	Platforms.Register("netlify", BuiltinFactory("netlify", component.PlatformType))
+	Platforms.Register("docker", BuiltinFactory("docker", component.PlatformType))
 
 	Releasers.Register("google-cloud-run", BuiltinFactory("google-cloud-run", component.ReleaseManagerType))
 	Releasers.Register("kubernetes", BuiltinFactory("kubernetes", component.ReleaseManagerType))

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -1,0 +1,146 @@
+package serverinstall
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/hashicorp/waypoint/internal/clicontext"
+	configpkg "github.com/hashicorp/waypoint/internal/config"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/sdk/terminal"
+)
+
+func InstallDocker(
+	ctx context.Context, ui terminal.UI, st terminal.Status, scfg *Config) (
+	*clicontext.Config, *pb.ServerConfig_AdvertiseAddr, error,
+) {
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cli.NegotiateAPIVersion(ctx)
+
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{
+			Key:   "label",
+			Value: "waypoint-type=server",
+		}),
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	port := "9701"
+
+	var (
+		clicfg clicontext.Config
+		addr   pb.ServerConfig_AdvertiseAddr
+	)
+
+	clicfg.Server = configpkg.Server{
+		Address:  "localhost:" + port,
+		Insecure: true,
+	}
+
+	addr.Addr = "waypoint-server:" + port
+	addr.Insecure = true
+
+	// If we already have a server, bolt.
+	if len(containers) > 0 {
+		st.Step(terminal.StatusWarn, "Detected existing waypoint server")
+		return &clicfg, &addr, nil
+	}
+
+	st.Update("Creating waypoint network...")
+
+	nets, err := cli.NetworkList(ctx, types.NetworkListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", "use=waypoint")),
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(nets) == 0 {
+		_, err = cli.NetworkCreate(ctx, "waypoint", types.NetworkCreate{
+			Driver:         "bridge",
+			CheckDuplicate: true,
+			Internal:       false,
+			Attachable:     true,
+			Labels: map[string]string{
+				"use": "waypoint",
+			},
+		})
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	np, err := nat.NewPort("tcp", port)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	st.Update("Installing waypoint server to docker")
+
+	cfg := container.Config{
+		AttachStdout: true,
+		AttachStderr: true,
+		AttachStdin:  true,
+		OpenStdin:    true,
+		StdinOnce:    true,
+		Image:        scfg.ServerImage,
+		ExposedPorts: nat.PortSet{np: struct{}{}},
+		Env:          []string{"PORT=" + port},
+		Cmd:          []string{"server", "-vvv", "-db=/data/data.db", "-listen-grpc=0.0.0.0:9701"},
+	}
+
+	bindings := nat.PortMap{}
+	bindings[np] = []nat.PortBinding{
+		{
+			HostPort: port,
+		},
+	}
+
+	hostconfig := container.HostConfig{
+		Binds:        []string{"waypoint-server:/data"},
+		PortBindings: bindings,
+	}
+
+	netconfig := network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			"waypoint": {},
+		},
+	}
+
+	cfg.Labels = map[string]string{
+		"waypoint-type": "server",
+	}
+
+	cr, err := cli.ContainerCreate(ctx, &cfg, &hostconfig, &netconfig, "waypoint-server")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = cli.ContainerStart(ctx, cr.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// KLUDGE: There isn't a way to find out if the container is up or not, so we just give it 5 seconds
+	// to normalize before trying to use it.
+	time.Sleep(5 * time.Second)
+
+	st.Step(terminal.StatusOK, "Server container started")
+
+	return &clicfg, &addr, nil
+}

--- a/test-apps/docker/Gemfile
+++ b/test-apps/docker/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "sinatra"
+
+gem "puma"
+
+gem "pg"

--- a/test-apps/docker/Gemfile.lock
+++ b/test-apps/docker/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.2)
+    pg (1.2.3)
+    puma (4.3.5)
+      nio4r (~> 2.0)
+    rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
+    ruby2_keywords (0.0.2)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pg
+  puma
+  sinatra
+
+BUNDLED WITH
+   2.0.2

--- a/test-apps/docker/Procfile
+++ b/test-apps/docker/Procfile
@@ -1,0 +1,1 @@
+web: ruby app.rb

--- a/test-apps/docker/app.rb
+++ b/test-apps/docker/app.rb
@@ -1,0 +1,10 @@
+require 'sinatra'
+get '/' do
+  address = ENV["NAME"]
+
+  if address
+    "Hello #{address}, Welcome to Waypoint!"
+  else
+    'Welcome to Waypoint!'
+  end
+end

--- a/test-apps/docker/waypoint.hcl
+++ b/test-apps/docker/waypoint.hcl
@@ -1,0 +1,15 @@
+project = "wpmini"
+
+app "wpmini" {
+
+  labels = {
+    "service" = "wpmini",
+    "env" = "dev"
+  }
+
+  build "pack" {
+  }
+
+  deploy "docker" {
+  }
+}


### PR DESCRIPTION
This adds the ability to install the waypoint-server into docker and deploy an app into that same docker. The app is configured to use the server properly, providing a very easy testbed for demo and development.

## Demo:

https://asciinema.org/a/8puBpvNpEtRr5orjEThMv4nVc