### PR TITLE
Make waypoint config set command pipeable

### DIFF
--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -25,9 +26,30 @@ func (c *ConfigSetCommand) Run(args []string) int {
 		return 1
 	}
 
+	var configArgs []string
+
+	// If there are no command arguments, check if the command has
+	// been invoked with a pipe like `cat .env | waypoint config set`.
 	if len(c.args) == 0 {
-		fmt.Fprintf(os.Stderr, "config-set requires at least one key=value entry")
-		return 1
+		info, err := os.Stdin.Stat()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to get console mode for stdin")
+			return 1
+		}
+
+		// If there's no pipe, there are no arguments. Fail.
+		if info.Mode()&os.ModeNamedPipe == 0 {
+			_, _ = fmt.Fprintf(os.Stderr, "config set requires at least one key=value entry")
+			return 1
+		}
+
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			configArgs = append(configArgs, scanner.Text())
+		}
+	} else {
+		// Otherwise, just use the given command arguments.
+		configArgs = c.args
 	}
 
 	// Get our API client
@@ -35,7 +57,7 @@ func (c *ConfigSetCommand) Run(args []string) int {
 
 	var req pb.ConfigSetRequest
 
-	for _, arg := range c.args {
+	for _, arg := range configArgs {
 		idx := strings.IndexByte(arg, '=')
 		if idx == -1 || idx == 0 {
 			fmt.Fprintf(os.Stderr, "variables must be in the form key=value")
@@ -90,7 +112,7 @@ func (c *ConfigSetCommand) Synopsis() string {
 
 func (c *ConfigSetCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint config-set <name> <value>
+Usage: waypoint config set <name>=<value>
 
   Set a config variable that will be available to deployments as an
   environment variable.

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -26,8 +26,6 @@ func (c *ConfigSetCommand) Run(args []string) int {
 		return 1
 	}
 
-	var configArgs []string
-
 	// If there are no command arguments, check if the command has
 	// been invoked with a pipe like `cat .env | waypoint config set`.
 	if len(c.args) == 0 {
@@ -45,11 +43,8 @@ func (c *ConfigSetCommand) Run(args []string) int {
 
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
-			configArgs = append(configArgs, scanner.Text())
+			c.args = append(c.args, scanner.Text())
 		}
-	} else {
-		// Otherwise, just use the given command arguments.
-		configArgs = c.args
 	}
 
 	// Get our API client
@@ -57,7 +52,7 @@ func (c *ConfigSetCommand) Run(args []string) int {
 
 	var req pb.ConfigSetRequest
 
-	for _, arg := range configArgs {
+	for _, arg := range c.args {
 		idx := strings.IndexByte(arg, '=')
 		if idx == -1 || idx == 0 {
 			fmt.Fprintf(os.Stderr, "variables must be in the form key=value")


### PR DESCRIPTION
Fixes #561.

This change allows the user to pass arguments to `waypoint config set` using pipes:

```
$ cat .env | waypoint config set
```

---

The linked issue also proposes a `-raw` flag for `config get`, but this flag apparently already exists:

https://github.com/hashicorp/waypoint/blob/b00f8ab1b17db429bc8242cb06a922bcdd9c8203/internal/cli/config_get.go#L137-L141

However, `waypoint config get -raw` doesn't print anything to my console. Maybe this is a separate issue.