### PR TITLE
builtin/docker: use correct image tag

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -157,7 +157,11 @@ func (b *Builder) Build(
 		return nil, status.Errorf(codes.Internal, "unable to stream build logs to the terminal: %s", err)
 	}
 
+	step.Done()
+
 	if !b.config.DisableCEB {
+		step = sg.Add("Injecting Waypoint Entrypoint...")
+
 		tmpdir, err := ioutil.TempDir("", "waypoint")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to create temporary directory: %s", err)
@@ -184,9 +188,9 @@ func (b *Builder) Build(
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to set modify Docker entrypoint: %s", err)
 		}
-	}
 
-	step.Done()
+		step.Done()
+	}
 
 	return result, nil
 }

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -141,7 +141,7 @@ func (p *Platform) Deploy(
 		AttachStdin:  true,
 		OpenStdin:    true,
 		StdinOnce:    true,
-		Image:        img.Image,
+		Image:        img.Image + ":" + img.Tag,
 		ExposedPorts: nat.PortSet{np: struct{}{}},
 		Env:          []string{"PORT=" + port},
 	}


### PR DESCRIPTION
It was not referencing the tag so we were always picking up "latest".
Now that we can retag we need to make sure we need to get the right one!