### PR TITLE
builtin/kubernetes: output a message about which kubernetes cluster and namespace are in use

### DIFF
--- a/builtin/k8s/api.go
+++ b/builtin/k8s/api.go
@@ -4,11 +4,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // clientset returns a K8S clientset and configured namespace.
-func clientset(kubeconfig, context string) (*kubernetes.Clientset, string, error) {
+func clientset(kubeconfig, context string) (*kubernetes.Clientset, string, *rest.Config, error) {
 	loader := clientcmd.NewDefaultClientConfigLoadingRules()
 
 	// Path to the kube config file
@@ -27,21 +28,21 @@ func clientset(kubeconfig, context string) (*kubernetes.Clientset, string, error
 	// Get our configured namespace
 	ns, _, err := config.Namespace()
 	if err != nil {
-		return nil, "", status.Errorf(codes.Aborted,
+		return nil, "", nil, status.Errorf(codes.Aborted,
 			"failed to initialize K8S client configuration: %s", err)
 	}
 
 	clientconfig, err := config.ClientConfig()
 	if err != nil {
-		return nil, "", status.Errorf(codes.Aborted,
+		return nil, "", nil, status.Errorf(codes.Aborted,
 			"failed to initialize K8S client configuration: %s", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(clientconfig)
 	if err != nil {
-		return nil, "", status.Errorf(codes.Aborted,
+		return nil, "", nil, status.Errorf(codes.Aborted,
 			"failed to initialize K8S client: %s", err)
 	}
 
-	return clientset, ns, nil
+	return clientset, ns, clientconfig, nil
 }

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -49,10 +49,13 @@ func (r *Releaser) Release(
 	defer st.Close()
 
 	// Get our clientset
-	clientset, ns, err := clientset(r.config.KubeconfigPath, r.config.Context)
+	clientset, ns, config, err := clientset(r.config.KubeconfigPath, r.config.Context)
 	if err != nil {
 		return nil, err
 	}
+
+	ui.Output("Configuring %s in namespace %s", config.Host, ns, terminal.WithHeaderStyle())
+
 	serviceclient := clientset.CoreV1().Services(ns)
 
 	// Determine if we have a deployment that we manage already


### PR DESCRIPTION
This is a QoL change found because I was trying to figure out WHY waypoint was failing to install an app into kubernetes when I realized, welp, the current kubectl context was pointed to a different cluster. 