### PR TITLE
Docker Remote Engine

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -391,7 +391,7 @@ type ClientConfig struct {
 	CertPath string `hcl:"cert_path,optional"`
 
 	// Docker API version to use for connection
-	APIVersion string `hcl:"api_Version,optional"`
+	APIVersion string `hcl:"api_version,optional"`
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -2,6 +2,9 @@ package docker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"fmt"
 
@@ -10,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
@@ -78,16 +82,22 @@ func (p *Platform) Deploy(
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
-	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker client: %s", err)
-	}
-
 	if p.config.ServicePort == 0 {
 		p.config.ServicePort = 3000
 	}
 
+	cli, err := p.getDockerClient()
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker client: %s", err)
+	}
+
 	cli.NegotiateAPIVersion(ctx)
+
+	// Pull the image
+	err = p.pullImage(cli, log, ui, img, p.config.ForcePull)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unable to pull image from Docker registry: %s", err)
+	}
 
 	// Create our deployment and set an initial ID
 	var result Deployment
@@ -211,9 +221,9 @@ func (p *Platform) Destroy(
 	deployment *Deployment,
 	ui terminal.UI,
 ) error {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := p.getDockerClient()
 	if err != nil {
-		return err
+		return status.Errorf(codes.FailedPrecondition, "unable to create Docker client: %s", err)
 	}
 
 	cli.NegotiateAPIVersion(ctx)
@@ -233,6 +243,108 @@ func (p *Platform) Destroy(
 	return cli.ContainerRemove(ctx, deployment.Container, types.ContainerRemoveOptions{
 		Force: true,
 	})
+}
+
+func (p *Platform) getDockerClient() (*client.Client, error) {
+	if p.config.ClientConfig == nil {
+		return client.NewClientWithOpts(client.FromEnv)
+	}
+
+	opts := []client.Opt{}
+
+	if host := p.config.ClientConfig.Host; host != "" {
+		opts = append(opts, client.WithHost(host))
+	}
+
+	if path := p.config.ClientConfig.CertPath; path != "" {
+		opts = append(opts, client.WithTLSClientConfig(
+			filepath.Join(path, "ca.pem"),
+			filepath.Join(path, "cert.pem"),
+			filepath.Join(path, "key.pem"),
+		))
+	}
+
+	if version := p.config.ClientConfig.APIVersion; version != "" {
+		opts = append(opts, client.WithVersion(version))
+	}
+
+	return client.NewClientWithOpts(opts...)
+}
+
+func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.UI, img *Image, force bool) error {
+	in := fmt.Sprintf("%s:%s", img.Image, img.Tag)
+	args := filters.NewArgs()
+	args.Add("reference", in)
+
+	sg := ui.StepGroup()
+
+	// only pull if image is not in current registry so check to see if the image is present
+	// if force then skip this check
+	if force == false {
+		sg.Add("Checking Docker image cache for Image " + in)
+
+		sum, err := cli.ImageList(context.Background(), types.ImageListOptions{Filters: args})
+		if err != nil {
+			return fmt.Errorf("unable to list images in local Docker cache: %w", err)
+		}
+
+		// if we have images do not pull
+		if len(sum) > 0 {
+			return nil
+		}
+	}
+
+	step := sg.Add("Pulling Docker Image " + in)
+	defer step.Abort()
+
+	ipo := types.ImagePullOptions{}
+
+	// if the username and password is not null make an authenticated
+	// image pull
+	/*
+		if image.Username != "" && image.Password != "" {
+			ipo.RegistryAuth = createRegistryAuth(image.Username, image.Password)
+		}
+	*/
+
+	in = makeImageCanonical(in)
+	log.Debug("pulling image", "image", in)
+
+	out, err := cli.ImagePull(context.Background(), in, ipo)
+	if err != nil {
+		return fmt.Errorf("unable to pull image: %w", err)
+	}
+
+	stdout, _, err := ui.OutputWriters()
+	if err != nil {
+		return fmt.Errorf("unable to get output writers: %s", err)
+	}
+
+	var termFd uintptr
+	if f, ok := stdout.(*os.File); ok {
+		termFd = f.Fd()
+	}
+
+	err = jsonmessage.DisplayJSONMessagesStream(out, step.TermOutput(), termFd, true, nil)
+	if err != nil {
+		return status.Errorf(codes.Internal, "unable to stream build logs to the terminal: %s", err)
+	}
+
+	return nil
+}
+
+// makeImageCanonical makes sure the image reference uses full canonical name i.e.
+// consul:1.6.1 -> docker.io/library/consul:1.6.1
+func makeImageCanonical(image string) string {
+	imageParts := strings.Split(image, "/")
+	switch len(imageParts) {
+	case 1:
+		return fmt.Sprintf("docker.io/library/%s", imageParts[0])
+	case 2:
+		return fmt.Sprintf("docker.io/%s/%s", imageParts[0], imageParts[1])
+	}
+
+	return image
 }
 
 // Config is the configuration structure for the Platform.
@@ -257,6 +369,29 @@ type PlatformConfig struct {
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port.
 	ServicePort uint `hcl:"service_port,optional"`
+
+	// Force pull the image from the remote repository
+	ForcePull bool `hcl:"force_pull,optional"`
+
+	// ClientConfig allow the user to specify the connection to the Docker
+	// engine. By default we try to load this from env vars:
+	// DOCKER_HOST to set the url to the docker server.
+	// DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
+	// DOCKER_CERT_PATH to load the TLS certificates from.
+	// DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
+	ClientConfig *ClientConfig `hcl:"client_config,block"`
+}
+
+type ClientConfig struct {
+	// Host to use when connecting to Docker
+	// This can be used to connect to remote Docker instances
+	Host string `hcl:"host,optional"`
+
+	// Path to load the certificates for the Docker Engine
+	CertPath string `hcl:"cert_path,optional"`
+
+	// Docker API version to use for connection
+	APIVersion string `hcl:"api_Version,optional"`
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
@@ -312,6 +447,27 @@ deploy {
 		"service_port",
 		"port that your service is running on in the container",
 		docs.Default("3000"),
+	)
+
+	doc.SetField(
+		"force_pull",
+		"always pull the docker container from the registry",
+		docs.Default("false"),
+	)
+
+	doc.SetField(
+		"client_config",
+		"client config for remote Docker engine",
+		docs.Summary(
+			"this config block can be used to configure",
+			"a remote Docker engine.",
+			"by default Waypoint will attempt to discover this configuration",
+			"using the environment variables:",
+			"DOCKER_HOST to set the url to the docker server.",
+			"DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.",
+			"DOCKER_CERT_PATH to load the TLS certificates from.",
+			"DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.",
+		),
 	)
 
 	return doc, nil

--- a/website/content/docs/extending-waypoint/creating-plugins/compiling.mdx
+++ b/website/content/docs/extending-waypoint/creating-plugins/compiling.mdx
@@ -30,10 +30,10 @@ protos:
 	@echo ""
 	@echo "Build Protos"
 
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./registry/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./platform/output.proto
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./release/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:registry --go_opt=paths=source_relative ./registry/output.proto
+  protoc -I . --go_out=plugins=grpc:platform --go_opt=paths=source_relative ./platform/output.proto
+  protoc -I . --go_out=plugins=grpc:release --go_opt=paths=source_relative ./release/output.proto
 
 build:
 	@echo ""
@@ -52,7 +52,7 @@ By default, the templated plugin will generate the Go code for all the different
 implements the `Builder` component, you can remove all the other `protoc` commands.
 
 ```
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 ```
 
 Your `Makefile` should now look like:
@@ -66,7 +66,7 @@ protos:
 	@echo ""
 	@echo "Build Protos"
 
-	protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+  protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 
 build:
 	@echo ""
@@ -81,7 +81,8 @@ With the `Makefile` changed, you can now run `make` to build the plugin.
 make
 
 Build Protos
-protoc -I . --go_opt=plugins=grpc --go_out=../../../../ ./builder/output.proto
+
+protoc -I . --go_out=plugins=grpc:builder --go_opt=paths=source_relative ./builder/output.proto
 
 Compile Plugin
 go build -o ./bin/waypoint-plugin-gobuilder ./main.go

--- a/website/content/docs/extending-waypoint/passing-values.mdx
+++ b/website/content/docs/extending-waypoint/passing-values.mdx
@@ -88,25 +88,24 @@ message Binary {
 }
 ```
 
-To generate the Go code you use the protoc command setting the correct flags. The `--go_opt=plugins=grpc` flag specifies
-that you want to use the Go gRPC plugin to generate the code.
+To generate the Go code you use the protoc command setting the correct flags. The `--go_opt=plugins=grpc:./` flag specifies
+that you want to use the Go gRPC plugin to generate the code, and that the output directory for the generated code will be `.`
 
-Then the `--go_out=../../../../` flag is specified. The `go_package` option specified in the Protocol Buffer definition
-file has the path of the go package defined; if you set the flag `--go_out=./` then the resulting go code would be
-output in the path `./github.com/hashicorp/waypoint-plugin-examples/golang/builder`, since the path for the plugin is
-already `github.com/hashicorp/waypoint-plugin-examples/golang/builder` you can set `go_out` to use parent paths, which
-results in the go code being generated in the current folder.
+By default the go plugin for gRPC uses the `go_package` path and the output directory specfied in the
+`-go_opt` flag as the location for the generated code. You can change this behaviour by setting the flag
+`--go_opt=paths=source_relative`. The generated code will now be created at a path relative to the intput proto file.
 
 Finally, you specify the proto files you would like to generate code for; this is the `plugin.proto` file in the current
 directory.
 
 ```shell
-protoc --go_opt=plugins=grpc --go_out=../../../../ ./plugin.proto
+protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./output.proto
 ```
 
-If successful, the command will not output any text but generates a file called `plugin.pb.go` in the current directory.
+If successful, the command will not output any text but generates a file called `output.pb.go` in the same directory as
+the `output.proto` file.
 
-This file will contain the struct definition for the `Binary` message and the code that enables the serialization of
+The `output.proto` file contains the struct definition for the `Binary` message and the code that enables the serialization of
 the model to the Protocol Buffer binary format. This file should `never` be manually edited, if you need to make changes
 to your Output Type, you should always modify the `.proto` file and regenerate the Go code using the protoc command.
 


### PR DESCRIPTION
This PR enables the ability for the Docker plugin to target a remote docker engine when doing a deployment.

While it is possible to target the Remote Docker Engine using the environment variables `DOCKER_HOST` this would take effect for the build and deploy phases. It is not possible to build locally and then deploy to a remote instance.  The individual options can be specified independently.

```javascript
project = "wpmini"

app "wpmini" {
  labels = {
    "service" = "wpmini",
    "env"     = "dev"
  }

  build {
    use "pack" {}
  }

  deploy {
    use "docker" {
      client_config {
        host = "tcp://remote.ip:2375"
       cert_path = "./remote_certs"
       api_version = "19.03"
    }
  }
}
```

In addition, this PR checks the presence of a Docker Image in the Engine cache before attempting to start a container, an option has been created to force pull the image regardless of it being cached locally.

```
  deploy {
    use "docker" {
      force_pull  = true
    }
 }
```