### PR TITLE
shell.nix: Add vendorSha256 attr to go modules

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,7 @@ in with pkgs; let
     };
 
     modSha256 = "0lnk1zpl6y9vnq6h3l42ssghq6iqvmixd86g2drpa4z8xxk116wf";
+    vendorSha256 = "04w9vhkrwb2zfqk73xmhignjyvjqmz1j93slkqp7v8jj2dhyla54";
 
     subPackages = [ "protoc-gen-go" ];
   };
@@ -46,6 +47,7 @@ in with pkgs; let
     };
 
     modSha256 = "01wrk2qhrh74nkv6davfifdz7jq6fcl3snn4w2g7vr8p0incdlcf";
+    vendorSha256 = "1hx31gr3l2f0nc8316c9ipmk1xx435g732msr5b344rcfcfrlaxh";
   };
 
   go-tools = buildGoModule rec {
@@ -60,6 +62,7 @@ in with pkgs; let
     };
 
     modSha256 = "1pijbkp7a9n2naicg21ydii6xc0g4jm5bw42lljwaks7211ag8k9";
+    vendorSha256 = "0pplmqxrnc8qnr5708igx4dm7rb0hicvhg6lh5hj8zkx38nb19s0";
 
     subPackages = [ "cmd/stringer" ];
   };
@@ -76,6 +79,7 @@ in with pkgs; let
     };
 
     modSha256 = "0wyzfmhk7plazadbi26rzq3w9cmvqz2dd5jsl6kamw53ps5yh536";
+    vendorSha256 = "0fai4hs3q822dg36a2zrxb191f71xdpafapn6ymi1w9dx68navcb";
 
     subPackages = [ "cmd/mockery" ];
   };


### PR DESCRIPTION
This fixes the following error, discovered on a fresh install of nix on
Linux:

```
error: while evaluating the attribute 'buildInputs' of the derivation 'waypoint' at /home/hicks/workspace/git/github.com/hashicorp/waypoint/shell.nix:83:3:
while evaluating 'getOutput' at /nix/store/5sg4ww1hmh574swgrsr6kr6i82cfgng4-nixpkgs-21.03pre243353.6d4b93323e7/nixpkgs/lib/attrsets.nix:464:23, called from undefined position:
while evaluating anonymous function at /nix/store/5sg4ww1hmh574swgrsr6kr6i82cfgng4-nixpkgs-21.03pre243353.6d4b93323e7/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:143:17, called from undefined position:
anonymous function at /nix/store/5sg4ww1hmh574swgrsr6kr6i82cfgng4-nixpkgs-21.03pre243353.6d4b93323e7/nixpkgs/pkgs/development/go-modules/generic/default.nix:3:1 called without required argument 'vendorSha256', at /home/hicks/workspace/git/github.com/hashicorp/waypoint/shell.nix:21:17
```

I am wondering why I'm the one to discover this error; is it a Linux thing? Is it related to my version of nix-pkgs?

This isn't all that's required to get it building for me; go-1.14.5.drv fails to build:

```
sed: can't read src/cmd/link/internal/ld/fallocate_test.go: No such file or directory
builder for '/nix/store/alci1lr6n3gl0xyiqwsd5z8v4hqgdcv7-go-1.14.5.drv' failed with exit code 2
error: build of '/nix/store/alci1lr6n3gl0xyiqwsd5z8v4hqgdcv7-go-1.14.5.drv' failed
```

Both 1.13.15 and 1.15.2 worked, however. :shrug: