### PR TITLE
ui: pass protocol version metadata

### DIFF
--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -24,7 +24,7 @@ const protocolVersions = {
   // This is defined by the UI and can be
   // later used to identify different versions of the UI
   // todo: policy for when we change this..
-  'client-version': '1.0.0',
+  'client-version': 'ui-0.0.1',
 };
 
 export default class ApiService extends Service {


### PR DESCRIPTION
This configures the UI to include protocol versions with all gRPC requests.

The client version is probably ignored on the server for now, but eventually need to figure out how to version this.

Unfortunately not good way to test this metadata being passed at the moment.

Related to #292