### PR TITLE
Increase K8s install timeout

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -330,7 +330,7 @@ func (c *InstallCommand) Run(args []string) int {
 	log.Info("connecting to the server so we can set the server config", "addr", contextConfig.Server.Address)
 	conn, err := serverclient.Connect(ctx,
 		serverclient.FromContextConfig(contextConfig),
-		serverclient.Timeout(1*time.Minute),
+		serverclient.Timeout(2*time.Minute),
 	)
 	if err != nil {
 		c.ui.Output(


### PR DESCRIPTION
AKS takes a longer than the other platforms to spin up due to the way PVCs are handled within Azure. As a result, the Waypoint server will consistently not meet the 1 minute deadline for installation. In testing, The waypoint server is ready at about the 80-90 second mark. Proposing bumping this up to 2 minutes instead to give necessary time.