### PR TITLE
Fix deploy docker command doc

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -270,7 +270,7 @@ func (p *Platform) Documentation() (*docs.Documentation, error) {
 	doc.Example(`
 deploy {
   use "docker" {
-	command      = "ps"
+	command      = ["ps"]
 	service_port = 3000
 	static_environment = {
 	  "environment": "production",

--- a/website/content/partials/components/platform-docker.mdx
+++ b/website/content/partials/components/platform-docker.mdx
@@ -49,7 +49,7 @@ These environment variables should not be run of the mill configuration variable
 
 deploy {
   use "docker" {
-	command      = "ps"
+	command      = ["ps"]
 	service_port = 3000
 	static_environment = {
 	  "environment": "production",


### PR DESCRIPTION
I had to define the command as an array otherwise it fails during the build phase with the following error:
```
! waypoint.hcl:15,17-19: Unsuitable value type; Unsuitable value: list of string
```