### PR TITLE
internal/cli: use public docker image

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -448,7 +448,7 @@ func (c *InstallCommand) Flags() *flag.Sets {
 			Name:    "server-image",
 			Target:  &c.config.ServerImage,
 			Usage:   "Docker image for the server image.",
-			Default: "docker.pkg.github.com/hashicorp/waypoint/alpha:latest",
+			Default: "hashicorp/waypoint:latest",
 		})
 
 		f.StringMapVar(&flag.StringMapVar{


### PR DESCRIPTION
Switch to the public docker image. This will be done for the last build.