### PR TITLE
Add CGO_ENABLED to entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ CGO_ENABLED?=0
 
 .PHONY: bin
 bin: # bin creates the binaries for Waypoint for the current platform
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
-	CGO_ENABLED=$(CGO_ENABLED) go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
 
 .PHONY: bin/windows
 bin/windows: # create windows binaries

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ CGO_ENABLED?=0
 
 .PHONY: bin
 bin: # bin creates the binaries for Waypoint for the current platform
-	GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
-	go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
+	CGO_ENABLED=$(CGO_ENABLED) go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
 
 .PHONY: bin/windows
 bin/windows: # create windows binaries


### PR DESCRIPTION
alpine docker images and scratch images [were not working](https://discuss.hashicorp.com/t/how-do-you-build-a-project-with-a-dockerfile-that-has-its-own-entrypoint/16086/8) until CGO_ENABLED was used in the build for `waypoint-entrypoint`.