### PR TITLE
internal/{cli/exec, .../execclient}: Add ability to cancel the exec with the ssh escape sequence

### DIFF
--- a/internal/server/execclient/client.go
+++ b/internal/server/execclient/client.go
@@ -124,6 +124,8 @@ func (c *Client) Run() (int, error) {
 	ctx, cancel := context.WithCancel(c.Context)
 	defer cancel()
 
+	input := &EscapeWatcher{Cancel: cancel, Input: c.Stdin}
+
 	// Build our connection. We only build the stdin sending side because
 	// we can receive other message types from our recv.
 	go io.Copy(&grpc_net_conn.Conn{
@@ -139,7 +141,7 @@ func (c *Client) Run() (int, error) {
 
 			return &req.Event.(*pb.ExecStreamRequest_Input_).Input.Data
 		}),
-	}, c.Stdin)
+	}, input)
 
 	// Add our recv blocker that sends data
 	recvCh := make(chan *pb.ExecStreamResponse)

--- a/internal/server/execclient/escape.go
+++ b/internal/server/execclient/escape.go
@@ -1,0 +1,51 @@
+package execclient
+
+import (
+	"io"
+)
+
+type EscapeWatcher struct {
+	Cancel func()
+	Input  io.Reader
+
+	state int
+}
+
+const (
+	escNormal = iota
+	escNewline
+	escTilde
+)
+
+func (ew *EscapeWatcher) Read(b []byte) (int, error) {
+	n, err := ew.Input.Read(b)
+	if err != nil {
+		return n, err
+	}
+
+	for _, r := range b[:n] {
+		switch ew.state {
+		case escNewline:
+			switch r {
+			case '~':
+				ew.state = escTilde
+			case '\n':
+				ew.state = escNewline
+			default:
+				ew.state = escNormal
+			}
+		case escTilde:
+			if r == '.' {
+				ew.Cancel()
+			} else {
+				ew.state = escNormal
+			}
+		case escNormal:
+			if r == '\n' {
+				ew.state = escNewline
+			}
+		}
+	}
+
+	return n, nil
+}

--- a/internal/server/execclient/escape_test.go
+++ b/internal/server/execclient/escape_test.go
@@ -1,0 +1,171 @@
+package execclient
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscape(t *testing.T) {
+	t.Run("closes the context when the escape sequence is seen", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		buf.WriteByte('\n')
+		buf.WriteByte('~')
+		buf.WriteByte('.')
+
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: &buf}
+
+		io.Copy(ioutil.Discard, ew)
+
+		assert.True(t, ok, "context was not canceled")
+	})
+
+	t.Run("can see the sequence within a buffer", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		buf.WriteString("hello")
+		buf.WriteByte('\n')
+		buf.WriteByte('~')
+		buf.WriteByte('.')
+		buf.WriteString("bye")
+
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: &buf}
+
+		io.Copy(ioutil.Discard, ew)
+
+		assert.True(t, ok, "context was not canceled")
+	})
+
+	t.Run("can see the sequence across reads", func(t *testing.T) {
+		r, w := io.Pipe()
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: r}
+
+		go w.Write([]byte("hello\n"))
+
+		junk := make([]byte, 1024)
+
+		n, err := ew.Read(junk)
+		require.NoError(t, err)
+
+		assert.Equal(t, 6, n)
+
+		go w.Write([]byte("~."))
+
+		n, err = ew.Read(junk)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, n)
+
+		assert.True(t, ok, "context was not canceled")
+	})
+
+	t.Run("can see the sequence across reads split on ~ and .", func(t *testing.T) {
+		r, w := io.Pipe()
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: r}
+
+		go w.Write([]byte("hello\n~"))
+
+		junk := make([]byte, 1024)
+
+		n, err := ew.Read(junk)
+		require.NoError(t, err)
+
+		assert.Equal(t, 7, n)
+
+		go w.Write([]byte("."))
+
+		n, err = ew.Read(junk)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, n)
+
+		assert.True(t, ok, "context was not canceled")
+	})
+
+	t.Run("resets track state after newline", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		buf.WriteString("\nx~.")
+
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: &buf}
+
+		io.Copy(ioutil.Discard, ew)
+
+		assert.False(t, ok, "context was canceled")
+		assert.Equal(t, escNormal, ew.state)
+	})
+
+	t.Run("resets track state after tilde", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		buf.WriteString("\n~x.")
+
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: &buf}
+
+		io.Copy(ioutil.Discard, ew)
+
+		assert.False(t, ok, "context was canceled")
+
+		assert.Equal(t, escNormal, ew.state)
+	})
+
+	t.Run("follows newlines into escape state", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		buf.WriteString("\n\n~.")
+
+		var ok bool
+
+		cancel := func() {
+			ok = true
+		}
+
+		ew := &EscapeWatcher{Cancel: cancel, Input: &buf}
+
+		io.Copy(ioutil.Discard, ew)
+
+		assert.True(t, ok, "context was not canceled")
+	})
+
+}


### PR DESCRIPTION
This makes exec support the newline + tilde + . escape sequence, the same as ssh uses, to perform a client side close of the session.

Two differences than ssh:
* This passes the escape sequence on as it's attempting to resolve it. Ssh buffers it such that if it's a successful escape sequence, the remote side doesn't see it at all. Because we only support closing, it's not a big deal to just pass the data on. The one place this will matter is if someone ssh's from inside their `waypoint exec` session, but in that case canceling both is probably what you want anyway.
* This hardcodes the escape character to ~, where as ssh supports the ability to change it.