### PR TITLE
docs: fix service typo

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -480,7 +480,7 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		f.BoolVar(&flag.BoolVar{
 			Name:   "advertise-internal",
 			Target: &c.advertiseInternal,
-			Usage: "Advertise the internal servivce address rather than the external. " +
+			Usage: "Advertise the internal service address rather than the external. " +
 				"This is useful if all your deployments will be able to access the private " +
 				"service address. This will default to false but will be automatically set to " +
 				"true if the external host is detected to be localhost.",

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -31,7 +31,7 @@ Usage: `waypoint install [options]`
 - `-pull-secret=<string>` - Secret to use to access the waypoint server image
 - `-pull-policy=<string>` -
 - `-show-yaml` - Show the YAML to be send to the cluster.
-- `-advertise-internal` - Advertise the internal servivce address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the server into.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -31,7 +31,7 @@ Usage: `waypoint server install [options]`
 - `-pull-secret=<string>` - Secret to use to access the waypoint server image
 - `-pull-policy=<string>` -
 - `-show-yaml` - Show the YAML to be send to the cluster.
-- `-advertise-internal` - Advertise the internal servivce address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the server into.


### PR DESCRIPTION
Fixes a small typo in the install cmd + docs.