### PR TITLE
#745 environment variables to be used instead of 'region' property for aws-ecr registry

### DIFF
--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,6 +47,22 @@ func (r *Registry) Push(
 	ui terminal.UI,
 	src *component.Source,
 ) (*docker.Image, error) {
+
+	// If there is no region setup.  Try and load it from environment variables.
+	if r.config.Region == "" {
+		r.config.Region = os.Getenv("AWS_REGION")
+
+		if r.config.Region == "" {
+			r.config.Region = os.Getenv("AWS_REGION_DEFAULT")
+		}
+	}
+
+	if r.config.Region == "" {
+		return nil, status.Error(
+			codes.FailedPrecondition,
+			"Please set your aws region in the deployment config, or set the environment variable 'AWS_REGION' or 'AWS_DEFAULT_REGION'")
+	}
+
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
@@ -218,7 +236,7 @@ func (r *Registry) Push(
 // Config is the configuration structure for the registry.
 type Config struct {
 	// AWS Region to access ECR in
-	Region string `hcl:"region,attr"`
+	Region string `hcl:"region,optional"`
 
 	// Repository to store the image into
 	Repository string `hcl:"repository,optional"`
@@ -251,6 +269,9 @@ registry {
 	doc.SetField(
 		"region",
 		"the AWS region the ECR repository is in",
+		docs.Summary("if not set uses the environment variable AWS_REGION or AWS_REGION_DEFAULT"),
+		docs.EnvVar("AWS_REGION"),
+		docs.EnvVar("AWS_REGION_DEFAULT"),
 	)
 
 	doc.SetField(


### PR DESCRIPTION
I thought I'd give this a go as it looked like a pretty simple change and a good "first issue"

A few thoughts:
1. This logic should be centralised for all aws environment config.
2. Packer and terraform use https://github.com/hashicorp/aws-sdk-go-base which seems reasonable to migrate to.
3. This logic is too simple, it should try and lean on the SDK more (ie: load region from default profile)
4. The logic about leaning on the sdk seems similar between terraform and packer - maybe we can push that into the aws-sdk-go-base?

Finally, my dev environment is not healthy enough to check the documentation output.
After installing protobuf from homebrew and running:
```make gen/doc```

> ./vendor/proto/api-common-protos/: warning: directory does not exist.
google/rpc/status.proto: File not found.
internal/server/proto/server.proto:10:1: Import "google/rpc/status.proto" was not found or had errors.
...