### PR TITLE
Allow configuration of container listening port on ECS

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1311,5 +1311,11 @@ deploy {
 		),
 	)
 
+	doc.SetField(
+		"service_port",
+		"the TCP port that the application is listening on",
+		docs.Default("3000"),
+	)
+
 	return doc, nil
 }


### PR DESCRIPTION
This PR enables users to configure the listening port for container workloads to deploy in ECS. This is useful for application workloads that require a specific port configured, or application deployments done via a Dockerfile. 

The default port remains 3000. This PR is similar to exposed configurations we have in Nomad, K8s, and Docker currently.  