### PR TITLE
Fix URL of Azure Container Instance to match plugin

### DIFF
--- a/website/content/docs/lifecycle/deploy.mdx
+++ b/website/content/docs/lifecycle/deploy.mdx
@@ -49,7 +49,7 @@ You can currently use Waypoint to deploy your app to any of these platforms.
 - [AWS EC2](/plugins/aws-ec2)
 - [AWS ECS](/plugins/aws-ecs)
 - [Google Cloud Run](/plugins/google-cloud-run)
-- [Azure Container Instances](/plugins/azure-container-instances)
+- [Azure Container Instances](/plugins/azure-container-instance)
 - [Netlify](/plugins/netlify)
 
 ~> You may use the Kuberenetes plugin to target any Kubernetes instance. For example, AWS EKS, Azure AKS, Google GKE, and Kuberenetes for Docker Desktop.

--- a/website/content/plugins/azure-container-instance.mdx
+++ b/website/content/plugins/azure-container-instance.mdx
@@ -1,7 +1,7 @@
 ---
 layout: plugins
 page_title: 'Plugin: Azure Container Instances'
-sidebar_title: 'azure-container-instances'
+sidebar_title: 'azure-container-instance'
 description: 'Deploy and Release on Azure Container Instances'
 ---
 

--- a/website/data/plugins-navigation.js
+++ b/website/data/plugins-navigation.js
@@ -1,7 +1,7 @@
 export default [
   'aws-ec2',
   'aws-ecs',
-  'azure-container-instances',
+  'azure-container-instance',
   'docker',
   'exec',
   'google-cloud-run',


### PR DESCRIPTION
The URL was previously plural but the code is singular. This commit renames the
file so the URL is singular.

```
use "azure-container-instance"
```