### PR TITLE
ui: only show release url if it is available

### DIFF
--- a/ui/app/components/latest-release-url/index.hbs
+++ b/ui/app/components/latest-release-url/index.hbs
@@ -1,4 +1,6 @@
+{{#if this.firstRelease.url}}
 <ExternalLink href={{this.firstRelease.url}} class="button button--primary">
   <span>{{this.firstRelease.url}}</span>
   {{inline-svg "exit" class="icon"}}
 </ExternalLink>
+{{/if}}

--- a/ui/app/templates/components/app-card/release.hbs
+++ b/ui/app/templates/components/app-card/release.hbs
@@ -14,9 +14,11 @@
         </span>
       </small>
     </LinkTo>
+    {{#if @model.url}}
     <ExternalLink href={{@model.url}} class="button button--primary">
       {{inline-svg "exit" class="icon"}}
     </ExternalLink>
+    {{/if}}
   </div>
 {{else}}
   <li class="app-card-item">

--- a/ui/app/templates/components/app-item/release.hbs
+++ b/ui/app/templates/components/app-item/release.hbs
@@ -17,7 +17,7 @@
     </small>
   </LinkTo>
 
-  {{#if @isLatest}}
+  {{#if (and @isLatest @release.url)}}
     <ExternalLink href={{@release.url}} class="button button--primary">
       <span>{{@release.url}}</span>
       {{inline-svg "exit" class="icon"}}


### PR DESCRIPTION
The release URL will not always be available, so this just hides it if it isn't. The user will still be able to access the deployment URL in this scenario. For Docker, you won't ever have a "released" URL in the getting started experience.

Fixes #228 and related to #270.