### PR TITLE
Fixes #813: Improve error handling for config get command

### DIFF
--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -90,11 +90,18 @@ func (c *ConfigGetCommand) Run(args []string) int {
 			return 1
 		}
 
+		if prefix == "" {
+			fmt.Fprintf(os.Stderr, "flag '-raw' requires a named variable argument to be given")
+			return 1
+		}
+
 		if len(resp.Variables) == 0 {
+			fmt.Fprintf(os.Stderr, "named variable '%s' was not found in config", prefix)
 			return 1
 		}
 
 		if resp.Variables[0].Name != prefix {
+			fmt.Fprintf(os.Stderr, "name '%s' doesn't match prefix: %s", resp.Variables[0].Name, prefix)
 			return 1
 		}
 


### PR DESCRIPTION
Prior to this commit, if a user left off an argument for `waypoint
config get -raw`, it would simply exit 1. This commit first ensures that
a named variable was passed in to match against, and otherwise adds some
additional error output to let the user know what went wrong.