### PR TITLE
backport version and label regex updates

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,19 +10,19 @@
     backport:
       if: github.event.pull_request.merged
       runs-on: ubuntu-latest
-      container: hashicorpdev/backport-assistant:0.2.1
+      container: hashicorpdev/backport-assistant:0.2.2
       steps:
         - name: Run Backport Assistant for stable-website
           run: |
             backport-assistant backport -automerge
           env:
-            BACKPORT_LABEL_REGEXP: "(?P<target>website)/cherrypick"
+            BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
             BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
             GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         - name: Run Backport Assistant for release branches
           run: |
             backport-assistant backport -automerge
           env:
-            BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d\\.\\d\\.\\w)"
+            BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
             BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
             GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
Updates:
- v0.2.2 bug fixes:
  - PRs opened by users without write access will request review from the person who merged the PR, rather than the original PR author
  - PRs that are automerged skip requesting reviews
  - team review requests uses slugs only now to avoid excessive checks (we don't use team assignments in waypoint; FYI only)
- changed the `stable-website` label to `backport/website` to match the backport labels format in this project
- updated regex for release branch label

I'll create the `backport/website` and delete the `website/cherrypick` labels when this is merged.