### PR TITLE
internal/core: load default releaser with new deferred config

### DIFF
--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -107,34 +107,6 @@ func newApp(
 		}
 	}
 
-	// If we don't have a releaser but our platform implements release then
-	// we use that.
-	/* TODO(config2)
-	if app.Releaser == nil && app.Platform != nil {
-		app.logger.Trace("no releaser configured, checking if platform supports release")
-		if r, ok := app.Platform.(component.PlatformReleaser); ok && r.DefaultReleaserFunc() != nil {
-			app.logger.Info("platform capable of release, using platform for release")
-			raw, err := app.callDynamicFunc(
-				ctx,
-				app.logger,
-				(*component.ReleaseManager)(nil),
-				app.Platform,
-				r.DefaultReleaserFunc(),
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			app.Releaser = raw.(component.ReleaseManager)
-			app.components[app.Releaser] = app.components[app.Platform]
-		} else {
-			app.logger.Info("no releaser configured, platform does not support a default releaser",
-				"platform_type", fmt.Sprintf("%T", app.Platform),
-			)
-		}
-	}
-	*/
-
 	return app, nil
 }
 

--- a/internal/core/app_release_destroy.go
+++ b/internal/core/app_release_destroy.go
@@ -80,7 +80,7 @@ func (a *App) DestroyRelease(ctx context.Context, d *pb.Release) error {
 		}
 	}
 
-	c, err := componentCreatorMap[component.ReleaseManagerType].Create(context.Background(), a, &evalCtx)
+	c, err := a.createReleaser(ctx, &evalCtx)
 	if status.Code(err) == codes.Unimplemented {
 		c = nil
 		err = nil
@@ -151,7 +151,7 @@ func (a *App) destroyReleaseWorkspace(ctx context.Context) error {
 	}
 
 	// Start the plugin
-	c, err := componentCreatorMap[component.ReleaseManagerType].Create(ctx, a, nil)
+	c, err := a.createReleaser(ctx, nil)
 	if status.Code(err) == codes.Unimplemented {
 		return nil
 	}


### PR DESCRIPTION
This was an outstanding TODO from #680 I forgot to complete.

This takes the deferred loading and still loads the default releaser if
that is set. Without this, our default releasers weren't loading at all.