### PR TITLE
Fix dev version to be current released 0.1.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,7 +10,7 @@ var (
 	GitCommit   string
 	GitDescribe string
 
-	Version           = "0.1.4"
+	Version           = "0.1.5"
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
I'm not sure if this got missed in the last release, but I noticed when I compile waypoint locally I kept getting `0.1.4`, and noticed the Makefile references this file on github to determine its version. It might of just got missed, so this PR updates that version to match the current release of `0.1.5`.