### PR TITLE
Fix path for server proto when using go generate

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-//go:generate sh -c "protoc -I../../vendor/proto/api-common-protos -I ../.. internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
+//go:generate sh -c "protoc -I../../vendor/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.."
 //go:generate mv ./proto/server.pb.json.go ./gen
 //go:generate mockery -all -case underscore -dir ./gen -output ./gen/mocks
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-//go:generate sh -c "protoc -I../../vendor/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.."
+//go:generate sh -c "protoc -I../../vendor/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
 //go:generate mv ./proto/server.pb.json.go ./gen
 //go:generate mockery -all -case underscore -dir ./gen -output ./gen/mocks
 


### PR DESCRIPTION
Prior to this commit, go generate would run in the dir
`internal/server`, so when it went to look for the server.proto, it
would look inside
`waypoint/internal/server/internal/server/proto/server.proto`. This
commit fixes that by ensuring it goes back to the root dir to find
`server.proto`.