### PR TITLE
Empty dockerfile

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -132,10 +132,10 @@ func (b *Builder) Build(
 	if !filepath.IsAbs(dockerfile) {
 		//if no dockerfile is provided take common default and look for Dockerfile in src.Path
 		if dockerfile == "" {
-			dockerfile = filepath.Join(src.Path, "Dockerfile")
-		} else {
-			dockerfile = filepath.Join(src.Path, dockerfile)
+			dockerfile = "Dockerfile"
 		}
+		dockerfile = filepath.Join(src.Path, dockerfile)
+
 	}
 
 	// If the dockerfile is outside of our build context, then we copy it

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -128,8 +128,14 @@ func (b *Builder) Build(
 	cli.NegotiateAPIVersion(ctx)
 
 	dockerfile := b.config.Dockerfile
+
 	if !filepath.IsAbs(dockerfile) {
-		dockerfile = filepath.Join(src.Path, dockerfile)
+		//if no dockerfile is provided take common default and look for Dockerfile in src.Path
+		if dockerfile == "" {
+			dockerfile = filepath.Join(src.Path, "Dockerfile")
+		} else {
+			dockerfile = filepath.Join(src.Path, dockerfile)
+		}
 	}
 
 	// If the dockerfile is outside of our build context, then we copy it


### PR DESCRIPTION
Fix for issue https://github.com/hashicorp/waypoint/issues/799#issue-742595747

IsAbs() is respecting an empty string as an absolute filepath.

checking for the docker cli default seems like an easy and low risk fix.