### PR TITLE
Fix typo in docs

### DIFF
--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -24,7 +24,7 @@ The kubectl context to use, as defined in the kubeconfig file.
 
 #### image_secret
 
-Name of the Kubernetes secrete to use for the image.
+Name of the Kubernetes secret to use for the image.
 
 This references an existing secret, waypoint does not create this secret.
 


### PR DESCRIPTION
`secrete` -> `secret`