### PR TITLE
Update ECS plugin to not assign public ip on ec2_cluster

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1067,7 +1067,7 @@ func (p *Platform) Launch(
 		SecurityGroups: []*string{sgecsport},
 	}
 
-	if p.config.EC2Cluster == false {
+	if !p.config.EC2Cluster {
 		netCfg.AssignPublicIp = aws.String("ENABLED")
 	}
 

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1067,7 +1067,9 @@ func (p *Platform) Launch(
 		SecurityGroups: []*string{sgecsport},
 	}
 
-	netCfg.AssignPublicIp = aws.String("ENABLED")
+	if p.config.EC2Cluster == false {
+		netCfg.AssignPublicIp = aws.String("ENABLED")
+	}
 
 	s.Status("Creating ECS Service (%s, cluster-name: %s)", serviceName, clusterName)
 	servOut, err := ecsSvc.CreateService(&ecs.CreateServiceInput{


### PR DESCRIPTION
When using `ec2_cluster = true` there is an error `InvalidParameterException: Assign public IP is not supported for this launch type`. This wraps the `AssignPublicIp` network configuration so that on ec2_clusters this is not set to enabled.

This was reported in #643, and I've experienced it myself. Without ec2_cluster = true, Fargate will be used, and this setting works.