### PR TITLE
builtin/aws: use SharedConfig to load ~/.aws/config

### DIFF
--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -39,7 +38,9 @@ func (r *Releaser) Release(
 	ui terminal.UI,
 	target *TargetGroup,
 ) (*Release, error) {
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(target.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: target.Region,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ami/builder.go
+++ b/builtin/aws/ami/builder.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
 // Builder uses `docker build` to build a Docker iamge.
@@ -86,7 +86,9 @@ func (b *Builder) Build(
 	ui terminal.UI,
 	src *component.Source,
 ) (*Image, error) {
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(b.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: b.config.Region,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ec2/platform.go
+++ b/builtin/aws/ec2/platform.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -90,7 +89,9 @@ func (p *Platform) Deploy(
 
 	st.Update("Creating EC2 instances in ASG...")
 
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: p.config.Region,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +303,9 @@ func (p *Platform) Destroy(
 	deployment *Deployment,
 	ui terminal.UI,
 ) error {
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: p.config.Region,
+	})
 	if err != nil {
 		return err
 	}

--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/builtin/docker"
 	"github.com/mattn/go-isatty"
 )
@@ -54,7 +54,9 @@ func (r *Registry) Push(
 
 	cli.NegotiateAPIVersion(ctx)
 
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(r.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: r.config.Region,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/builtin/docker"
 )
 
@@ -221,7 +222,9 @@ func (p *Platform) Deploy(
 
 	lf := &Lifecycle{
 		Init: func(s LifecycleStatus) error {
-			sess, err = session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+			sess, err = utils.GetSession(&utils.SessionConfig{
+				Region: p.config.Region,
+			})
 			if err != nil {
 				return err
 			}
@@ -1019,7 +1022,9 @@ func (p *Platform) Destroy(
 ) error {
 	log.Debug("removing deployment target group from load balancer")
 
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(p.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: p.config.Region,
+	})
 	if err != nil {
 		return err
 	}

--- a/builtin/aws/ecs/releaser.go
+++ b/builtin/aws/ecs/releaser.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
 // Releaser is the ReleaseManager implementation for Amazon ECS.
@@ -37,7 +37,9 @@ func (r *Releaser) Release(
 	ui terminal.UI,
 	target *Deployment,
 ) (*Release, error) {
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(r.p.config.Region))
+	sess, err := utils.GetSession(&utils.SessionConfig{
+		Region: r.p.config.Region,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/utils/session.go
+++ b/builtin/aws/utils/session.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+func GetSession(c *SessionConfig) (*session.Session, error) {
+	config := aws.NewConfig().WithRegion(c.Region)
+
+	return session.NewSessionWithOptions(session.Options{
+		Config:            *config,
+		SharedConfigState: session.SharedConfigEnable,
+	})
+}
+
+type SessionConfig struct {
+	Region string
+}


### PR DESCRIPTION
Fixes #604

This enables loading ~/.aws/config for assumed role auth.

We should talk to the Terraform team about making aws-sdk-go-base less
Terraform-specific so we can share it, since they've solved a lot more
problems that we're going to run into: https://github.com/hashicorp/aws-sdk-go-base

But for now, this will work.