### PR TITLE
Fix trailing ) on github URL

### DIFF
--- a/website/content/docs/extending-waypoint/main-func.mdx
+++ b/website/content/docs/extending-waypoint/main-func.mdx
@@ -12,7 +12,7 @@ A plugin is a Go binary containing one or more components. A single plugin may b
 application (Platform), archiving application artifacts (Registry), releasing it (ReleaseManager) or more. In fact, a
 single plugin can be responsible for the entire Waypoint lifecycle.
 
-Technically, plugins are gRPC Go-Plugins (https://github.com/hashicorp/go-plugin); however, as a plugin developer, the
+Technically, plugins are [gRPC Go-Plugins](https://github.com/hashicorp/go-plugin); however, as a plugin developer, the
 Waypoint SDK abstracts this complexity for you. To implement a plugin, you can use the `sdk.Main` function. You pass
 Main the components you would like to register for the plugin. You do not need to specify the type of component when you
 register a component; the Waypoint SDK inspects the interfaces you have added and automatically hooks it up to the


### PR DESCRIPTION
This commit updates the URL to properly link to the go-plugin repo.
Previously it would try to open the URL with a trailing ). (i.e. `https://github.com/hashicorp/go-plugin)` resulting in a 404)