### PR TITLE
Removing confusing lines from copy/paste

### DIFF
--- a/website/pages/docs/getting-started/k8s-example-app/install-waypoint.mdx
+++ b/website/pages/docs/getting-started/k8s-example-app/install-waypoint.mdx
@@ -76,7 +76,7 @@ In this step we will innstall the Waypoint server onto Kubernetes. This allows y
 containerd rather than DockerD, the Waypoint server install will fail with an ImagePullBackOff error. The team is currently working on resolving this issue.
 
 ```shell
- $ waypoint install 
+ $ waypoint install -platform=kubernetes
 ```
 
 In addition to Kubernetes, the Waypoint server can be installed on Docker or a [Nomad cluster](https://nomadproject.io). 


### PR DESCRIPTION
Document was copied from Docker guide for consistently however left descriptions calling out installation Docker for Desktop. Correcting. Also mistakenly removed the -platform=kubernetes option thinking it was committed by mistake. Restored in the subsequent commit. 