### PR TITLE
Check for active ECS cluster

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -299,9 +299,11 @@ func (p *Platform) SetupCluster(ctx context.Context, s LifecycleStatus, sess *se
 		return "", err
 	}
 
-	if len(desc.Clusters) >= 1 {
-		s.Status("Found existing ECS cluster: %s", cluster)
-		return cluster, nil
+	for _, c := range desc.Clusters {
+		if *c.ClusterName == cluster && strings.ToLower(*c.Status) == "active" {
+			s.Status("Found existing ECS cluster: %s", cluster)
+			return cluster, nil
+		}
 	}
 
 	if p.config.EC2Cluster {


### PR DESCRIPTION
As far as I can tell, when an ECS user deletes a cluster it does not actually remove all references to it from the API. The describe-clusters endpoint still returns the deleted cluster with the status of `INACTIVE`.

After deleting the cluster myself and attempting to test a different change I noticed waypoint logged that the cluster existed and skipped creation later on failing for a non existent cluster.

This PR adds a check for this status before determining if the cluster is found.

I have tested this change for both existing and deleted clusters.

