### PR TITLE
Add Service Account Field to Cloud Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ IMPROVEMENTS:
 * core: add better error messaging when prefix is missing from the `-raw` flag in `waypoint config set` [GH-815]
 * install/k8s: support for OpenShift [GH-715]
 * server: APIs for Waypoint database snapshot/restore [GH-723]
+* plugin/google-cloud-run: added service account name field [GH-850]
+
 
 BUG FIXES:
 

--- a/builtin/google/cloudrun/deployment.go
+++ b/builtin/google/cloudrun/deployment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/grpc/codes"
@@ -46,6 +47,16 @@ func (d *Deployment) apiService(ctx context.Context) (*run.APIService, error) {
 	result, err := run.NewService(ctx,
 		option.WithEndpoint("https://"+d.Resource.Location+"-run.googleapis.com"),
 	)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, err.Error())
+	}
+
+	return result, nil
+}
+
+// iamAPIService returns the IAM API service for GCP client usage.
+func (d *Deployment) iamAPIService(ctx context.Context) (*iam.Service, error) {
+	result, err := iam.NewService(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, err.Error())
 	}

--- a/builtin/google/cloudrun/platform.go
+++ b/builtin/google/cloudrun/platform.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"google.golang.org/api/iam/v1"
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -119,10 +120,10 @@ func (p *Platform) ValidateAuth(
 		src.App,
 	)
 
-	st.Update("Testing IAM permissions...")
+	st.Update("Testing Cloud Run IAM permissions...")
 	result, err := client.TestIamPermissions(apiResource, &testReq).Do()
 	if err != nil {
-		st.Step(terminal.StatusError, "Error testing IAM permissions: "+err.Error())
+		st.Step(terminal.StatusError, "Error testing Cloud Run IAM permissions: "+err.Error())
 		return err
 	}
 
@@ -132,10 +133,48 @@ func (p *Platform) ValidateAuth(
 		return fmt.Errorf("incorrect IAM permissions, received %s", strings.Join(result.Permissions, ", "))
 	}
 
+	// Validate if user has access to the service account specified
+	if p.config.ServiceAccountName != "" {
+
+		iamAPIService, err := deployment.iamAPIService(ctx)
+		if err != nil {
+			ui.Output("Error constructing api client: "+err.Error(), terminal.WithErrorStyle())
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+
+		client := iam.NewProjectsServiceAccountsService(iamAPIService)
+
+		expectedPermissions := []string{
+			"iam.serviceAccounts.actAs",
+		}
+
+		// We need to ensure that the service creator has Service Account User role.
+		testReq := iam.TestIamPermissionsRequest{
+			Permissions: expectedPermissions,
+		}
+
+		apiResource := fmt.Sprintf("projects/%s/serviceAccounts/%s",
+			p.config.Project,
+			p.config.ServiceAccountName,
+		)
+
+		st.Update("Testing IAM permissions on the supplied service account...")
+		result, err := client.TestIamPermissions(apiResource, &testReq).Do()
+		if err != nil {
+			st.Step(terminal.StatusError, "Error testing IAM permissions of the Service Account: "+err.Error())
+			return err
+		}
+
+		// If our resulting permissions do not equal our expected permissions, auth does not validate
+		if !reflect.DeepEqual(result.Permissions, expectedPermissions) {
+			st.Step(terminal.StatusError, "Incorrect IAM permissions on the Service Account, received "+strings.Join(result.Permissions, ", "))
+			return fmt.Errorf("Incorrect IAM permissions on the Service Account, received %s", strings.Join(result.Permissions, ", "))
+		}
+	}
 	return nil
 }
 
-// Deploy deploys an image to GCR.
+// Deploy deploys an image to Cloud Run.
 func (p *Platform) Deploy(
 	ctx context.Context,
 	log hclog.Logger,
@@ -323,6 +362,10 @@ func (p *Platform) Deploy(
 		*/
 	}
 
+	if p.config.ServiceAccountName != "" {
+		service.Spec.Template.Spec.ServiceAccountName = p.config.ServiceAccountName
+	}
+
 	if create {
 		// Create the service
 		log.Info("creating the service")
@@ -433,6 +476,8 @@ app "wpmini" {
         request_timeout            = 300
       }
 
+	  service_account_name = "cloudrun@waypoint-project-id.iam.gserviceaccount.com"
+
       auto_scaling {
         max = 10
       }
@@ -505,6 +550,11 @@ app "wpmini" {
 	)
 
 	doc.SetField(
+		"service_account_name",
+		"Specify a service account email that Cloud Run will use to run the service. You must have the `iam.serviceAccounts.actAs` permission on the service account.",
+	)
+
+	doc.SetField(
 		"auto_scaling.max",
 		`Maximum number of Cloud Run instances. When the maximum requests per container is exceeded, Cloud Run will create an additional container instance to handle load.
 		This parameter controls the maximum number of instances that can be created.`,
@@ -543,6 +593,9 @@ type Config struct {
 
 	// AutoScaling details.
 	AutoScaling *AutoScaling `hcl:"auto_scaling,block"`
+
+	// Service Account details
+	ServiceAccountName string `hcl:"service_account_name,optional"`
 }
 
 // Capacity defines configuration for deployed Cloud Run resources


### PR DESCRIPTION
fixes: https://github.com/hashicorp/waypoint/issues/764

Also I can't seem to run `make gen/doc` , getting the following error

```
protoc -I=. \
                -I=./vendor/proto/api-common-protos/ \
                --doc_out=./doc --doc_opt=html,index.html \
                ./internal/server/proto/server.proto
google/rpc/status.proto: File not found.
internal/server/proto/server.proto:10:1: Import "google/rpc/status.proto" was not found or had errors.
internal/server/proto/server.proto:403:3: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:502:3: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:687:7: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:694:7: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:583:3: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:945:5: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:952:5: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:1045:5: "google.rpc.Status" is not defined.
internal/server/proto/server.proto:1979:5: "google.rpc.Status" is not defined.
make: *** [gen/doc] Error 1
```﻿
