### PR TITLE
internal/server: don't use monotonic ulids

### DIFF
--- a/internal/server/id.go
+++ b/internal/server/id.go
@@ -6,13 +6,11 @@ import (
 	"github.com/oklog/ulid"
 )
 
-var ulidReader = ulid.Monotonic(rand.Reader, 1)
-
 // Id returns a unique Id that can be used for new values. This generates
 // a ulid value but the ID itself should be an internal detail. An error will
 // be returned if the ID could be generated.
 func Id() (string, error) {
-	id, err := ulid.New(ulid.Now(), ulidReader)
+	id, err := ulid.New(ulid.Now(), rand.Reader)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
These are not concurrency-safe. Realistically our operations that
generate IDs are not fast enough to worry about forcing monotonic
behavior: it should happen naturally from the timestamp.