### PR TITLE
Hide scrollbars for Feature Terminals

### DIFF
--- a/website/components/terminal/Terminal.module.css
+++ b/website/components/terminal/Terminal.module.css
@@ -60,6 +60,16 @@
   position: relative;
   overflow: scroll;
 
+  /* Hides the scrollbars */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    /* Safari */
+    -webkit-appearance: none;
+    width: 0;
+    height: 0;
+  }
+
   & .codeWrapper {
     & pre {
       padding: 0;
@@ -95,14 +105,6 @@
 
 .noScrollOverflowWrapper {
   composes: overflowWrapper;
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-  &::-webkit-scrollbar {
-    /* Safari */
-    -webkit-appearance: none;
-    width: 0;
-    height: 0;
-  }
 
   & .codeWrapper {
     bottom: 0;


### PR DESCRIPTION
Fix a bug where scrollbars were showing in the features terminals.

![CleanShot 2020-10-13 at 13 10 11@2x](https://user-images.githubusercontent.com/2105067/95910789-73233300-0d55-11eb-8638-54c61c9679e1.png)