### PR TITLE
internal/core: destroy deploy with no Deployment is not an error

### DIFF
--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -9,10 +9,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/hashicorp/waypoint/internal/config"
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/config"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 // CanDestroyDeploy returns true if this app supports destroying deployments.
@@ -26,11 +26,6 @@ func (a *App) DestroyDeploy(ctx context.Context, d *pb.Deployment) error {
 	// If the deploy is destroyed already then do nothing.
 	if d.State == pb.Operation_DESTROYED {
 		a.logger.Info("deployment already destroyed, doing nothing", "id", d.Id)
-		return nil
-	}
-
-	if d.Deployment == nil {
-		a.logger.Info("no deployment info attached (deployment crashed?)")
 		return nil
 	}
 

--- a/internal/core/arg.go
+++ b/internal/core/arg.go
@@ -9,6 +9,10 @@ import (
 // argNamedAny returns an argmapper.Arg that specifies the Any value
 // with the proper subtype.
 func argNamedAny(n string, v *any.Any) argmapper.Arg {
+	if v == nil {
+		return nil
+	}
+
 	msg, err := ptypes.AnyMessageName(v)
 	if err != nil {
 		// This should never happen.


### PR DESCRIPTION
This can happen in some erroneous scenarios. In this case we just mark
the deployment as destroyed.

Post 0.1 we need to do a much tighter job of managing the physical state
of deploys. @evanphx and I chatted about this already. But for now this will
band-aid a situation where deploys _cant_ be destroyed even though they
don't exist.

I saw this happen during plugin development when I was returning an empty proto message.