### PR TITLE
builtin/azure/aci: fix dropped error

### DIFF
--- a/builtin/azure/aci/deployment.go
+++ b/builtin/azure/aci/deployment.go
@@ -49,6 +49,9 @@ func (d *Deployment) authenticate(ctx context.Context) (autorest.Authorizer, err
 
 	// the environment variable auth has failed fall back to CLI auth
 	authorizer, err = auth.NewAuthorizerFromCLI()
+	if err != nil {
+		return authorizer, err
+	}
 	_, err = d.getLocations(timeoutContext, authorizer)
 	if err == nil {
 		return authorizer, nil


### PR DESCRIPTION
This fixes a dropped `err` variable in `builtin/azure/aci`.