### PR TITLE
Website: Add action for automerging docs updates into stable-website

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,21 @@
+---
+  name: Backport Assistant Runner
+  
+  on:
+    pull_request:
+      types:
+        - closed
+  
+  jobs:
+    backport:
+      if: github.event.pull_request.merged
+      runs-on: ubuntu-latest
+      container: hashicorpdev/backport-assistant:0.2.0
+      steps:
+        - name: Run Backport Assistant
+          run: |
+            backport-assistant backport -automerge
+          env:
+            BACKPORT_LABEL_REGEXP: "(?P<target>website)/cherrypick"
+            BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
***Note:** This should only be merged after we create a `stable-website` branch.*

`backport-assistant` enables us to merge documentation around future releases into `main`, and selectively automerge documentation for the current release into `stable-website.`

If there are no merge conflicts it will create and automerge the targeted PR into stable-website - [example automerged PR](https://github.com/krantzinator/waypoint/pull/3)
If there are merge conflicts, it will leave the PR open - [example open PR](https://github.com/krantzinator/waypoint/pull/5)
This action runs if a merged PR has the label `website/cherrypick`, and it targets the branch `stable-website` for automerging.