### PR TITLE
internal/cli: fix precedence on conn info to context => env => flags

### DIFF
--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -78,12 +78,14 @@ func (c *baseCommand) initClient() (*clientpkg.Project, error) {
 		flagConnection = &v
 	}
 
-	// Get the context we'll use.
+	// Get the context we'll use. The ordering here is purposeful and creates
+	// the following precedence: (1) context (2) env (3) flags where the
+	// later values override the former.
 	var err error
 	connectOpts := []serverclient.ConnectOption{
-		serverclient.FromContextConfig(flagConnection),
 		serverclient.FromContext(c.contextStorage, ""),
 		serverclient.FromEnv(),
+		serverclient.FromContextConfig(flagConnection),
 	}
 	c.clientContext, err = serverclient.ContextConfig(connectOpts...)
 	if err != nil {


### PR DESCRIPTION
Fixes #673

Without this, a flag never takes precedence if a context exists and
therefore doesn't work at all.