### PR TITLE
Remove CEB from glossary Entrypoint heading

### DIFF
--- a/website/content/docs/glossary.mdx
+++ b/website/content/docs/glossary.mdx
@@ -34,9 +34,9 @@ a single project, which may represent a project that is comprised of
 separate depoloyable units. For example: a backend, a frontend, a service
 worker, etc. may each be a separate application.
 
-## Entrypoint (or "CEB")
+## Entrypoint
 
-The entrypoint is a special binary that launches your application and is
+The Waypoint Entrypoint is a special binary (named `waypoint-entrypoint`) that launches your application and is
 used to enable a lot of [Waypoint functionality](/docs/entrypoint#functionality).
 The entrypoint is sometimes referred to as the "CEB" which stands for
 "custom entrypoint binary."


### PR DESCRIPTION
Remove CEB in the heading and update the text.