### PR TITLE
Add command to stop Waypoint server in Docker

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/go-glint"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/signalcontext"
 	"github.com/hashicorp/waypoint/internal/version"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 const (
@@ -261,6 +261,11 @@ func Commands(
 		},
 		"server config-set": func() (cli.Command, error) {
 			return &ServerConfigSetCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+		"server docker stop": func() (cli.Command, error) {
+			return &ServerDockerStopCommand{
 				baseCommand: baseCommand,
 			}, nil
 		},

--- a/internal/cli/server_docker_stop.go
+++ b/internal/cli/server_docker_stop.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/serverstop"
+)
+
+type ServerDockerStopCommand struct {
+	*baseCommand
+}
+
+func (c *ServerDockerStopCommand) Run(args []string) int {
+	ctx := c.Ctx
+
+	if err := c.Init(
+		WithArgs(args),
+		WithNoConfig(),
+		WithFlags(c.Flags()),
+		WithClient(false),
+	); err != nil {
+		return 1
+	}
+
+	status := c.ui.Status()
+	defer func() {
+		_ = status.Close()
+	}()
+
+	if err := serverstop.StopDocker(ctx, status); err != nil {
+		c.ui.Output(
+			"Error stopping server installed in Docker: %s",
+			clierrors.Humanize(err), terminal.WithErrorStyle(),
+		)
+		return 1
+	}
+
+	c.ui.Output(
+		"Successfully stopped and removed server installed in Docker",
+		terminal.WithSuccessStyle(),
+	)
+
+	return 0
+}
+
+func (c *ServerDockerStopCommand) Synopsis() string {
+	return "Stop and remove the Waypoint Docker container and its volume"
+}
+
+func (c *ServerDockerStopCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint server docker stop
+
+  Stops and removes a Waypoint server installed in Docker along with its volume.
+  ...`)
+}
+
+func (c *ServerDockerStopCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {})
+}

--- a/internal/serverstop/docker.go
+++ b/internal/serverstop/docker.go
@@ -1,0 +1,102 @@
+package serverstop
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+)
+
+const (
+	containerLabel = "waypoint-type=server"
+	volumeId       = "waypoint-server"
+)
+
+// StopDocker stops and removes the Waypoint Docker container along
+// with its Docker volume.
+func StopDocker(ctx context.Context, status terminal.Status) error {
+	dockerCli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = dockerCli.Close()
+	}()
+
+	dockerCli.NegotiateAPIVersion(ctx)
+
+	containers, err := dockerCli.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{
+			Key:   "label",
+			Value: containerLabel,
+		}),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if len(containers) < 1 {
+		return fmt.Errorf("cannot find a Waypoint Docker container")
+	}
+
+	// Pick the first container regardless of the number of matching
+	// containers, as there should be only one.
+	containerId := containers[0].ID
+
+	status.Update("Stopping Waypoint Docker container...")
+
+	// Stop the container gracefully, respecting the Engine's default timeout.
+	if err := dockerCli.ContainerStop(ctx, containerId, nil); err != nil {
+		return err
+	}
+
+	removeOptions := types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+		Force:         true,
+	}
+
+	if err := dockerCli.ContainerRemove(ctx, containerId, removeOptions); err != nil {
+		return err
+	}
+
+	volumeExists, err := volumeExists(ctx, dockerCli)
+	if err != nil {
+		return err
+	}
+
+	// If the Waypoint Docker volume does not exist, return. This normally
+	// shouldn't happen.
+	if !volumeExists {
+		status.Update("Couldn't find Waypoint Docker volume")
+		return nil
+	}
+
+	status.Update("Removing Waypoint Docker volume...")
+
+	if err := dockerCli.VolumeRemove(ctx, volumeId, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// volumeExists determines whether the Waypoint Docker volume exists.
+func volumeExists(ctx context.Context, dockerCli *client.Client) (bool, error) {
+	listBody, err := dockerCli.VolumeList(ctx, filters.NewArgs(filters.KeyValuePair{
+		Key:   "name",
+		Value: volumeId,
+	}))
+
+	if err != nil {
+		return false, err
+	}
+
+	exists := len(listBody.Volumes) > 0
+
+	return exists, nil
+}


### PR DESCRIPTION
Addresses #479. 

This PR is an attempt to implement a command for stopping a Waypoint server running in Docker and basically uninstalling it. As proposed in [this comment](https://github.com/hashicorp/waypoint/issues/479#issuecomment-710738422), the command name is `waypoint server docker stop`.

The current workflow looks as follows:
1. Look for a running Waypoint container.
2. Shut it down gracefully.
3. Remove the container.
4. Check whether the `waypoint-server` volume exists, which should be the case.
5. If it does, remove it as well.

Two things came to my mind:
* Would it make sense to offer a CLI flag to preserve the volume?
* Strictly speaking, this command isn't the inverse operation of `server run` but of `server install` instead. May `server docker uninstall` be an appropriate alternative command name?

I'm happy to hear your opinions and ideas on this.