### PR TITLE
Reenable terminal wrapping

### DIFF
--- a/website/components/terminal/Terminal.module.css
+++ b/website/components/terminal/Terminal.module.css
@@ -70,6 +70,7 @@
       font-weight: normal;
       font-size: 12px;
       line-height: 27px;
+      white-space: pre-wrap;
       color: var(--blue);
       &.short {
         line-height: 16px;


### PR DESCRIPTION
I busted this when I did the refactor switching the lines to be to `<pre>` rather than `<code>`. 

Lines now will wrap again.

![CleanShot 2020-10-13 at 01 04 25@2x](https://user-images.githubusercontent.com/2105067/95833126-117cad80-0cf0-11eb-965b-9da08496343e.png)