### PR TITLE
Update k8s example path

### DIFF
--- a/website/content/docs/getting-started/k8s-example-app/update-app.mdx
+++ b/website/content/docs/getting-started/k8s-example-app/update-app.mdx
@@ -12,7 +12,7 @@ One of the most powerful parts of Waypoint is its ability to iterate on deployme
 
 Open the following file in your preferred development editor:
 
-`view/index.ejs`
+`views/pages/index.ejs`
 
 On `line 17`, change the text to anything that you like and then save the file.
 


### PR DESCRIPTION
The view file path has changed, it's `views/pages/index.ejs` now (see https://github.com/hashicorp/waypoint-examples/pull/3 I think)