### PR TITLE
Docs for path vars, template functions, and artifact/deploy variables

### DIFF
--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -447,7 +447,7 @@ func (c *AppDocsCommand) funcsMDX() int {
 	for _, k := range keys {
 		fn := all[k]
 
-		fmt.Fprintf(w, "# `%s` Function\n\n", k)
+		fmt.Fprintf(w, "## `%s`\n\n", k)
 
 		var (
 			args     []string
@@ -478,7 +478,7 @@ func (c *AppDocsCommand) funcsMDX() int {
 
 		fmt.Fprintf(w, "```hcl\n%s(%s) %s\n```\n\n", k, strings.Join(args, ", "), rt.FriendlyName())
 		if d, ok := docs[k]; ok {
-			fmt.Fprintf(w, "`%s`: %s\n\n", k, d)
+			fmt.Fprintf(w, "%s\n\n", d)
 		}
 	}
 

--- a/website/content/docs/waypoint-hcl/functions/all.mdx
+++ b/website/content/docs/waypoint-hcl/functions/all.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: Full List - Functions - waypoint.hcl
+sidebar_title: Full Reference
+description: |-
+  This page contains an automatically generated list of all the available functions within the Waypoint configuration file.
+---
+
+# Full Function Reference
+
+This page contains an automatically generated list of all the available
+functions within the Waypoint configuration file. To navigate this page
+more easily, we recommend using your browser's find feature
+(`Cmd-F` or `Ctrl-F`) along with the "Jump to Section" dropdown above.
+
+-> **Note:** This page is currently missing some functions such as
+the template functions (`templatedir`, etc.) and configuration functions
+(`configdynamic`). We are working to fix this. In the mean time, these
+functions are documented elsewhere in context with their purpose.
+
+@include "funcs.mdx"

--- a/website/content/docs/waypoint-hcl/functions/all.mdx
+++ b/website/content/docs/waypoint-hcl/functions/all.mdx
@@ -15,7 +15,7 @@ more easily, we recommend using your browser's find feature
 
 -> **Note:** This page is currently missing some functions such as
 the template functions (`templatedir`, etc.) and configuration functions
-(`configdynamic`). We are working to fix this. In the mean time, these
+(`configdynamic`). We are working to fix this. In the meantime, these
 functions are documented elsewhere in context with their purpose.
 
 @include "funcs.mdx"

--- a/website/content/docs/waypoint-hcl/functions/index.mdx
+++ b/website/content/docs/waypoint-hcl/functions/index.mdx
@@ -1,0 +1,52 @@
+---
+layout: docs
+page_title: Functions - waypoint.hcl
+sidebar_title: Functions
+description: |-
+  The `waypoint.hcl` file uses HCL which is able to call predefined functions. Functions enable Waypoint configurations to represent complex configurations using programming techniques.
+---
+
+# Functions in `waypoint.hcl`
+
+The `waypoint.hcl` file uses [HCL](https://github.com/hashicorp/hcl) which
+is able to call predefined functions. Functions enable Waypoint configurations
+to represent complex configurations using programming techniques.
+
+Most functions can be used anywhere in the Waypoint configuration file.
+Some functions are context-specific and are only valid when called from the correct locations.
+Function documentation pages may use [placement tables](/docs/waypoint-hcl#placement-tables)
+to document where functions are valid. If a placement table is not present
+for a function, it is safe to assume that it can be used anywhere.
+
+## Calling Functions
+
+Function usage is similar to many mainstream programming languages such
+as Javascript, Ruby, or Python. Functions can be called directly and
+assigned to values:
+
+```hcl
+port = floor(8080.4)
+```
+
+Functions can be composed:
+
+```hcl
+port = floor(abs(-8080.4))
+```
+
+Functions arguments can be any expressions: variables, mathematical operations, etc.:
+
+```hcl
+port = floor(abs(artifact.port) + 42)
+```
+
+Functions can be used as part of string interpolations. Regardless of the
+return value HCL will attempt to coerce it into a string:
+
+```hcl
+port = "80${floor(80.4)}" // 8080
+```
+
+## Custom Functions
+
+Waypoint does not support custom defined functions.

--- a/website/content/docs/waypoint-hcl/functions/template.mdx
+++ b/website/content/docs/waypoint-hcl/functions/template.mdx
@@ -25,7 +25,7 @@ be provided to the template.
 templatefile(path[, vars...]) path
 ```
 
-`templatefile` takes a path to a file and optionally one more maps of variables
+`templatefile` takes a path to a file and optionally one or more maps of variables
 for the template, renders the template at `path`, and returns the path to
 the rendered template. The returned path is a copy of the original template
 in a temporary location. This function _does not modify the original file_.

--- a/website/content/docs/waypoint-hcl/functions/template.mdx
+++ b/website/content/docs/waypoint-hcl/functions/template.mdx
@@ -1,0 +1,87 @@
+---
+layout: docs
+page_title: Templating - Functions - waypoint.hcl
+sidebar_title: Templating
+description: |-
+  Waypoint has a set of functions for templating strings, files, and directories with both predefined and custom variable values. These templates can use conditionals, loops, and more to dynamically generate content.
+---
+
+# Templating Functions
+
+Waypoint has a set of functions for templating strings, files, and directories
+with both predefined and custom variable values. These templates can use
+conditionals, loops, and more to dynamically generate content.
+
+Waypoint has three templating functions documented below: `templatefile`,
+`templatedir`, and `templatestring`. All of these functions use the same
+templating syntax. The templates have access to all the same variables
+and functions that are available at the function call-site (where the
+function such as `templatedir` is called). Custom variables can also
+be provided to the template.
+
+## `templatefile`
+
+```hcl
+templatefile(path[, vars...]) path
+```
+
+`templatefile` takes a path to a file and optionally one more maps of variables
+for the template, renders the template at `path`, and returns the path to
+the rendered template. The returned path is a copy of the original template
+in a temporary location. This function _does not modify the original file_.
+
+**Reminder:** This function returns a file path, not the rendered contents of the file.
+If you want the contents of the rendered file, you can wrap this function
+with [`file`](/docs/waypoint-hcl/functions/all#file).
+
+This function is useful for parameters that expect file paths. The example
+below shows using this function with Docker to template the Dockerfile:
+
+```hcl
+app "web" {
+  build {
+    use "docker" {
+      dockerfile = templatefile("${path.app}/Dockerfile.tpl", {
+        theme = "rainbow"
+      })
+    }
+  }
+}
+```
+
+## `templatedir`
+
+```hcl
+templatedir(path[, vars...]) path
+```
+
+`templatedir` is similar to `templatefile`, except it takes a path to
+a directory, treats all files within that directory as a template, copies
+the results to a new temporary directory, and returns the temporary
+directory path.
+
+This function will recursively render all files in `path`.
+
+This function is useful for parameters that expect directory paths, such
+as specifying a directory of YAML files for Kubernetes.
+
+## `templatestring`
+
+```hcl
+templatestring(string[, vars...]) string
+```
+
+`templatestring` renders a string as a template directly and returns
+the rendered contents.
+
+-> **If you have a static template string, you probably want to use
+string literals instead.** This function is primarily for dynamically
+sourced templates (such as reading a file or the contents of some
+other variable). If you have a static string you can use HCL interpolations
+directly, for example: `"Port: ${deploy.port}"`
+
+Example, rendering a template file and returning the contents directly:
+
+```hcl
+userdata = templatestring(file("${path.app}/userdata.tpl"))
+```

--- a/website/content/docs/waypoint-hcl/index.mdx
+++ b/website/content/docs/waypoint-hcl/index.mdx
@@ -84,6 +84,13 @@ and `release`. These are documented further in their respective pages.
 
 A stanza is a parameter, but not all parameters are stanzas.
 
+## Variables
+
+Waypoint configuration files have access to a number of predefined variables.
+Using variables helps make a Waypoint configuration more robust by more
+explicitly specifying paths, reducing duplication, etc. You can learn more about
+variables in the dedicated [variables section](/docs/waypoint-hcl/variables).
+
 ## Top-level Parameters
 
 ### Required

--- a/website/content/docs/waypoint-hcl/index.mdx
+++ b/website/content/docs/waypoint-hcl/index.mdx
@@ -50,6 +50,19 @@ plugin "plugin-name" {
 }
 ```
 
+## Placement Tables
+
+Many pages within the `waypoint.hcl` documentation section will have
+a _placement table_ just beneath the header. This table documents where
+a configuration, function, or variable may be used. An example placement
+table is shown below.
+
+If the example below were present on the documentation page, the documented
+feature is only valid within the context of an `app` stanza. It is not valid
+at the top-level, or any further nested locations.
+
+<Placement groups={[['app', 'build']]} />
+
 ## Top-level
 
 The "top-level" refers to the objects that are not nested in any other

--- a/website/content/docs/waypoint-hcl/variables/artifact.mdx
+++ b/website/content/docs/waypoint-hcl/variables/artifact.mdx
@@ -51,4 +51,4 @@ app "web" {
 The example uses the `artifact.image` value which is the image name
 (without a tag). Other fields such as `artifact.tag` and
 `artifact.name` (the full name with the tag) are also available.
-For the full list of available field, see the Docker plugin documentation.
+For the full list of available fields, see the Docker plugin documentation.

--- a/website/content/docs/waypoint-hcl/variables/artifact.mdx
+++ b/website/content/docs/waypoint-hcl/variables/artifact.mdx
@@ -1,0 +1,54 @@
+---
+layout: docs
+page_title: artifact - Variables - waypoint.hcl
+sidebar_title: <code>artifact</code>
+description: |-
+  The `artifact` variable can be used to reference information about built artifacts. This can be used to access information such as the name and tag of a built Docker image, or the AMI of a built EC2 machine image.
+---
+
+# `artifact` Variable
+
+<Placement
+  groups={[
+    ['app', 'build', 'registry'],
+    ['app', 'deploy'],
+    ['app', 'release'],
+  ]}
+/>
+
+The `artifact` variable can be used to reference information about
+built artifacts. This can be used to access information such as
+the name and tag of a built Docker image, or the AMI of a built
+EC2 machine image.
+
+The exact fields within an `artifact` variable are dependent on the
+[plugin used for the build](/plugins) and the available fields are
+documented alongside plugins.
+
+## Example: Docker
+
+The example below uses the `artifact` variable to reuse the
+Docker image name from the build when pushing it to a registry. This
+configuration makes it so that if the build name is changed, it will
+also automatically change for the registry without having to modify
+the configuration.
+
+```hcl
+app "web" {
+  build {
+    use "docker" {}
+
+    registry {
+      use "docker" {
+        image = artifact.image
+        tag = gitrefpretty()
+      }
+    }
+  }
+}
+```
+
+The example uses the `artifact.image` value which is the image name
+(without a tag). Other fields such as `artifact.tag` and
+`artifact.name` (the full name with the tag) are also available.
+For the full list of available field, see the Docker plugin documentation.

--- a/website/content/docs/waypoint-hcl/variables/deploy.mdx
+++ b/website/content/docs/waypoint-hcl/variables/deploy.mdx
@@ -1,0 +1,46 @@
+---
+layout: docs
+page_title: deploy - Variables - waypoint.hcl
+sidebar_title: <code>deploy</code>
+description: |-
+  The `deploy` variable can be used to reference information about the deployment within a release. This can be used to access information such as the resulting instance ID, IP address, etc.
+---
+
+# `deploy` Variable
+
+<Placement groups={[['app', 'release']]} />
+
+The `deploy` variable can be used to reference information about
+the deployment within a release. This can be used to access information
+such as the resulting instance ID, IP address, etc.
+
+The exact fields within a `deploy` variable are dependent on the
+[plugin used for the build](/plugins) and the available fields are
+documented alongside plugins.
+
+## Example: AWS ECS
+
+The example below uses the `deploy` variable to store the ECS Task ARN
+as a label as part of the release operation. While Waypoint keeps track
+of the backlinks of what deployment created a release, this information
+may be useful to have directly in a label:
+
+```hcl
+app "web" {
+  deploy {
+    use "aws-ecs" {
+      # ...
+    }
+  }
+
+  release {
+    labels = {
+      "example.com/task-arn": deploy.task_arn,
+    }
+
+    use "aws-ecs" {
+      # ...
+    }
+  }
+}
+```

--- a/website/content/docs/waypoint-hcl/variables/entrypoint.mdx
+++ b/website/content/docs/waypoint-hcl/variables/entrypoint.mdx
@@ -1,0 +1,50 @@
+---
+layout: docs
+page_title: entrypoint - Variables - waypoint.hcl
+sidebar_title: <code>entrypoint</code>
+description: |-
+  The `entrypoint` variable contains important information about the Waypoint Entrypoint, such as the required environment variables that must be set for proper entrypoint behavior.
+---
+
+# `entrypoint` Variable
+
+<Placement groups={[['app', 'deploy']]} />
+
+The `entrypoint` variable contains important information about
+the [Waypoint Entrypoint](/docs/entrypoint), such as the required
+environment variables that must be set for proper entrypoint behavior.
+
+## `entrypoint.env`
+
+**Type: `map<string,string>`**
+
+These are the environment variables that must be set on startup
+for the entrypoint to function properly. **You do not normally need
+to use this** because deployment plugins will automatically set these
+environment variables in most cases.
+
+This is useful for manual configuration in cases where the platform
+may not do it automatically (for example, if you specify a custom set
+of YAML files for Kubernetes).
+
+### Example: Kubernetes
+
+The example below shows how we can configure the Kubernetes plugin
+with the required environment variables. **Note: this is not necessary
+since the Kubernetes plugin automatically does this.** This is just
+shown as an example for illustrative purposes.
+
+```hcl
+app "web" {
+  deploy {
+    use "kubernetes" {
+      static_environment = merge({
+        MY_CUSTOM_VAR = "hello, world"
+      }, entrypoint.env)
+    }
+  }
+}
+```
+
+This example sets some custom variables and uses the `merge` function
+to merge in the Waypoint Entrypoint environment variables as well.

--- a/website/content/docs/waypoint-hcl/variables/index.mdx
+++ b/website/content/docs/waypoint-hcl/variables/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: waypoint.hcl Variables
+page_title: Variables - waypoint.hcl
 sidebar_title: Variables
 description: |-
   The `waypoint.hcl` file uses HCL which is able to reference predefined variables. This section will document the list of available variables within the `waypoint.hcl`.

--- a/website/content/docs/waypoint-hcl/variables/index.mdx
+++ b/website/content/docs/waypoint-hcl/variables/index.mdx
@@ -34,6 +34,6 @@ dockerfile = "${path.app}/Dockerfile"
 ## Custom Variables
 
 Waypoint currently only supports predefined variables plus the dynamic
-variables introduced by plugins, such as [`artifact`](#). A future version
+variables introduced by plugins, such as [`artifact`](artifact). A future version
 of Waypoint will enable a mechanism for custom variables that can be populated
 by user input.

--- a/website/content/docs/waypoint-hcl/variables/index.mdx
+++ b/website/content/docs/waypoint-hcl/variables/index.mdx
@@ -1,0 +1,39 @@
+---
+layout: docs
+page_title: waypoint.hcl Variables
+sidebar_title: Variables
+description: |-
+  The `waypoint.hcl` file uses HCL which is able to reference predefined variables. This section will document the list of available variables within the `waypoint.hcl`.
+---
+
+# Variables in `waypoint.hcl`
+
+The `waypoint.hcl` file uses [HCL](https://github.com/hashicorp/hcl) which
+is able to reference predefined variables. This section will document the
+list of available variables within the `waypoint.hcl`. Variable documentation
+pages use [placement tables](/docs/waypoint-hcl#placement-tables)
+to document where variables are valid.
+
+## Using Variables
+
+Variable usage is similar to many mainstream programming languages such
+as Javascript, Ruby, or Python. Variables can be used directly, such as
+in the example below where `path.app` is assigned to `dockerfile`.
+
+```hcl
+dockerfile = path.app
+```
+
+Variables can also be interpolated in strings to concatenate multiple
+values together:
+
+```hcl
+dockerfile = "${path.app}/Dockerfile"
+```
+
+## Custom Variables
+
+Waypoint currently only supports predefined variables plus the dynamic
+variables introduced by plugins, such as [`artifact`](#). A future version
+of Waypoint will enable a mechanism for custom variables that can be populated
+by user input.

--- a/website/content/docs/waypoint-hcl/variables/path.mdx
+++ b/website/content/docs/waypoint-hcl/variables/path.mdx
@@ -1,0 +1,74 @@
+---
+layout: docs
+page_title: path - Variables - waypoint.hcl
+sidebar_title: <code>path</code>
+description: |-
+  Path variables are used to construct an absolute path to reference files or directories that may be used within your Waypoint configuration.
+---
+
+# `path` Variables
+
+Path variables are used to construct an absolute path to reference
+files or directories that may be used within your Waypoint configuration.
+For example, path variables may be used with the Docker builder to
+specify the path to the Dockerfile to build.
+
+## `path.app`
+
+<Placement groups={[['app']]} />
+
+The directory of the application being built or deployed with Waypoint.
+
+If [`path`](/docs/waypoint-hcl/app#path) is not set for the app, this will
+always equal `path.project`. If you are referencing app-relative data,
+you should always use `path.app` in case you move the application in
+the future.
+
+Example:
+
+```hcl
+dockerfile = "${path.app}/Dockerfile"
+```
+
+## `path.project`
+
+<Placement groups={[['* (global)']]} />
+
+The directory that contains the `waypoint.hcl`. **This is the recommended
+variable to use** when referencing files relative to the `waypoint.hcl` file.
+
+Unlike `path.pwd`, this will always point to the directory where the
+`waypoint.hcl` is. If you execute Waypoint from a subdirectory and it loads
+a `waypoint.hcl` file in some parent directory, that directory will be
+the value of `path.project`.
+When executing the `waypoint` CLI in the same directory as the `waypoint.hcl`
+file, `path.pwd` and `path.project` are equivalent.
+
+Example:
+
+```hcl
+dockerfile = "${path.project}/Dockerfile"
+```
+
+## `path.pwd`
+
+<Placement groups={[['* (global)']]} />
+
+The working directory for the CLI. This is equivalent to the result of
+`pwd` in the shell.
+
+When executed from a subdirectory, Waypoint will search parent directories
+for a `waypoint.hcl`. In this case, the `path.pwd` variable will point to
+the subdirectory where you executed Waypoint, _not_ the directory where
+the `waypoint.hcl` is.
+
+Example:
+
+```hcl
+dockerfile = "${path.pwd}/Dockerfile"
+```
+
+~> **`path.pwd` is not recommended.** You almost always want `path.project`
+or `path.app` instead. Using `path.pwd` makes Waypoint execution dependent
+on the current working directory when executing `waypoint`, which can be
+surprising to users.

--- a/website/content/partials/funcs.mdx
+++ b/website/content/partials/funcs.mdx
@@ -1,559 +1,551 @@
-# `abs` Function
+## `abs`
 
 ```hcl
 abs(num) number
 ```
 
-`abs`: return the absolute value of the given number
+return the absolute value of the given number
 
-# `abspath` Function
+## `abspath`
 
 ```hcl
 abspath(path) string
 ```
 
-`abspath`: convert the path into an absolute path
+convert the path into an absolute path
 
-# `base64decode` Function
+## `base64decode`
 
 ```hcl
 base64decode(str) string
 ```
 
-`base64decode`: decode the given string in base64 encoding back to binary
+decode the given string in base64 encoding back to binary
 
-# `base64encode` Function
+## `base64encode`
 
 ```hcl
 base64encode(str) string
 ```
 
-`base64encode`: encode the given string to base64 encoding
+encode the given string to base64 encoding
 
-# `base64gzip` Function
+## `base64gzip`
 
 ```hcl
 base64gzip(str) string
 ```
 
-`base64gzip`: gzip the given string and encode the compressed body as base64
+gzip the given string and encode the compressed body as base64
 
-# `basename` Function
+## `basename`
 
 ```hcl
 basename(path) string
 ```
 
-`basename`: return the last component of the string interpreted as a filesystem path
+return the last component of the string interpreted as a filesystem path
 
-# `ceil` Function
+## `ceil`
 
 ```hcl
 ceil(num) number
 ```
 
-`ceil`: round the given number to the next integer
+round the given number to the next integer
 
-# `chomp` Function
+## `chomp`
 
 ```hcl
 chomp(str) string
 ```
 
-`chomp`: remove white space from the start and end of the given string
+remove white space from the start and end of the given string
 
-# `chunklist` Function
+## `chunklist`
 
 ```hcl
 chunklist(list, size) list of list of dynamic
 ```
 
-`chunklist`: a single list into fixed-size chunks, returning a list of lists
+a single list into fixed-size chunks, returning a list of lists
 
-# `coalescelist` Function
+## `coalescelist`
 
 ```hcl
 coalescelist(vals) dynamic
 ```
 
-`coalescelist`: take any number of list arguments and returns the first one that isn't empty
+take any number of list arguments and returns the first one that isn't empty
 
-# `compact` Function
+## `compact`
 
 ```hcl
 compact(list) list of string
 ```
 
-`compact`: remove empty strings from a list
+remove empty strings from a list
 
-# `concat` Function
+## `concat`
 
 ```hcl
 concat(seqs) dynamic
 ```
 
-`concat`: combine 2 or more lists into a single list
+combine 2 or more lists into a single list
 
-# `contains` Function
+## `contains`
 
 ```hcl
 contains(list, value) dynamic
 ```
 
-`contains`: determines whether a given list or set contains a given single value as one of its elements
+determines whether a given list or set contains a given single value as one of its elements
 
-# `csvdecode` Function
+## `csvdecode`
 
 ```hcl
 csvdecode(str) dynamic
 ```
 
-`csvdecode`: decodes a string containing CSV-formatted data and produces a list of maps representing that data
+decodes a string containing CSV-formatted data and produces a list of maps representing that data
 
-# `dirname` Function
+## `dirname`
 
 ```hcl
 dirname(path) string
 ```
 
-`dirname`: return all except the last component of the string interpreted as a filesystem path
+return all except the last component of the string interpreted as a filesystem path
 
-# `distinct` Function
+## `distinct`
 
 ```hcl
 distinct(list) list of dynamic
 ```
 
-`distinct`: removes any duplicate elements from a list
+removes any duplicate elements from a list
 
-# `element` Function
+## `element`
 
 ```hcl
 element(list, index) dynamic
 ```
 
-`element`: return the value at given numeric index in the list
+return the value at given numeric index in the list
 
-# `file` Function
+## `file`
 
 ```hcl
 file(path) string
 ```
 
-`file`: return the data in the file located at the given path
+return the data in the file located at the given path
 
-# `filebase64` Function
+## `filebase64`
 
 ```hcl
 filebase64(path) string
 ```
 
-`filebase64`: return the data in the file located at the given path after base64 decoding it
+return the data in the file located at the given path after base64 decoding it
 
-# `fileexists` Function
+## `fileexists`
 
 ```hcl
 fileexists(path) bool
 ```
 
-`fileexists`: indicate if a file exists at the given path
+indicate if a file exists at the given path
 
-# `fileset` Function
+## `fileset`
 
 ```hcl
 fileset(path, pattern) set of string
 ```
 
-`fileset`: gather a list of paths that match the given pattern under the given directory
+gather a list of paths that match the given pattern under the given directory
 
-# `flatten` Function
+## `flatten`
 
 ```hcl
 flatten(list) dynamic
 ```
 
-`flatten`: remove any embedded lists by moving the contents to the outer list
+remove any embedded lists by moving the contents to the outer list
 
-# `floor` Function
+## `floor`
 
 ```hcl
 floor(num) number
 ```
 
-`floor`: round the given number to the lowest next integer
+round the given number to the lowest next integer
 
-# `format` Function
+## `format`
 
 ```hcl
 format(format, args) dynamic
 ```
 
-`format`: format a string according to the given parameters
+format a string according to the given parameters
 
-# `formatdate` Function
+## `formatdate`
 
 ```hcl
 formatdate(format, time) string
 ```
 
-`formatdate`: format the current date as a string according to the given parameters
+format the current date as a string according to the given parameters
 
-# `formatlist` Function
+## `formatlist`
 
 ```hcl
 formatlist(format, args) dynamic
 ```
 
-`formatlist`: apply the format() function across all values in the given lists
+apply the format() function across all values in the given lists
 
-# `gitrefhash` Function
+## `gitrefhash`
 
 ```hcl
 gitrefhash() string
 ```
 
-`gitrefhash`: return the full git hash for the HEAD ref
+return the full git hash for the HEAD ref
 
-# `gitrefpretty` Function
+## `gitrefpretty`
 
 ```hcl
 gitrefpretty() string
 ```
 
-`gitrefpretty`: return a humanized version of the git hash, taking into account tags and changes
+return a humanized version of the git hash, taking into account tags and changes
 
-# `gitreftag` Function
+## `gitreftag`
 
 ```hcl
 gitreftag() string
 ```
 
-`gitreftag`: return the tag name that points to the HEAD ref
+return the tag name that points to the HEAD ref
 
-# `gitremoteurl` Function
+## `gitremoteurl`
 
 ```hcl
 gitremoteurl(name) string
 ```
 
-`gitremoteurl`: return the remote url of the git repo
+return the remote url of the git repo
 
-# `indent` Function
+## `indent`
 
 ```hcl
 indent(spaces, str) string
 ```
 
-`indent`: indent each line of the given string
+indent each line of the given string
 
-# `join` Function
+## `join`
 
 ```hcl
 join(separator, lists) string
 ```
 
-`join`: create a string by joining each list element with the given separator
+create a string by joining each list element with the given separator
 
-# `jsondecode` Function
+## `jsondecode`
 
 ```hcl
 jsondecode(str) dynamic
 ```
 
-`jsondecode`: decode the given string as json into HCL values
+decode the given string as json into HCL values
 
-# `jsonencode` Function
+## `jsonencode`
 
 ```hcl
 jsonencode(val) string
 ```
 
-`jsonencode`: encode the given HCL value as json
+encode the given HCL value as json
 
-# `keys` Function
+## `keys`
 
 ```hcl
 keys(inputMap) dynamic
 ```
 
-`keys`: return a list of the keys present in the given map
+return a list of the keys present in the given map
 
-# `log` Function
+## `log`
 
 ```hcl
 log(num, base) number
 ```
 
-`log`: returns the logarithm of a given number in a given base
+returns the logarithm of a given number in a given base
 
-# `lower` Function
+## `lower`
 
 ```hcl
 lower(str) string
 ```
 
-`lower`: convert the given string to lower case according the unicode rules
+convert the given string to lower case according the unicode rules
 
-# `max` Function
+## `max`
 
 ```hcl
 max(numbers) number
 ```
 
-`max`: return the largest number present in the list
+return the largest number present in the list
 
-# `merge` Function
+## `merge`
 
 ```hcl
 merge(maps) dynamic
 ```
 
-`merge`: combine a set of map or objects together as one map
+combine a set of map or objects together as one map
 
-# `min` Function
+## `min`
 
 ```hcl
 min(numbers) number
 ```
 
-`min`: return the smallest number present in the list
+return the smallest number present in the list
 
-# `parseint` Function
+## `parseint`
 
 ```hcl
 parseint(number, base) dynamic
 ```
 
-`parseint`: parse the string as a number of the given base and return an HCL number value
+parse the string as a number of the given base and return an HCL number value
 
-# `pathexpand` Function
+## `pathexpand`
 
 ```hcl
 pathexpand(path) string
 ```
 
-`pathexpand`: expand any tildes in the given path
+expand any tildes in the given path
 
-# `pow` Function
+## `pow`
 
 ```hcl
 pow(num, power) number
 ```
 
-`pow`: raise the given number to the given power
+raise the given number to the given power
 
-# `range` Function
+## `range`
 
 ```hcl
 range(params) list of number
 ```
 
-`range`: generate a list of numbers
+generate a list of numbers
 
-# `regex` Function
+## `regex`
 
 ```hcl
 regex(pattern, string) dynamic
 ```
 
-`regex`: match the given string against the given regular expression pattern, returning captures if defined
+match the given string against the given regular expression pattern, returning captures if defined
 
-# `regexall` Function
+## `regexall`
 
 ```hcl
 regexall(pattern, string) list of dynamic
 ```
 
-`regexall`: same as regex but look for all matches of the given pattern rather than just the first
+same as regex but look for all matches of the given pattern rather than just the first
 
-# `reverse` Function
+## `reverse`
 
 ```hcl
 reverse(list) dynamic
 ```
 
-`reverse`: reverse the order of the elements in the list
+reverse the order of the elements in the list
 
-# `setintersection` Function
+## `setintersection`
 
 ```hcl
 setintersection(first_set, other_sets) set of dynamic
 ```
 
-`setintersection`: takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the intersection of the sets
+takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the intersection of the sets
 
-# `setproduct` Function
+## `setproduct`
 
 ```hcl
 setproduct(sets) dynamic
 ```
 
-`setproduct`: finds all of the possible combinations of elements from all of the given sets by computing the Cartesian product
+finds all of the possible combinations of elements from all of the given sets by computing the Cartesian product
 
-# `setsubtract` Function
+## `setsubtract`
 
 ```hcl
 setsubtract(a, b) set of dynamic
 ```
 
-`setsubtract`: returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the relative complement of the first set in the second set
+returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the relative complement of the first set in the second set
 
-# `setunion` Function
+## `setunion`
 
 ```hcl
 setunion(first_set, other_sets) set of dynamic
 ```
 
-`setunion`: takes multiple sets and produces a single set containing the elements from all of the given sets. In other words, it computes the union of the sets
+takes multiple sets and produces a single set containing the elements from all of the given sets. In other words, it computes the union of the sets
 
-# `signum` Function
+## `signum`
 
 ```hcl
 signum(num) number
 ```
 
-`signum`: indicates the sign of the given number by -1, 0, or 1
+indicates the sign of the given number by -1, 0, or 1
 
-# `slice` Function
+## `slice`
 
 ```hcl
 slice(list, start_index, end_index) dynamic
 ```
 
-`slice`: return a subset of the given list
+return a subset of the given list
 
-# `sort` Function
+## `sort`
 
 ```hcl
 sort(list) list of string
 ```
 
-`sort`: reorder the given elements according to their sorting order
+reorder the given elements according to their sorting order
 
-# `split` Function
+## `split`
 
 ```hcl
 split(separator, str) list of string
 ```
 
-`split`: break the given string up into substrings
+break the given string up into substrings
 
-# `strrev` Function
+## `strrev`
 
 ```hcl
 strrev(str) string
 ```
 
-`strrev`: reverse the characters in the given string
+reverse the characters in the given string
 
-# `substr` Function
+## `substr`
 
 ```hcl
 substr(str, offset, length) string
 ```
 
-`substr`: return a subset of the given string
+return a subset of the given string
 
-# `templatefile` Function
-
-```hcl
-templatefile(path, vars) dynamic
-```
-
-`templatefile`: expand the template defined at the given file path and return the result
-
-# `timeadd` Function
+## `timeadd`
 
 ```hcl
 timeadd(timestamp, duration) string
 ```
 
-`timeadd`: add a quantum of time to the given timestamp to calculate a new timestamp
+add a quantum of time to the given timestamp to calculate a new timestamp
 
-# `title` Function
+## `title`
 
 ```hcl
 title(str) string
 ```
 
-`title`: upper case each character on each word in the given string
+upper case each character on each word in the given string
 
-# `trim` Function
+## `trim`
 
 ```hcl
 trim(str, cutset) string
 ```
 
-`trim`: remove characters present in the cutset from the given string from the head and tail of the string
+remove characters present in the cutset from the given string from the head and tail of the string
 
-# `trimprefix` Function
+## `trimprefix`
 
 ```hcl
 trimprefix(str, prefix) string
 ```
 
-`trimprefix`: remove the given prefix from the string
+remove the given prefix from the string
 
-# `trimspace` Function
+## `trimspace`
 
 ```hcl
 trimspace(str) string
 ```
 
-`trimspace`: remove space charaters from the head and tail of the string
+remove space charaters from the head and tail of the string
 
-# `trimsuffix` Function
+## `trimsuffix`
 
 ```hcl
 trimsuffix(str, suffix) string
 ```
 
-`trimsuffix`: remove the given suffix from the string
+remove the given suffix from the string
 
-# `upper` Function
+## `upper`
 
 ```hcl
 upper(str) string
 ```
 
-`upper`: convert each character to upper case according to the unicode rules
+convert each character to upper case according to the unicode rules
 
-# `urlencode` Function
+## `urlencode`
 
 ```hcl
 urlencode(str) string
 ```
 
-`urlencode`: encode the given string according to the url encoding rules
+encode the given string according to the url encoding rules
 
-# `values` Function
+## `values`
 
 ```hcl
 values(values) dynamic
 ```
 
-`values`: return the list of values in the given map or object
+return the list of values in the given map or object
 
-# `yamldecode` Function
+## `yamldecode`
 
 ```hcl
 yamldecode(src) dynamic
 ```
 
-`yamldecode`: decode the string as YAML and return the equiv HCL values
+decode the string as YAML and return the equiv HCL values
 
-# `yamlencode` Function
+## `yamlencode`
 
 ```hcl
 yamlencode(value) string
 ```
 
-`yamlencode`: convert the given HCL values to YAML
+convert the given HCL values to YAML
 
-# `zipmap` Function
+## `zipmap`
 
 ```hcl
 zipmap(keys, values) dynamic
 ```
 
-`zipmap`: construct a map from a list of keys and a corresponding list of values
+construct a map from a list of keys and a corresponding list of values

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -29,6 +29,10 @@ export default [
   {
     category: 'waypoint-hcl',
     content: [
+      {
+        category: 'variables',
+        content: ['artifact', 'deploy', 'entrypoint', 'path'],
+      },
       'app',
       'build',
       'deploy',

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -33,6 +33,10 @@ export default [
         category: 'variables',
         content: ['artifact', 'deploy', 'entrypoint', 'path'],
       },
+      {
+        category: 'functions',
+        content: ['all', 'template'],
+      },
       'app',
       'build',
       'deploy',


### PR DESCRIPTION
This adds complete documentation for:

  * `path` vars
  * `template*` functions
  * Full function reference (completing Evan's work!)
  * `artifact` and `deploy` variables

This **does not** include docs for dynamic config since that is not merged yet to main and also is huge on its own so I want to PR those docs separately.