### PR TITLE
builtin/k8s: default releaser should mirror namespace settings

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/mapstructure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,7 +66,17 @@ func (p *Platform) ValidateAuth() error {
 
 // DefaultReleaserFunc implements component.PlatformReleaser
 func (p *Platform) DefaultReleaserFunc() interface{} {
-	return func() *Releaser { return &Releaser{} }
+	var rc ReleaserConfig
+	if err := mapstructure.Decode(p.config, &rc); err != nil {
+		// shouldn't happen
+		panic("error decoding config: " + err.Error())
+	}
+
+	return func() *Releaser {
+		return &Releaser{
+			config: rc,
+		}
+	}
 }
 
 // Deploy deploys an image to Kubernetes.


### PR DESCRIPTION
Default releasers do not get configured (as documented) since they have
no config. It is up to the platform to specify any default configs as
well. We need to forward along the Namespace config to ensure it starts
in the same NS.

I also copied over other shared fields.

Fixes #727