### PR TITLE
Include https on the URLs in output

### DIFF
--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -108,8 +108,8 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 
 		case hostname != nil:
 			app.UI.Output(strings.TrimSpace(deployURLService)+"\n", terminal.WithSuccessStyle())
-			app.UI.Output("           URL: %s", hostname.Fqdn, terminal.WithSuccessStyle())
-			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
 
 		default:
 			app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())

--- a/internal/cli/releases_create.go
+++ b/internal/cli/releases_create.go
@@ -140,7 +140,7 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 			return ErrSentinel
 		}
 
-		app.UI.Output("\nURL: %s", result.Release.Url, terminal.WithSuccessStyle())
+		app.UI.Output("\nURL: https://%s", result.Release.Url, terminal.WithSuccessStyle())
 		return nil
 	})
 	if err != nil {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -121,8 +121,8 @@ func (c *UpCommand) Run(args []string) int {
 
 		case hostname != nil:
 			app.UI.Output(strings.TrimSpace(deployURLService)+"\n", terminal.WithSuccessStyle())
-			app.UI.Output("           URL: %s", hostname.Fqdn, terminal.WithSuccessStyle())
-			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
 
 		default:
 			app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())


### PR DESCRIPTION
Adding https:// makes them easy to open in most terminals these days AND avoids the issue that our http => https redirect isn't working right now, so anyone that copies and pastes just the hostname will get a browser hang at present.