### PR TITLE
internal/runner: in local mode, exact ID of queued job must match

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -42,6 +42,10 @@ func (c *Project) job() *pb.Job {
 func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.Job_Result, error) {
 	log := c.logger
 
+	// cb is used in local mode only to get a callback of the job ID
+	// so we can tell our runner what ID to expect.
+	var cb func(string)
+
 	// In local mode we have to start a runner.
 	if c.local {
 		log.Info("local mode, starting local runner")
@@ -57,12 +61,15 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 		// the job is complete.
 		defer r.Close()
 
-		// Accept a job. Our local runners execute exactly one job.
-		go func() {
-			if err := r.Accept(ctx); err != nil {
-				log.Error("runner job accept error", "err", err)
-			}
-		}()
+		// Set our callback up so that we will accept a job once it is queued
+		// so that we can accept exactly this job.
+		cb = func(id string) {
+			go func() {
+				if err := r.AcceptExact(ctx, id); err != nil {
+					log.Error("runner job accept error", "err", err)
+				}
+			}()
+		}
 
 		// Modify the job to target this runner and use the local data source.
 		job.TargetRunner = &pb.Ref_Runner{
@@ -74,7 +81,7 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 		}
 	}
 
-	return c.queueAndStreamJob(ctx, job, ui)
+	return c.queueAndStreamJob(ctx, job, ui, cb)
 }
 
 // queueAndStreamJob will queue the job. If the client is configured to watch the job,
@@ -83,6 +90,7 @@ func (c *Project) queueAndStreamJob(
 	ctx context.Context,
 	job *pb.Job,
 	ui terminal.UI,
+	jobIdCallback func(string),
 ) (*pb.Job_Result, error) {
 	log := c.logger
 
@@ -104,6 +112,11 @@ func (c *Project) queueAndStreamJob(
 		return nil, err
 	}
 	log = log.With("job_id", queueResp.JobId)
+
+	// Call our callback if it was given
+	if jobIdCallback != nil {
+		jobIdCallback(queueResp.JobId)
+	}
 
 	// Get the stream
 	log.Debug("opening job stream")

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -24,6 +24,18 @@ var heartbeatDuration = 5 * time.Second
 // This is safe to be called concurrently which can be used to execute
 // multiple jobs in parallel as a runner.
 func (r *Runner) Accept(ctx context.Context) error {
+	return r.accept(ctx, "")
+}
+
+// AcceptExact is the same as Accept except that it accepts only
+// a job with exactly the given ID. This is used by Waypoint only in
+// local execution mode as an extra security measure to prevent other
+// jobs from being assigned to the runner.
+func (r *Runner) AcceptExact(ctx context.Context, id string) error {
+	return r.accept(ctx, id)
+}
+
+func (r *Runner) accept(ctx context.Context, id string) error {
 	if r.closed() {
 		return ErrClosed
 	}
@@ -75,6 +87,24 @@ func (r *Runner) Accept(ctx context.Context) error {
 	// and exit here.
 	r.acceptWg.Add(1)
 	defer r.acceptWg.Done()
+
+	// If this isn't the job we expected then we nack and error.
+	if id != "" {
+		if assignment.Assignment.Job.Id != id {
+			log.Warn("unexpected job id for exact match, nacking")
+			if err := client.Send(&pb.RunnerJobStreamRequest{
+				Event: &pb.RunnerJobStreamRequest_Error_{
+					Error: &pb.RunnerJobStreamRequest_Error{},
+				},
+			}); err != nil {
+				return err
+			}
+
+			return status.Errorf(codes.Aborted, "server sent us an invalid job")
+		}
+
+		log.Trace("assigned job matches expected ID for local mode")
+	}
 
 	// Ack the assignment
 	log.Trace("acking job assignment")


### PR DESCRIPTION
This is just a tiny little protection so that local mode runners that are registered can _never_ be assigned unexpected jobs.

The prior implementation relied on a well-behaved server. One security fear is that a compromised server could send down arbitrary git clone + exec (via plugins) commands as we introduce jobs with data sources and so on. This eliminates that possibility entirely.