### PR TITLE
internal/core: default the release component to the deployment

### DIFF
--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -46,6 +46,7 @@ func (op *releaseOperation) Init(app *App) (proto.Message, error) {
 		Workspace:    app.workspace,
 		DeploymentId: op.Target.Id,
 		State:        pb.Operation_CREATED,
+		Component:    op.Target.Component,
 	}
 
 	if app.Releaser != nil {


### PR DESCRIPTION
This relates to #224. 

This ensures that a release always has a component set. If no releaser exists, it will use the same component as the deployment.