### PR TITLE
internal/cli: install doesn't require a client

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -194,6 +194,7 @@ func (c *InstallCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
+		WithClient(false),
 	); err != nil {
 		return 1
 	}


### PR DESCRIPTION
This prevents a "context deadline exceeded" hang when using `waypoint install` while your context is set to an unreachable server.