### PR TITLE
Humanize errors before showing them to humans

### DIFF
--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -33,7 +34,7 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 			DisablePush: !c.flagPush,
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/artifact_list.go
+++ b/internal/cli/artifact_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
@@ -47,7 +48,7 @@ func (c *ArtifactListCommand) Run(args []string) int {
 			Workspace:   wsRef,
 		})
 		if err != nil {
-			c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		sort.Sort(serversort.ArtifactStartDesc(resp.Artifacts))

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -7,6 +7,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -35,7 +36,7 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 			Workspace:   c.project.WorkspaceRef(),
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 
@@ -44,7 +45,7 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 			Build: build,
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
@@ -101,7 +102,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 	// Parse flags
 	if err := baseCfg.Flags.Parse(baseCfg.Args); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err
 	}
 	c.args = baseCfg.Flags.Args()
@@ -112,7 +113,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 	// Setup our base config path
 	homeConfigPath, err := xdg.ConfigFile("waypoint/.ignore")
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err
 	}
 	homeConfigPath = filepath.Dir(homeConfigPath)
@@ -122,7 +123,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 	contextStorage, err := clicontext.NewStorage(
 		clicontext.WithDir(filepath.Join(homeConfigPath, "context")))
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err
 	}
 	c.contextStorage = contextStorage

--- a/internal/cli/build_list.go
+++ b/internal/cli/build_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
@@ -47,7 +48,7 @@ func (c *BuildListCommand) Run(args []string) int {
 			Workspace:   wsRef,
 		})
 		if err != nil {
-			c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		sort.Sort(serversort.BuildStartDesc(resp.Builds))

--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -59,7 +60,7 @@ func (c *ConfigGetCommand) Run(args []string) int {
 
 	resp, err := client.GetConfig(c.Ctx, req)
 	if err != nil {
-		c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -68,7 +69,7 @@ func (c *ConfigGetCommand) Run(args []string) int {
 		// and want color detection to work.
 		out, _, err := c.project.UI.OutputWriters()
 		if err != nil {
-			c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return 1
 		}
 
@@ -87,7 +88,7 @@ func (c *ConfigGetCommand) Run(args []string) int {
 		// and want color detection to work.
 		out, _, err := c.project.UI.OutputWriters()
 		if err != nil {
-			c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return 1
 		}
 

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -66,7 +67,7 @@ func (c *ConfigSetCommand) Run(args []string) int {
 
 	_, err := client.SetConfig(c.Ctx, &req)
 	if err != nil {
-		c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_clear.go
+++ b/internal/cli/context_clear.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -33,7 +34,7 @@ func (c *ContextClearCommand) Run(args []string) int {
 
 	// Get our contexts
 	if err := c.contextStorage.UnsetDefault(); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/posener/complete"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -40,7 +41,7 @@ func (c *ContextCreateCommand) Run(args []string) int {
 
 	// Get our contexts
 	if err := c.contextStorage.Set(name, &c.flagConfig); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_delete.go
+++ b/internal/cli/context_delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -41,7 +42,7 @@ func (c *ContextDeleteCommand) Run(args []string) int {
 
 	// Get our contexts
 	if err := c.contextStorage.Delete(name); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -58,13 +59,13 @@ func (c *ContextDeleteCommand) runDeleteAll(args []string) int {
 	// Delete all
 	list, err := c.contextStorage.List()
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
 	for _, name := range list {
 		if err := c.contextStorage.Delete(name); err != nil {
-			c.ui.Output(err.Error(), terminal.WithErrorStyle())
+			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return 1
 		}
 	}

--- a/internal/cli/context_list.go
+++ b/internal/cli/context_list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -29,14 +30,14 @@ func (c *ContextListCommand) Run(args []string) int {
 	// and want color detection to work.
 	out, _, err := c.ui.OutputWriters()
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
 	// Get our contexts
 	names, err := c.contextStorage.List()
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -48,7 +49,7 @@ func (c *ContextListCommand) Run(args []string) int {
 	// Get our default
 	def, err := c.contextStorage.Default()
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_rename.go
+++ b/internal/cli/context_rename.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -32,7 +33,7 @@ func (c *ContextRenameCommand) Run(args []string) int {
 	}
 
 	if err := c.contextStorage.Rename(args[0], args[1]); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_use.go
+++ b/internal/cli/context_use.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/sdk/terminal"
 )
@@ -42,7 +43,7 @@ func (c *ContextUseCommand) Run(args []string) int {
 			err = fmt.Errorf("Context %q doesn't exist.", name)
 		}
 
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -38,7 +39,7 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 			Workspace:   c.project.WorkspaceRef(),
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 
@@ -48,7 +49,7 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 			Artifact: push,
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		deployment := result.Deployment
@@ -93,7 +94,7 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 				},
 			})
 			if err != nil {
-				app.UI.Output(err.Error(), terminal.WithErrorStyle())
+				app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 				return ErrSentinel
 			}
 

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -41,7 +42,7 @@ func (c *DeploymentDestroyCommand) Run(args []string) int {
 			DeploymentId: args[0],
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
@@ -47,7 +48,7 @@ func (c *DeploymentListCommand) Run(args []string) int {
 			Workspace:   wsRef,
 		})
 		if err != nil {
-			c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		sort.Sort(serversort.DeploymentCompleteDesc(resp.Deployments))

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -7,6 +7,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/server/execclient"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
@@ -44,7 +45,7 @@ func (c *ExecCommand) Run(args []string) int {
 			},
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		if len(resp.Deployments) == 0 {
@@ -64,7 +65,7 @@ func (c *ExecCommand) Run(args []string) int {
 
 		exitCode, err = client.Run()
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/hostname_delete.go
+++ b/internal/cli/hostname_delete.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"strings"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -33,7 +34,7 @@ func (c *HostnameDeleteCommand) Run(args []string) int {
 		Hostname: hostname,
 	})
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/hostname_list.go
+++ b/internal/cli/hostname_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -27,7 +28,7 @@ func (c *HostnameListCommand) Run(args []string) int {
 
 	resp, err := c.project.Client().ListHostnames(c.Ctx, &pb.ListHostnamesRequest{})
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/hostname_register.go
+++ b/internal/cli/hostname_register.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -44,7 +45,7 @@ func (c *HostnameRegisterCommand) Run(args []string) int {
 			},
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/cli/datagen"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	configpkg "github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
@@ -38,7 +39,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	path, err := c.initConfigPath()
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -93,7 +94,7 @@ func (c *InitCommand) initNew() bool {
 	}
 
 	if err := ioutil.WriteFile(configpkg.Filename, data, 0644); err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return false
 	}
 
@@ -411,7 +412,7 @@ func (c *InitCommand) stepError(s terminal.Step, step initStepType, err error) {
 		c.ui.Output(strings.TrimSpace(v), terminal.WithErrorStyle())
 		c.ui.Output("")
 	}
-	c.ui.Output(err.Error(), terminal.WithErrorStyle())
+	c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 }
 
 func (c *InitCommand) inputContinue(style string) (bool, error) {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -43,7 +43,7 @@ func (c *LogsCommand) Run(args []string) int {
 			},
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		if len(resp.Deployments) == 0 {

--- a/internal/cli/releases_create.go
+++ b/internal/cli/releases_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/posener/complete"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -75,7 +76,7 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 			},
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 		if len(resp.Deployments) == 0 {
@@ -136,7 +137,7 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 			},
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 

--- a/internal/cli/server_config_set.go
+++ b/internal/cli/server_config_set.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"strings"
 
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -35,7 +36,7 @@ func (c *ServerConfigSetCommand) Run(args []string) int {
 		Config: cfg,
 	})
 	if err != nil {
-		c.ui.Output(err.Error(), terminal.WithErrorStyle())
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -33,7 +34,7 @@ func (c *GetInviteCommand) Run(args []string) int {
 		Duration: c.duration.String(),
 	})
 	if err != nil {
-		c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -104,7 +105,7 @@ func (c *ExchangeInviteCommand) Run(args []string) int {
 	})
 
 	if err != nil {
-		c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -164,7 +165,7 @@ func (c *GetTokenCommand) Run(args []string) int {
 
 	resp, err := client.GenerateLoginToken(c.Ctx, &empty.Empty{})
 	if err != nil {
-		c.project.UI.Output(err.Error(), terminal.WithErrorStyle())
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/sdk/terminal"
@@ -33,7 +34,7 @@ func (c *UpCommand) Run(args []string) int {
 
 		_, err := app.Build(ctx, &pb.Job_BuildOp{})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 
@@ -43,7 +44,7 @@ func (c *UpCommand) Run(args []string) int {
 			Workspace:   c.project.WorkspaceRef(),
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 
@@ -54,7 +55,7 @@ func (c *UpCommand) Run(args []string) int {
 			Artifact: push,
 		})
 		if err != nil {
-			app.UI.Output(err.Error(), terminal.WithErrorStyle())
+			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
 
@@ -106,7 +107,7 @@ func (c *UpCommand) Run(args []string) int {
 				},
 			})
 			if err != nil {
-				app.UI.Output(err.Error(), terminal.WithErrorStyle())
+				app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 				return ErrSentinel
 			}
 
@@ -133,7 +134,7 @@ func (c *UpCommand) Run(args []string) int {
 
 	if err != nil {
 		if err != ErrSentinel {
-			c.ui.Output(err.Error(), terminal.WithErrorStyle())
+			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		}
 
 		return 1

--- a/internal/clierrors/humanize.go
+++ b/internal/clierrors/humanize.go
@@ -1,0 +1,14 @@
+package clierrors
+
+import (
+	"google.golang.org/grpc/status"
+)
+
+func Humanize(err error) string {
+	s, ok := status.FromError(err)
+	if !ok {
+		return err.Error()
+	}
+
+	return s.Message()
+}


### PR DESCRIPTION
This removes the gRPC Status prelude, for example with this PR:

```
❯ wp build
rpc error: code = NotFound desc = Application gs-ruby/gs-ruby was not found! Please ensure that 'waypoint init' was run with this project.
```

becomes

```
❯ wp build
Application gs-ruby/gs-ruby was not found! Please ensure that 'waypoint init' was run with this project.
```