### PR TITLE
internal/config: hook `when` should be a field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ type DataSource struct {
 
 // Hook is the configuration for a hook that runs at specified times.
 type Hook struct {
-	When      string   `hcl:",label"`
+	When      string   `hcl:"when,attr"`
 	Command   []string `hcl:"command,attr"`
 	OnFailure string   `hcl:"on_failure,optional"`
 }


### PR DESCRIPTION
This is how we documented it but the implementation was different. Let's go with the docs since that matches Terraform better.