### PR TITLE
Final timing adjustments to terminal

### DIFF
--- a/website/components/animated-steps-list/index.jsx
+++ b/website/components/animated-steps-list/index.jsx
@@ -7,10 +7,10 @@ import FramedTerminal from 'components/animated-terminal/framed-terminal'
 import { useState } from 'react'
 
 // The breakpoints where the next step of each animation triggers
-const breakpoints = [0, 350, 1258, 2309, 2880]
+const breakpoints = [0, 350, 1400, 2450, 2880]
 
 // The number of pixels before the next breakpoint that the animation should complete
-const animationBottomPadding = [0, 400, 250, 0]
+const animationBottomPadding = [0, 620, 575, -50]
 
 function calculateCurrentFrame(terminalSteps, currentIndex, scrollPosition) {
   const percentage = Math.min(

--- a/website/components/animated-steps-list/steps-list/StepsList.module.css
+++ b/website/components/animated-steps-list/steps-list/StepsList.module.css
@@ -11,5 +11,13 @@
         margin-bottom: 88px;
       }
     }
+
+    &:last-of-type {
+      margin-bottom: 40px;
+
+      @media (max-width: 850px) {
+        margin-bottom: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
Give one last final sweep to nail the perfect timing for these transitions for the terminal.

Additionally, adding some padding to the bottom of the last item so the content on the left & the terminal on the right are roughly centered when they both lock.

![CleanShot 2020-10-14 at 20 50 38](https://user-images.githubusercontent.com/2105067/96075081-19a72b00-0e5f-11eb-9e48-2a8d35bc764f.gif)