### PR TITLE
ignore generated /pkg/dist when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tmp/
 .waypoint/
 /waypoint
 /waypoint-entrypoint
+/pkg
 
 # System-specific
 .DS_Store


### PR DESCRIPTION
This dir is generated as part of our release process; we should ignore it.