### PR TITLE
Do not include state DB for buildpacks on Windows, 

### DIFF
--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/buildpacks/pack"
@@ -53,6 +52,7 @@ var skipBuildPacks = map[string]struct{}{
 func (b *Builder) Build(
 	ctx context.Context,
 	ui terminal.UI,
+	jobInfo *component.JobInfo,
 	src *component.Source,
 ) (*DockerImage, error) {
 	builder := b.config.Builder
@@ -87,10 +87,7 @@ func (b *Builder) Build(
 			// Do not include the bolt.db or bolt.db.lock
 			// These files hold the local state when Waypoint is running without a server
 			// on Windows it will not be possible to copy these files due to a file lock.
-			//
-			// This needs handled correctly as there may be a legitimate reason why you would
-			// want to include data.db in your application
-			if runtime.GOOS == "windows" {
+			if jobInfo.Local {
 				if strings.HasSuffix(file, "data.db") || strings.HasSuffix(file, "data.db.lock") {
 					return false
 				}


### PR DESCRIPTION
When using Buildpacks on Windows without a server the build fails as Buildpacks can not read the file data.db and data.db.lock due to a filesystem lock. This PR excludes these two files from the build bypassing the issue.

There is a legitimate reason for someone to include `data.db` in their application, however, `waypoint init` does not currently work with user-created data.db. We should look at both of these in more depth post-launch.

```shell
 │ 0.9.1: Pulling from buildpacksio/lifecycle
 │ Digest: sha256:53bf0e18a734e0c4071aa39b950ed8841f82936e53fb2a0df56c6aa07f9c5023
 │ Status: Image is up to date for buildpacksio/lifecycle:0.9.1
 │ 2020/10/15 14:45:06.712653 DEBUG:  Using build cache volume pack-cache-c54b8f779
 │ ceb.build
 │ 2020/10/15 14:45:06.712653 INFO:   ===> DETECTING
! failed to copy files to 'detector' container: read
  C:\Users\jacks\go\src\github.com\hashicorp\waypoint\test-apps\cloudrun\data.db.lock:
  The process cannot access the file because another process has locked a portion
  of the file.
```