### PR TITLE
core: Don't panic if build or deploy are unconfigured

### DIFF
--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -79,11 +79,19 @@ func (op *deployOperation) Init(app *App) (proto.Message, error) {
 }
 
 func (op *deployOperation) Hooks(app *App) map[string][]*config.Hook {
-	return app.components[app.Platform].Hooks
+	platform, ok := app.components[app.Platform]
+	if !ok {
+		return nil
+	}
+	return platform.Hooks
 }
 
 func (op *deployOperation) Labels(app *App) map[string]string {
-	return app.components[app.Platform].Labels
+	platform, ok := app.components[app.Platform]
+	if !ok {
+		return nil
+	}
+	return platform.Labels
 }
 
 func (op *deployOperation) Upsert(


### PR DESCRIPTION
Previously `waypoint up` would crash if either the build or deploy block were omitted. It seems (from existing test cases) like it's intended to be okay to omit the block for steps that you aren't running, but running an unconfigured step will now return an explicit error rather than panicking.

I found this by accidentally commenting out all of my `deploy` blocks while I was experimenting with some different permutations. The initial failure I saw was this:

```shell-session
$ waypoint up

==> Building...

==> Deploying...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x28b66db]

goroutine 119 [running]:
github.com/hashicorp/waypoint/internal/core.(*deployOperation).Hooks(0xc000211d80, 0xc0003f8380, 0xc000606340)
	waypoint/internal/core/app_deploy.go:82 +0x6b
github.com/hashicorp/waypoint/internal/core.(*App).doOperation(0xc0003f8380, 0x3b4c900, 0xc0005e6200, 0x3b8e4c0, 0xc00042e8c0, 0x3b6a000, 0xc000211d80, 0x0, 0x0, 0x0, ...)
	waypoint/internal/core/operation.go:57 +0x88
github.com/hashicorp/waypoint/internal/core.(*App).Deploy(0xc0003f8380, 0x3b4c900, 0xc0005e6200, 0xc000a86780, 0xc000c5e8a8, 0x13, 0xc0006f5e80)
	waypoint/internal/core/app_deploy.go:27 +0x1da
github.com/hashicorp/waypoint/internal/runner.(*Runner).executeDeployOp(0xc0000380c0, 0x3b4c900, 0xc0005e6200, 0xc000aa4d00, 0xc00068d2b0, 0x2, 0xf, 0x0)
	waypoint/internal/runner/operation_deploy.go:27 +0xae
github.com/hashicorp/waypoint/internal/runner.(*Runner).executeJob(0xc0000380c0, 0x3b4c900, 0xc0005e6200, 0x3b8e4c0, 0xc00041b3b0, 0x3b70060, 0xc0007679c0, 0xc000aa4d00, 0x0, 0x0, ...)
	waypoint/internal/runner/operation.go:101 +0xeb1
github.com/hashicorp/waypoint/internal/runner.(*Runner).accept(0xc0000380c0, 0x3b4c900, 0xc0005e6200, 0xc000a49ae0, 0x1a, 0x0, 0x0)
	waypoint/internal/runner/accept.go:210 +0x13ba
github.com/hashicorp/waypoint/internal/runner.(*Runner).AcceptExact(...)
	waypoint/internal/runner/accept.go:35
github.com/hashicorp/waypoint/internal/client.(*Project).doJob.func1.1(0xc0000380c0, 0x3b4c900, 0xc000abc240, 0xc000a49ae0, 0x1a, 0x3b8e4c0, 0xc0006bb570)
	waypoint/internal/client/job.go:79 +0x57
created by github.com/hashicorp/waypoint/internal/client.(*Project).doJob.func1
	waypoint/internal/client/job.go:78 +0x76
```

After my interest in addressing this was piqued I found a similar panic for omitting the `build` block, and for having empty `deploy` and `build` blocks, so this attempts to address all four cases.

Now it returns an error when trying to run the unconfigured operation:

```shell-session
$ waypoint up

==> Building...
no builder configured
```

```shell-session
$ waypoint up

==> Building...

==> Deploying...
no deployment configured
```

I've not yet used waypoint enough to know if the other operation blocks are similarly affected, but they do seem to be implemented in a similar way.

I initially considered adding validation rules to the `internal/configs` package, but on further investigation it seemed like it's supposed to be okay to omit the operation blocks if you don't intend to actually use the operation in question (some existing tests depend on that) so I thought it better to fail at the point of executing each operation instead. For robustness I also added `nil` checks to some of the other methods, but since those don't return errors I made them behave as no-ops instead.

I'm sorry there are no new tests here. I only had a short time to look at this today and that wasn't long enough to figure out how best to test something like this. I could probably spend a little more time adding some tests if someone can give me pointers on how/where stuff like this would typically be tested in this codebase.
