### PR TITLE
Adding namespace config to k8s deploy/release

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -96,6 +96,11 @@ func (p *Platform) Deploy(
 		return nil, err
 	}
 
+	// Override namespace if set
+	if p.config.Namespace != "" {
+		ns = p.config.Namespace
+	}
+
 	step.Update("Kubernetes client connected to %s with namespace %s", config.Host, ns)
 	step.Done()
 
@@ -405,6 +410,11 @@ func (p *Platform) Destroy(
 		return err
 	}
 
+	// Override namespace if set
+	if p.config.Namespace != "" {
+		ns = p.config.Namespace
+	}
+
 	step.Update("Kubernetes client connected to %s with namespace %s", config.Host, ns)
 	step.Done()
 	step = sg.Add("Deleting deployment...")
@@ -466,6 +476,9 @@ type Config struct {
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port.
 	ServicePort uint `hcl:"service_port,optional"`
+
+	// Namespace is the Kubernetes namespace to target the deployment to.
+	Namespace string `hcl:"namespace,optional"`
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
@@ -562,6 +575,15 @@ deploy "kubernetes" {
 		docs.Summary(
 			"service account is the name of the Kubernetes service account to add to the pod.",
 			"This is useful to apply Kubernetes RBAC to the application.",
+		),
+	)
+
+	doc.SetField(
+		"namespace",
+		"namespace to target deployment into",
+		docs.Summary(
+			"namespace is the name of the Kubernetes namespace to apply the deployment in",
+			"This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each",
 		),
 	)
 

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -61,6 +61,11 @@ func (r *Releaser) Release(
 		return nil, err
 	}
 
+	// Override namespace if set
+	if r.config.Namespace != "" {
+		ns = r.config.Namespace
+	}
+
 	step.Update("Kubernetes client connected to %s with namespace %s", config.Host, ns)
 	step.Done()
 
@@ -200,6 +205,11 @@ func (r *Releaser) Destroy(
 		return err
 	}
 
+	// Override namespace if set
+	if r.config.Namespace != "" {
+		ns = r.config.Namespace
+	}
+
 	step.Update("Kubernetes client connected to %s with namespace %s", config.Host, ns)
 	step.Done()
 	step = sg.Add("Deleting service...")
@@ -233,6 +243,9 @@ type ReleaserConfig struct {
 	// NodePort configures a port to access the service on whichever node
 	// is running service.
 	NodePort int `hcl:"node_port,optional"`
+
+	// Namespace is the Kubernetes namespace to target the deployment to.
+	Namespace string `hcl:"namespace,optional"`
 }
 
 func (r *Releaser) Documentation() (*docs.Documentation, error) {
@@ -277,6 +290,15 @@ func (r *Releaser) Documentation() (*docs.Documentation, error) {
 		"port",
 		"the TCP port that the application is listening on",
 		docs.Default("80"),
+	)
+
+	doc.SetField(
+		"namespace",
+		"namespace to create Service in",
+		docs.Summary(
+			"namespace is the name of the Kubernetes namespace to create the deployment in",
+			"This is useful to create Services in non-default namespaces without creating kubeconfig contexts for each",
+		),
 	)
 
 	return doc, nil

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -93,6 +93,12 @@ Environment variables that are meant to configure the application in a static wa
 - Type: **map[string]string**
 - **Optional**
 
+#### namespace
+
+Namespace is the Kubernetes namespace for the deployment to target
+- Type: **string**
+- **Optional**
+
 ### Examples
 
 ```

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -47,3 +47,9 @@ The TCP port that the application is listening on.
 - Type: **int**
 - **Optional**
 - Default: 80
+
+#### namespace
+
+Namespace is the Kubernetes namespace to create the service in
+- Type: **string**
+- **Optional**


### PR DESCRIPTION
Adding namespace as a configuration parameter to the Kubernetes plugin allows for
dynamically setting the namespace to target without having to set a different kubeconfig
context for each.