### PR TITLE
Fix form action on sign in button

### DIFF
--- a/website/components/auth-gate/index.jsx
+++ b/website/components/auth-gate/index.jsx
@@ -39,7 +39,7 @@ function SignInForm() {
 
 function Form({ callbackUrl, token }) {
   return (
-    <form action="http://localhost:3000/api/auth/signin/okta" method="POST">
+    <form action={`${callbackUrl}api/auth/signin/okta`} method="POST">
       <input type="hidden" name="csrfToken" value={token} />
       <input type="hidden" name="callbackUrl" value={callbackUrl} />
       <Button


### PR DESCRIPTION
Quick fix for the `callbackUrl` hardcoded into form