### PR TITLE
internal/serverclient: connections from env will send token if set

### DIFF
--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -117,6 +117,7 @@ func FromEnv() ConnectOption {
 			c.Addr = v
 			c.Tls = os.Getenv(EnvServerTls) != ""
 			c.TlsSkipVerify = os.Getenv(EnvServerTlsSkipVerify) != ""
+			c.Auth = os.Getenv(EnvServerToken) != ""
 		}
 
 		return nil


### PR DESCRIPTION
Without this, env-var based connection is totally broken. 😄 