### PR TITLE
Fix syntax for Azure Container Instance

### DIFF
--- a/website/content/partials/components/platform-azure-container-instance.mdx
+++ b/website/content/partials/components/platform-azure-container-instance.mdx
@@ -97,27 +97,27 @@ Specify if the volume is read only.
 ### Examples
 
 ```
+deploy {
+  use "azure-container-instance" {
+    resource_group = "resource-group-name"
+    location       = "westus"
+    ports          = [8080]
 
-deploy "azure-container-instance" {
-	resource_group = "resource-group-name"
-	location       = "westus"
-	ports          = [8080]
-
-	capacity {
-      memory = "1024"
+    capacity {
+      memory    = "1024"
       cpu_count = 4
-	}
+    }
 
-	volume {
-      name = "vol1"
-      path = "/consul"
+    volume {
+      name      = "vol1"
+      path      = "/consul"
       read_only = true
 
       git_repo {
         repository = "https://github.com/hashicorp/consul"
-        revision = "v1.8.3"
+        revision   = "v1.8.3"
       }
     }
+  }
 }
-
 ```


### PR DESCRIPTION
It said `deploy "azure..."` but should be `use "azure...`