### PR TITLE
Fix URL to examples and Prerequisites

### DIFF
--- a/website/pages/docs/getting-started/k8s-example-app/index.mdx
+++ b/website/pages/docs/getting-started/k8s-example-app/index.mdx
@@ -11,8 +11,8 @@ description: |-
 This walkthrough takes you through leveraging Waypoint to deploy applications onto Kubernetes as well as give you a quick overview of how Waypoint works.
 
 - Time required: About 30 minutes
-- Prerequisites: Access to a Kubernetes cluster (such as one running in Public Cloud, Kubernetes in Docker for Desktop, or KIND) and the [Waypoint Examples applications repository](https://github.com/hashicorp/waypoiont-examples)
+- Prerequisites: Access to a Kubernetes cluster (such as one running in Public Cloud, Kubernetes in Docker for Desktop, or KIND) and the [Waypoint Examples applications repository](https://github.com/hashicorp/waypoint-examples)
 
 ### Next Step
 
-[Getting Started: Prerequisites](/docs/getting-started/k8s-example-app/install-rereqs)
+[Getting Started: Prerequisites](/docs/getting-started/k8s-example-app/install-prereqs)


### PR DESCRIPTION
This fixes URL typos to the `waypoint-examples` repository and to the next step in the Kubernetes Get Started tutorial.