### PR TITLE
fix: updated waypoint link as current link points to a dead website

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Waypoint Documentation Website
 
-This subdirectory contains the entire source for the [Waypoint Website](https://waypoint.io/). This is a [NextJS](https://nextjs.org/) project, which builds a static site from these source files.
+This subdirectory contains the entire source for the [Waypoint Website](https://waypointproject.io/). This is a [NextJS](https://nextjs.org/) project, which builds a static site from these source files.
 
 <!--
   This readme file contains several blocks of generated text, to make it easier to share common information


### PR DESCRIPTION
updated link to direct to waypointproject.io which I assume is the correct site.