### PR TITLE
Fix plugin example link

### DIFF
--- a/website/content/docs/extending-waypoint/creating-plugins/testing.mdx
+++ b/website/content/docs/extending-waypoint/creating-plugins/testing.mdx
@@ -66,4 +66,4 @@ can be found in the [Plugin Components](/docs/extending-waypoint/plugin-interfac
 Extending Waypoint section also contains other reference documentation related to plugin creation.
 
 A full example of the plugin created in this guide can be found at the following location:
-[https://github.com/hashicorp/waypoint-plugin-examples/tree/main/gobuilder_final](https://github.com/hashicorp/waypoint-plugin-examples/tree/main/gobuilder_final_)
+[https://github.com/hashicorp/waypoint-plugin-examples/tree/main/plugins/gobuilder_final](https://github.com/hashicorp/waypoint-plugin-examples/tree/main/plugins/gobuilder_final)


### PR DESCRIPTION
The link to the plugin examples was broken.