### PR TITLE
Flip downloads to Waypoint Releases

### DIFF
--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,1 +1,1 @@
-export default '1.4.1'
+export default '0.1.0'

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -68,7 +68,7 @@ export default function DownloadsPage({ releaseData, previousVersions }) {
 
       <ReleaseInformation
         brand="blue"
-        productId="vault"
+        productId="waypoint"
         productName={productName}
         releases={previousVersions}
         latestVersion={releaseData.version}
@@ -78,8 +78,7 @@ export default function DownloadsPage({ releaseData, previousVersions }) {
 }
 
 export async function getStaticProps() {
-  // NOTE: make sure to change "vault" here to your product slug
-  return fetch(`https://releases.hashicorp.com/vault/${VERSION}/index.json`)
+  return fetch(`https://releases.hashicorp.com/waypoint/${VERSION}/index.json`)
     .then((r) => r.json())
     .then((releaseData) => ({ props: { releaseData } }))
     .catch(() => {


### PR DESCRIPTION
Flip the downloads page to point to waypoint binaries in the releases directory.

This build will fail, as we have not yet deployed the waypoint binaries.

This will be merged immediately after binaries go live, which will trigger our final build before going live.