### PR TITLE
builtin: inject ceb at /waypoint-entrypoint

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -185,9 +185,9 @@ func (b *Builder) Build(
 
 		_, err = epinject.AlterEntrypoint(ctx, result.Name(), func(cur []string) (*epinject.NewEntrypoint, error) {
 			ep := &epinject.NewEntrypoint{
-				Entrypoint: append([]string{"/bin/wpceb"}, cur...),
+				Entrypoint: append([]string{"/waypoint-entrypoint"}, cur...),
 				InjectFiles: map[string]string{
-					filepath.Join(tmpdir, "ceb/ceb"): "/bin/wpceb",
+					filepath.Join(tmpdir, "ceb/ceb"): "/waypoint-entrypoint",
 				},
 			}
 

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -153,9 +153,9 @@ func (b *Builder) Build(
 
 		imageId, err := epinject.AlterEntrypoint(ctx, src.App+":latest", func(cur []string) (*epinject.NewEntrypoint, error) {
 			ep := &epinject.NewEntrypoint{
-				Entrypoint: append([]string{"/bin/wpceb"}, cur...),
+				Entrypoint: append([]string{"/waypoint-entrypoint"}, cur...),
 				InjectFiles: map[string]string{
-					filepath.Join(tmpdir, "ceb/ceb"): "/bin/wpceb",
+					filepath.Join(tmpdir, "ceb/ceb"): "/waypoint-entrypoint",
 				},
 			}
 


### PR DESCRIPTION
Due to #380 we can't assume /bin exists, so for now we'll inject at /
which is more likely to work. We'll still fix #380 in time so we can act
more normal here.