### PR TITLE
statically compile ceb to make injection easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CGO_ENABLED?=0
 
 .PHONY: bin
 bin: # bin creates the binaries for Waypoint for the current platform
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w -extldflags "-static"' -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
 	CGO_ENABLED=0 go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint


### PR DESCRIPTION
Resolves #614

Nix build & then injecting worked just fine.
I didn't actually use the built artifact though as I haven't had much of a go with `waypoint` yet.
Nix derivation I used: https://github.com/06kellyjac/nixpkgs/blob/07abbe37a02fa2683fb66c9169086a5f4163c793/pkgs/applications/networking/cluster/waypoint/default.nix

![nixpkgs_waypoint](https://user-images.githubusercontent.com/9866621/99130911-974e8a00-2609-11eb-8b7f-898af5ceb431.png)
