### PR TITLE
add GitHub code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,6 @@
 name: "Code scanning - scheduled (weekly)"
 
 on:
-  push:
-    branches: [ sec/enable_code_scanning ]
-  pull_request:
-    branches: [ sec/enable_code_scanning ]
   schedule:
     - cron: '0 17 * * 0'
 


### PR DESCRIPTION
We're in the process of adopting GitHub "Advanced Security", which includes CodeQL code scanning capabilities.

We'll start by enabling just for this PR's branch, then switch to run a weekly scheduled scan, similar to https://github.com/hashicorp/boundary/pull/422.

Results of scans will be available only to users with 'write' access to this repo, via the 'Security' tab (https://github.com/hashicorp/waypoint/security/code-scanning).