### PR TITLE
internal/datasource: local data should return pwd

### DIFF
--- a/internal/datasource/local.go
+++ b/internal/datasource/local.go
@@ -3,6 +3,8 @@ package datasource
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
@@ -39,7 +41,15 @@ func (s *LocalSource) Get(
 	raw *pb.Job_DataSource,
 	baseDir string,
 ) (string, func() error, error) {
-	return "", nil, nil
+	pwd, err := os.Getwd()
+	if err == nil && !filepath.IsAbs(pwd) {
+		// This should never happen because os.Getwd I believe always
+		// returns an absolute path but we want to be absolutely sure
+		// so we'll make it abs here.
+		pwd, err = filepath.Abs(pwd)
+	}
+
+	return pwd, nil, err
 }
 
 var _ Sourcer = (*LocalSource)(nil)


### PR DESCRIPTION
The local datasource needs to return the pwd so that plugin discovery
uses an absolute path and doesn't attempt to search by PATH (#691).

This also adds validation in internal/runner that this behavior holds.

/cc @tomhjp 