### PR TITLE
Add builtin/docker/client

### DIFF
--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/builtin/docker"
+	wpdockerclient "github.com/hashicorp/waypoint/builtin/docker/client"
 	"github.com/mattn/go-isatty"
 )
 
@@ -47,7 +48,7 @@ func (r *Registry) Push(
 		return nil, err
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := wpdockerclient.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -16,10 +16,12 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"github.com/hashicorp/waypoint/internal/assets"
-	"github.com/hashicorp/waypoint/internal/pkg/epinject"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	wpdockerclient "github.com/hashicorp/waypoint/builtin/docker/client"
+	"github.com/hashicorp/waypoint/internal/assets"
+	"github.com/hashicorp/waypoint/internal/pkg/epinject"
 )
 
 // Builder uses `docker build` to build a Docker iamge.
@@ -107,7 +109,7 @@ func (b *Builder) Build(
 		Tag:   "latest",
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := wpdockerclient.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker client: %s", err)
 	}

--- a/builtin/docker/client/client.go
+++ b/builtin/docker/client/client.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/docker/cli/cli/connhelper"
+	"github.com/docker/docker/client"
+)
+
+// NewClientWithOpts wraps Docker's NewClientWithOpts with withConnectionHelper
+func NewClientWithOpts(ops ...client.Opt) (*client.Client, error) {
+	ops = append(ops, withConnectionHelper)
+	return client.NewClientWithOpts(ops...)
+}
+
+// withConnectionHelper applies a Docker-specific connection helper (concept from the
+// Docker CLI) for a given daemon host. As an example, a connection helper makes it
+// possible to use the client given a DOCKER_HOST with an ssh scheme.
+func withConnectionHelper(c *client.Client) error {
+	host := c.DaemonHost()
+	helper, err := connhelper.GetConnectionHelper(host)
+	if err != nil {
+		return err
+	}
+
+	if helper == nil {
+		return nil
+	}
+	httpClient := &http.Client{
+		// No tls
+		// No proxy
+		Transport: &http.Transport{
+			DialContext: helper.Dialer,
+		},
+	}
+
+	opts := []client.Opt{
+		client.WithHTTPClient(httpClient),
+		client.WithHost(helper.Host),
+		client.WithDialContext(helper.Dialer),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	wpdockerclient "github.com/hashicorp/waypoint/builtin/docker/client"
 )
 
 const (
@@ -247,7 +248,7 @@ func (p *Platform) Destroy(
 
 func (p *Platform) getDockerClient() (*client.Client, error) {
 	if p.config.ClientConfig == nil {
-		return client.NewClientWithOpts(client.FromEnv)
+		return wpdockerclient.NewClientWithOpts(client.FromEnv)
 	}
 
 	opts := []client.Opt{}
@@ -268,7 +269,7 @@ func (p *Platform) getDockerClient() (*client.Client, error) {
 		opts = append(opts, client.WithVersion(version))
 	}
 
-	return client.NewClientWithOpts(opts...)
+	return wpdockerclient.NewClientWithOpts(opts...)
 }
 
 func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.UI, img *Image, force bool) error {

--- a/builtin/docker/pull/builder.go
+++ b/builtin/docker/pull/builder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	wpdocker "github.com/hashicorp/waypoint/builtin/docker"
+	wpdockerclient "github.com/hashicorp/waypoint/builtin/docker/client"
 	"github.com/hashicorp/waypoint/internal/assets"
 	"github.com/hashicorp/waypoint/internal/pkg/epinject"
 )
@@ -140,7 +141,7 @@ func (b *Builder) Build(
 		Tag:   b.config.Tag,
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := wpdockerclient.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker client: %s", err)
 	}

--- a/builtin/docker/registry.go
+++ b/builtin/docker/registry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	wpdockerclient "github.com/hashicorp/waypoint/builtin/docker/client"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -51,7 +52,7 @@ func (r *Registry) Push(
 	step := sg.Add("Initializing Docker client...")
 	defer func() { step.Abort() }()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := wpdockerclient.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker client:%s", err)
 	}


### PR DESCRIPTION
Resolves https://github.com/hashicorp/waypoint/issues/663

This package makes possible the creation of a Docker client that can connect to a remote daemon host that requires custom logic. It uses the connhelper package from the Docker CLI to accomplish this.