### PR TITLE
Remove post-install hook

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -35,9 +35,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "next-hashicorp precommit",
-      "post-merge": "post-npm-install",
-      "post-rebase": "post-npm-install"
+      "pre-commit": "next-hashicorp precommit"
     }
   },
   "main": "index.js",


### PR DESCRIPTION
It was broken, unfortunately, and logging an error message after every pull. Its removal does open up a potential issue - if someone updates a dependency past a breaking version, then pushes that change, anyone else who pulls it down and wants to work with the website will need to run `npm i` or face a cryptic error. I'm going to work on getting this hook fixed so that this loophole can be closed, just want to warn in the meantime.

If it's still running for you after this merge, `cd website && npm rebuild` should remove the hook.