### PR TITLE
Docs update for `config get raw`

### DIFF
--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -107,7 +107,7 @@ func (c *ConfigGetCommand) Run(args []string) int {
 			return 1
 		}
 
-		fmt.Fprintln(out, resp.Variables[0].Value)
+		fmt.Fprintln(out, fmt.Sprintf("%s=%s", resp.Variables[0].Name, resp.Variables[0].Value))
 		return 0
 	}
 
@@ -146,7 +146,7 @@ func (c *ConfigGetCommand) Flags() *flag.Sets {
 		f.BoolVar(&flag.BoolVar{
 			Name:   "raw",
 			Target: &c.raw,
-			Usage:  "Output the value for the named variable only (disables prefix matching)",
+			Usage:  "Output in key=val",
 		})
 	})
 }

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -26,6 +26,6 @@ Usage: `waypoint config get [options]`
 #### Command Options
 
 - `-json` - Output in JSON
-- `-raw` - Output the value for the named variable only (disables prefix matching)
+- `-raw` - Output in key=val
 
 @include "commands/config-get_more.mdx"


### PR DESCRIPTION
This pull request updates the docs around the new behavior of the `-raw` flag for `waypoint config get`. It also ensures that if an argument is passed, it still prints it as a `key=value` so that it behaves just like the `json` flag.

Built off of the initial commit https://github.com/hashicorp/waypoint/pull/828, can be merged once the manual backport PR is merged https://github.com/hashicorp/waypoint/pull/832