### PR TITLE
Adding documentation for Procfile usage

### DIFF
--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -82,8 +82,10 @@ app "my-app" {
 }
 ```
 
-The Docker Pull plugin is ideal when you prefer to use an existing Docker image as-is without rebuilding it.
-This plugin performs a `docker pull`. The plugin injects the Waypoint Entrypoint by default, which can be disabled.
+The Docker Pull plugin is ideal when you prefer to use an existing Docker image as-is
+without rebuilding it.
+This plugin performs a `docker pull`. The plugin injects the Waypoint Entrypoint by
+default, which can be disabled.
 
 #### Cloud Native Buildpacks
 
@@ -106,17 +108,29 @@ located on Docker Hub at
 
 #### Customizing the Buildpack Launch Command
 
-When using the default Heroku Buildpack, you have the ability to customize the command that starts your server process within the container workload. This is done by using adding a `Procfile` to the project directory. An example of this model in practice would be the build process generating the static binaries for your web service within your application image, and then executing the necessary commands to start ExpressJS to host those static files. See the [waypoint-examples](https://github.com/hashicorp/waypoint-examples) repository for more examples of this model.
+When using the default Heroku Buildpack, you can customize the command that
+starts your server process within the workload. This is done by using
+adding a `Procfile` to the project directory.
 
-The `Procfile` syntax is `web: <server process> <server file>`. See the sample Procfile below:
+An example of this model in practice would be the build process generating
+the static binaries for your web service within your application image, and
+then executing the necessary commands to start ExpressJS to host those static files.
+
+See the [waypoint-examples](https://github.com/hashicorp/waypoint-examples)
+repository for more examples of this model.The `Procfile` syntax
+is `web: <server process> <server file>`. A sample Procfile with this syntax is below:
 
 ```bash
 web: node server.js
 ```
 
-You will need to include a file that can be executed by a server process (`server.js` above) in order to use this capability.
+You will need to include a file that can be executed by a server
+process (`server.js` above) in order to use this capability.
 
-The ability to use a Procfile is dependent on the Buildpack provider. This capability can be added to alternative buildpack providers, however you will need to build your own builder image and store it in an accessible repository. Please see the Buildpack provider's documentation for further details around this capability.
+The ability to use a Procfile is dependent on the Buildpack provider. This capability
+can be added to alternative buildpack providers, however you will need to build your
+own builder image and store it in an accessible repository. Please see the Buildpack
+provider's documentation for further details around this capability.
 
 #### Configuring an Alternative Buildpack Provider
 
@@ -128,8 +142,10 @@ The ability to use a Procfile is dependent on the Buildpack provider. This capab
 
 Several `waypoint.hcl` adjustments may be required to enable alternative builders.
 
-1. The `builder` variable of the `pack` build plugin should explicitly specify the buildpacks builder image like `paketobuildpacks/builder:base`.
-1. The `service_port` variable of the deploy plugin must match the buildpacks port. Paketo buildpacks commonly use `8080` and the default Waypoint `service_port` is `3000`.
+1. The `builder` variable of the `pack` build plugin should explicitly specify the
+   buildpacks builder image like `paketobuildpacks/builder:base`.
+1. The `service_port` variable of the deploy plugin must match the buildpacks port.
+   Paketo buildpacks commonly use `8080` and the default Waypoint `service_port` is `3000`.
 
 Paketo buildpacks example `waypoint.hcl`:
 


### PR DESCRIPTION
Several of the examples in our examples repository use the Procfile method of launching an ExpressJS server to host the generated binaries. This functionality exists out of the box in the Heroku buildpacks, and can be added to the Packeto and Google buildpacks. 

Adding this documentation to explain what it is/how it can be used. 