### PR TITLE
Updating homepage bgcolor

### DIFF
--- a/website/pages/home/style.css
+++ b/website/pages/home/style.css
@@ -1,3 +1,8 @@
 p {
   color: black;
 }
+
+/* Changing content background color to match the hero since we have no body copy for the internal beta */
+.content {
+  background-color: #f7f7f9;
+}


### PR DESCRIPTION
Changed the background color of the home page's content class to match the color of the hero for the initial version of the waypoint website. Without body copy, there's a white block of empty space about 100px hight. This update ensures that the primary content area all has the same background and that the header and footer are still using the lighter color.  This style update can be reverted later, and I have included a comment.

/* Changing content background color to match the hero since we have no body copy for the internal beta */ 
.content {
  background-color: #f7f7f9;
}