### PR TITLE
nix: move depricated nixpkgs-channels to nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -13,14 +13,14 @@
     },
     "nixpkgs": {
         "branch": "nixpkgs-unstable",
-        "description": "DEPRECATED! This is an obsolete, read-only mirror of the NixOS/nixpkgs repository.",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs-channels",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "nixos",
+        "repo": "nixpkgs",
         "rev": "502845c3e31ef3de0e424f3fcb09217df2ce6df6",
         "sha256": "0fcqpsy6y7dgn0y0wgpa56gsg0b0p8avlpjrd79fp4mp9bl18nda",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/502845c3e31ef3de0e424f3fcb09217df2ce6df6.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/502845c3e31ef3de0e424f3fcb09217df2ce6df6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Lovely to see nix in the wild :heart: I was looking forward to something like this since @mitchellh's first nix related tweet

https://github.com/nixos/nixpkgs-channels has been depricated.
Updated niv source to use main https://github.com/nixos/nixpkgs repo.
Using the same channel/branch and rev there shouldn't be any incompatibilities.