### PR TITLE
Interactively ask user before destroying app

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -13,13 +13,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // baseCommand is embedded in all commands to provide common logic and data.
@@ -90,6 +90,9 @@ type baseCommand struct {
 
 	// flagConnection contains manual flag-based connection info.
 	flagConnection clicontext.Config
+
+	// flagAutoApprove is whether to run an action automatically
+	flagAutoApprove bool
 
 	// args that were present after parsing flags
 	args []string
@@ -384,6 +387,13 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Usage: "Override configurations for how remote runners source data. " +
 				"This is specified to the data source type being used in your configuration. " +
 				"This is used for example to set a specific Git ref to run against.",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "auto-approve",
+			Target:  &c.flagAutoApprove,
+			Default: false,
+			Usage:   "True to disable interactive destroy approval.",
 		})
 	}
 

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -91,8 +91,8 @@ type baseCommand struct {
 	// flagConnection contains manual flag-based connection info.
 	flagConnection clicontext.Config
 
-	// flagAutoApprove is whether to run an action automatically
-	flagAutoApprove bool
+	// flagForce is whether to run an action automatically
+	flagForce bool
 
 	// args that were present after parsing flags
 	args []string
@@ -390,10 +390,10 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 		})
 
 		f.BoolVar(&flag.BoolVar{
-			Name:    "auto-approve",
-			Target:  &c.flagAutoApprove,
+			Name:    "force",
+			Target:  &c.flagForce,
 			Default: false,
-			Usage:   "True to disable interactive destroy approval.",
+			Usage:   "True to disable interactive approval.",
 		})
 	}
 

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -27,7 +27,7 @@ func (c *DestroyCommand) Run(args []string) int {
 	}
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
-		if !c.flagAutoApprove {
+		if !c.flagForce {
 			// show confirmation dialog asking user for approval
 			choice, err := app.UI.Input(&terminal.Input{
 				Prompt: "Are you sure you want to destroy this app? Type 'yes' to confirm.",

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type DestroyCommand struct {
@@ -27,6 +27,21 @@ func (c *DestroyCommand) Run(args []string) int {
 	}
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+		if !c.flagAutoApprove {
+			// show confirmation dialog asking user for approval
+			choice, err := app.UI.Input(&terminal.Input{
+				Prompt: "Are you sure you want to destroy this app? Type 'yes' to confirm.",
+				Style:  terminal.WarningStyle,
+			})
+			if err != nil {
+				return err
+			}
+			if choice != "yes" {
+				app.UI.Output("Aborting destroy.")
+				return nil
+			}
+		}
+
 		if err := app.Destroy(ctx, &pb.Job_DestroyOp{
 			Target: &pb.Job_DestroyOp_Workspace{
 				Workspace: &empty.Empty{},


### PR DESCRIPTION
_Thanks for this really nice project! To a bit familiar with the codebase, I decided to pick up this simple issue._

To make sure users don't accidentally delete their deployment, ask for
confirmation before doing so (similar to terraform destroy).
This patch also adds a flag (-auto-approve) to override this
interactive prompt (e.g. for scripting).

Fixes https://github.com/hashicorp/waypoint/issues/284