### PR TITLE
Replace Deprecated AWS session.New

### DIFF
--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -39,7 +39,10 @@ func (r *Releaser) Release(
 	ui terminal.UI,
 	target *TargetGroup,
 ) (*Release, error) {
-	sess := session.New(aws.NewConfig().WithRegion(target.Region))
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(target.Region))
+	if err != nil {
+		return nil, err
+	}
 	elbsrv := elbv2.New(sess)
 
 	lbName := r.config.Name

--- a/builtin/aws/ami/builder.go
+++ b/builtin/aws/ami/builder.go
@@ -86,8 +86,10 @@ func (b *Builder) Build(
 	ui terminal.UI,
 	src *component.Source,
 ) (*Image, error) {
-	sess := session.New(aws.NewConfig().WithRegion(b.config.Region))
-
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(b.config.Region))
+	if err != nil {
+		return nil, err
+	}
 	e := ec2.New(sess)
 
 	var (

--- a/builtin/aws/ec2/platform.go
+++ b/builtin/aws/ec2/platform.go
@@ -90,8 +90,10 @@ func (p *Platform) Deploy(
 
 	st.Update("Creating EC2 instances in ASG...")
 
-	sess := session.New(aws.NewConfig().WithRegion(p.config.Region))
-
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	if err != nil {
+		return nil, err
+	}
 	e := ec2.New(sess)
 
 	var (
@@ -300,11 +302,13 @@ func (p *Platform) Destroy(
 	deployment *Deployment,
 	ui terminal.UI,
 ) error {
-	sess := session.New(aws.NewConfig().WithRegion(p.config.Region))
-
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	if err != nil {
+		return err
+	}
 	as := autoscaling.New(sess)
 
-	_, err := as.DeleteAutoScalingGroup(&autoscaling.DeleteAutoScalingGroupInput{
+	_, err = as.DeleteAutoScalingGroup(&autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(deployment.ServiceName),
 		ForceDelete:          aws.Bool(true),
 	})

--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -54,8 +54,10 @@ func (r *Registry) Push(
 
 	cli.NegotiateAPIVersion(ctx)
 
-	sess := session.New(aws.NewConfig().WithRegion(r.config.Region))
-
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(r.config.Region))
+	if err != nil {
+		return nil, err
+	}
 	svc := ecr.New(sess)
 
 	repOut, err := svc.DescribeRepositories(&ecr.DescribeRepositoriesInput{

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -221,8 +221,10 @@ func (p *Platform) Deploy(
 
 	lf := &Lifecycle{
 		Init: func(s LifecycleStatus) error {
-			sess = session.New(aws.NewConfig().WithRegion(p.config.Region))
-
+			sess, err = session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+			if err != nil {
+				return err
+			}
 			cluster, err = p.SetupCluster(ctx, s, sess)
 			if err != nil {
 				return err
@@ -1015,7 +1017,10 @@ func (p *Platform) Destroy(
 ) error {
 	log.Debug("removing deployment target group from load balancer")
 
-	sess := session.New(aws.NewConfig().WithRegion(p.config.Region))
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	if err != nil {
+		return err
+	}
 	elbsrv := elbv2.New(sess)
 
 	listeners, err := elbsrv.DescribeListeners(&elbv2.DescribeListenersInput{

--- a/builtin/aws/ecs/releaser.go
+++ b/builtin/aws/ecs/releaser.go
@@ -37,7 +37,10 @@ func (r *Releaser) Release(
 	ui terminal.UI,
 	target *Deployment,
 ) (*Release, error) {
-	sess := session.New(aws.NewConfig().WithRegion(r.p.config.Region))
+	sess, err := session.NewSession(aws.NewConfig().WithRegion(r.p.config.Region))
+	if err != nil {
+		return nil, err
+	}
 	elbsrv := elbv2.New(sess)
 
 	dlb, err := elbsrv.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{


### PR DESCRIPTION
From the `godoc` for `github.com/aws/aws-sdk-go/aws/session`:
> Deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.

This replaces `session.New()` with `session.NewSession()` throughout `builtin/aws`. 

I'm happy to squash this into a single commit, if that is preferred.