### PR TITLE
internal/pkg/flag: string slice defaults only if no flags given

### DIFF
--- a/internal/pkg/flag/flag_string_slice.go
+++ b/internal/pkg/flag/flag_string_slice.go
@@ -48,6 +48,7 @@ func (f *Set) StringSliceVar(i *StringSliceVar) {
 type stringSliceValue struct {
 	hidden bool
 	target *[]string
+	set    bool
 }
 
 func newStringSliceValue(def []string, target *[]string, hidden bool) *stringSliceValue {
@@ -59,6 +60,11 @@ func newStringSliceValue(def []string, target *[]string, hidden bool) *stringSli
 }
 
 func (s *stringSliceValue) Set(val string) error {
+	if !s.set {
+		s.set = true
+		*s.target = nil
+	}
+
 	*s.target = append(*s.target, strings.TrimSpace(val))
 	return nil
 }


### PR DESCRIPTION
Fixes #601

We should only use the default string slice value if no flags are given.
Nomad is currently the only user of this flag and this is the expected
behavior there, plus I believe elsewhere.