### PR TITLE
Reformat the build/deploy clause explainations

### DIFF
--- a/website/content/docs/getting-started/docker-example-app/init-waypoint.mdx
+++ b/website/content/docs/getting-started/docker-example-app/init-waypoint.mdx
@@ -46,11 +46,13 @@ app "example-ruby" {
 }
 ```
 
-The `build` clause defines how Waypoint will build the app.
+The `build` clause defines how Waypoint will build the app. The `pack` option
+tells Waypoint to use the most relevant Cloud Native Buildpack to build the
+application. Since the example app is written in Ruby, Waypoint will use Ruby
+Cloud Native Buildpacks.
 
-The `pack` option tells Waypoint to use the most relevant Cloud Native Buildpack to build the application. Since the example app is written in Ruby, Waypoint will use Ruby Cloud Native Buildpacks.
-
-The `deploy` clause defines how Waypoint will deploy the app. The `docker` option tells Waypoint to deploy the application to Docker.
+The `deploy` clause defines how Waypoint will deploy the app. The `docker`
+option tells Waypoint to deploy the application to Docker.
 
 ## Initialize Waypoint for the Example App
 

--- a/website/content/docs/getting-started/k8s-example-app/init-waypoint.mdx
+++ b/website/content/docs/getting-started/k8s-example-app/init-waypoint.mdx
@@ -62,16 +62,17 @@ project = "example-nodejs"
   }
 ```
 
-The `build` clause defines how Waypoint will build the app.
+The `build` clause defines how Waypoint will build the app. The `pack` option
+tells Waypoint to use the most relevant Cloud Native Buildpack to build the
+application. Since this example app is written for NodeJS, Waypoint will use
+NodeJS Buildpacks.
 
-The `pack` option tells Waypoint to use the most relevant Cloud Native
-Buildpack to build the application. Since this example app is written for NodeJS, Waypoint will use NodeJS Buildpacks.
+The `deploy` clause defines where Waypoint will deploy the app. The `kubernetes`
+option tells Waypoint to deploy the application to Kubernetes.
 
-The `deploy` clause defines where Waypoint will deploy the app. The `kubernetes` option tells Waypoint to deploy the application to Kubernetes.
-
-
-The `release` stanza defines how our application will be released to our environment. For example, in the case of external Kubernetes
-clusters this would be where you would configure a `load_balanacer` on a specific `port`.
+The `release` clause defines how our application will be released to our
+environment. For example, in the case of external Kubernetes clusters this would
+be where you would configure a `load_balanacer` on a specific `port`.
 
 -> Note: You may also want to update your `image`,`location`, and remove the `local` configuration if you plan to run this application
 on an external Kubernetes cluster. The current example uses a local based image.

--- a/website/content/docs/getting-started/nomad-example-app/init-waypoint.mdx
+++ b/website/content/docs/getting-started/nomad-example-app/init-waypoint.mdx
@@ -58,12 +58,14 @@ project = "example-nodejs"
   }
 ```
 
-The `build` clause defines how Waypoint will build the app.
+The `build` clause defines how Waypoint will build the app. The `pack` option
+tells Waypoint to use the most relevant Cloud Native Buildpack to build the
+application. Since this example app is written for NodeJS, Waypoint will use
+NodeJS Buildpacks.
 
-The `pack` option tells Waypoint to use the most relevant Cloud Native
-Buildpack to build the application. Since this example app is written for NodeJS, Waypoint will use NodeJS Buildpacks.
-
-The `deploy` clause defines where Waypoint will deploy the app. The `nomad` and `datacenter` fields tell Waypoint to deploy the application to Nomad to the dc1 datacenter.
+The `deploy` clause defines where Waypoint will deploy the app. The `nomad` and
+`datacenter` fields tell Waypoint to deploy the application to Nomad to the dc1
+datacenter.
 
 -> Note: You might also want to update your docker `image`,`location`, and remove the `local` configuration if you plan to run this application
 on an external Nomad cluster. The current example uses a local based image.


### PR DESCRIPTION
This PR tries to clarify the `init-waypoint` documentation. The current documentation details the `build`, `deploy`, and sometimes `release` clauses. For kube and docker, it also mentions the `pack` option of the `build` clause, but it lists it in it's own paragraph which to me implied it was a clause at the same level as `build` or `deploy`, when it's actually an option of `build`. 

This PR also standardized on `clause`, where the `release` part of the Kubernetes docs referred to `release` as a stanza. The Terraform documentation refers to these as [blocks](https://www.terraform.io/docs/configuration/syntax.html#blocks) but I thought it best to just conform to `clause` for now.