### PR TITLE
ui: handle empty deployment urls

### DIFF
--- a/ui/app/templates/components/app-card/deployment.hbs
+++ b/ui/app/templates/components/app-card/deployment.hbs
@@ -14,9 +14,11 @@
       </span>
     </small>
   </LinkTo>
+  {{#if @model.preload.deployUrl}}
   <ExternalLink href="https://{{@model.preload.deployUrl}}" class="button button--secondary">
     {{inline-svg "exit" class="icon"}}
   </ExternalLink>
+  {{/if}}
 </div>
 {{else}}
 <li class="app-card-item">
@@ -36,8 +38,10 @@
       </span>
     </small>
   </LinkTo>
+  {{#if @model.preload.deployUrl}}
   <ExternalLink href="https://{{@model.preload.deployUrl}}" class="button button--secondary button--compact">
     {{inline-svg "exit" class="icon"}}
   </ExternalLink>
+  {{/if}}
 </li>
 {{/if}}

--- a/ui/app/templates/components/app-item/deployment.hbs
+++ b/ui/app/templates/components/app-item/deployment.hbs
@@ -16,8 +16,10 @@
       </span>
     </small>
   </LinkTo>
+  {{#if @deployment.preload.deployUrl}}
   <ExternalLink href="https://{{@deployment.preload.deployUrl}}" class="button button--secondary">
     <span>{{lowercase @deployment.preload.deployUrl}}</span>
     {{inline-svg "exit" class="icon"}}
   </ExternalLink>
+  {{/if}}
 </li>


### PR DESCRIPTION
This is the deployment version of #279, it is not always true that a deployment has an associated URL.