### PR TITLE
ui: add local arg for `ember serve`

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -7,22 +7,41 @@ A short introduction of this app could easily go here.
 
 You will need the following things properly installed on your computer.
 
-* [Git](https://git-scm.com/)
-* [Node.js](https://nodejs.org/) (with npm)
-* [Ember CLI](https://ember-cli.com/)
-* [Google Chrome](https://google.com/chrome/)
+- [Git](https://git-scm.com/)
+- [Node.js](https://nodejs.org/) (with npm)
+- [Ember CLI](https://ember-cli.com/)
+- [Google Chrome](https://google.com/chrome/)
 
 ## Installation
 
-* `git clone <repository-url>` this repository
-* `cd waypoint`
-* `npm install`
+- `git clone <repository-url>` this repository
+- `cd waypoint`
+- `npm install`
 
 ## Running / Development
 
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+There are two modes of development.
+
+### Running with Mocks
+
+This returns data in-browser with Mirage.js (a mocking framework)
+active. This means that the network requests will be intercepted
+and return [mocked objects](https://github.com/hashicorp/waypoint/tree/master/ui/mirage/services)
+that are static and are re-loaded on page refresh.
+
+- `ember serve`
+- The app will be available at [http://localhost:4200](http://localhost:4200).
+
+### Running with a local Waypoint Server
+
+This option assumes there is a Waypoint server running
+at `https://localhost:9702`.
+
+Note: You'll need to visit the above address in the same browser session to
+accept the invalid certificate warning in your browser for this to work.
+
+- `ember serve local`
+- The app will be available at [http://localhost:4200](http://localhost:4200).
 
 ### Code Generators
 
@@ -30,19 +49,19 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Running Tests
 
-* `ember test`
-* `ember test --server`
+- `ember test`
+- `ember test --server`
 
 ### Linting
 
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
+- `npm run lint:hbs`
+- `npm run lint:js`
+- `npm run lint:js -- --fix`
 
 ### Building
 
-* `ember build` (development)
-* `ember build --environment production` (production)
+- `ember build` (development)
+- `ember build --environment production` (production)
 
 ### Deploying
 
@@ -50,8 +69,8 @@ Specify what it takes to deploy your app.
 
 ## Further Reading / Useful Links
 
-* [ember.js](https://emberjs.com/)
-* [ember-cli](https://ember-cli.com/)
-* Development Browser Extensions
-  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
-  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+- [ember.js](https://emberjs.com/)
+- [ember-cli](https://ember-cli.com/)
+- Development Browser Extensions
+  - [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  - [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)

--- a/ui/app/config/environment.d.ts
+++ b/ui/app/config/environment.d.ts
@@ -8,6 +8,7 @@ export default config;
  * since different ember addons can materialize new entries.
  */
 declare const config: {
+  apiAddress: string;
   environment: any;
   modulePrefix: string;
   podModulePrefix: string;

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -16,6 +16,7 @@ import {
   ListReleasesRequest,
   ListReleasesResponse,
 } from 'waypoint-pb';
+import config from 'waypoint/config/environment';
 
 const protocolVersions = {
   // These map to upstream protocol versions
@@ -29,7 +30,9 @@ const protocolVersions = {
 
 export default class ApiService extends Service {
   @service session!: SessionService;
-  client = new WaypointClient('/grpc', null, null);
+  // If the the apiAddress is not set, this will use the /grpc prefix on the
+  // same host as the UI is being served from
+  client = new WaypointClient(`${config.apiAddress}/grpc`, null, null);
 
   // Merges metadata with required metadata for the request
   WithMeta(meta?: any) {

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -2,6 +2,7 @@
 
 module.exports = function (environment) {
   let ENV = {
+    apiAddress: '',
     modulePrefix: 'waypoint',
     environment,
     rootURL: '/',
@@ -33,6 +34,14 @@ module.exports = function (environment) {
       // Allows for `ember serve no-mirage`
       enabled: process.argv.includes('no-mirage') ? false : true,
     };
+
+    if (process.argv.includes('local')) {
+      // Default Docker server address
+      ENV.apiAddress = 'https://localhost:9702';
+      ENV['ember-cli-mirage'] = {
+        enabled: false,
+      };
+    }
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
This formalizes a pattern of configuring the UI in development to not be mocked but interact directly with a Waypoint server at `localhost:9702`, which is the default for a Docker install.