### PR TITLE
Fix linguist reporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ui/lib/* linguist-generated

--- a/ui/types/ember-data/types/registries/model.d.ts
+++ b/ui/types/ember-data/types/registries/model.d.ts
@@ -1,6 +1,0 @@
-/**
- * Catch-all for ember-data.
- */
-export default interface ModelRegistry {
-  [key: string]: any;
-}


### PR DESCRIPTION
This adds a [.gitattributes file for linguist](https://github.com/github/linguist#using-gitattributes) that ignores some of the generated Javascript code added for the UI in #70.

Before this change:

```
$ github-linguist
61.59%  JavaScript
35.64%  Go
2.17%   TypeScript
0.11%   Makefile
0.11%   HTML
0.10%   Nix
0.08%   Ruby
0.08%   Shell
0.06%   Dockerfile
0.06%   HCL
```

After this change:

```
$ github-linguist
95.89%  Go
1.39%   TypeScript
1.11%   JavaScript
0.30%   Makefile
0.29%   HTML
0.27%   Nix
0.22%   Ruby
0.21%   Shell
0.17%   Dockerfile
0.15%   HCL
```

Note I also removed an unused generated types file while reviewing what was in there.