### PR TITLE
Change builder parameter key `disable_ceb` -> `disable_entrypoint`

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -35,7 +35,7 @@ func (b *Builder) BuildFunc() interface{} {
 // Config is the configuration structure for the registry.
 type BuilderConfig struct {
 	// Control whether or not to inject the entrypoint binary into the resulting image
-	DisableCEB bool `hcl:"disable_ceb,optional"`
+	DisableCEB bool `hcl:"disable_entrypoint,optional"`
 
 	// Controls whether or not the image should be build with buildkit or docker v1
 	UseBuildKit bool `hcl:"buildkit,optional"`
@@ -53,7 +53,7 @@ func (b *Builder) Documentation() (*docs.Documentation, error) {
 build {
   use "docker" {
 	buildkit    = false
-	disable_ceb = false
+	disable_entrypoint = false
   }
 }
 `)
@@ -62,7 +62,7 @@ build {
 	doc.Output("docker.Image")
 
 	doc.SetField(
-		"disable_ceb",
+		"disable_entrypoint",
 		"if set, the entrypoint binary won't be injected into the image",
 		docs.Summary(
 			"The entrypoint binary is what provides extended functionality",

--- a/builtin/docker/pull/builder.go
+++ b/builtin/docker/pull/builder.go
@@ -37,7 +37,7 @@ type BuilderConfig struct {
 	Tag   string `hcl:"tag,attr"`
 
 	// Control whether or not to inject the entrypoint binary into the resulting image
-	DisableCEB bool `hcl:"disable_ceb,optional"`
+	DisableCEB bool `hcl:"disable_entrypoint,optional"`
 
 	// The docker specific encoded authentication string to use to talk to the registry.
 	EncodedAuth string `hcl:"encoded_auth,optional"`
@@ -53,7 +53,7 @@ func (b *Builder) Documentation() (*docs.Documentation, error) {
 Use an existing, pre-built Docker image
 
 This builder will automatically inject the Waypoint entrypoint. You
-can disable this with the "disable_ceb" configuration.
+can disable this with the "disable_entrypoint" configuration.
 
 If you wish to rename or retag an image, use this along with the
 "docker" registry option which will rename/retag the image and then
@@ -87,7 +87,7 @@ build {
 	)
 
 	doc.SetField(
-		"disable_ceb",
+		"disable_entrypoint",
 		"if set, the entrypoint binary won't be injected into the image",
 		docs.Summary(
 			"The entrypoint binary is what provides extended functionality",

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -31,7 +31,7 @@ func (b *Builder) BuildFunc() interface{} {
 // Config is the configuration structure for the registry.
 type BuilderConfig struct {
 	// Control whether or not to inject the entrypoint binary into the resulting image
-	DisableCEB bool `hcl:"disable_ceb,optional"`
+	DisableCEB bool `hcl:"disable_entrypoint,optional"`
 
 	// The Buildpack builder image to use, defaults to the standard heroku one.
 	Builder string `hcl:"builder,optional"`
@@ -197,7 +197,7 @@ func (b *Builder) Documentation() (*docs.Documentation, error) {
 build {
   use "pack" {
 	builder     = "heroku/buildpacks:18"
-	disable_ceb = false
+	disable_entrypoint = false
   }
 }
 `)
@@ -211,7 +211,7 @@ build {
 	)
 
 	doc.SetField(
-		"disable_ceb",
+		"disable_entrypoint",
 		"if set, the entrypoint binary won't be injected into the image",
 		docs.Summary(
 			"The entrypoint binary is what provides extended functionality",

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -16,7 +16,7 @@ If set, use the buildkit builder from Docker.
 - Type: **bool**
 - **Optional**
 
-#### disable_ceb
+#### disable_entrypoint
 
 If set, the entrypoint binary won't be injected into the image.
 
@@ -32,7 +32,7 @@ The entrypoint binary is what provides extended functionality such as logs and e
 build {
   use "docker" {
 	buildkit    = false
-	disable_ceb = false
+	disable_entrypoint = false
   }
 }
 

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -24,7 +24,7 @@ The buildpack builder image to use.
 - **Optional**
 - Default: heroku/buildpacks:18
 
-#### disable_ceb
+#### disable_entrypoint
 
 If set, the entrypoint binary won't be injected into the image.
 
@@ -40,7 +40,7 @@ The entrypoint binary is what provides extended functionality such as logs and e
 build {
   use "pack" {
 	builder     = "heroku/buildpacks:18"
-	disable_ceb = false
+	disable_entrypoint = false
   }
 }
 


### PR DESCRIPTION
This PR updates the configuration field which toggles entrypoint injection to match its intended form (as initially documented in https://github.com/hashicorp/waypoint/commit/ec29dac2358163923ee826d552aa1a83e08eb018).