### PR TITLE
docs: fix string example for aws-ecs memory

### DIFF
--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -144,7 +144,7 @@ The VPC subnets to use for the application.
 deploy {
   use "aws-ecs" {
     region = "us-east-1"
-    memory = "512"
+    memory = 512
   }
 }
 


### PR DESCRIPTION
since above it is described as an `int`, as well as in the Config struct https://github.com/hashicorp/waypoint/blob/cabbaf7d25c17a9dd94b5576f597bc8a986e6e07/builtin/aws/ecs/platform.go#L1130

In my testing, strings do work though :shrug: