### PR TITLE
Rename Cloud Foundry Paketo -> Paketo

### DIFF
--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -137,7 +137,7 @@ provider's documentation for further details around this capability.
 | Provider              | Builder Image                 |
 | --------------------- | ----------------------------- |
 | Heroku                | heroku/buildpacks:18          |
-| Cloud Foundry Paketo  | paketobuildpacks/builder:base |
+| Paketo                | paketobuildpacks/builder:base |
 | Google Cloud Platform | gcr.io/buildpacks/builder:v1  |
 
 Several `waypoint.hcl` adjustments may be required to enable alternative builders.


### PR DESCRIPTION
While the Paketo buildpacks project is in the CFF, their OSS name is just Paketo Buildpacks.

CC @sclevine