### PR TITLE
Ci slack notify on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,11 @@ workflows:
       - check-vendor
       - lint
       - go-test
-      - dev-build
+      - dev-build:
+          filters:
+            branches:
+              ignore:
+                - main
 
   integration:
     jobs:


### PR DESCRIPTION
Things done:
* Added a notification that triggers only on the `main` branch for failed jobs
* set the redundant `dev-build` job under the `go-tests` workflow to not run on `main`

Example notification:
![image](https://user-images.githubusercontent.com/8461333/95886560-bcbb5000-0d4c-11eb-8fcb-639c3090b5ee.png)
