### PR TITLE
Update -from-project to handle local projects

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -210,7 +210,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 	// If we're loading the config, then get it.
 	if baseCfg.Config {
-		cfg, err := c.initConfig(baseCfg.ConfigOptional)
+		cfg, err := c.initConfig("", baseCfg.ConfigOptional)
 		if err != nil {
 			c.logError(c.Log, "failed to load config", err)
 			return err

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -210,7 +210,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 	// If we're loading the config, then get it.
 	if baseCfg.Config {
-		cfg, err := c.initConfig("", baseCfg.ConfigOptional)
+		cfg, err := c.initConfig(baseCfg.ConfigOptional)
 		if err != nil {
 			c.logError(c.Log, "failed to load config", err)
 			return err

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -18,10 +18,10 @@ import (
 // between Init and "init" to help ensure that "init" succeeding means that
 // other commands will succeed as well.
 
-// initConfig initializes the configuration with the specified filename.
+// initConfig initializes the configuration with the specified filename from the CLI.
 // If filename is empty, it will default to configpkg.Filename.
-func (c *baseCommand) initConfig(filename string, optional bool) (*configpkg.Config, error) {
-	path, err := c.initConfigPath(filename)
+func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
+	path, err := c.initConfigPath(c.fromProject)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -20,8 +20,8 @@ import (
 
 // initConfig initializes the configuration with the specified filename from the CLI.
 // If filename is empty, it will default to configpkg.Filename.
-func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
-	path, err := c.initConfigPath(c.fromProject)
+func (c *baseCommand) initConfig(filename string, optional bool) (*configpkg.Config, error) {
+	path, err := c.initConfigPath(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +39,8 @@ func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
 
 // initConfigPath returns the path for the configuration file with the
 // specified filename.
-func (c *baseCommand) initConfigPath() (string, error) {
-	path, err := configpkg.FindPath("", c.fromProject, true)
+func (c *baseCommand) initConfigPath(filename string) (string, error) {
+	path, err := configpkg.FindPath("", filename, true)
 	if err != nil {
 		return "", fmt.Errorf("Error looking for a Waypoint configuration: %s", err)
 	}

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -18,9 +18,10 @@ import (
 // between Init and "init" to help ensure that "init" succeeding means that
 // other commands will succeed as well.
 
-// initConfig initializes the configuration.
-func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
-	path, err := c.initConfigPath()
+// initConfig initializes the configuration with the specified filename.
+// If filename is empty, it will default to configpkg.Filename.
+func (c *baseCommand) initConfig(filename string, optional bool) (*configpkg.Config, error) {
+	path, err := c.initConfigPath(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -36,9 +37,10 @@ func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
 	return c.initConfigLoad(path)
 }
 
-// initConfigPath returns the configuration path to load.
-func (c *baseCommand) initConfigPath() (string, error) {
-	path, err := configpkg.FindPath("", "", true)
+// initConfigPath returns the path for the configuration file with the
+// specified filename.
+func (c *baseCommand) initConfigPath(filename string) (string, error) {
+	path, err := configpkg.FindPath("", filename)
 	if err != nil {
 		return "", fmt.Errorf("Error looking for a Waypoint configuration: %s", err)
 	}

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -39,8 +39,8 @@ func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
 
 // initConfigPath returns the path for the configuration file with the
 // specified filename.
-func (c *baseCommand) initConfigPath(filename string) (string, error) {
-	path, err := configpkg.FindPath("", filename)
+func (c *baseCommand) initConfigPath() (string, error) {
+	path, err := configpkg.FindPath("", c.fromProject, true)
 	if err != nil {
 		return "", fmt.Errorf("Error looking for a Waypoint configuration: %s", err)
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -557,7 +557,8 @@ func (c *InitCommand) Flags() *flag.Sets {
 			Name:    "from-project",
 			Target:  &c.fromProject,
 			Default: "",
-			Usage:   "Create a new application by fetching the given application from a remote source or from a local file on disk.",
+			Usage: "Create a new application by fetching the given application from" +
+				"a remote source or from a local project folder or fileon disk.",
 		})
 
 		f.StringVar(&flag.StringVar{

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -131,7 +131,7 @@ func (c *InitCommand) Run(args []string) int {
 		return 0
 	}
 
-	path, err := c.initConfigPath()
+	path, err := c.initConfigPath(c.fromProject)
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
@@ -214,7 +214,7 @@ func (c *InitCommand) validateConfig() bool {
 	defer sg.Wait()
 
 	s := sg.Add("Validating configuration file...")
-	cfg, err := c.initConfig(false)
+	cfg, err := c.initConfig(c.fromProject, false)
 	if err != nil {
 		c.stepError(s, initStepConfig, err)
 		return false

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -27,9 +27,9 @@ import (
 type InitCommand struct {
 	*baseCommand
 
-	from   string
-	into   string
-	update bool
+	fromProject string
+	into        string
+	update      bool
 
 	project *clientpkg.Project
 	cfg     *configpkg.Config
@@ -46,12 +46,12 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.from != "" {
+	if c.fromProject != "" {
 		if c.into == "" {
-			if u, err := url.Parse(c.from); err == nil {
+			if u, err := url.Parse(c.fromProject); err == nil {
 				c.into = filepath.Base(u.Path)
 			} else {
-				c.into = filepath.Base(c.from)
+				c.into = filepath.Base(c.fromProject)
 			}
 
 			ext := filepath.Ext(c.into)
@@ -84,7 +84,7 @@ func (c *InitCommand) Run(args []string) int {
 		c.ui.NamedValues([]terminal.NamedValue{
 			{
 				Name:  "Location",
-				Value: c.from,
+				Value: c.fromProject,
 			},
 			{
 				Name:  "Directory",
@@ -102,7 +102,7 @@ func (c *InitCommand) Run(args []string) int {
 		}
 
 		client := &getter.Client{
-			Src: c.from,
+			Src: c.fromProject,
 			Dst: dir,
 			Pwd: pwd,
 			Dir: true,
@@ -554,7 +554,7 @@ func (c *InitCommand) Flags() *flag.Sets {
 
 		f.StringVar(&flag.StringVar{
 			Name:    "from-project",
-			Target:  &c.from,
+			Target:  &c.fromProject,
 			Default: "",
 			Usage:   "Create a new application by fetching the given application from a remote source",
 		})
@@ -563,7 +563,7 @@ func (c *InitCommand) Flags() *flag.Sets {
 			Name:    "into",
 			Target:  &c.into,
 			Default: "",
-			Usage:   "Where to write the application fetched via -from",
+			Usage:   "Where to write the application fetched via -from-project",
 		})
 
 		f.BoolVar(&flag.BoolVar{

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -214,7 +214,7 @@ func (c *InitCommand) validateConfig() bool {
 	defer sg.Wait()
 
 	s := sg.Add("Validating configuration file...")
-	cfg, err := c.initConfig(c.from, false)
+	cfg, err := c.initConfig(false)
 	if err != nil {
 		c.stepError(s, initStepConfig, err)
 		return false

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -214,7 +214,7 @@ func (c *InitCommand) validateConfig() bool {
 	defer sg.Wait()
 
 	s := sg.Add("Validating configuration file...")
-	cfg, err := c.initConfig(false)
+	cfg, err := c.initConfig(c.from, false)
 	if err != nil {
 		c.stepError(s, initStepConfig, err)
 		return false

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -557,7 +557,7 @@ func (c *InitCommand) Flags() *flag.Sets {
 			Name:    "from-project",
 			Target:  &c.fromProject,
 			Default: "",
-			Usage:   "Create a new application by fetching the given application from a remote source",
+			Usage:   "Create a new application by fetching the given application from a remote source or from a local file on disk.",
 		})
 
 		f.StringVar(&flag.StringVar{

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -574,13 +574,6 @@ func (c *InitCommand) Flags() *flag.Sets {
 			Usage: "Update the project configuration if it already exists. This can be used " +
 				"to update settings such as the remote runner data source.",
 		})
-
-		f.StringVar(&flag.StringVar{
-			Name:    "from",
-			Target:  &c.from,
-			Default: configpkg.Filename,
-			Usage:   "Initialize a new project using the specified HCL file.",
-		})
 	})
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -30,6 +30,7 @@ type InitCommand struct {
 	fromProject string
 	into        string
 	update      bool
+	from        string
 
 	project *clientpkg.Project
 	cfg     *configpkg.Config
@@ -130,7 +131,7 @@ func (c *InitCommand) Run(args []string) int {
 		return 0
 	}
 
-	path, err := c.initConfigPath()
+	path, err := c.initConfigPath(c.from)
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
@@ -572,6 +573,13 @@ func (c *InitCommand) Flags() *flag.Sets {
 			Default: false,
 			Usage: "Update the project configuration if it already exists. This can be used " +
 				"to update settings such as the remote runner data source.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "from",
+			Target:  &c.from,
+			Default: configpkg.Filename,
+			Usage:   "Initialize a new project using the specified HCL file.",
 		})
 	})
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -131,7 +131,7 @@ func (c *InitCommand) Run(args []string) int {
 		return 0
 	}
 
-	path, err := c.initConfigPath(c.from)
+	path, err := c.initConfigPath()
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1


### PR DESCRIPTION
Fixes #717.

This is some approach to solve #717. It does 3 things:
* Rename the `from` struct field for `-from-project` to `fromProject` for consistency.
* Introduce the `-from` option and store it in the "new" `from` struct field.
* Read the configuration based on `-from` instead of `configpkg.Filename`.

Happy to hear your suggestions and improvements.