### PR TITLE
shell.nix: Use <nixpkgs>.go_1_14 when overriding attrs for go

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ let
   pkgs = import pkgsPath {
     overlays = [(self: super: {
 
-      go = super.go.overrideAttrs ( old: rec {
+      go = super.go_1_14.overrideAttrs ( old: rec {
         version = "1.14.5";
         src = super.fetchurl {
           url = "https://dl.google.com/go/go${version}.src.tar.gz";


### PR DESCRIPTION
This pins the builder for go to the same minor version of go that's being installed.

The `fallocate_test.go` problem I mentioned in #183 is due to overriding the default `go`, which in my nix-pkgs is go 1.15. The prePatch step expects that file to exist in the source but it does not exist in go 1.14's source.