### PR TITLE
Multi-port service support for Kubernetes

### DIFF
--- a/builtin/k8s/config_test.go
+++ b/builtin/k8s/config_test.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/r3labs/diff"
+
+	"testing"
+)
+
+func TestServicePortCoersion(t *testing.T) {
+	var defaultPort uint = 9999
+	var config Config
+
+	cases := []struct {
+		id     string
+		config string
+		expect []uint
+	}{
+		{"nil", "", []uint{defaultPort}},
+		{"integer", `service_port = 88`, []uint{88}},
+		{"array", `service_port = [88, 99]`, []uint{88, 99}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.id, func(t *testing.T) {
+			// Should populate defaultPort value for unspecified config
+			err := hclsimple.Decode("config.hcl", []byte(c.config), nil, &config)
+			if err != nil {
+				t.Fatal("Decode error: ", err)
+			}
+
+			ports, err := coerceConfigPortArray(config.ServicePort, defaultPort)
+			if err != nil {
+				t.Fatal("Coerce error: ", err)
+			} else if d, _ := diff.Diff(c.expect, ports); len(d) > 0 {
+				t.Errorf("Outcomes differ: %+v", d)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Following up on issue #821, I've made a first attempt at implementing multi-port support in the Kubernetes plugin. Looking for guidance on the following points:

What's the best developer aesthetic for allowing a single-port configuration, as well as multi-port? Should both singular and plural configuration keys exist? Should singular be deprecated? Is there a way to consolidate them into a single configuration key by creating a custom HCL type that accepts either an array of ints, or coerces a single int into a 1-item array?

Similar issue with `PORT` environmental variable? I assume this one should stay for Heroku buildpack/app compatibility, but do we add another `PORTS` variable for multiple ports?

Please let me know how I should proceed on these, and if there's anything else to be added to this PR.