### PR TITLE
Docs: Add GitLab CI/CD exec integration

### DIFF
--- a/website/content/docs/automating-execution/gitlab-cicd.mdx
+++ b/website/content/docs/automating-execution/gitlab-cicd.mdx
@@ -59,7 +59,7 @@ waypoint:
     WAYPOINT_SERVER_TLS: '1'
     WAYPOINT_SERVER_TLS_SKIP_VERIFY: '1'
   script:
-    - wget -q -O /tmp/waypoint.zip http://ihngtake2gyn8nbyfgtgvu449dnsbrgopvukjdbntyndmlv7tb.s3-website-us-east-1.amazonaws.com/waypoint/${WAYPOINT_VERSION}/waypoint_${WAYPOINT_VERSION}_linux_amd64.zip
+    - wget -q -O /tmp/waypoint.zip https://releases.hashicorp.com/waypoint/${WAYPOINT_VERSION}/waypoint_${WAYPOINT_VERSION}_linux_amd64.zip
     - unzip -d /usr/local/bin /tmp/waypoint.zip
     - rm -rf /tmp/waypoint*
     - waypoint init
@@ -67,4 +67,3 @@ waypoint:
     - waypoint deploy
     - waypoint release
 ```
-

--- a/website/content/docs/automating-execution/gitlab-cicd.mdx
+++ b/website/content/docs/automating-execution/gitlab-cicd.mdx
@@ -1,0 +1,70 @@
+---
+layout: docs
+page_title: Integrating Waypoint with GitLab CI/CD
+sidebar_title: GitLab CI/CD
+description: |-
+  How to utilize Waypoint in a GitLab development workflow and
+  with GitLab CI/CD
+---
+
+# Integrating Waypoint with GitLab CI/CD
+
+Using Waypoint to deploy an application from within GitLab CI/CD is similar to how you might deploy an application from your own workspace.
+
+The example demonstrates the main steps:
+
+1. **Set-up the dependencies Waypoint might use.** This could be
+   a Kubernetes context for a more advanced application, or in the
+   below example, a Docker daemon to run applications on.
+2. **Install Waypoint from the official source.** If you are
+   using a Docker custom image executor with your other deploy
+   dependencies, you could utilize the public Docker image in a multi-stage build.
+3. **Run `waypoint init`.** This depends on the environment variables listed
+   below and documented in the [Automating Execution](/docs/automating-execution#init)
+   overview.
+4. **Run the build, deploy, and release.** In this case, instead of using `waypoint up`,
+   it breaks out each stage as a separate command to be easier to read and
+   filter through in the GitLab UI.
+
+## Workspaces
+
+This example assumes the use of a single default workspace.
+
+You can also use defined GitLab environments:
+
+```yaml
+run: waypoint build -workspace $CI_ENVIRONMENT_NAME
+```
+
+If this was in a job triggered by a Git commit or merge request and may be an ephemeral development environment, you may want to interpolate the relevant Git ref for the workspace parameter, as demonstrated below:
+
+```yaml
+run: waypoint build -workspace $CI_COMMIT_BRANCH
+```
+
+See the GitLab CI/CD [predefined environment variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) page for a full list of variables that could be utilized in this way.
+
+## Example
+
+```yaml
+waypoint:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  variables:
+    WAYPOINT_VERSION: 0.0.1-beta1
+    WAYPOINT_SERVER_ADDR: ''
+    WAYPOINT_SERVER_TOKEN: ''
+    WAYPOINT_SERVER_TLS: '1'
+    WAYPOINT_SERVER_TLS_SKIP_VERIFY: '1'
+  script:
+    - wget -q -O /tmp/waypoint.zip http://ihngtake2gyn8nbyfgtgvu449dnsbrgopvukjdbntyndmlv7tb.s3-website-us-east-1.amazonaws.com/waypoint/${WAYPOINT_VERSION}/waypoint_${WAYPOINT_VERSION}_linux_amd64.zip
+    - unzip -d /usr/local/bin /tmp/waypoint.zip
+    - rm -rf /tmp/waypoint*
+    - waypoint init
+    - waypoint build
+    - waypoint deploy
+    - waypoint release
+```
+

--- a/website/content/docs/automating-execution/gitlab-cicd.mdx
+++ b/website/content/docs/automating-execution/gitlab-cicd.mdx
@@ -52,8 +52,9 @@ waypoint:
   stage: build
   services:
     - docker:dind
+  # Define environment variables, e.g. `WAYPOINT_VERSION: '0.1.1'`
   variables:
-    WAYPOINT_VERSION: 0.0.1-beta1
+    WAYPOINT_VERSION: ''
     WAYPOINT_SERVER_ADDR: ''
     WAYPOINT_SERVER_TOKEN: ''
     WAYPOINT_SERVER_TLS: '1'

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -39,5 +39,6 @@ in your Waypoint configuration. Contribute by writing your own plugin with this
 
 Integrate Waypoint into your continuous delivery workflow with examples for
 [GitHub Actions](/docs/automating-execution/github-actions),
+[GitLab CI/CD](/docs/automating-execution/gitlab-cicd),
 [CircleCI](/docs/automating-execution/circle-ci), or
 [Jenkins](/docs/automating-execution/jenkins).

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -95,7 +95,7 @@ export default [
   },
   {
     category: 'automating-execution',
-    content: ['github-actions', 'circle-ci', 'jenkins'],
+    content: ['github-actions', 'gitlab-cicd', 'circle-ci', 'jenkins'],
   },
   'troubleshooting',
   'glossary',


### PR DESCRIPTION
Hi,

we've tested Waypoint with GitLab CI/CD and EC2 in this project: https://gitlab.com/brendan-demo/waypoint/ 

This PR adds the integration documentation for involving the GitLab CI/CD configuration, and tips for using GitLab environments with Waypoint workspaces.