### PR TITLE
add sha tag for prerelease alpha iterations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,11 +218,12 @@ jobs:
               --secret id=ssh.key,src="${HOME}/.ssh/id_rsa_c6969882dc046c39ddac8305e3151c98" \
               --progress=plain \
               -t docker.pkg.github.com/hashicorp/waypoint/alpha:latest \
+              -t docker.pkg.github.com/hashicorp/waypoint/alpha:$GIT_COMMIT
               .
       - run:
           name: "Docker: Push image"
           command: |
-            docker push docker.pkg.github.com/hashicorp/waypoint/alpha:latest
+            docker push docker.pkg.github.com/hashicorp/waypoint/alpha
 
   # todo: re-enable when we need a UI
   #


### PR DESCRIPTION
This satisfies [Asana ticket for commit tags](https://app.asana.com/0/1179575525730913/1190456555754904/f).
The Docker publishing will soon be housed in [waypoint-releases](https://github.com/hashicorp/waypoint-releases) for the main release pipeline (which must be in a permanently private repo for security reasons), but for the internal release, this should suffice.