### PR TITLE
internal/cli: server config set doesn't require waypoint.hcl

### DIFF
--- a/internal/cli/server_config_set.go
+++ b/internal/cli/server_config_set.go
@@ -19,6 +19,7 @@ func (c *ServerConfigSetCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
+		WithNoConfig(),
 	); err != nil {
 		return 1
 	}


### PR DESCRIPTION
Fixes #780