### PR TITLE
website: fix h1 for /plugins/nomad

### DIFF
--- a/website/pages/plugins/nomad.mdx
+++ b/website/pages/plugins/nomad.mdx
@@ -5,7 +5,7 @@ sidebar_title: 'nomad'
 description: 'Deploy on Nomad'
 ---
 
-# Google Cloud Run
+# Nomad
 
 ## Builders
 


### PR DESCRIPTION
the title of the nomad plugin page was mislabeled as `Google Cloud Run` -- obviously just an artifact from a copy paste.