### PR TITLE
Use Dockerhub Mirror.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,17 +76,17 @@ jobs:
   go-test:
     docker:
       - image: *GOLANG_IMAGE
-      - image: localstack/localstack:latest
-      - image: letsencrypt/pebble
+      - image: docker.mirror.hashicorp.services/localstack/localstack:latest
+      - image: docker.mirror.hashicorp.services/letsencrypt/pebble
         command: ["pebble"]
         environment:
           PEBBLE_VA_NOSLEEP: 1
           PEBBLE_VA_ALWAYS_VALID: 1
-      - image: circleci/postgres:11-alpine
+      - image: docker.mirror.hashicorp.services/circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: waypoint_test
-      - image: vault
+      - image: docker.mirror.hashicorp.services/vault
         command: ["server", "-dev", "-dev-root-token-id=hznroot"]
     parallelism: 4
     environment:
@@ -191,7 +191,7 @@ jobs:
   image-release:
     docker:
       # Use a modern Circle image as we just need up-to-date Docker here
-      - image: cimg/base:2020.07-20.04
+      - image: docker.mirror.hashicorp.services/cimg/base:2020.07-20.04
     environment:
       <<: *ENVIRONMENT
     shell: /usr/bin/env bash -euo pipefail -c

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.15.3
-    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.44
-    ember: &EMBER_IMAGE circleci/node:12-browsers
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.15.3
+    middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
+    ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:12-browsers
 
   paths:
     test-results: &TEST_RESULTS_DIR /tmp/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# syntax = docker/dockerfile:experimental
+# syntax = hashicorp.jfrog.io/docker/docker/dockerfile:experimental
 
-FROM golang:alpine AS builder
+FROM hashicorp.jfrog.io/docker/golang:alpine AS builder
 
 RUN apk add --no-cache git gcc libc-dev openssh
 
@@ -25,7 +25,7 @@ RUN apk add --no-cache make
 RUN go get github.com/kevinburke/go-bindata/...
 RUN --mount=type=cache,target=/root/.cache/go-build make bin
 
-FROM alpine
+FROM hashicorp.jfrog.io/docker/alpine
 
 COPY --from=builder /tmp/wp-src/waypoint /usr/bin/waypoint
 


### PR DESCRIPTION
Dockerhub is going to rate limit unauthenticated pulls.

Use internal mirror for CI and Dockerfiles built in CI.