### PR TITLE
internal/cli: remove redundant default docs

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -303,7 +303,7 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Name:    "workspace",
 			Target:  &c.flagWorkspace,
 			Default: "default",
-			Usage:   "Workspace to operate in. Defaults to 'default'.",
+			Usage:   "Workspace to operate in.",
 		})
 	}
 


### PR DESCRIPTION
This fixes #221.

Going to merge once green due to trivial change.