### PR TITLE
website: use relative paths for markdown links

### DIFF
--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -14,11 +14,11 @@ All of these walkthroughs use example applications and are designed to help you 
 
 ### Start Here
 
-[Deploy an example app with Docker](https://waypointproject.io/docs/getting-started/docker-example-app)
+[Deploy an example app with Docker](/docs/getting-started/docker-example-app)
 
 If you're new to Waypoint, we recommend you start with the Docker walkthrough. This walkthrough will take about 10 minutes and uses an example app and Docker Desktop to illustrate the Waypoint workflow.
 
 Once you have mastered the basics of Waypoint, try deploying an example app to Kubernetes or Nomad.
 
-- [Kubernetes](https://waypointproject.io/docs/getting-started/k8s-example-app)
-- [Nomad](https://waypointproject.io/docs/getting-started/nomad-example-app)
+- [Kubernetes](/docs/getting-started/k8s-example-app)
+- [Nomad](/docs/getting-started/nomad-example-app)

--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -38,7 +38,7 @@ Waypoint includes these builtin plugins to build a Docker container for your app
 - Docker Build
 - Cloud Native Buildpacks
 
-You can also create a [plugin](https://waypointproject.io/plugins) to extend Waypoint with your own builder.
+You can also create a [plugin](/plugins) to extend Waypoint with your own builder.
 
 ### Choosing How to Build Your App
 
@@ -60,7 +60,7 @@ Most developers using Waypoint for current applications will likely want to use 
 
 When building your app's container, Docker will use a [Dockerfile](https://docs.docker.com/engine/reference/builder/) as a set of instructions for how to configure the container. Dockerfiles may include information such as which base operating system to use in the container, directory structure, etc.
 
-[Learn how to use Docker Build in your app](https://waypointproject.io/plugins/docker)
+[Learn how to use Docker Build in your app](/plugins/docker)
 
 #### Cloud Native Buildpacks
 

--- a/website/content/docs/lifecycle/deploy.mdx
+++ b/website/content/docs/lifecycle/deploy.mdx
@@ -41,19 +41,19 @@ To deploy your app with Waypoint, you will need to select which platform to use.
 
 You can currently use Waypoint to deploy your app to any of these platforms.
 
-- [Kubernetes](https://waypointproject.io/plugins/kubernetes)
-- [HashiCorp Nomad](https://waypointproject.io/plugins/nomad)
-- [AWS EC2](https://waypointproject.io/plugins/aws-ec2)
-- [AWS ECS](https://waypointproject.io/plugins/aws-ecs)
-- [Google Cloud Run](https://waypointproject.io/plugins/google-cloud-run)
-- [Azure Container Instances](https://waypointproject.io/plugins/azure-container-instances)
-- [Netlify](https://waypointproject.io/plugins/netlify)
+- [Kubernetes](/plugins/kubernetes)
+- [HashiCorp Nomad](/plugins/nomad)
+- [AWS EC2](/plugins/aws-ec2)
+- [AWS ECS](/plugins/aws-ecs)
+- [Google Cloud Run](/plugins/google-cloud-run)
+- [Azure Container Instances](/plugins/azure-container-instances)
+- [Netlify](/plugins/netlify)
 
 ~> You may use the Kuberenetes plugin to target any Kubernetes instance. For example, AWS EKS, Azure AKS, Google GKE, and Kuberenetes for Docker Desktop.
 
 #### How to Add a Deployment Platform to Waypoint
 
-You can also create a [plugin](https://waypointproject.io/plugins) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
+You can also create a [plugin](/plugins) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
 
 ## Automatic Release
 


### PR DESCRIPTION
> ⚠️ note: this PR targets your `docs-deployment-platforms` branch, so merging won't trigger a production deploy, it'll just update your WIP branch. 

i noticed in your WIP branch that you were starting to use full URLs for links and best practice is to use relative links. one main reason is when reviewing locally or on a deploy preview, if you follow one of these links you won't be surprisingly jumped into the production website without realizing.

i noticed 2 other spots that were already on the live site of this full url usage and i corrected those too. they aren't related to your `docs-deployment-platforms` work

