### PR TITLE
update waypoint-plugin-sdk for <= Windows 10 1809 compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/hashicorp/horizon v0.0.0-20201009172236-66fd2d9af591
 	github.com/hashicorp/nomad/api v0.0.0-20200814140818-42de70466a9d
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201015055750-7833de86f9fa
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201016002013-59421183d54f
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2 h1:b65cSyZq
 github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201015055750-7833de86f9fa h1:A+WaSSQo8Tm+fRSdBuPzntZZqxzwbb9jaIooa7kHckY=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201015055750-7833de86f9fa/go.mod h1:TAzCz7NdqFM9KnxR5GdOttWKmG05qeE8xeOFFjX72UQ=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201016002013-59421183d54f h1:UaeSZwPNp+Lm3ettv+UiViVjO2YTogkCziPVk+9q+Og=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201016002013-59421183d54f/go.mod h1:TAzCz7NdqFM9KnxR5GdOttWKmG05qeE8xeOFFjX72UQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d h1:W+SIwDdl3+jXWeidYySAgzytE3piq6GumXeBjFBG67c=


### PR DESCRIPTION
We try to use the ConPTY set of APIs which were introduced in 1809. The
Waypoint SDK was updated to fallback to pipes for earlier versions of
Windows:

https://github.com/hashicorp/waypoint-plugin-sdk/commit/59421183d54fd19cbeaa37b72bcd48ab7252699e