### PR TITLE
Update test-apps to use new config structure

### DIFF
--- a/test-apps/docker/waypoint.hcl
+++ b/test-apps/docker/waypoint.hcl
@@ -3,10 +3,14 @@ project = "wpmini"
 app "wpmini" {
   labels = {
     "service" = "wpmini",
-    "env" = "dev"
+    "env"     = "dev"
   }
 
-  build "pack" {}
+  build {
+    use "pack" {}
+  }
 
-  deploy "docker" {}
+  deploy {
+    use "docker" {}
+  }
 }

--- a/test-apps/wpmini/waypoint.hcl
+++ b/test-apps/wpmini/waypoint.hcl
@@ -3,23 +3,30 @@ project = "wpmini"
 app "wpmini" {
   labels = {
     "service" = "wpmini",
-    "env" = "dev"
+    "env"     = "dev"
   }
 
-  build "pack" {
-    registry "docker" {
-      image = "waypoint-example.local/wpmini"
-      tag = "latest"
-      local = true
+  build {
+    use "pack" {}
+    registry {
+      use "docker" {
+        image = "waypoint-example.local/wpmini"
+        tag   = "latest"
+        local = true
+      }
     }
   }
 
-  deploy "kubernetes" {
-    probe_path = "/"
+  deploy {
+    use "kubernetes" {
+      probe_path = "/"
+    }
   }
 
-  release "kubernetes" {
-    load_balancer = true
-    port = 8080
+  release {
+    use "kubernetes" {
+      load_balancer = true
+      port          = 8080
+    }
   }
 }


### PR DESCRIPTION
Updates the `waypoint.hcl` in test-apps to use the new format merged in #109 