### PR TITLE
Add more descriptive output to `waypoint destroy`

### DIFF
--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -114,7 +115,7 @@ func (a *App) destroyAllDeploys(ctx context.Context) error {
 	}
 	defer c.Close()
 
-	a.UI.Output("Destroying deployments...", terminal.WithHeaderStyle())
+	a.UI.Output(fmt.Sprintf("Destroying deployments for application '%s'...", a.config.Name), terminal.WithHeaderStyle())
 	for _, v := range results {
 		err := a.DestroyDeploy(ctx, v)
 		if err != nil {
@@ -165,7 +166,7 @@ func (a *App) destroyDeployWorkspace(ctx context.Context) error {
 		return nil
 	}
 
-	a.UI.Output("Destroying shared deploy resources...", terminal.WithHeaderStyle())
+	a.UI.Output(fmt.Sprintf("Destroying shared deploy resources for application '%s'...", a.config.Name), terminal.WithHeaderStyle())
 	_, err = a.callDynamicFunc(ctx,
 		log,
 		nil,

--- a/internal/core/app_release_destroy.go
+++ b/internal/core/app_release_destroy.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -113,7 +114,7 @@ func (a *App) destroyAllReleases(ctx context.Context) error {
 		return nil
 	}
 
-	a.UI.Output("Destroying releases...", terminal.WithHeaderStyle())
+	a.UI.Output(fmt.Sprintf("Destroying releases for application '%s'...", a.config.Name), terminal.WithHeaderStyle())
 	for _, rel := range rels {
 		err := a.DestroyRelease(ctx, rel)
 		if err != nil {
@@ -167,7 +168,7 @@ func (a *App) destroyReleaseWorkspace(ctx context.Context) error {
 		return nil
 	}
 
-	a.UI.Output("Destroying shared release resources...", terminal.WithHeaderStyle())
+	a.UI.Output(fmt.Sprintf("Destroying shared release resources for application '%s'...", a.config.Name), terminal.WithHeaderStyle())
 	_, err = a.callDynamicFunc(ctx,
 		log,
 		nil,


### PR DESCRIPTION
This commit includes the application name that waypoint is destroying to
give the user a bit more information when the destroy command is
running.