### PR TITLE
Remove the footer border-top (per design)

### DIFF
--- a/website/components/footer/style.module.css
+++ b/website/components/footer/style.module.css
@@ -2,7 +2,6 @@
   padding: 25px 0 17px 0;
   flex-shrink: 0;
   display: flex;
-  border-top: 1px solid var(--gray-6);
 
   & .g-container {
     display: flex;


### PR DESCRIPTION
Design called me out for this in design review.  Most all .io sites do not have this.

![CleanShot 2020-10-08 at 23 20 19@2x](https://user-images.githubusercontent.com/2105067/95549853-dbbc8980-09bc-11eb-89cc-5878bb61a8ba.png)