### PR TITLE
support backporting into release branches via labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,10 +12,17 @@
       runs-on: ubuntu-latest
       container: hashicorpdev/backport-assistant:0.2.1
       steps:
-        - name: Run Backport Assistant
+        - name: Run Backport Assistant for stable-website
           run: |
             backport-assistant backport -automerge
           env:
             BACKPORT_LABEL_REGEXP: "(?P<target>website)/cherrypick"
             BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        - name: Run Backport Assistant for release branches
+          run: |
+            backport-assistant backport -automerge
+          env:
+            BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d\\.\\d\\.\\w)"
+            BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
             GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
One day we will want to cherrypick bug fixes into previous releases when we merge them into `main`. Merging this in now means we are ready to go when we decide to start using this pattern.

Example use case:
- add a label `backport/0.1.x`
- merge PR
- Backport Assistant attempts to duplicate the PR+commits into the corresponding `release/0.1.x` branch and automerge; if cherrypicks fail, the PR stays open noting that the cherrypicks failed and it requires manual attention

This pattern allows us to make use of both general (`0.1.x`) and specific (`0.1.1`) branch names in the `backport/*` labels.