### PR TITLE
Fix running plugins from working directory

### DIFF
--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/waypoint/internal/config"
 )
 
+const currentDirectory = "." + string(filepath.Separator)
+
 // Discover finds the given plugin and returns the command for it. The command
 // can subsequently be used with Factory to build a factory for a specific
 // plugin type. If the plugin is not found `(nil, nil)` is returned.
@@ -35,7 +37,13 @@ func Discover(cfg *config.Plugin, paths []string) (*exec.Cmd, error) {
 
 	// Search our paths
 	for _, path := range paths {
-		path = filepath.Join(path, expected)
+		// If the plugin is found in the current directory, use ./ (or .\ on Windows) to ensure the command
+		// we generate is interpreted as a file, and not searched for in $PATH
+		if path == "" {
+			path = currentDirectory + expected
+		} else {
+			path = filepath.Join(path, expected)
+		}
 
 		_, err := os.Stat(path)
 		if err != nil {

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestDiscover(t *testing.T) {
 	cases := []struct {
-		Name   string
-		Paths  []string
-		Plugin *config.Plugin
+		Name    string
+		Paths   []string
+		Plugin  *config.Plugin
 		WorkDir string
-		Err    string
-		Result *exec.Cmd
+		Err     string
+		Result  *exec.Cmd
 	}{
 		{
 			"No paths",


### PR DESCRIPTION
I was working through the "Creating a Waypoint plugin" guide and noticed that when I copied my plugin to the same directory as `waypoint.hcl`, `waypoint init` didn't work despite the working directory being a search path. It looks like #691 has a detailed bug report with the same behaviour I saw.

At [this](https://www.waypointproject.io/docs/extending-waypoint/creating-plugins/testing) point in the guide, running with `-vv`, and my compiled `gobuilder` plugin in the current directory, the following happens on Mac (with some log lines omitted):

```bash
waypoint init -vv
2020-10-24T23:15:39.501+0100 [INFO]  waypoint: waypoint version: full_string="Waypoint v0.1.3" version=v0.1.3 prerelease= metadata= revision=
2020-10-24T23:15:39.502+0100 [DEBUG] waypoint: home configuration directory: path=/Users/tom/Library/Preferences/waypoint
2020-10-24T23:15:39.503+0100 [INFO]  waypoint.server: attempting to source credentials and connect
...
2020-10-24T23:15:39.534+0100 [INFO]  waypoint.runner: starting job execution: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0
2020-10-24T23:15:39.535+0100 [DEBUG] waypoint.runner: plugin search path: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 path=[, .waypoint/plugins, /Users/tom/Library/Preferences/waypoint/plugins]
2020-10-24T23:15:39.535+0100 [DEBUG] waypoint.runner: searching for plugin: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 plugin_name=gobuilder
2020-10-24T23:15:39.535+0100 [DEBUG] waypoint.runner: plugin found as external binary: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 plugin_name=gobuilder path=waypoint-plugin-gobuilder
✓ Configuration file appears valid
✓ Connection to Waypoint server was successful
✓ Project "guides" and all apps are registered with the server.
⠙ Validating required plugins...2020-10-24T23:15:39.566+0100 [INFO]  waypoint.runner.app.example.builder: launching plugin: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 type=Builder path=waypoint-plugin-gobuilder args=[waypoint-plugin-gobuilder]
2020-10-24T23:15:39.566+0100 [DEBUG] waypoint.runner.app.example.builder: starting plugin: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 path=waypoint-plugin-gobuilder args=[waypoint-plugin-gobuilder]
2020-10-24T23:15:39.566+0100 [ERROR] waypoint.runner.app.example.builder: error creating plugin client: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 err="exec: "waypoint-plugin-gobuilder": executable file not found in $PATH"
2020-10-24T23:15:39.566+0100 [DEBUG] waypoint.runner: job finished: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 error="exec: "waypoint-plugin-gobuilder": executable file not found in $PATH"
2020-10-24T23:15:39.566+0100 [WARN]  waypoint.runner: error during job execution: job_id=01ENEAWY8S0T1QMQ1WN04SYJQ0 err="exec: "waypoint-plugin-gobuilder": executable file not found in $PATH"
✓ Configuration file appears valid
✓ Connection to Waypoint server was successful
✓ Project "guides" and all apps are registered with the server.
❌ Failed to load and validate plugins!

! This validation check ensures that you have all the required plugins available
  and the configuration for each plugin (if it exists) is valid. The error message
  below should tell you which plugin(s) failed.

! exec: "waypoint-plugin-gobuilder": executable file not found in $PATH
! Project had errors during initialization.
  Waypoint experienced some errors during project initialization. The output
  above should contain the failure messages. Please correct these errors and
  run 'waypoint init' again.
```

So it looks like it finds `waypoint-plugin-gobuilder` in the working directory, but when it later tries to execute, it uses `waypoint-plugin-gobuilder` without a `./` prefix, which triggers a search in `$PATH` and ignores the binary in the current directory.

This PR adds a `./` to the discovered path to ensure it uses the binary in the current directory instead. Sorry for the slightly awkward path formation, I couldn't see a way to stop `filepath.Join` from "cleaning" the `./` away from the resulting path.

I've added a unit test, and a local build of `waypoint` from this branch fixes the above initialization error for me.