### PR TITLE
builtin/aws/ecr: Create the repository if it doesn't exist, add defaust repo name

### DIFF
--- a/website/content/partials/components/registry-aws-ecr.mdx
+++ b/website/content/partials/components/registry-aws-ecr.mdx
@@ -19,9 +19,10 @@ The AWS region the ECR repository is in.
 
 The ECR repository to store the image into.
 
-This ECR repository must already exist, waypoint will not create it.
+This defaults to waypoint- then the application name. The repository will be automatically created if needed.
 
 - Type: **string**
+- **Optional**
 
 #### tag
 
@@ -36,7 +37,6 @@ The docker tag to assign to the new image.
 registry {
     use "aws-ecr" {
       region = "us-east-1"
-      repository = "waypoint-example"
       tag = "latest"
     }
 }


### PR DESCRIPTION
This came up on discuss (https://discuss.hashicorp.com/t/trying-to-understand-the-boundaries-envisioned-for-waypoint/16037/6) and given we create everything else in the case of ECS deployments, makes sense to create the ECR repo as well.