### PR TITLE
builtin/nomad: destroy works

### DIFF
--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -186,7 +186,7 @@ func (p *Platform) Destroy(
 	}
 
 	st.Update("Deleting job...")
-	_, _, err = client.Jobs().Deregister(deployment.Id, true, nil)
+	_, _, err = client.Jobs().Deregister(deployment.Name, true, nil)
 	return err
 }
 


### PR DESCRIPTION
We were targeting the ID when it should've been the name.

Fixes #560