### PR TITLE
Handle case where there is only one ECS cluster with a given name

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -297,7 +297,7 @@ func (p *Platform) SetupCluster(ctx context.Context, s LifecycleStatus, sess *se
 		return "", err
 	}
 
-	if len(desc.Clusters) > 1 {
+	if len(desc.Clusters) >= 1 {
 		s.Status("Found existing ECS cluster: %s", cluster)
 		return cluster, nil
 	}


### PR DESCRIPTION
Closes: https://github.com/hashicorp/waypoint/issues/513

This will allow you to use an existing ECS cluster with Waypoint even when there is only one ECS cluster in the AWS account.