### PR TITLE
cli: allow passing auth token to context create

### DIFF
--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -62,6 +62,11 @@ func (c *ContextCreateCommand) Flags() *flag.Sets {
 			Target: &c.flagConfig.Server.Address,
 			Usage:  "Address for the server.",
 		})
+		f.StringVar(&flag.StringVar{
+			Name:   "server-auth-token",
+			Target: &c.flagConfig.Server.AuthToken,
+			Usage:  "Authentication token to use to connect to the server.",
+		})
 		f.BoolVar(&flag.BoolVar{
 			Name:    "server-tls",
 			Target:  &c.flagConfig.Server.Tls,


### PR DESCRIPTION
This uses the `config.Server` block so all we need to do here is configure the flag and it will set the AuthToken.