### PR TITLE
Update guide to use simpler command for protocol buffer generation

### DIFF
--- a/website/content/docs/extending-waypoint/creating-plugins/compiling.mdx
+++ b/website/content/docs/extending-waypoint/creating-plugins/compiling.mdx
@@ -30,10 +30,10 @@ protos:
 	@echo ""
 	@echo "Build Protos"
 
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./registry/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./platform/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./release/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:registry --go_opt=paths=source_relative ./registry/output.proto
+  protoc -I . --go_out=plugins=grpc:platform --go_opt=paths=source_relative ./platform/output.proto
+  protoc -I . --go_out=plugins=grpc:release --go_opt=paths=source_relative ./release/output.proto
 
 build:
 	@echo ""
@@ -52,7 +52,7 @@ By default, the templated plugin will generate the Go code for all the different
 implements the `Builder` component, you can remove all the other `protoc` commands.
 
 ```
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 ```
 
 Your `Makefile` should now look like:
@@ -66,7 +66,7 @@ protos:
 	@echo ""
 	@echo "Build Protos"
 
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 
 build:
 	@echo ""
@@ -81,7 +81,8 @@ With the `Makefile` changed, you can now run `make` to build the plugin.
 make
 
 Build Protos
-protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+
+protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 
 Compile Plugin
 go build -o ./bin/waypoint-plugin-gobuilder ./main.go

--- a/website/content/docs/extending-waypoint/passing-values.mdx
+++ b/website/content/docs/extending-waypoint/passing-values.mdx
@@ -88,25 +88,24 @@ message Binary {
 }
 ```
 
-To generate the Go code you use the protoc command setting the correct flags. The `--go_opt=plugins=grpc` flag specifies
-that you want to use the Go gRPC plugin to generate the code.
+To generate the Go code you use the protoc command setting the correct flags. The `--go_opt=plugins=grpc:./` flag specifies
+that you want to use the Go gRPC plugin to generate the code, and that the output directory for the generated code will be `.`
 
-Then the `--go_out=../../../../` flag is specified. The `go_package` option specified in the Protocol Buffer definition
-file has the path of the go package defined; if you set the flag `--go_out=./` then the resulting go code would be
-output in the path `./github.com/hashicorp/waypoint-plugin-examples/golang/builder`, since the path for the plugin is
-already `github.com/hashicorp/waypoint-plugin-examples/golang/builder` you can set `go_out` to use parent paths, which
-results in the go code being generated in the current folder.
+By default the go plugin for gRPC uses the `go_package` path and the output directory specfied in the
+`-go_opt` flag as the location for the generated code. You can change this behaviour by setting the flag
+`--go_opt=paths=source_relative`. The generated code will now be created at a path relative to the intput proto file.
 
 Finally, you specify the proto files you would like to generate code for; this is the `plugin.proto` file in the current
 directory.
 
 ```shell
-protoc --go_opt=plugins=grpc --go_out=../../../../ ./plugin.proto
+protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./output.proto
 ```
 
-If successful, the command will not output any text but generates a file called `plugin.pb.go` in the current directory.
+If successful, the command will not output any text but generates a file called `output.pb.go` in the same directory as
+the `output.proto` file.
 
-This file will contain the struct definition for the `Binary` message and the code that enables the serialization of
+The `output.proto` file contains the struct definition for the `Binary` message and the code that enables the serialization of
 the model to the Protocol Buffer binary format. This file should `never` be manually edited, if you need to make changes
 to your Output Type, you should always modify the `.proto` file and regenerate the Go code using the protoc command.
 


### PR DESCRIPTION
This PR updates the plugin guide to use the `--go_opt=paths=source_relative` flag when generating Protocol Buffers. This removes the need for the parent paths when using `go_package`.