### PR TITLE
website: proper path for examples directory

### DIFF
--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -70,7 +70,7 @@ $ git clone https://github.com/hashicorp/waypoint-examples.git
 Navigate to the `docker/nodejs` directory.
 
 ```shell-session
-$ cd waypoint-example/docker/nodejs
+$ cd waypoint-examples/docker/nodejs
 ```
 
 All the code you need is provided in this directory, including a `waypoint.hcl`


### PR DESCRIPTION
This path is named `waypoint-examples` not `waypoint-example` because we clone `https://github.com/hashicorp/waypoint-examples.git`.