### PR TITLE
Temporarily remove metadata from app.js

### DIFF
--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -32,9 +32,6 @@ function App({ Component, pageProps }) {
           is={Head}
           title={`${productName} by HashiCorp`}
           siteName={`${productName} by HashiCorp`}
-          description="Waypoint is an open source solution that provides a modern workflow for build, deploy, and release across platforms."
-          image="https://waypointproject.io/img/og-image.png"
-          icon={[{ href: '/favicon.ico' }]}
         />
         {ALERT_BANNER_ACTIVE && (
           <AlertBanner {...alertBannerData} theme="blue" />


### PR DESCRIPTION
Being EXTRA careful here -- this content never renders (from our Auth blocker), but a savvy person could actually extract this from the raw app.js file (which gets transmitted over the wire).

Removing this metadata for now.