### PR TITLE
Add back docs blue theme

### DIFF
--- a/website/components/temporary_docs-page/index.jsx
+++ b/website/components/temporary_docs-page/index.jsx
@@ -29,7 +29,7 @@ export default function DocsPage({
   return (
     <>
       <DocsPageComponent
-        product={productSlug}
+        product="blue"
         head={{
           is: Head,
           title: `${frontMatter.page_title} | ${productName} by HashiCorp`,


### PR DESCRIPTION
There was a regression caused that ended up breaking this when we fixed the 'edit this page' bug, when we changed the product passed in here to be waypoint.  That was the right call, but another unexpected bug was that the DocsPage component actually expects `blue` here, and not waypoint.  This is an artifact of our product codename usage that we'll clean up soon.

Here's a hotfix that gives us the right theme, while also maintaining the right edit this page links.

![CleanShot 2020-10-15 at 15 59 08@2x](https://user-images.githubusercontent.com/2105067/96194521-63475280-0eff-11eb-820a-4a6745f2518b.png)
