### PR TITLE
website: add notes about status.hashicorp.com

### DIFF
--- a/website/components/footer/index.jsx
+++ b/website/components/footer/index.jsx
@@ -25,6 +25,9 @@ export default function Footer({ openConsentManager }) {
           </Link>
           <a href="/files/press-kit.zip">Press Kit</a>
           <a onClick={openConsentManager}>Consent Manager</a>
+          <Link href="https://status.hashicorp.com">
+            <a>URL Service Status</a>
+          </Link>
         </div>
       </div>
     </footer>

--- a/website/content/docs/url.mdx
+++ b/website/content/docs/url.mdx
@@ -18,7 +18,8 @@ A Waypoint URL looks like this:
 
 The Waypoint URL service is a free, public service hosted by HashiCorp. The URL
 service is open source, and you can host it yourself, if you choose. We have put
-limits on the public service to prevent abuse.
+limits on the public service to prevent abuse. Operational status for the Hashicorp-hosted
+version of the service is available on the [HashiCorp Services status page](https://status.hashicorp.com/).
 
 -> **For Development Only!** Waypoint URLs should only be used for development
 purposes and do not currently support


### PR DESCRIPTION
We want any URL service users to be able to find the status page, so I put it in the footer and on the URL service page.

Longer term, it'd be great if we could render this dynamically in the header or similar if that statuspage.io component has issues.

Ref #519.