### PR TITLE
builtin/k8s: add annotation and serviceaccount

### DIFF
--- a/builtin/k8s/service_account.go
+++ b/builtin/k8s/service_account.go
@@ -1,0 +1,15 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newServiceAccount returns the basic structure for a service account.
+func newServiceAccount(name string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}


### PR DESCRIPTION
Two new deploy fields for Kubernetes are introduced by this PR: `annotations` and `service_account`.  These allow deployed applications to specify annotations and service accounts to be applied to the application pod.

Having these two fields gives users the ability to use Vault Agent Injector to consume Vault secrets in K8s.

Here's an example deploy configuration:

```
   ...
   deploy {
      use "kubernetes" {
          probe_path = "/"
          static_environment = { "CI"="true" }
          annotations = {
            "vault.hashicorp.com/agent-inject" = "true"
            "vault.hashicorp.com/agent-inject-secret-kv-secret": "secret/hashiconf"
            "vault.hashicorp.com/agent-inject-template-kv-secret": <<EOF
                 {{ with secret "secret/hashiconf" }}{{ .Data | toJSONPretty }}{{ end }}
             EOF
            "vault.hashicorp.com/role": "waypoint"
            "vault.hashicorp.com/tls-secret": "tls-test-client"
            "vault.hashicorp.com/ca-cert": "/vault/tls/ca.crt"
          }
          service_account = "app"
      }
    }
    ...
```

Service accounts must exist before trying to create deployments with them configured, so I've added some logic to check and create if needed.

One thing I'm unsure of is how these objects get cleaned up. This could potentially leak service accounts. One idea is to apply a label with the name of the deployment. Thoughts?