### PR TITLE
internal/cli: validate config on init properly

### DIFF
--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -62,6 +62,11 @@ func (c *baseCommand) initConfigLoad(path string) (*configpkg.Config, error) {
 		return nil, err
 	}
 
+	// Validate
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -155,7 +155,6 @@ func (c *InitCommand) Run(args []string) int {
 	}
 	for _, step := range steps {
 		if !step() {
-			c.ui.Output("")
 			c.ui.Output("Project had errors during initialization.\n"+
 				"Waypoint experienced some errors during project initialization. The output\n"+
 				"above should contain the failure messages. Please correct these errors and\n"+


### PR DESCRIPTION
Fix #552 

We weren't validating the basic config structure on `init`, only semantics with plugins. This can cause panics. We need to validate much earlier. 