### PR TITLE
bug: change k8s liveness probe to use httpGet

### DIFF
--- a/internal/serverinstall/data/k8s-install/app.yaml
+++ b/internal/serverinstall/data/k8s-install/app.yaml
@@ -62,8 +62,10 @@ spec:
           tcpSocket:
             port: grpc
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /
             port: http
+            scheme: HTTPS
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
This PR fixes a small bug with the Waypoint server liveness probe for K8s. Currently `tcpSocket` is being used and due to the nature of the self signed certificates used by the server, the logs are full of handshake errors:

```
2020/09/18 00:21:44 http: TLS handshake error from 10.0.0.1:35500: EOF
2020/09/18 00:21:54 http: TLS handshake error from 10.0.0.1:35508: EOF
...
```

I've changed the liveness probe to use `httpGet`, which automatically disables TLS certificate verification.  This does not cut down on spam, though, but replaces the errors with GET logs:

```
==> Server logs:

2020-09-18T00:09:14.504Z [INFO]  waypoint.server: starting built-in server: addr=[::]:9701
2020-09-18T00:09:14.504Z [INFO]  waypoint.server.http: starting HTTP server: addr=[::]:9702
2020-09-18T00:09:14.504Z [INFO]  waypoint.server.grpc: starting gRPC server: addr=[::]:9701
2020-09-18T00:09:14.771Z [INFO]  waypoint.server.http: HTTP request: GET /: date=2020-09-18T00:09:14.770994527Z http.host=10.0.0.46:9702 http.method=GET http.request_path=/ http.remote_addr=10.0.0.1 http.response_size=3462 http.scheme= http.status_code=200 http.useragent=kube-probe/1.15+ http.version=HTTP/1.1
2020-09-18T00:09:24.779Z [INFO]  waypoint.server.http: HTTP request: GET /: date=2020-09-18T00:09:24.779214392Z http.host=10.0.0.46:9702 http.method=GET http.request_path=/ http.remote_addr=10.0.0.1 http.response_size=3462 http.scheme= http.status_code=200 http.useragent=kube-probe/1.15+ http.version=HTTP/1.1
...
```