### PR TITLE
Fixes a nav bug

### DIFF
--- a/website/components/subnav/index.jsx
+++ b/website/components/subnav/index.jsx
@@ -4,6 +4,11 @@ import Link from 'next/link'
 import subnavItems from 'data/navigation'
 import { productSlug } from 'data/metadata'
 
+// A regex to match the pathname that comes out of router.pathname
+// when the path is a content page (e.g. /docs/[[...page]]) to strip
+// out the part that we're not interested in.
+const multipathRegex = /\/\[\[.*\]\]/g
+
 export default function ProductSubnav() {
   const router = useRouter()
   return (
@@ -22,7 +27,7 @@ export default function ProductSubnav() {
           url: '/downloads',
         },
       ]}
-      currentPath={router.pathname}
+      currentPath={router.pathname.replace(multipathRegex, '')}
       menuItemsAlign="right"
       menuItems={subnavItems}
       constrainWidth


### PR DESCRIPTION
Fix a nav bug where the active underline was not applying to docs / cli / plugins pages.

<img width="1350" alt="Screen Shot 2020-10-07 at 12 24 15 AM" src="https://user-images.githubusercontent.com/2105067/95300222-be0fe880-0833-11eb-8fa2-fe76dad95c96.png">