### PR TITLE
Add container_port to K8s, Nomad, and Docker deploy configuration 

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -79,8 +79,8 @@ func (p *Platform) Deploy(
 		return nil, err
 	}
 
-	if p.config.ContainerPort == 0 {
-		p.config.ContainerPort = 3000
+	if p.config.ServicePort == 0 {
+		p.config.ServicePort = 3000
 	}
 
 	cli.NegotiateAPIVersion(ctx)
@@ -125,7 +125,7 @@ func (p *Platform) Deploy(
 
 	s = sg.Add("Creating new container")
 
-	port := fmt.Sprint(p.config.ContainerPort)
+	port := fmt.Sprint(p.config.ServicePort)
 	np, err := nat.NewPort("tcp", port)
 	if err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ type PlatformConfig struct {
 	// Defaults to port 3000. 
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port. 
-	ContainerPort uint `hcl:"container_port,optional"`
+	ServicePort uint `hcl:"service_port,optional"`
 }
 
 var (

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -109,15 +109,15 @@ func (p *Platform) Deploy(
 		return nil, err
 	}
 
-	if p.config.ContainerPort == 0 {
-		p.config.ContainerPort = 3000
+	if p.config.ServicePort == 0 {
+		p.config.ServicePort = 3000
 	}
 
 	// Build our env vars
 	env := []corev1.EnvVar{
 		{
 			Name:  "PORT",
-			Value: fmt.Sprint(p.config.ContainerPort),
+			Value: fmt.Sprint(p.config.ServicePort),
 		},
 	}
 
@@ -166,13 +166,13 @@ func (p *Platform) Deploy(
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http",
-						ContainerPort: int32(p.config.ContainerPort),
+						ContainerPort: int32(p.config.ServicePort),
 					},
 				},
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(p.config.ContainerPort)),
+							Port: intstr.FromInt(int(p.config.ServicePort)),
 						},
 					},
 					InitialDelaySeconds: 5,
@@ -182,7 +182,7 @@ func (p *Platform) Deploy(
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(p.config.ContainerPort)),
+							Port: intstr.FromInt(int(p.config.ServicePort)),
 						},
 					},
 					InitialDelaySeconds: 5,
@@ -199,7 +199,7 @@ func (p *Platform) Deploy(
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: p.config.ProbePath,
-					Port: intstr.FromInt(int(p.config.ContainerPort)),
+					Port: intstr.FromInt(int(p.config.ServicePort)),
 				},
 			},
 			InitialDelaySeconds: 5,
@@ -211,7 +211,7 @@ func (p *Platform) Deploy(
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: p.config.ProbePath,
-					Port: intstr.FromInt(int(p.config.ContainerPort)),
+					Port: intstr.FromInt(int(p.config.ServicePort)),
 				},
 			},
 			InitialDelaySeconds: 5,
@@ -363,7 +363,7 @@ type Config struct {
 	// Defaults to port 3000. 
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port. 
-	ContainerPort uint `hcl:"container_port,optional"`
+	ServicePort uint `hcl:"service_port,optional"`
 }
 
 var (

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -85,8 +85,8 @@ func (p *Platform) Deploy(
 	}
 	jobclient := client.Jobs()
 
-	if p.config.ContainerPort == 0 {
-		p.config.ContainerPort = 3000
+	if p.config.ServicePort == 0 {
+		p.config.ServicePort = 3000
 	}
 
 	// Determine if we have a job that we manage already
@@ -101,7 +101,7 @@ func (p *Platform) Deploy(
 				DynamicPorts: []api.Port{
 					{
 						Label: "waypoint",
-						To:    int(p.config.ContainerPort),
+						To:    int(p.config.ServicePort),
 					},
 				},
 			},
@@ -119,7 +119,7 @@ func (p *Platform) Deploy(
 
 	// Build our env vars
 	env := map[string]string{
-		"PORT": fmt.Sprint(p.config.ContainerPort),
+		"PORT": fmt.Sprint(p.config.ServicePort),
 	}
 
 	for k, v := range p.config.StaticEnvVars {
@@ -213,7 +213,7 @@ type Config struct {
 	// Defaults to port 3000. 
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port. 
-	ContainerPort uint `hcl:"container_port,optional"`
+	ServicePort uint `hcl:"service_port,optional"`
 }
 
 var (


### PR DESCRIPTION
This PR allows the developer to configure the port that is listening/expected to be listening on their deployment. Currently it's set as a static port (3000) which requires the user to ensure that port is whats exposed as part of their build. With this in place, we can leverage a build configuration like below to set that port -

```
deploy {
      use "kubernetes" {
          probe_path="/"
          container_port=80
      }
    }
```

I worked with @nicholasjackson on this PR (Thanks Nic!) to check my work along the way. First HashiCorp code PR!