### PR TITLE
ui: send users to workspaces after onboarding

### DIFF
--- a/ui/app/templates/onboarding/start.hbs
+++ b/ui/app/templates/onboarding/start.hbs
@@ -23,5 +23,5 @@
 <hr />
 
 <div class="onboarding-footer">
-  <a href="/projects" class="button button--primary">Finish Setup</a>
+  <LinkTo class="button button--primary" @route="workspaces">Finish Setup</LinkTo>
 </div>


### PR DESCRIPTION
This `<a>` tag was leftover I think from some early work on the onboarding feature. It was never replaced because it "worked"
as in, it sent you to a page with the projects visible, but because of how the routing works it just quietly set `projects` as the workspace to filter all operations on. So, you'd get a non-error state but no operations.

A couple things we may want to do in the future:

- On the server side, reject filters by workspace where the workspace doesn't exist
- In the UI, check the existence of a workspace when you load the /:workspace route

Either one of those would have caught this.