### PR TITLE
website: set up public build logs for vercel

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,6 @@
 {
+  "version": 2,
+  "public": true,
   "github": {
     "silent": true
   }


### PR DESCRIPTION
this will make the website’s build logs public to outside contributors to view and troubleshoot potential build errors on their PRs. it also sneaks in the `version: 2` config, which is encouraged by vercel. 

reference docs: https://vercel.com/docs/configuration#project/public 