### PR TITLE
website: drop link to github actions demo

### DIFF
--- a/website/content/docs/automating-execution/github-actions.mdx
+++ b/website/content/docs/automating-execution/github-actions.mdx
@@ -59,8 +59,7 @@ This results in an experience in a pull request similar to the below screenshot.
 
 ![GitHub Action screenshot](/img/github-action.png)
 
-The source is available on GitHub at [hashicorp/action-waypoint](https://github.com/hashicorp/action-waypoint) and
-a demo is available at [hashicorp/action-waypoint-demo](https://github.com/hashicorp/action-waypoint-demo)
+The source is available on GitHub at [hashicorp/action-waypoint](https://github.com/hashicorp/action-waypoint).
 
 ### Example
 


### PR DESCRIPTION
Closes #579.

This demo uses the experimental action-waypoint, which may not be maintained longer term,  and I'd rather us limit the maintenance burden associated with this demo repository (that is currently private). I think the screenshot serves this well, and the example is the same as is used in the demo.

This demo can easily be demonstrated by:

- Copying the example action workflow in the documentation
- Grabbing one of the examples (https://github.com/hashicorp/waypoint-examples)
- Pushing it up to GitHub