### PR TITLE
Change  Docker Image used by GitLab CI/CD

### DIFF
--- a/website/content/docs/automating-execution/gitlab-cicd.mdx
+++ b/website/content/docs/automating-execution/gitlab-cicd.mdx
@@ -48,21 +48,17 @@ See the GitLab CI/CD [predefined environment variables](https://docs.gitlab.com/
 
 ```yaml
 waypoint:
-  image: docker:latest
+  # Image bootstraps the latest version of Waypoint, See https://gitlab.com/gitlab-org/waypoint-images/container_registry for more details.
+  image: registry.gitlab.com/gitlab-org/waypoint-images:latest
   stage: build
   services:
     - docker:dind
-  # Define environment variables, e.g. `WAYPOINT_VERSION: '0.1.1'`
   variables:
-    WAYPOINT_VERSION: ''
     WAYPOINT_SERVER_ADDR: ''
     WAYPOINT_SERVER_TOKEN: ''
     WAYPOINT_SERVER_TLS: '1'
     WAYPOINT_SERVER_TLS_SKIP_VERIFY: '1'
   script:
-    - wget -q -O /tmp/waypoint.zip https://releases.hashicorp.com/waypoint/${WAYPOINT_VERSION}/waypoint_${WAYPOINT_VERSION}_linux_amd64.zip
-    - unzip -d /usr/local/bin /tmp/waypoint.zip
-    - rm -rf /tmp/waypoint*
     - waypoint init
     - waypoint build
     - waypoint deploy

--- a/website/content/docs/automating-execution/gitlab-cicd.mdx
+++ b/website/content/docs/automating-execution/gitlab-cicd.mdx
@@ -48,7 +48,7 @@ See the GitLab CI/CD [predefined environment variables](https://docs.gitlab.com/
 
 ```yaml
 waypoint:
-  # Image bootstraps the latest version of Waypoint, See https://gitlab.com/gitlab-org/waypoint-images/container_registry for more details.
+  # GitLab created images, which basically rewraps Hashicorp's officially released binaries and may not match Hashicorp's checksums, See https://gitlab.com/gitlab-org/waypoint-images for more details about what goes into the images.
   image: registry.gitlab.com/gitlab-org/waypoint-images:latest
   stage: build
   services:


### PR DESCRIPTION
Instead of downloading the images on every run, GitLab provides regularly updated custom images for Waypoint hosted on GitLab's container registry for every version and the latest version tagged with `latest`.