### PR TITLE
fix(documentation)

### DIFF
--- a/website/content/docs/server/index.mdx
+++ b/website/content/docs/server/index.mdx
@@ -40,11 +40,11 @@ a set of flags to configure how to connect to the server. The example
 below configures a context:
 
 ```shell-session
-$ waypoint context create my-server \
+$ waypoint context create \
     -server-addr=localhost:9701 \
     -server-auth-token=abcd1234 \
     -server-tls \
-    -set-default
+    -set-default my-server
 ```
 
 The `-set-default` flag will set this as the default connection information.


### PR DESCRIPTION
Fix documentation about adding a new context. Name of the context must be at the end of the command and not right after the `create` parameter.

This way it works, the other way around it does not work.