### PR TITLE
ui: remove windows onboarding install for now

### DIFF
--- a/ui/app/routes/onboarding/install/index.ts
+++ b/ui/app/routes/onboarding/install/index.ts
@@ -8,8 +8,9 @@ export default class OnboardingInstallIndex extends Route {
     switch (parser.getResult().os.name) {
       case 'Mac OS':
         return this.transitionTo('onboarding.install.homebrew');
-      case 'Windows':
-        return this.transitionTo('onboarding.install.chocolatey');
+      // There isn't yet a chocolatey package for Waypoint
+      // case 'Windows':
+      //   return this.transitionTo('onboarding.install.chocolatey');
       case 'Debian':
       case 'Ubuntu':
         return this.transitionTo('onboarding.install.linux.ubuntu');

--- a/ui/app/templates/onboarding/install/chocolatey.hbs
+++ b/ui/app/templates/onboarding/install/chocolatey.hbs
@@ -1,9 +1,14 @@
-<p>Chocolatey is a free and open-source package management system for Windows. Install the <ExternalLink href="https://go.hashi.co/waypoint-beta-binaries">Waypoint package</ExternalLink> from the command-line.</p>
+<p>
+  Chocolatey is a free and open-source package management system for Windows.
+</p>
 
 <CopyableCode @ref="choco-install">
   <pre><code id="choco-install">choco install waypoint</code></pre>
 </CopyableCode>
 
 <div class="onboarding-note">
-  <p><b>NOTE:</b> Chocolatey and the Waypoint package are NOT directly maintained by HashiCorp. The latest version of Waypoint is always available by manual installation.</p>
+  <p>
+    <b>Note:</b> Chocolatey and the Waypoint package are <strong>not</strong> directly maintained by HashiCorp. The
+    latest version of Waypoint is always available by manual installation.
+  </p>
 </div>

--- a/ui/tests/acceptance/onboarding-test.ts
+++ b/ui/tests/acceptance/onboarding-test.ts
@@ -25,13 +25,11 @@ module('Acceptance | onboarding index', function (hooks) {
     setUa(userAgent.valueOf());
   });
 
-  test('visiting as windows', async function (assert) {
-    setUa(
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'
-    );
+  test('visiting as ubuntu', async function (assert) {
+    setUa('Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1');
     await page.visit();
 
-    assert.equal(currentURL(), `${onboardingUrl}/install/chocolatey`);
+    assert.equal(currentURL(), `${onboardingUrl}/install/linux/ubuntu`);
   });
 
   test('advances to connect', async function (assert) {


### PR DESCRIPTION
We don't currently have a chocolatey package, so we can't list this as an option. Though, did leave the Chocolatey stuff there for the future and fixed a broken link.

Also means we need to switch the test to linux.