### PR TITLE
builtin/google/cloudrun: default releaser

### DIFF
--- a/builtin/google/cloudrun/platform.go
+++ b/builtin/google/cloudrun/platform.go
@@ -67,6 +67,11 @@ func (p *Platform) Auth() error {
 	return nil
 }
 
+// DefaultReleaserFunc implements component.PlatformReleaser
+func (p *Platform) DefaultReleaserFunc() interface{} {
+	return func() *Releaser { return &Releaser{} }
+}
+
 func (p *Platform) ValidateAuth(
 	ctx context.Context,
 	log hclog.Logger,


### PR DESCRIPTION
This makes the default experience for Google Cloud Run better because it
will actually release the site and make it able to be visited. This
seems to also fix an issue where GCR locks down network access
completely without this set.