### PR TITLE
Allow Nomad sentinel policy override on install

### DIFF
--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	nomadRegionF      string
-	nomadDatacentersF []string
-	nomadNamespaceF   string
+	nomadRegionF         string
+	nomadDatacentersF    []string
+	nomadNamespaceF      string
+	nomadPolicyOverrideF bool
 )
 
 // InstallNomad registers a waypoint-server job with a Nomad cluster
@@ -79,8 +80,11 @@ func InstallNomad(
 
 	st.Update("Installing waypoint server to Nomad")
 	job := waypointNomadJob(scfg)
+	jobOpts := &api.RegisterOptions{
+		PolicyOverride: nomadPolicyOverrideF,
+	}
 
-	resp, _, err := client.Jobs().Register(job, nil)
+	resp, _, err := client.Jobs().RegisterOpts(job, jobOpts, nil)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -261,4 +261,11 @@ func NomadFlags(f *flag.Set) {
 		Default: "default",
 		Usage:   "Nomad namespace to install to if using Nomad platform",
 	})
+
+	f.BoolVar(&flag.BoolVar{
+		Name:    "nomad-policy-override",
+		Target:  &nomadPolicyOverrideF,
+		Default: false,
+		Usage:   "Override the Nomad sentinel policy if using enterprise Nomad platform",
+	})
 }


### PR DESCRIPTION
When running `waypoint server install ...` there is no way to override Nomad sentinel policies. This allows a simple override flag to allow folks to get running as quickly as possible.