### PR TITLE
builtin/netlify: handle auth flow for non-local mode

### DIFF
--- a/builtin/netlify/authenticate.go
+++ b/builtin/netlify/authenticate.go
@@ -76,7 +76,6 @@ func apiContext(accessToken string) context.Context {
 
 // Authenticate makes API calls and user interactions appropriate to create
 // and return an API access token
-// todo(pearkes): use Authenticator when it exists
 func Authenticate(
 	ctx context.Context,
 	log hclog.Logger,


### PR DESCRIPTION
This is pretty simple, just outputs a message that the user can click. After it outputs it blocks on `WaitUntilTicketAuthorized` as with the `open()` experience, so pretty similar.