### PR TITLE
Enable mandatory go formatting check in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
             golangci-lint run --build-tags="$GOTAGS" -v --concurrency 2 \
               --disable-all \
               --timeout 10m \
+              --enable gofmt \
               --enable gosimple \
               --enable govet
       - notify_main_failure


### PR DESCRIPTION
As discussed in https://github.com/hashicorp/waypoint/pull/524#issuecomment-710144890
everyone should run `make format` before submitting their code, otherwise
the pipeline will fail (now).