### PR TITLE
s/Nomad/Kubernetes typo

### DIFF
--- a/website/pages/docs/getting-started/k8s-example-app/init-waypoint.mdx
+++ b/website/pages/docs/getting-started/k8s-example-app/init-waypoint.mdx
@@ -60,7 +60,7 @@ The `deploy` clause defines where Waypoint will deploy the app. In our case, thi
 The `release` stanza defines how our application will be released to our environment, in our case we're using a `load_balanacer`
 on a specific `port`.
 
--> Note: You maybe also want to update your docker image and location to a location that you have access to, if this is running on an external Nomad cluster.
+-> Note: You maybe also want to update your docker image and location to a location that you have access to, if this is running on an external Kubernetes cluster.
 
 ```shell
 app "example-nodejs"" {


### PR DESCRIPTION
Probably a copy/paste typo, but this is the wrong section to be suggesting Nomad clusters!

The typo:

![CleanShot 2020-09-18 at 15 55 09@2x](https://user-images.githubusercontent.com/10213/93651751-7847c900-f9c7-11ea-92c3-e047b6a9aaf3.png)
