### PR TITLE
Typos for word "Successfully"

### DIFF
--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -130,7 +130,7 @@ func (r *Releaser) Release(
 		return nil, err
 	}
 
-	st.Step(terminal.StatusOK, "Service succesfully configured!")
+	st.Step(terminal.StatusOK, "Service successfully configured!")
 
 	if r.config.LoadBalancer {
 		ingress := service.Status.LoadBalancer.Ingress[0]

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -2,7 +2,7 @@
 <div class="flash flash--success">
   <div class="flash-header">
     {{inline-svg "check-circle-fill" class="icon"}}
-    <p>Authenticated succesfully via the Waypoint CLI</p>
+    <p>Authenticated successfully via the Waypoint CLI</p>
   </div>
 </div>
 {{/if}}


### PR DESCRIPTION
Was moving some screenshots into the keynote decks and noticed "succesfully" was typo'd twice. Did a search, these were the only occurrences. 