### PR TITLE
Download links directly to S3.

### DIFF
--- a/website/components/subnav/index.jsx
+++ b/website/components/subnav/index.jsx
@@ -17,7 +17,11 @@ export default function ProductSubnav() {
           text: 'GitHub',
           url: `https://www.github.com/hashicorp/${productSlug}`,
         },
-        { text: 'Download', url: 'https://go.hashi.co/waypoint-beta-binaries' },
+        {
+          text: 'Download',
+          url:
+            'http://ihngtake2gyn8nbyfgtgvu449dnsbrgopvukjdbntyndmlv7tb.s3-website-us-east-1.amazonaws.com/waypoint/',
+        },
       ]}
       currentPath={router.pathname}
       menuItemsAlign="right"

--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -23,7 +23,8 @@ export default function HomePage() {
         links={[
           {
             text: 'Download',
-            url: 'https://go.hashi.co/waypoint-beta-binaries',
+            url:
+              'http://ihngtake2gyn8nbyfgtgvu449dnsbrgopvukjdbntyndmlv7tb.s3-website-us-east-1.amazonaws.com/waypoint/',
             type: 'download',
           },
           {


### PR DESCRIPTION
The download link will need to be accessible to the folks who are
authing via Auth0, and right now our shortened link is behind Okta.

This should be safe to open up, as everyone who can access this site
should be allowed to access this link.