### PR TITLE
internal/ceb: error if no args are given to exec

### DIFF
--- a/internal/ceb/child_exec.go
+++ b/internal/ceb/child_exec.go
@@ -57,6 +57,12 @@ func (ceb *CEB) execChildCmd(ctx context.Context) <-chan error {
 }
 
 func (ceb *CEB) buildCmd(ctx context.Context, args []string) (*exec.Cmd, error) {
+	// Avoid a crash below by verifying we got some arguments.
+	if len(args) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"command was empty")
+	}
+
 	// Exec requires a full path to a binary. If we weren't given an absolute
 	// path then we need to look it up via the PATH.
 	if !filepath.IsAbs(args[0]) {


### PR DESCRIPTION
This avoids FUBAR-ing your entire terminal if exec has no args.

This exposes a slightly larger issue which is that if the CEB panics and crashes during exec, the client is never notified or exited. We probably need some heartbeat mechanism here too. For now though, let's just fix the crash.

This doesn't have tests cause we don't yet test exec in the CEB. That's a TODO, we have the machinery to do this.