### PR TITLE
up version of backport-assistant to handle forked PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,7 +2,7 @@
   name: Backport Assistant Runner
   
   on:
-    pull_request:
+    pull_request_target:
       types:
         - closed
   
@@ -10,7 +10,7 @@
     backport:
       if: github.event.pull_request.merged
       runs-on: ubuntu-latest
-      container: hashicorpdev/backport-assistant:0.2.0
+      container: hashicorpdev/backport-assistant:0.2.1
       steps:
         - name: Run Backport Assistant
           run: |


### PR DESCRIPTION
Version 0.2.1 of `backport-assistant` includes the ability to parse `pull_request_target` events along with `pull_request`. This will let us assess all PRs, including from forked repos, for backporting.