### PR TITLE
Add support for environment variables with pack build

### DIFF
--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -249,7 +249,7 @@ build {
 
 	doc.SetField(
 		"static_environment",
-		"environment variables to expose to the application",
+		"environment variables to expose to the buildpack",
 		docs.Summary(
 			"these environment variables should not be run of the mill",
 			"configuration variables, use waypoint config for that.",

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -35,6 +35,12 @@ type BuilderConfig struct {
 
 	// The Buildpack builder image to use, defaults to the standard heroku one.
 	Builder string `hcl:"builder,optional"`
+
+	// Environment variables that are meant to configure the application in a static
+	// way. This might be control an image that has mulitple modes of operation,
+	// selected via environment variable. Most configuration should use the waypoint
+	// config commands.
+	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 }
 
 const DefaultBuilder = "heroku/buildpacks:18"
@@ -83,6 +89,7 @@ func (b *Builder) Build(
 		Image:   src.App,
 		Builder: builder,
 		AppPath: src.Path,
+		Env:     b.config.StaticEnvVars,
 		FileFilter: func(file string) bool {
 			// Do not include the bolt.db or bolt.db.lock
 			// These files hold the local state when Waypoint is running without a server
@@ -238,6 +245,17 @@ build {
 		"builder",
 		"The buildpack builder image to use",
 		docs.Default(DefaultBuilder),
+	)
+
+	doc.SetField(
+		"static_environment",
+		"environment variables to expose to the application",
+		docs.Summary(
+			"these environment variables should not be run of the mill",
+			"configuration variables, use waypoint config for that.",
+			"These variables are used to control over all container modes,",
+			"such as configuring it to start a web app vs a background worker",
+		),
 	)
 
 	return doc, nil


### PR DESCRIPTION
This PR adds support for environment variables with the pack build phase 

Some buildpacks allow configuration via environment variables such as https://github.com/GoogleCloudPlatform/buildpacks see https://github.com/GoogleCloudPlatform/buildpacks#common-options for available environment variables

I copied the configuration style from the docker build stage so configuration looks like the following: 

```
    build {
        use "pack" {
            builder     = "gcr.io/buildpacks/builder"
            static_environment = {
                "GOOGLE_BUILDABLE" : "./cmd/webhook"
            }
        }
    }
```

I've tested it locally and can see from the output that it used my environment variable as expected 
```
 │ [builder] Running "go build -o /layers/google.go.build/bin/main ./cmd/webhook (GOCACHE=/layers/google.go.build/gocache)"
```