### PR TITLE
waypoint config get: Make -raw print all variables

### DIFF
--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -91,8 +91,10 @@ func (c *ConfigGetCommand) Run(args []string) int {
 		}
 
 		if prefix == "" {
-			fmt.Fprintf(os.Stderr, "flag '-raw' requires a named variable argument to be given")
-			return 1
+			for _, cv := range resp.Variables {
+				fmt.Printf("%s=%s\n", cv.Name, cv.Value)
+			}
+			return 0
 		}
 
 		if len(resp.Variables) == 0 {


### PR DESCRIPTION
Fixes #823.

This is a rather simple fix, so let me know if this is actually sufficient.

**Before this PR:**

```shell script
$ waypoint config get -raw
  # Error
```

**With this PR:**
```
$ waypoint config get -raw
  PASSWORD=test
  USERNAME=alice
```