### PR TITLE
Backport of Fix doc typo

### DIFF
--- a/website/content/docs/workspaces.mdx
+++ b/website/content/docs/workspaces.mdx
@@ -23,7 +23,7 @@ By default, all operations are performed in the "default" workspace. By
 specifying the `-workspace` flag to any operation, Waypoint will operate
 in a different workspace but on the same underlying infrastructure (by
 default).
-Workspace are created on-demand. By using the `-workspace` flag with
+Workspaces are created on-demand. By using the `-workspace` flag with
 a new value, the workspace will be automatically created.
 
 All builds, deploys, and releases are scoped to their given workspace.


### PR DESCRIPTION
Apologies, forgot to tag the typo fix PR with the right cherry-pick label, so doing it manually.