### PR TITLE
Make the listening port on the Kubernetes pod a optional configurable

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -110,7 +110,12 @@ func (p *Platform) Deploy(
 	}
 
 	// Build our env vars
-	env := []corev1.EnvVar{}
+	env := []corev1.EnvVar{
+		{
+			Name:  "PORT",
+			Value: string(p.config.ContainerPort),
+		},
+	}
 
 	for k, v := range p.config.StaticEnvVars {
 		env = append(env, corev1.EnvVar{


### PR DESCRIPTION
This PR allows the developer to configure the port that is listening/expected to be listening on their deployment. Currently it's set as a static port (3000) which requires the user to ensure that port is whats exposed as part of their build. With this in place, we can leverage a build configuration like below to set that port - 

```
deploy {
      use "kubernetes" {
          probe_path="/"
          container_port=80
      }
    }
```

I worked with @nicholasjackson on this PR (Thanks Nic!) to check my work.  