### PR TITLE
Authenticate Docker Pushes for Cloud Run using access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ IMPROVEMENTS:
 * core: add better error messaging when prefix is missing from the `-raw` flag in `waypoint config set` [GH-815]
 * install/k8s: support for OpenShift [GH-715]
 * server: APIs for Waypoint database snapshot/restore [GH-723]
+* plugin/google-cloud-run: Waypoint now uses Access Token authentication to Google Cloud Artifact Registry which means you can use Waypoint without configuring a gcloud credential helper as long as a valid google ADC credential is available. [GH-851]
 
 BUG FIXES:
 

--- a/builtin/docker/registry.go
+++ b/builtin/docker/registry.go
@@ -114,7 +114,6 @@ func (r *Registry) Push(
 			}
 
 			token, _ := defaultTS.Token()
-			log.Warn("Current Token: ", token.AccessToken)
 
 			authConfig := types.AuthConfig{
 				Username: "oauth2accesstoken",

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/zclconf/go-cty v1.5.1
 	github.com/zclconf/go-cty-yaml v1.0.2
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d
 	google.golang.org/api v0.20.0
 	google.golang.org/genproto v0.0.0-20201002142447-3860012362da


### PR DESCRIPTION
Added access token auths to GCR/AR, waypoint can now be run without configuring gcloud credential helper.﻿
