### PR TITLE
internal/core: return error if type is ErrSentinel to signal exit codes

### DIFF
--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -443,7 +443,7 @@ func (c *AppDocsCommand) Run(args []string) int {
 		return c.builtinMDX(args)
 	}
 
-	c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+	err = c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		docs, err := app.Docs(ctx, &pb.Job_DocsOp{})
 		if err != nil {
 			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
@@ -537,6 +537,9 @@ func (c *AppDocsCommand) Run(args []string) int {
 
 		return nil
 	})
+	if err != nil {
+		return 1
+	}
 
 	return 0
 }

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -28,7 +28,7 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		_, err := app.Build(ctx, &pb.Job_BuildOp{
 			DisablePush: !c.flagPush,
 		})
@@ -39,6 +39,9 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 
 		return nil
 	})
+	if err != nil {
+		return 1
+	}
 
 	return 0
 }

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -28,7 +28,7 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 
 	client := c.project.Client()
 
-	c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		// Get the most recent build
 		build, err := client.GetLatestBuild(ctx, &pb.GetLatestBuildRequest{
 			Application: app.Ref(),
@@ -50,6 +50,9 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 
 		return nil
 	})
+	if err != nil {
+		return 1
+	}
 
 	return 0
 }

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -275,7 +275,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 // thread-safe.
 //
 // If any error is returned, the caller should just exit. The error handling
-// including messaging to the user is handling by this function call.
+// including messaging to the user is handled by this function call.
 //
 // If you want to early exit all the running functions, you should use
 // the callback closure properties to cancel the passed in context. This
@@ -306,6 +306,9 @@ func (c *baseCommand) DoApp(ctx context.Context, f func(context.Context, *client
 		if err := f(ctx, app); err != nil {
 			if err != ErrSentinel {
 				finalErr = multierror.Append(finalErr, err)
+			} else {
+				// if we have an ErrSentinel here, we've already output info to the UI
+				return err
 			}
 		}
 	}

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -297,6 +297,7 @@ func (c *baseCommand) DoApp(ctx context.Context, f func(context.Context, *client
 
 	// Just a serialize loop for now, one day we'll parallelize.
 	var finalErr error
+	var didErrSentinel bool
 	for _, app := range apps {
 		// Support cancellation
 		if err := ctx.Err(); err != nil {
@@ -307,10 +308,12 @@ func (c *baseCommand) DoApp(ctx context.Context, f func(context.Context, *client
 			if err != ErrSentinel {
 				finalErr = multierror.Append(finalErr, err)
 			} else {
-				// if we have an ErrSentinel here, we've already output info to the UI
-				return err
+				didErrSentinel = true
 			}
 		}
+	}
+	if finalErr == nil && didErrSentinel {
+		finalErr = ErrSentinel
 	}
 
 	return finalErr

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -31,7 +31,7 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 
 	client := c.project.Client()
 
-	c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		// Get the most recent pushed artifact
 		push, err := client.GetLatestPushedArtifact(ctx, &pb.GetLatestPushedArtifactRequest{
 			Application: app.Ref(),
@@ -106,6 +106,9 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 
 		return nil
 	})
+	if err != nil {
+		return 1
+	}
 
 	return 0
 }

--- a/internal/core/operation.go
+++ b/internal/core/operation.go
@@ -112,7 +112,7 @@ func (a *App) doOperation(
 			log.Warn("error running before hook", "err", err)
 
 			if h.ContinueOnFailure() {
-				log.Info("hook configured to continueon failure, ignoring error")
+				log.Info("hook configured to continue on failure, ignoring error")
 				doErr = nil
 			}
 		}


### PR DESCRIPTION
Address #719 
We were neglecting to return a non-nil error when dealing with `ErrSentinel` types, which is what we use most of the time.