### PR TITLE
internal/ceb: support child process restarts on config change

### DIFF
--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -55,6 +55,13 @@ type CEB struct {
 	// commands will stop the old command first. Values sent here are coalesced
 	// in case many changes are sent in a row.
 	childCmdCh chan<- *exec.Cmd
+	childInit  uint32
+
+	// childReadyCh should be closed exactly once (and set to nil) when the
+	// FIRST child command is ready to be started. This can be closed before
+	// any command is sent to childCmdCh. It indicates that the child process
+	// watcher can begin executing.
+	childReadyCh chan struct{}
 
 	// childCmdBase is the base command to use for making any changes to the
 	// child; use the copyCmd() function to copy this safetly to make changes.

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -107,6 +107,10 @@ func Run(ctx context.Context, os ...Option) error {
 		}
 	}
 
+	// We're disabled also if we have no client set and the server address is empty.
+	// This means we have nothing to connect to.
+	cfg.disable = cfg.disable || (ceb.client == nil && cfg.ServerAddr == "")
+
 	ceb.logger.Info("entrypoint starting",
 		"deployment_id", ceb.deploymentId,
 		"instance_id", ceb.id,

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
@@ -38,10 +39,29 @@ type CEB struct {
 	deploymentId string
 	logger       hclog.Logger
 	context      context.Context
-	client       pb.WaypointClient
-	childCmd     *exec.Cmd
 	execIdx      int64
 
+	// clientMu must be held anytime reading/writing client. internally
+	// you probably want to use waitClient() instead of this directly.
+	clientMu   sync.Mutex
+	clientCond *sync.Cond
+	client     pb.WaypointClient
+
+	// childDoneCh is sent a value (incl. nil) when the child process exits.
+	// This is not sent anything for restarts.
+	childDoneCh <-chan error
+
+	// childCmdCh can be sent new commands to restart the child process. New
+	// commands will stop the old command first. Values sent here are coalesced
+	// in case many changes are sent in a row.
+	childCmdCh chan<- *exec.Cmd
+
+	// childCmdBase is the base command to use for making any changes to the
+	// child; use the copyCmd() function to copy this safetly to make changes.
+	// Do not write to this directly.
+	childCmdBase *exec.Cmd
+
+	closedVal   uint32
 	cleanupFunc func()
 
 	urlAgentMu     sync.Mutex
@@ -68,6 +88,7 @@ func Run(ctx context.Context, os ...Option) error {
 		logger:  hclog.L(),
 		context: ctx,
 	}
+	ceb.clientCond = sync.NewCond(&ceb.clientMu)
 	defer ceb.Close()
 
 	// Set our options
@@ -94,29 +115,26 @@ func Run(ctx context.Context, os ...Option) error {
 		"revision", vsn.Revision,
 	)
 
-	// Initialize our command
+	// Initialize our base child command. We do this before any server
+	// connections and so on because if this fails we just want to fail fast
+	// before any network activity.
 	if err := ceb.initChildCmd(ctx, &cfg); err != nil {
-		return status.Errorf(codes.Aborted,
-			"failed to connect to server: %s", err)
+		return err
 	}
 
 	// If we are enabled, initialize the CEB feature set.
-	if !cfg.disable {
-		if err := ceb.init(ctx, &cfg, false); err != nil {
-			return err
-		}
+	if err := ceb.init(ctx, &cfg, false); err != nil {
+		return err
 	}
 
 	// Run our subprocess
-	errCh := ceb.execChildCmd(ctx)
 	select {
-	case err := <-errCh:
+	case err := <-ceb.childDoneCh:
 		return err
 
 	case <-ctx.Done():
-		ceb.logger.Info("received cancellation request, gracefully exiting")
-		ceb.childCmd.Process.Kill()
-		<-errCh
+		ceb.logger.Info("received cancellation request, waiting for child to exit")
+		<-ceb.childDoneCh
 	}
 
 	return nil
@@ -125,11 +143,21 @@ func Run(ctx context.Context, os ...Option) error {
 // Close cleans up any resources created by the CEB and should be called
 // to gracefully exit.
 func (ceb *CEB) Close() error {
+	// Only close ones
+	if !atomic.CompareAndSwapUint32(&ceb.closedVal, 0, 1) {
+		return nil
+	}
+
 	if f := ceb.cleanupFunc; f != nil {
 		f()
 	}
 
 	return nil
+}
+
+// closed returns true if Close was called
+func (ceb *CEB) closed() bool {
+	return atomic.LoadUint32(&ceb.closedVal) != 0
 }
 
 // cleanup stacks cleanup functions to call when Close is called.

--- a/internal/ceb/ceb_test.go
+++ b/internal/ceb/ceb_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRun(t *testing.T) {
+func TestRun_reconnect(t *testing.T) {
 	require := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -337,6 +337,15 @@ func TestMain(m *testing.M) {
 		}
 
 		ioutil.WriteFile(path, []byte("hello"), 0600)
+		time.Sleep(10 * time.Minute)
+
+	case "write-env":
+		path := os.Getenv("HELPER_PATH")
+		if path == "" {
+			panic("bad")
+		}
+
+		ioutil.WriteFile(path, []byte("value: "+os.Getenv("TEST_VALUE")), 0600)
 		time.Sleep(10 * time.Minute)
 
 	default:

--- a/internal/ceb/ceb_test.go
+++ b/internal/ceb/ceb_test.go
@@ -345,7 +345,7 @@ func TestMain(m *testing.M) {
 			panic("bad")
 		}
 
-		ioutil.WriteFile(path, []byte("value: "+os.Getenv("TEST_VALUE")), 0600)
+		ioutil.WriteFile(path, []byte(fmt.Sprintf("%d,%s", os.Getpid(), os.Getenv("TEST_VALUE"))), 0600)
 		time.Sleep(10 * time.Minute)
 
 	default:

--- a/internal/ceb/config_test.go
+++ b/internal/ceb/config_test.go
@@ -1,0 +1,83 @@
+package ceb
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/server"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess"
+)
+
+// Test that our child process is restarted with an env var change.
+func TestConfig_envVarChange(t *testing.T) {
+	require := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start up the server
+	restartCh := make(chan struct{})
+	impl := singleprocess.TestImpl(t)
+	client := server.TestServer(t, impl,
+		server.TestWithContext(ctx),
+		server.TestWithRestart(restartCh),
+	)
+
+	// Create a temporary directory for our test
+	td, err := ioutil.TempDir("", "test")
+	require.NoError(err)
+	defer os.RemoveAll(td)
+	path := filepath.Join(td, "hello")
+
+	// Start the CEB
+	ceb := testRun(t, context.Background(), &testRunOpts{
+		Client: client,
+		Helper: "write-env",
+		HelperEnv: map[string]string{
+			"HELPER_PATH": path,
+			"TEST_VALUE":  "",
+		},
+	})
+
+	// The child should still start up
+	require.Eventually(func() bool {
+		_, err := ioutil.ReadFile(path)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Get our deployment
+	deployment, err := client.GetDeployment(ctx, &pb.GetDeploymentRequest{
+		Ref: &pb.Ref_Operation{
+			Target: &pb.Ref_Operation_Id{
+				Id: ceb.DeploymentId(),
+			},
+		},
+	})
+	require.NoError(err)
+
+	// Change our config
+	_, err = client.SetConfig(ctx, &pb.ConfigSetRequest{
+		Variables: []*pb.ConfigVar{
+			{
+				Scope: &pb.ConfigVar_Application{
+					Application: deployment.Application,
+				},
+				Name:  "TEST_VALUE",
+				Value: "hello",
+			},
+		},
+	})
+	require.NoError(err)
+
+	// The child should still start up
+	require.Eventually(func() bool {
+		data, err := ioutil.ReadFile(path)
+		return err == nil && string(data) == "value: hello"
+	}, 5*time.Second, 10*time.Millisecond)
+}

--- a/internal/ceb/exec.go
+++ b/internal/ceb/exec.go
@@ -41,9 +41,15 @@ func (ceb *CEB) startExecGroup(es []*pb.EntrypointConfig_Exec) {
 func (ceb *CEB) startExec(execConfig *pb.EntrypointConfig_Exec) {
 	log := ceb.logger.Named("exec").With("index", execConfig.Index)
 
+	// wait for initial server connection
+	serverClient := ceb.waitClient()
+	if serverClient == nil {
+		log.Warn("nil client, can't execute")
+	}
+
 	// Open the stream
 	log.Info("starting exec stream", "args", execConfig.Args)
-	client, err := ceb.client.EntrypointExecStream(ceb.context)
+	client, err := serverClient.EntrypointExecStream(ceb.context)
 	if err != nil {
 		log.Warn("error opening exec stream", "err", err)
 		return

--- a/internal/ceb/init.go
+++ b/internal/ceb/init.go
@@ -11,6 +11,7 @@ func (ceb *CEB) init(ctx context.Context, cfg *config, retry bool) error {
 	if cfg.disable {
 		// Send our initial child command down.
 		ceb.childCmdCh <- ceb.copyCmd(ceb.childCmdBase)
+		ceb.markChildCmdReady()
 		return nil
 	}
 

--- a/internal/ceb/init.go
+++ b/internal/ceb/init.go
@@ -2,57 +2,37 @@ package ceb
 
 import (
 	"context"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (ceb *CEB) init(ctx context.Context, cfg *config, retry bool) error {
 	log := ceb.logger.Named("init")
 
-RETRY_INIT:
-	// First thing we need to do is connect to the server.
-	if ceb.client == nil {
-		if cfg.ServerAddr == "" {
-			log.Info("no waypoint server configured, disabled entrypoint")
-			return nil
-		}
-
-		err := ceb.dialServer(ctx, cfg, retry)
-		if status.Code(err) == codes.Unavailable {
-			// If we require a server connection, then just retry.
-			if cfg.ServerRequired {
-				log.Warn("server unavailable but ceb configured to require it, retrying synchronously")
-				retry = true
-				goto RETRY_INIT
-			}
-
-			// If we don't require a server connection, then we start a
-			// goroutine to retry and eventually connect (hopefully).
-			log.Warn("server unavailable, will retry in the background")
-			go ceb.init(ctx, cfg, true)
-
-			return nil
-		}
-	}
-
-	// This should never happen
-	if ceb.client == nil {
-		log.Error("client is still nil, not expected, quitting init")
+	// If the entrypoint is full disabled, just connect to our command.
+	if cfg.disable {
+		// Send our initial child command down.
+		ceb.childCmdCh <- ceb.copyCmd(ceb.childCmdBase)
 		return nil
 	}
 
-	// Get our configuration and start the long-running stream for it.
-	if err := ceb.initConfigStream(ctx, cfg, retry); err != nil {
+	// Initialize our client. This will retry in the background on failure.
+	if err := ceb.initClient(ctx, log, cfg, false); err != nil {
 		return err
 	}
 
-	// Initialize our log stream
+	// Initialize our log stream. We do this first so we can set the proper
+	// stdout/stderr on our base child command.
 	// NOTE(mitchellh): at some point we want this to be configurable
 	// but for now we're just going for it.
 	if err := ceb.initLogStream(ctx, cfg); err != nil {
 		return err
 	}
+
+	// Send our initial child command down.
+	ceb.childCmdCh <- ceb.copyCmd(ceb.childCmdBase)
+
+	// Get our configuration and start the long-running stream for it.
+	// Goroutine since this requires the client and will wait for it.
+	go ceb.initConfigStream(ctx, cfg, retry)
 
 	return nil
 }

--- a/internal/ceb/server.go
+++ b/internal/ceb/server.go
@@ -62,6 +62,11 @@ RETRY_INIT:
 		log.Warn("server unavailable, will retry in the background")
 		go ceb.initClient(ctx, log, cfg, true)
 
+		// We also mark that we can begin executing the child command.
+		// We usually don't do this because we wait for initial config, but
+		// if we fail to connect to the client, we can just start it.
+		ceb.markChildCmdReady()
+
 		return nil
 	}
 

--- a/website/content/docs/app-config.mdx
+++ b/website/content/docs/app-config.mdx
@@ -27,12 +27,9 @@ $ waypoint config set DATABASE_URL="postgresql://example.com:5432"
 ```
 
 This will make the `DATABASE_URL` environment variable present with the
-given value for all deployed applications.
-
--> **Waypoint currently will not restart your application when configuration
-changes.** Configuration changes will only take effect when you redeploy
-your application. A future version of Waypoint will restart deployed
-applications.
+given value for all deployed applications. For already-deployed applications,
+Waypoint will [restart running applications](#application-restart-behavior)
+when configuration changes.
 
 ### Project Scope
 
@@ -53,3 +50,19 @@ $ waypoint config set -app web PORT=8080
 ## Unsetting Configuration
 
 To delete a configuration variable, set it to the empty string.
+
+## Application Restart Behavior
+
+Waypoint will automatically restart your running applications whenever
+a configuration change is detected for that application. Waypoint restarts
+your application with the following steps:
+
+1. The `SIGTERM` signal is sent to your application process. This signal
+   can be trapped to perform last minute cleanup and shutdown.
+
+2. Waypoint will wait up to 30 seconds for your application to gracefully exit.
+
+3. After 30 seconds, Waypoint will send the `SIGKILL` signal to your
+   application process group. This will kill the application process as well
+   as any subprocesses it may have started. This signal is not able to be trapped
+   and your application will be killed immediately.


### PR DESCRIPTION
When config variables change, this will gracefully restart the child process to get the new config variables.

"Graceful restart" follows the same process as [Heroku](https://devcenter.heroku.com/articles/what-happens-to-ruby-apps-when-they-are-restarted): we send the child a SIGTERM and if the child doesn't exit in 30 seconds we send a SIGKILL.

This required quite a bit of refactoring, but all tests are passing and I added a test to verify we restart properly for env var changes.