### PR TITLE
internal/ceb: prevent multiple horizon agents from running in the same ceb

### DIFF
--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"sync"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
@@ -42,6 +43,10 @@ type CEB struct {
 	execIdx      int64
 
 	cleanupFunc func()
+
+	mu             sync.Mutex
+	urlAgentCtx    context.Context
+	urlAgentCancel func()
 }
 
 // Run runs a CEB with the given options.

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -44,7 +44,7 @@ type CEB struct {
 
 	cleanupFunc func()
 
-	mu             sync.Mutex
+	urlAgentMu     sync.Mutex
 	urlAgentCtx    context.Context
 	urlAgentCancel func()
 }

--- a/internal/ceb/url.go
+++ b/internal/ceb/url.go
@@ -28,8 +28,8 @@ func (ceb *CEB) initURLService(ctx context.Context, port int, cfg *pb.Entrypoint
 
 	L := ceb.logger.Named("url")
 
-	ceb.mu.Lock()
-	defer ceb.mu.Unlock()
+	ceb.urlAgentMu.Lock()
+	defer ceb.urlAgentMu.Unlock()
 
 	if ceb.urlAgentCancel != nil {
 		L.Info("detected old agent, requesting it close")

--- a/internal/ceb/url.go
+++ b/internal/ceb/url.go
@@ -27,6 +27,19 @@ func (ceb *CEB) initURLService(ctx context.Context, port int, cfg *pb.Entrypoint
 	}
 
 	L := ceb.logger.Named("url")
+
+	ceb.mu.Lock()
+	defer ceb.mu.Unlock()
+
+	if ceb.urlAgentCancel != nil {
+		L.Info("detected old agent, requesting it close")
+		ceb.urlAgentCancel()
+	}
+
+	ceb.urlAgentCtx, ceb.urlAgentCancel = context.WithCancel(ctx)
+
+	ctx = ceb.urlAgentCtx
+
 	L.Info("url service enabled, configuring",
 		"addr", cfg.ControlAddr,
 		"service_port", port,


### PR DESCRIPTION
Looking through the connect and reconnect code paths, it's pretty clear that we're leaking an agent instance on every reconnect. If a user had a waypoint server that was having trouble running steady state (perhaps due to too tight of a memory budget), then it would be easy to see how an entrypoint could spawn thousands of agents accidentally.

This code just makes sure that we only run one at a time by canceling the context for the previous one if there is a context set.