### PR TITLE
Delete ECS ALB listener if there is a single target group on destroy

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1023,6 +1023,8 @@ func (p *Platform) Destroy(
 	}
 	elbsrv := elbv2.New(sess)
 
+	log.Debug("load balancer arn", "arn", deployment.LoadBalancerArn)
+
 	listeners, err := elbsrv.DescribeListeners(&elbv2.DescribeListenersInput{
 		LoadBalancerArn: &deployment.LoadBalancerArn,
 	})
@@ -1035,11 +1037,24 @@ func (p *Platform) Destroy(
 	if len(listeners.Listeners) > 0 {
 		listener = listeners.Listeners[0]
 
+		log.Debug("listener arn", "arn", *listener.ListenerArn)
+
 		def := listener.DefaultActions
 
 		var tgs []*elbv2.TargetGroupTuple
 
-		if len(def) > 0 && def[0].ForwardConfig != nil {
+		// If there is only 1 target group, delete the listener
+		if len(def) == 1 {
+			log.Debug("only 1 target group, deleting listener")
+			_, err = elbsrv.DeleteListener(&elbv2.DeleteListenerInput{
+				ListenerArn: listener.ListenerArn,
+			})
+
+			if err != nil {
+				return err
+			}
+		} else if len(def) > 1 && def[0].ForwardConfig != nil {
+			// Multiple target groups means we can keep the listener
 			var active bool
 
 			for _, tg := range def[0].ForwardConfig.TargetGroups {


### PR DESCRIPTION
Fixes #369 

An ALB listener cannot exist without a target group.

This PR deletes the ALB listener if there is only one target group to avoid a validation error.

I'm not sure if this is the best route forward here but opening to discuss.

Other options to consider:

* Delete the ALB altogether
* Leave the target group but remove the targets? I think ECS handles this registration.