### PR TITLE
[Website] Add GitLab to CI/CD + VCS section on Homepage

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -631,7 +631,7 @@ export default function HomePage() {
             {
               title: 'CI/CD and Version Control Integration',
               description:
-                'Integrate with existing CI/CD providers and version control providers like GitHub, CircleCI, Jenkins, and more',
+                'Integrate with existing CI/CD providers and version control providers like GitHub, CircleCI, Jenkins, GitLab, and more',
               learnMoreLink: '/docs/automating-execution',
               content: (
                 <Terminal


### PR DESCRIPTION
Adds GitLab to CI/CD + VCS section on homepage

[🔍  Preview link](https://waypoint-git-jmwebsite-gitlab-txt.hashicorp.vercel.app)