### PR TITLE
internal/server/state: job assignment by ID should check ID

### DIFF
--- a/internal/server/singleprocess/state/job.go
+++ b/internal/server/singleprocess/state/job.go
@@ -890,7 +890,7 @@ func (s *State) jobCandidateById(memTxn *memdb.Txn, ws memdb.WatchSet, r *runner
 		}
 
 		job := raw.(*jobIndex)
-		if job.State != pb.Job_QUEUED || job.TargetRunnerId == "" {
+		if job.State != pb.Job_QUEUED || job.TargetRunnerId != r.Id {
 			continue
 		}
 


### PR DESCRIPTION
We were doing a LowerBound query by ID which would return subsequent IDs
too. We need to verify that the IDs MATCH. The result before this was
that we'd get some jobs assigned to the wrong runners.