### PR TITLE
Add `make format` command and run it on the codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ bin/linux: # create Linux binaries
 test: # run tests
 	go test ./...
 
+.PHONY: format
+format: # format go code
+	go fmt ./...
+
 .PHONY: docker/mitchellh
 docker/mitchellh:
 	DOCKER_BUILDKIT=1 docker build \

--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -11,10 +11,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
 type Releaser struct {

--- a/builtin/aws/ec2/platform.go
+++ b/builtin/aws/ec2/platform.go
@@ -14,11 +14,11 @@ import (
 	"github.com/hashicorp/go-hclog"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/hashicorp/waypoint/builtin/aws/ami"
-	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/ami"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
 const (

--- a/builtin/google/cloudrun/platform_test.go
+++ b/builtin/google/cloudrun/platform_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/waypoint/builtin/docker"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/docker"
 	"github.com/stretchr/testify/require"
 )
 

--- a/builtin/netlify/platform.go
+++ b/builtin/netlify/platform.go
@@ -11,11 +11,11 @@ import (
 	netlify "github.com/netlify/open-api/go/porcelain"
 	"github.com/skratchdot/open-golang/open"
 
-	"github.com/hashicorp/waypoint/builtin/files"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/files"
 )
 
 // Platform is the Platform implementation for Google Cloud Run.

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ArtifactBuildCommand struct {

--- a/internal/cli/artifact_list.go
+++ b/internal/cli/artifact_list.go
@@ -12,12 +12,12 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ArtifactListCommand struct {

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ArtifactPushCommand struct {

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -13,13 +13,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // baseCommand is embedded in all commands to provide common logic and data.

--- a/internal/cli/build_list.go
+++ b/internal/cli/build_list.go
@@ -8,12 +8,12 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type BuildListCommand struct {

--- a/internal/cli/context_clear.go
+++ b/internal/cli/context_clear.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextClearCommand struct {

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextCreateCommand struct {

--- a/internal/cli/context_delete.go
+++ b/internal/cli/context_delete.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextDeleteCommand struct {

--- a/internal/cli/context_list.go
+++ b/internal/cli/context_list.go
@@ -4,9 +4,9 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextListCommand struct {

--- a/internal/cli/context_rename.go
+++ b/internal/cli/context_rename.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextRenameCommand struct {

--- a/internal/cli/context_use.go
+++ b/internal/cli/context_use.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextUseCommand struct {

--- a/internal/cli/context_verify.go
+++ b/internal/cli/context_verify.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverclient"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ContextVerifyCommand struct {

--- a/internal/cli/datagen/datagen.go
+++ b/internal/cli/datagen/datagen.go
@@ -182,6 +182,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"init.tpl.hcl": &bintree{initTplHcl, map[string]*bintree{}},
 }}
@@ -232,4 +233,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type DeploymentDestroyCommand struct {

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -14,12 +14,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serversort "github.com/hashicorp/waypoint/internal/server/sort"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type DeploymentListCommand struct {

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type DestroyCommand struct {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/server/execclient"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ExecCommand struct {

--- a/internal/cli/hostname_delete.go
+++ b/internal/cli/hostname_delete.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/posener/complete"
 )
 

--- a/internal/cli/hostname_list.go
+++ b/internal/cli/hostname_list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type HostnameListCommand struct {

--- a/internal/cli/hostname_register.go
+++ b/internal/cli/hostname_register.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"context"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/posener/complete"
 )
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/cli/datagen"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type InitCommand struct {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -7,10 +7,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type LogsCommand struct {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/go-glint"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/signalcontext"
 	"github.com/hashicorp/waypoint/internal/version"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 const (

--- a/internal/cli/option.go
+++ b/internal/cli/option.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
-	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
 )
 
 // Option is used to configure Init on baseCommand.

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
-	"github.com/hashicorp/waypoint/internal/plugin"
 	"github.com/hashicorp/waypoint-plugin-sdk"
+	"github.com/hashicorp/waypoint/internal/plugin"
 )
 
 type PluginCommand struct {

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -6,11 +6,11 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	runnerpkg "github.com/hashicorp/waypoint/internal/runner"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverclient"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type RunnerAgentCommand struct {

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -8,9 +8,9 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 type ServerBootstrapCommand struct {

--- a/internal/cli/server_config_set.go
+++ b/internal/cli/server_config_set.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/posener/complete"
 )
 

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/posener/complete"
 )
 

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/posener/complete"
 	"github.com/skratchdot/open-golang/open"
 )

--- a/internal/client/app.go
+++ b/internal/client/app.go
@@ -3,8 +3,8 @@ package client
 import (
 	"context"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 // App is used for application-specific operations.

--- a/internal/client/operation.go
+++ b/internal/client/operation.go
@@ -3,9 +3,9 @@ package client
 import (
 	"context"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/server/logviewer"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 func (c *Project) Validate(ctx context.Context, op *pb.Job_ValidateOp) (*pb.Job_ValidateResult, error) {

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverclient"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // Project is the primary structure for interacting with a Waypoint

--- a/internal/config/funcs/encoding.go
+++ b/internal/config/funcs/encoding.go
@@ -17,8 +17,8 @@ func Encoding() map[string]function.Function {
 	return map[string]function.Function{
 		"base64decode": Base64DecodeFunc,
 		"base64encode": Base64EncodeFunc,
-		"base64gzip": Base64GzipFunc,
-		"urlencode": URLEncodeFunc,
+		"base64gzip":   Base64GzipFunc,
+		"urlencode":    URLEncodeFunc,
 	}
 }
 

--- a/internal/config/funcs/filesystem.go
+++ b/internal/config/funcs/filesystem.go
@@ -18,13 +18,13 @@ import (
 
 func Filesystem(pwd string) map[string]function.Function {
 	funcs := map[string]function.Function{
-		"file": MakeFileFunc(pwd, false),
+		"file":       MakeFileFunc(pwd, false),
 		"filebase64": MakeFileFunc(pwd, true),
 		"fileexists": MakeFileExistsFunc(pwd),
-		"fileset": MakeFileSetFunc(pwd),
-		"basename": BasenameFunc,
-		"dirname": DirnameFunc,
-		"abspath": AbsPathFunc,
+		"fileset":    MakeFileSetFunc(pwd),
+		"basename":   BasenameFunc,
+		"dirname":    DirnameFunc,
+		"abspath":    AbsPathFunc,
 		"pathexpand": PathExpandFunc,
 	}
 

--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint/internal/config"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 // Build builds the artifact from source for this app.

--- a/internal/core/app_push.go
+++ b/internal/core/app_push.go
@@ -8,9 +8,9 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint/internal/config"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 // Push pushes the given build to the configured registry. This requires

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -7,9 +7,9 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint/internal/config"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 // Release releases a set of deploys.

--- a/internal/core/operation.go
+++ b/internal/core/operation.go
@@ -9,11 +9,11 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/pkg/finalcontext"
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 // operation is a private interface that we implement for "operations" such

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -11,14 +11,14 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/hashicorp/waypoint/internal/config"
-	"github.com/hashicorp/waypoint/internal/factory"
-	"github.com/hashicorp/waypoint/internal/plugin"
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
 	"github.com/hashicorp/waypoint-plugin-sdk/internal-shared/protomappers"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/config"
+	"github.com/hashicorp/waypoint/internal/factory"
+	"github.com/hashicorp/waypoint/internal/plugin"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 // Project represents a project with one or more applications.

--- a/internal/datasource/datasource.go
+++ b/internal/datasource/datasource.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 // Sourcer is implemented by all data sourcers and is responsible for

--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 type GitSource struct{}

--- a/internal/datasource/git_test.go
+++ b/internal/datasource/git_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 var testHasGit bool

--- a/internal/datasource/local.go
+++ b/internal/datasource/local.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 type LocalSource struct{}

--- a/internal/runner/data.go
+++ b/internal/runner/data.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/datasource"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // downloadJobData takes the data source of the given job, gets the data,

--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -11,14 +11,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	configpkg "github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/core"
 	"github.com/hashicorp/waypoint/internal/factory"
 	"github.com/hashicorp/waypoint/internal/plugin"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
-	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // executeJob executes an assigned job. This will source the data (if necessary),

--- a/internal/runner/operation_docs.go
+++ b/internal/runner/operation_docs.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint/internal/core"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 func (r *Runner) executeDocsOp(

--- a/internal/runner/operation_release.go
+++ b/internal/runner/operation_release.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/core"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 func (r *Runner) executeReleaseOp(

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -10,12 +10,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/factory"
 	"github.com/hashicorp/waypoint/internal/plugin"
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 var ErrClosed = errors.New("runner is closed")

--- a/internal/server/component/component.go
+++ b/internal/server/component/component.go
@@ -5,8 +5,8 @@ package component
 import (
 	"github.com/golang/protobuf/proto"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 func Deployment(v *pb.Deployment) component.Deployment {

--- a/internal/server/logviewer/logviewer.go
+++ b/internal/server/logviewer/logviewer.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
 // Viewer implements component.LogViewer over the server-side log stream endpoint.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	pbmocks "github.com/hashicorp/waypoint/internal/server/gen/mocks"
-	"github.com/hashicorp/waypoint-plugin-sdk/component"
 )
 
 func TestComponentEnum(t *testing.T) {

--- a/internal/serverinstall/datagen/bindata.go
+++ b/internal/serverinstall/datagen/bindata.go
@@ -182,6 +182,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"k8s-install": &bintree{nil, map[string]*bintree{
 		"app.yaml": &bintree{k8sInstallAppYaml, map[string]*bintree{}},
@@ -234,4 +235,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
As described in CONTRIBUTING.md, everyone should run `make format` before committing and submitting their code.
This patch adds that functionality.

I also ran `make format` on the entire codebase, which fixed some minor formatting inconsistencies, mainly import order.
