### PR TITLE
Add template fields to docs, rearrange docs slightly

### DIFF
--- a/builtin/aws/ami/builder.go
+++ b/builtin/aws/ami/builder.go
@@ -38,7 +38,7 @@ type BuilderConfig struct {
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}))
+	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}), docs.FromFunc(b.BuildFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ec2/platform.go
+++ b/builtin/aws/ec2/platform.go
@@ -375,7 +375,7 @@ type PlatformConfig struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&PlatformConfig{}))
+	doc, err := docs.New(docs.FromConfig(&PlatformConfig{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -246,7 +246,7 @@ type Config struct {
 }
 
 func (r *Registry) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(r.PushFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1344,7 +1344,7 @@ type Config struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/azure/aci/platform.go
+++ b/builtin/azure/aci/platform.go
@@ -464,7 +464,7 @@ type GitRepoVolume struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -50,7 +50,10 @@ type BuilderConfig struct {
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}))
+	doc, err := docs.New(
+		docs.FromConfig(&BuilderConfig{}),
+		docs.FromFunc(b.BuildFunc()),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +69,6 @@ build {
 }
 `)
 
-	doc.Input("component.Source")
 	doc.Output("docker.Image")
 
 	doc.SetField(

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -396,7 +396,7 @@ type ClientConfig struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&PlatformConfig{}))
+	doc, err := docs.New(docs.FromConfig(&PlatformConfig{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}
@@ -462,12 +462,12 @@ deploy {
 		docs.Summary(
 			"this config block can be used to configure",
 			"a remote Docker engine.",
-			"by default Waypoint will attempt to discover this configuration",
+			"By default Waypoint will attempt to discover this configuration",
 			"using the environment variables:",
-			"DOCKER_HOST to set the url to the docker server.",
-			"DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.",
-			"DOCKER_CERT_PATH to load the TLS certificates from.",
-			"DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.",
+			"`DOCKER_HOST` to set the url to the docker server.",
+			"`DOCKER_API_VERSION` to set the version of the API to reach, leave empty for latest.",
+			"`DOCKER_CERT_PATH` to load the TLS certificates from.",
+			"`DOCKER_TLS_VERIFY` to enable or disable TLS verification, off by default.",
 		),
 	)
 

--- a/builtin/docker/pull/builder.go
+++ b/builtin/docker/pull/builder.go
@@ -50,7 +50,7 @@ type BuilderConfig struct {
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}))
+	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}), docs.FromFunc(b.BuildFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/docker/registry.go
+++ b/builtin/docker/registry.go
@@ -160,7 +160,7 @@ type Config struct {
 }
 
 func (r *Registry) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(r.PushFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/files/builder.go
+++ b/builtin/files/builder.go
@@ -38,7 +38,7 @@ func (b *Builder) Build(
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}))
+	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}), docs.FromFunc(b.BuildFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/files/registry.go
+++ b/builtin/files/registry.go
@@ -56,7 +56,7 @@ type Config struct {
 }
 
 func (r *Registry) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(r.PushFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/google/cloudrun/platform.go
+++ b/builtin/google/cloudrun/platform.go
@@ -431,7 +431,7 @@ func (p *Platform) Destroy(
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -493,7 +493,7 @@ type Config struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/netlify/platform.go
+++ b/builtin/netlify/platform.go
@@ -273,7 +273,7 @@ type Config struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -242,7 +242,7 @@ type AuthConfig struct {
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&Config{}))
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -226,7 +226,7 @@ func (b *Builder) Build(
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
-	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}))
+	doc, err := docs.New(docs.FromConfig(&BuilderConfig{}), docs.FromFunc(b.BuildFunc()))
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20200814140818-42de70466a9d
 	github.com/hashicorp/vault/api v1.0.5-0.20190909201928-35325e2c3262
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201173616-e7b892b19c32
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20200814140818-42de70466a9d
 	github.com/hashicorp/vault/api v1.0.5-0.20190909201928-35325e2c3262
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201114234355-ae0a7cdaa129
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2 h1:b65cSyZq
 github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201114234355-ae0a7cdaa129 h1:/uyU8vcqF2eit1wyqUUhjYLANV1IJ7HCZfGxx+dum10=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201114234355-ae0a7cdaa129/go.mod h1:/TtZN4o0eunv4v50BF8kEVDnADsk8v8a12e8Y8SE+K8=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363 h1:HkqjX7yw2NDHHEH4z60iqAkxb3zPbJgI+auM+fv2N5Y=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363/go.mod h1:+T5ugu6Dxv3uSe3EM5xBQ7u4Y1Em6zhHC0KTutBst84=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d h1:W+SIwDdl3+jXWeidYySAgzytE3piq6GumXeBjFBG67c=
@@ -934,8 +934,6 @@ github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YB
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/go-glint v0.0.0-20200930000256-df5e721f3258 h1:x7Z92EayV/P8BlKJnZpij7MUcqcCBah0YauEKyOIxow=
-github.com/mitchellh/go-glint v0.0.0-20200930000256-df5e721f3258/go.mod h1:NrJbv11op7A0gjSLtfvzm74YkVKRS24KxucwneYUX4M=
 github.com/mitchellh/go-glint v0.0.0-20201015034436-f80573c636de h1:zEtM2uLDYhUgehFO/lhsepZLz5TZpysDuwrezt+/w4k=
 github.com/mitchellh/go-glint v0.0.0-20201015034436-f80573c636de/go.mod h1:9X3rpO+I3yuihb6p8ktF8qWxROGwij9DBW/czUsMlhk=
 github.com/mitchellh/go-grpc-net-conn v0.0.0-20200427190222-eb030e4876f0 h1:oZuel4h7224ILBLg2SlTxdaMYXDyqcVfL4Cg1PJQHZs=

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2 h1:b65cSyZq
 github.com/hashicorp/vault/sdk v0.1.14-0.20190909201848-e0fbf9b652e2/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363 h1:HkqjX7yw2NDHHEH4z60iqAkxb3zPbJgI+auM+fv2N5Y=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201021711-a305f8522363/go.mod h1:+T5ugu6Dxv3uSe3EM5xBQ7u4Y1Em6zhHC0KTutBst84=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201173616-e7b892b19c32 h1:kAHmq49dSAb9tqTqC6PKq+fCf61OQWW4KYGnvFCJK40=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20201201173616-e7b892b19c32/go.mod h1:+T5ugu6Dxv3uSe3EM5xBQ7u4Y1Em6zhHC0KTutBst84=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d h1:W+SIwDdl3+jXWeidYySAgzytE3piq6GumXeBjFBG67c=

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -202,12 +202,15 @@ func (c *AppDocsCommand) mdxFormat(name, ct string, doc *docs.Documentation) {
 	}
 
 	hasRequired := false
-	fmt.Fprintf(w, "\n### Required Variables\n")
+	fmt.Fprintf(w, "\n### Required Parameters\n")
 	for _, f := range doc.Fields() {
 		if f.Optional {
 			continue
 		}
-		hasRequired = true
+		if !hasRequired {
+			hasRequired = true
+			fmt.Fprintf(w, "\nThese parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.\n")
+		}
 
 		fmt.Fprintf(w, "\n#### %s\n\n", f.Field)
 
@@ -234,12 +237,15 @@ func (c *AppDocsCommand) mdxFormat(name, ct string, doc *docs.Documentation) {
 	}
 
 	hasOptional := false
-	fmt.Fprintf(w, "\n### Optional Variables\n")
+	fmt.Fprintf(w, "\n### Optional Parameters\n")
 	for _, f := range doc.Fields() {
 		if !f.Optional {
 			continue
 		}
-		hasOptional = true
+		if !hasOptional {
+			hasOptional = true
+			fmt.Fprintf(w, "\nThese parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.\n")
+		}
 
 		fmt.Fprintf(w, "\n#### %s\n\n", f.Field)
 

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -233,7 +233,7 @@ func (c *AppDocsCommand) mdxFormat(name, ct string, doc *docs.Documentation) {
 		}
 	}
 	if !hasRequired {
-		fmt.Fprintf(w, "\nThis plugin has no required variables.\n")
+		fmt.Fprintf(w, "\nThis plugin has no required parameters.\n")
 	}
 
 	hasOptional := false
@@ -268,7 +268,7 @@ func (c *AppDocsCommand) mdxFormat(name, ct string, doc *docs.Documentation) {
 		}
 	}
 	if !hasOptional {
-		fmt.Fprintf(w, "\nThis plugin has no optional variables.\n")
+		fmt.Fprintf(w, "\nThis plugin has no optional parameters.\n")
 	}
 
 	if fields := doc.TemplateFields(); len(fields) > 0 {

--- a/website/content/partials/components/builder-aws-alb.mdx
+++ b/website/content/partials/components/builder-aws-alb.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-aws-alb.mdx
+++ b/website/content/partials/components/builder-aws-alb.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-alb (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-aws-alb.mdx
+++ b/website/content/partials/components/builder-aws-alb.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-aws-ami.mdx
+++ b/website/content/partials/components/builder-aws-ami.mdx
@@ -6,7 +6,15 @@ Search for and return an existing AMI.
 
 - Output: **ami.Image**
 
-### Variables
+### Required Variables
+
+#### region
+
+The AWS region to search in.
+
+- Type: **string**
+
+### Optional Variables
 
 #### filters
 
@@ -31,8 +39,10 @@ The set of AMI owners to restrict the search to.
 - Type: **[]string**
 - **Optional**
 
-#### region
+### Output Attributes
 
-The AWS region to search in.
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### image
 
 - Type: **string**

--- a/website/content/partials/components/builder-aws-ami.mdx
+++ b/website/content/partials/components/builder-aws-ami.mdx
@@ -6,7 +6,9 @@ Search for and return an existing AMI.
 
 - Output: **ami.Image**
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### region
 
@@ -14,7 +16,9 @@ The AWS region to search in.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### filters
 

--- a/website/content/partials/components/builder-aws-ec2.mdx
+++ b/website/content/partials/components/builder-aws-ec2.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-aws-ec2.mdx
+++ b/website/content/partials/components/builder-aws-ec2.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ec2 (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-aws-ec2.mdx
+++ b/website/content/partials/components/builder-aws-ec2.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-aws-ecr.mdx
+++ b/website/content/partials/components/builder-aws-ecr.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecr (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-aws-ecr.mdx
+++ b/website/content/partials/components/builder-aws-ecr.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-aws-ecr.mdx
+++ b/website/content/partials/components/builder-aws-ecr.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-aws-ecs.mdx
+++ b/website/content/partials/components/builder-aws-ecs.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecs (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-aws-ecs.mdx
+++ b/website/content/partials/components/builder-aws-ecs.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-aws-ecs.mdx
+++ b/website/content/partials/components/builder-aws-ecs.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-azure-container-instance.mdx
+++ b/website/content/partials/components/builder-azure-container-instance.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-azure-container-instance.mdx
+++ b/website/content/partials/components/builder-azure-container-instance.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-azure-container-instance.mdx
+++ b/website/content/partials/components/builder-azure-container-instance.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## azure-container-instance (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-docker-pull.mdx
+++ b/website/content/partials/components/builder-docker-pull.mdx
@@ -25,7 +25,9 @@ build {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### image
 
@@ -41,7 +43,9 @@ The tag of the image to pull.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### disable_entrypoint
 

--- a/website/content/partials/components/builder-docker-pull.mdx
+++ b/website/content/partials/components/builder-docker-pull.mdx
@@ -14,7 +14,34 @@ push it to the specified registry.
 - Input: **component.Source**
 - Output: **docker.Image**
 
-### Variables
+### Examples
+
+```hcl
+build {
+  use "docker-pull" {
+    image = "gcr.io/my-project/my-image"
+    tag   = "abcd1234"
+  }
+}
+```
+
+### Required Variables
+
+#### image
+
+The image to pull.
+
+This should NOT include the tag (the value following the ':' in a Docker image). Use `tag` to define the image tag.
+
+- Type: **string**
+
+#### tag
+
+The tag of the image to pull.
+
+- Type: **string**
+
+### Optional Variables
 
 #### disable_entrypoint
 
@@ -34,29 +61,14 @@ WARNING: be very careful to not leak the authentication information by hardcodin
 - Type: **string**
 - **Optional**
 
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
 #### image
-
-The image to pull.
-
-This should NOT include the tag (the value following the ':' in a Docker image). Use `tag` to define the image tag.
 
 - Type: **string**
 
 #### tag
 
-The tag of the image to pull.
-
 - Type: **string**
-
-### Examples
-
-```
-
-build {
-  use "docker-pull" {
-    image = "gcr.io/my-project/my-image"
-    tag   = "abcd1234"
-  }
-}
-
-```

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -4,10 +4,24 @@ Build a Docker image using the `docker build` protocol.
 
 ### Interface
 
-- Input: **component.Source**
 - Output: **docker.Image**
 
-### Variables
+### Examples
+
+```hcl
+build {
+  use "docker" {
+	buildkit    = false
+	disable_entrypoint = false
+  }
+}
+```
+
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### buildkit
 
@@ -27,18 +41,21 @@ The entrypoint binary is what provides extended functionality such as logs and e
 
 #### dockerfile
 
+The path to the Dockerfile.
+
+Set this when the Dockerfile is not APP-PATH/Dockerfile.
+
 - Type: **string**
 - **Optional**
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-build {
-  use "docker" {
-	buildkit    = false
-	disable_entrypoint = false
-  }
-}
+#### image
 
-```
+- Type: **string**
+
+#### tag
+
+- Type: **string**

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -17,11 +17,13 @@ build {
 }
 ```
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### buildkit
 

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -19,7 +19,7 @@ build {
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/builder-exec.mdx
+++ b/website/content/partials/components/builder-exec.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-exec.mdx
+++ b/website/content/partials/components/builder-exec.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## exec (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-exec.mdx
+++ b/website/content/partials/components/builder-exec.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-files.mdx
+++ b/website/content/partials/components/builder-files.mdx
@@ -14,11 +14,11 @@ build {
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.
 
 ### Output Attributes
 

--- a/website/content/partials/components/builder-files.mdx
+++ b/website/content/partials/components/builder-files.mdx
@@ -12,11 +12,11 @@ build {
 }
 ```
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.
 

--- a/website/content/partials/components/builder-files.mdx
+++ b/website/content/partials/components/builder-files.mdx
@@ -4,14 +4,26 @@ Generates a value representing a path on disk.
 
 ### Interface
 
-### Variables
-
 ### Examples
 
-```
-
+```hcl
 build {
   use "files" {}
 }
-
 ```
+
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
+
+This plugin has no optional variables.
+
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### path
+
+- Type: **string**

--- a/website/content/partials/components/builder-google-cloud-run.mdx
+++ b/website/content/partials/components/builder-google-cloud-run.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-google-cloud-run.mdx
+++ b/website/content/partials/components/builder-google-cloud-run.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## google-cloud-run (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-google-cloud-run.mdx
+++ b/website/content/partials/components/builder-google-cloud-run.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-kubernetes.mdx
+++ b/website/content/partials/components/builder-kubernetes.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## kubernetes (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-kubernetes.mdx
+++ b/website/content/partials/components/builder-kubernetes.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-kubernetes.mdx
+++ b/website/content/partials/components/builder-kubernetes.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-netlify.mdx
+++ b/website/content/partials/components/builder-netlify.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-netlify.mdx
+++ b/website/content/partials/components/builder-netlify.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## netlify (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-netlify.mdx
+++ b/website/content/partials/components/builder-netlify.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-nomad.mdx
+++ b/website/content/partials/components/builder-nomad.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/builder-nomad.mdx
+++ b/website/content/partials/components/builder-nomad.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## nomad (builder)
 
 ### Interface
 

--- a/website/content/partials/components/builder-nomad.mdx
+++ b/website/content/partials/components/builder-nomad.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -27,7 +27,7 @@ build {
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -25,11 +25,13 @@ build {
 - Input: **pack.Image**
 - Output: **docker.Image**
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### builder
 

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -7,6 +7,17 @@ Create a Docker image using CloudNative Buildpacks.
 - Input: **component.Source**
 - Output: **pack.Image**
 
+### Examples
+
+```hcl
+build {
+  use "pack" {
+	builder     = "heroku/buildpacks:18"
+	disable_entrypoint = false
+  }
+}
+```
+
 ### Mappers
 
 #### Allow pack images to be used as normal docker images
@@ -14,7 +25,11 @@ Create a Docker image using CloudNative Buildpacks.
 - Input: **pack.Image**
 - Output: **docker.Image**
 
-### Variables
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### builder
 
@@ -42,15 +57,18 @@ These environment variables should not be run of the mill configuration variable
 - Type: **map[string]string**
 - **Optional**
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-build {
-  use "pack" {
-	builder     = "heroku/buildpacks:18"
-	disable_entrypoint = false
-  }
-}
+#### build_labels
 
-```
+- Type: **map[string]string**
+
+#### image
+
+- Type: **string**
+
+#### tag
+
+- Type: **string**

--- a/website/content/partials/components/platform-aws-alb.mdx
+++ b/website/content/partials/components/platform-aws-alb.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-alb (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-aws-alb.mdx
+++ b/website/content/partials/components/platform-aws-alb.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-aws-alb.mdx
+++ b/website/content/partials/components/platform-aws-alb.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/platform-aws-ami.mdx
+++ b/website/content/partials/components/platform-aws-ami.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-aws-ami.mdx
+++ b/website/content/partials/components/platform-aws-ami.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ami (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-aws-ami.mdx
+++ b/website/content/partials/components/platform-aws-ami.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/platform-aws-ec2.mdx
+++ b/website/content/partials/components/platform-aws-ec2.mdx
@@ -7,7 +7,7 @@ Deploy the application into an AutoScaling Group on EC2.
 - Input: **ami.Image**
 - Output: **ec2.Deployment**
 
-### Variables
+### Required Variables
 
 #### count
 
@@ -16,6 +16,26 @@ How many EC2 instances to configure the ASG with.
 The fields here (desired, min, max) map directly to the typical ASG configuration.
 
 - Type: **\*ec2.countConfig**
+
+#### instance_type
+
+The EC2 instance type to deploy.
+
+- Type: **string**
+
+#### region
+
+The AWS region to deploy into.
+
+- Type: **string**
+
+#### service_port
+
+The TCP port on the instances that the app will be running on.
+
+- Type: **int**
+
+### Optional Variables
 
 #### extra_ports
 
@@ -26,24 +46,12 @@ These additional ports are usually used to allow secondary services, such as ssh
 - Type: **[]int**
 - **Optional**
 
-#### instance_type
-
-The EC2 instance type to deploy.
-
-- Type: **string**
-
 #### key
 
 The name of an SSH Key to associate with the instances, as preconfigured in EC2.
 
 - Type: **string**
 - **Optional**
-
-#### region
-
-The AWS region to deploy into.
-
-- Type: **string**
 
 #### security_groups
 
@@ -54,12 +62,6 @@ This plugin creates security groups that match the above ports by default. this 
 - Type: **[]string**
 - **Optional**
 
-#### service_port
-
-The TCP port on the instances that the app will be running on.
-
-- Type: **int**
-
 #### subnet
 
 The subnet to place the instances into.
@@ -67,3 +69,27 @@ The subnet to place the instances into.
 - Type: **string**
 - **Optional**
 - Default: a public subnet in the dafault VPC
+
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### public_dns
+
+- Type: **string**
+
+#### public_ip
+
+- Type: **string**
+
+#### region
+
+- Type: **string**
+
+#### service_name
+
+- Type: **string**
+
+#### target_group_arn
+
+- Type: **string**

--- a/website/content/partials/components/platform-aws-ec2.mdx
+++ b/website/content/partials/components/platform-aws-ec2.mdx
@@ -7,7 +7,9 @@ Deploy the application into an AutoScaling Group on EC2.
 - Input: **ami.Image**
 - Output: **ec2.Deployment**
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### count
 
@@ -35,7 +37,9 @@ The TCP port on the instances that the app will be running on.
 
 - Type: **int**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### extra_ports
 

--- a/website/content/partials/components/platform-aws-ecr.mdx
+++ b/website/content/partials/components/platform-aws-ecr.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-aws-ecr.mdx
+++ b/website/content/partials/components/platform-aws-ecr.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecr (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-aws-ecr.mdx
+++ b/website/content/partials/components/platform-aws-ecr.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -7,7 +7,18 @@ Deploy the application into an ECS cluster on AWS.
 - Input: **docker.Image**
 - Output: **ecs.Deployment**
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+  use "aws-ecs" {
+    region = "us-east-1"
+    memory = 512
+  }
+}
+```
+
+### Required Variables
 
 #### alb
 
@@ -34,6 +45,66 @@ When this is set, no ALB or Listener is created. Instead the application is conf
 Route53 ZoneID to create a DNS record into.
 
 Set along with alb.domain_name to have DNS automatically setup for the ALB.
+
+#### memory
+
+How much memory to assign to the container running the application.
+
+When running in Fargate, this must be one of a few values, specified in MB: 512, 1024, 2048, 3072, 4096, 5120, and up to 16384 in increments of 1024. The memory value also controls the possible values for cpu.
+
+- Type: **int**
+
+#### region
+
+The AWS region for the ECS cluster.
+
+- Type: **string**
+
+#### sidecar
+
+Additional container to run as a sidecar.
+
+This runs additional containers in addition to the main container that comes from the build phase.
+
+- Type: **[]\*ecs.ContainerConfig**
+
+#### sidecar.container_port
+
+The port number for the container.
+
+#### sidecar.host_port
+
+The port number on the host to reserve for the container.
+
+#### sidecar.image
+
+Image of the sidecar container.
+
+#### sidecar.memory
+
+The amount (in MiB) of memory to present to the container.
+
+#### sidecar.memory_reservation
+
+The soft limit (in MiB) of memory to reserve for the container.
+
+#### sidecar.name
+
+Name of the container.
+
+#### sidecar.protocol
+
+The protocol used for port mapping.
+
+#### sidecar.secrets
+
+Secrets to expose to this container.
+
+#### sidecar.static_environment
+
+Environment variables to expose to this container.
+
+### Optional Variables
 
 #### cluster
 
@@ -99,6 +170,14 @@ This controls if we should verify the ECS cluster in EC2 type. The cluster will 
 - Type: **bool**
 - **Optional**
 
+#### execution_role_name
+
+The name of the IAM role to use for ECS execution.
+
+- Type: **string**
+- **Optional**
+- Default: create a new exeuction IAM role based on the application name
+
 #### log_group
 
 The CloudWatchLogs log group to store container logs into.
@@ -107,35 +186,6 @@ The CloudWatchLogs log group to store container logs into.
 - **Optional**
 - Default: derived from the application name
 
-#### memory
-
-How much memory to assign to the container running the application.
-
-When running in Fargate, this must be one of a few values, specified in MB: 512, 1024, 2048, 3072, 4096, 5120, and up to 16384 in increments of 1024. The memory value also controls the possible values for cpu.
-
-- Type: **int**
-
-#### region
-
-The AWS region for the ECS cluster.
-
-- Type: **string**
-
-#### execution_role_name
-
-The name of the IAM role to use for ECS execution.
-
-- Type: **string**
-- **Optional**
-- Default: create a new IAM role based on the application name
-
-#### task_role_name
-
-The name of the task IAM role to assign.
-
-- Type: **string**
-- **Optional**
-
 #### secrets
 
 Secret key/values to pass to the ECS container.
@@ -143,49 +193,13 @@ Secret key/values to pass to the ECS container.
 - Type: **map[string]string**
 - **Optional**
 
-#### sidecar
+#### service_port
 
-Additional container to run as a sidecar.
+The TCP port that the application is listening on.
 
-This runs additional containers in addition to the main container that comes from the build phase.
-
-- Type: **[]\*ecs.ContainerConfig**
-
-#### sidecar.container_port
-
-The port number for the container.
-
-#### sidecar.host_port
-
-The port number on the host to reserve for the container.
-
-#### sidecar.image
-
-Image of the sidecar container.
-
-#### sidecar.memory
-
-The amount (in MiB) of memory to present to the container.
-
-#### sidecar.memory_reservation
-
-The soft limit (in MiB) of memory to reserve for the container.
-
-#### sidecar.name
-
-Name of the container.
-
-#### sidecar.protocol
-
-The protocol used for port mapping.
-
-#### sidecar.secrets
-
-Secrets to expose to this container.
-
-#### sidecar.static_environment
-
-Environment variables to expose to this container.
+- Type: **int64**
+- **Optional**
+- Default: 3000
 
 #### static_environment
 
@@ -202,15 +216,37 @@ The VPC subnets to use for the application.
 - **Optional**
 - Default: public subnets in the default VPC
 
-### Examples
+#### task_role_name
 
-```
+The name of the task IAM role to assign.
 
-deploy {
-  use "aws-ecs" {
-    region = "us-east-1"
-    memory = 512
-  }
-}
+- Type: **string**
+- **Optional**
 
-```
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### cluster
+
+- Type: **string**
+
+#### load_balancer_arn
+
+- Type: **string**
+
+#### service_arn
+
+- Type: **string**
+
+#### target_group_arn
+
+- Type: **string**
+
+#### task_arn
+
+- Type: **string**
+
+#### url
+
+- Type: **string**

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -18,7 +18,9 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### alb
 
@@ -104,7 +106,9 @@ Secrets to expose to this container.
 
 Environment variables to expose to this container.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### cluster
 

--- a/website/content/partials/components/platform-azure-container-instance.mdx
+++ b/website/content/partials/components/platform-azure-container-instance.mdx
@@ -35,7 +35,9 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### capacity
 
@@ -83,7 +85,9 @@ The path to mount the volume to in the container.
 
 Specify if the volume is read only.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### location
 

--- a/website/content/partials/components/platform-azure-container-instance.mdx
+++ b/website/content/partials/components/platform-azure-container-instance.mdx
@@ -7,7 +7,35 @@ Deploy a container to Azure Container Instances.
 - Input: **docker.Image**
 - Output: **aci.Deployment**
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+  use "azure-container-instance" {
+    resource_group = "resource-group-name"
+    location       = "westus"
+    ports          = [8080]
+
+    capacity {
+      memory = "1024"
+      cpu_count = 4
+    }
+
+    volume {
+      name = "vol1"
+      path = "/consul"
+      read_only = true
+
+      git_repo {
+        repository = "https://github.com/hashicorp/consul"
+        revision = "v1.8.3"
+      }
+    }
+  }
+}
+```
+
+### Required Variables
 
 #### capacity
 
@@ -23,50 +51,11 @@ Number of CPUs to allocate the container, min 1, max based on resource availabil
 
 Memory to allocate the container specified in MB, min 1024, max based on resource availability of the region.
 
-#### location
-
-The resource location to deploy the container instance to.
-
-- Type: **string**
-- **Optional**
-
-#### managed_identity
-
-The managed identity assigned to the container group.
-
-- Type: **string**
-- **Optional**
-
-#### ports
-
-The ports the container is listening on, the first port in this list will be used by the entrypoint binary to direct traffic to your application.
-
-- Type: **[]int**
-- **Optional**
-
 #### resource_group
 
 The resource group to deploy the container to.
 
 - Type: **string**
-
-#### static_environment
-
-Environment variables to control broad modes of the application.
-
-Environment variables that are meant to configure the application in a static way. This might be control an image that has multiple modes of operation, selected via environment variable. Most configuration should use the waypoint config commands.
-
-- Type: **map[string]string**
-- **Optional**
-
-#### subscription_id
-
-The Azure subscription id.
-
-If not set uses the environment variable AZURE_SUBSCRIPTION_ID.
-
-- Type: **string**
-- **Optional**
 
 #### volume
 
@@ -94,32 +83,59 @@ The path to mount the volume to in the container.
 
 Specify if the volume is read only.
 
-### Examples
+### Optional Variables
 
-```
+#### location
 
-deploy {
-  use "azure-container-instance" {
-    resource_group = "resource-group-name"
-    location       = "westus"
-    ports          = [8080]
+The resource location to deploy the container instance to.
 
-    capacity {
-      memory = "1024"
-      cpu_count = 4
-    }
+- Type: **string**
+- **Optional**
 
-    volume {
-      name = "vol1"
-      path = "/consul"
-      read_only = true
+#### managed_identity
 
-      git_repo {
-        repository = "https://github.com/hashicorp/consul"
-        revision = "v1.8.3"
-      }
-    }
-  }
-}
+The managed identity assigned to the container group.
 
-```
+- Type: **string**
+- **Optional**
+
+#### ports
+
+The ports the container is listening on, the first port in this list will be used by the entrypoint binary to direct traffic to your application.
+
+- Type: **[]int**
+- **Optional**
+
+#### static_environment
+
+Environment variables to control broad modes of the application.
+
+Environment variables that are meant to configure the application in a static way. This might be control an image that has multiple modes of operation, selected via environment variable. Most configuration should use the waypoint config commands.
+
+- Type: **map[string]string**
+- **Optional**
+
+#### subscription_id
+
+The Azure subscription id.
+
+If not set uses the environment variable AZURE_SUBSCRIPTION_ID.
+
+- Type: **string**
+- **Optional**
+
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### container_group
+
+- Type: **\*aci.Deployment_ContainerGroup**
+
+#### id
+
+- Type: **string**
+
+#### url
+
+- Type: **string**

--- a/website/content/partials/components/platform-docker-pull.mdx
+++ b/website/content/partials/components/platform-docker-pull.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## docker-pull (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-docker-pull.mdx
+++ b/website/content/partials/components/platform-docker-pull.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-docker-pull.mdx
+++ b/website/content/partials/components/platform-docker-pull.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/platform-docker.mdx
+++ b/website/content/partials/components/platform-docker.mdx
@@ -7,15 +7,32 @@ Deploy a container to Docker, local or remote.
 - Input: **docker.Image**
 - Output: **docker.Deployment**
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+  use "docker" {
+	command      = ["ps"]
+	service_port = 3000
+	static_environment = {
+	  "environment": "production",
+	  "LOG_LEVEL": "debug"
+	}
+  }
+}
+```
+
+### Required Variables
 
 #### client_config
 
 Client config for remote Docker engine.
 
-This config block can be used to configure a remote Docker engine. by default Waypoint will attempt to discover this configuration using the environment variables: DOCKER_HOST to set the url to the docker server. DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest. DOCKER_CERT_PATH to load the TLS certificates from. DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
+This config block can be used to configure a remote Docker engine. By default Waypoint will attempt to discover this configuration using the environment variables: `DOCKER_HOST` to set the url to the docker server. `DOCKER_API_VERSION` to set the version of the API to reach, leave empty for latest. `DOCKER_CERT_PATH` to load the TLS certificates from. `DOCKER_TLS_VERIFY` to enable or disable TLS verification, off by default.
 
 - Type: **\*docker.ClientConfig**
+
+### Optional Variables
 
 #### command
 
@@ -59,19 +76,18 @@ These environment variables should not be run of the mill configuration variable
 - Type: **map[string]string**
 - **Optional**
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-deploy {
-  use "docker" {
-	command      = ["ps"]
-	service_port = 3000
-	static_environment = {
-	  "environment": "production",
-	  "LOG_LEVEL": "debug"
-	}
-  }
-}
+#### container
 
-```
+- Type: **string**
+
+#### id
+
+- Type: **string**
+
+#### name
+
+- Type: **string**

--- a/website/content/partials/components/platform-docker.mdx
+++ b/website/content/partials/components/platform-docker.mdx
@@ -22,7 +22,9 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### client_config
 
@@ -32,7 +34,9 @@ This config block can be used to configure a remote Docker engine. By default Wa
 
 - Type: **\*docker.ClientConfig**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### command
 

--- a/website/content/partials/components/platform-exec.mdx
+++ b/website/content/partials/components/platform-exec.mdx
@@ -53,7 +53,31 @@ are available:
 - Input: **exec.Input**
 - Output: **exec.Deployment**
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+  use "exec" {
+    command = ["docker", "run", "{{.Input.DockerImageFull}}"]
+  }
+}
+```
+
+### Required Variables
+
+#### template
+
+A stanza that declares that a file or directory should be template-rendered.
+
+- Type: **\*exec.ConfigTemplate**
+
+#### template.path
+
+The path to the file or directory to render as a template.
+
+Templating uses the following format: https://golang.org/pkg/text/template/ Available template variables depends on the input artifact.
+
+### Optional Variables
 
 #### command
 
@@ -72,27 +96,3 @@ This will default to the same working directory as the Waypoint execution.
 
 - Type: **string**
 - **Optional**
-
-#### template
-
-A stanza that declares that a file or directory should be template-rendered.
-
-- Type: **\*exec.ConfigTemplate**
-
-#### template.path
-
-The path to the file or directory to render as a template.
-
-Templating uses the following format: https://golang.org/pkg/text/template/ Available template variables depends on the input artifact.
-
-### Examples
-
-```
-
-deploy {
-  use "exec" {
-    command = ["docker", "run", "{{.Input.DockerImageFull}}"]
-  }
-}
-
-```

--- a/website/content/partials/components/platform-exec.mdx
+++ b/website/content/partials/components/platform-exec.mdx
@@ -63,7 +63,9 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### template
 
@@ -77,7 +79,9 @@ The path to the file or directory to render as a template.
 
 Templating uses the following format: https://golang.org/pkg/text/template/ Available template variables depends on the input artifact.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### command
 

--- a/website/content/partials/components/platform-files.mdx
+++ b/website/content/partials/components/platform-files.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-files.mdx
+++ b/website/content/partials/components/platform-files.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## files (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-files.mdx
+++ b/website/content/partials/components/platform-files.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/platform-google-cloud-run.mdx
+++ b/website/content/partials/components/platform-google-cloud-run.mdx
@@ -4,7 +4,61 @@ Deploy a container to Google Cloud Run.
 
 ### Interface
 
-### Variables
+### Examples
+
+```hcl
+project = "wpmini"
+
+app "wpmini" {
+  labels = {
+    "service" = "wpmini",
+    "env"     = "dev"
+  }
+
+  build {
+    use "pack" {}
+
+    registry {
+      use "docker" {
+        image = "gcr.io/waypoint-project-id/wpmini"
+        tag   = "latest"
+      }
+    }
+  }
+
+  deploy {
+    use "google-cloud-run" {
+      project  = "waypoint-project-id"
+      location = "europe-north1"
+
+      port = 5000
+
+      static_environment = {
+        "NAME" : "World"
+      }
+
+      capacity {
+        memory                     = 128
+        cpu_count                  = 2
+        max_requests_per_container = 10
+        request_timeout            = 300
+      }
+
+	  service_account_name = "cloudrun@waypoint-project-id.iam.gserviceaccount.com"
+
+      auto_scaling {
+        max = 10
+      }
+    }
+  }
+
+  release {
+    use "google-cloud-run" {}
+  }
+}
+```
+
+### Required Variables
 
 #### auto_scaling
 
@@ -45,6 +99,14 @@ GCP location, e.g. europe-north-1.
 
 - Type: **string**
 
+#### project
+
+GCP project ID where the Cloud Run instance will be deployed.
+
+- Type: **string**
+
+### Optional Variables
+
 #### port
 
 The port your application listens on.
@@ -52,11 +114,12 @@ The port your application listens on.
 - Type: **int**
 - **Optional**
 
-#### project
+#### service_account_name
 
-GCP project ID where the Cloud Run instance will be deployed.
+Specify a service account email that Cloud Run will use to run the service. You must have the `iam.serviceAccounts.actAs` permission on the service account.
 
 - Type: **string**
+- **Optional**
 
 #### static_environment
 
@@ -72,56 +135,26 @@ Is public unauthenticated access allowed for the Cloud Run instance?.
 - Type: **\*bool**
 - **Optional**
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-project = "wpmini"
+#### id
 
-app "wpmini" {
-  labels = {
-    "service" = "wpmini",
-    "env"     = "dev"
-  }
+- Type: **string**
 
-  build {
-    use "pack" {}
+#### region
 
-    registry {
-      use "docker" {
-        image = "gcr.io/waypoint-project-id/wpmini"
-        tag   = "latest"
-      }
-    }
-  }
+- Type: **string**
 
-  deploy {
-    use "google-cloud-run" {
-      project  = "waypoint-project-id"
-      location = "europe-north1"
+#### resource
 
-      port = 5000
+- Type: **\*cloudrun.Deployment_Resource**
 
-      static_environment = {
-        "NAME" : "World"
-      }
+#### revision_id
 
-      capacity {
-        memory                     = 128
-        cpu_count                  = 2
-        max_requests_per_container = 10
-        request_timeout            = 300
-      }
+- Type: **string**
 
-      auto_scaling {
-        max = 10
-      }
-    }
-  }
+#### url
 
-  release {
-    use "google-cloud-run" {}
-  }
-}
-
-```
+- Type: **string**

--- a/website/content/partials/components/platform-google-cloud-run.mdx
+++ b/website/content/partials/components/platform-google-cloud-run.mdx
@@ -58,7 +58,9 @@ app "wpmini" {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### auto_scaling
 
@@ -105,7 +107,9 @@ GCP project ID where the Cloud Run instance will be deployed.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### port
 

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -16,7 +16,7 @@ deploy "kubernetes" {
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -4,7 +4,21 @@ Deploy the application into a Kubernetes cluster using Deployment objects.
 
 ### Interface
 
-### Variables
+### Examples
+
+```hcl
+deploy "kubernetes" {
+	image_secret = "registry_secret"
+	replicas = 3
+	probe_path = "/_healthz"
+}
+```
+
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### annotations
 
@@ -24,7 +38,7 @@ The kubectl context to use, as defined in the kubeconfig file.
 
 #### image_secret
 
-Name of the Kubernetes secret to use for the image.
+Name of the Kubernetes secrete to use for the image.
 
 This references an existing secret, waypoint does not create this secret.
 
@@ -36,6 +50,15 @@ This references an existing secret, waypoint does not create this secret.
 Path to the kubeconfig file to use.
 
 By default uses from current user's home directory.
+
+- Type: **string**
+- **Optional**
+
+#### namespace
+
+Namespace to target deployment into.
+
+Namespace is the name of the Kubernetes namespace to apply the deployment in This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each.
 
 - Type: **string**
 - **Optional**
@@ -93,20 +116,14 @@ Environment variables that are meant to configure the application in a static wa
 - Type: **map[string]string**
 - **Optional**
 
-#### namespace
+### Output Attributes
 
-Namespace is the Kubernetes namespace for the deployment to target
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### id
+
 - Type: **string**
-- **Optional**
 
-### Examples
+#### name
 
-```
-
-deploy "kubernetes" {
-	image_secret = "registry_secret"
-	replicas = 3
-	probe_path = "/_healthz"
-}
-
-```
+- Type: **string**

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -14,11 +14,13 @@ deploy "kubernetes" {
 }
 ```
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### annotations
 

--- a/website/content/partials/components/platform-netlify.mdx
+++ b/website/content/partials/components/platform-netlify.mdx
@@ -4,7 +4,23 @@ Deploy a site to netlify.
 
 ### Interface
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+	use "netlify" {
+		site_id = "yourside-id"
+		site_name = "waypoint"
+		access_token = "asb123"
+	}
+}
+```
+
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### access_token
 
@@ -28,16 +44,14 @@ Name of your netlify site.
 - **Optional**
 - Default: waypoint application name
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-deploy {
-	use "netlify" {
-		site_id = "yourside-id"
-		site_name = "waypoint"
-		access_token = "asb123"
-	}
-}
+#### site_id
 
-```
+- Type: **string**
+
+#### url
+
+- Type: **string**

--- a/website/content/partials/components/platform-netlify.mdx
+++ b/website/content/partials/components/platform-netlify.mdx
@@ -18,7 +18,7 @@ deploy {
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/platform-netlify.mdx
+++ b/website/content/partials/components/platform-netlify.mdx
@@ -16,11 +16,13 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### access_token
 

--- a/website/content/partials/components/platform-nomad.mdx
+++ b/website/content/partials/components/platform-nomad.mdx
@@ -4,7 +4,36 @@ Deploy to a nomad cluster as a service using docker.
 
 ### Interface
 
-### Variables
+### Examples
+
+```hcl
+deploy {
+        use "nomad" {
+          region = "global"
+          datacenter = "dc1"
+          auth = {
+            username = "username"
+            password = "password"
+          }
+          static_environment = {
+            "environment": "production",
+            "LOG_LEVEL": "debug"
+          }
+          service_port = 3000
+          replicas = 1
+        }
+}
+```
+
+### Required Variables
+
+#### auth
+
+The credentials for docker registry.
+
+- Type: **\*nomad.AuthConfig**
+
+### Optional Variables
 
 #### datacenter
 
@@ -51,21 +80,14 @@ Environment variables to add to the job.
 - Type: **map[string]string**
 - **Optional**
 
-### Examples
+### Output Attributes
 
-```
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-deploy {
-	use "nomad" {
-	  region = "global"
-	  datacenter = "dc1"
-	  static_environment = {
-	    "environment": "production",
-	    "LOG_LEVEL": "debug"
-	  }
-	  service_port = 3000
-	  replicas = 1
-	}
-}
+#### id
 
-```
+- Type: **string**
+
+#### name
+
+- Type: **string**

--- a/website/content/partials/components/platform-nomad.mdx
+++ b/website/content/partials/components/platform-nomad.mdx
@@ -25,7 +25,9 @@ deploy {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### auth
 
@@ -33,7 +35,9 @@ The credentials for docker registry.
 
 - Type: **\*nomad.AuthConfig**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### datacenter
 

--- a/website/content/partials/components/platform-pack.mdx
+++ b/website/content/partials/components/platform-pack.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## pack (platform)
 
 ### Interface
 

--- a/website/content/partials/components/platform-pack.mdx
+++ b/website/content/partials/components/platform-pack.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/platform-pack.mdx
+++ b/website/content/partials/components/platform-pack.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-aws-alb.mdx
+++ b/website/content/partials/components/registry-aws-alb.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-aws-alb.mdx
+++ b/website/content/partials/components/registry-aws-alb.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-alb (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-aws-alb.mdx
+++ b/website/content/partials/components/registry-aws-alb.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-aws-ami.mdx
+++ b/website/content/partials/components/registry-aws-ami.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-aws-ami.mdx
+++ b/website/content/partials/components/registry-aws-ami.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ami (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-aws-ami.mdx
+++ b/website/content/partials/components/registry-aws-ami.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-aws-ec2.mdx
+++ b/website/content/partials/components/registry-aws-ec2.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-aws-ec2.mdx
+++ b/website/content/partials/components/registry-aws-ec2.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ec2 (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-aws-ec2.mdx
+++ b/website/content/partials/components/registry-aws-ec2.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-aws-ecr.mdx
+++ b/website/content/partials/components/registry-aws-ecr.mdx
@@ -7,13 +7,35 @@ Store a docker image within an Elastic Container Registry on AWS.
 - Input: **docker.Image**
 - Output: **docker.Image**
 
-### Variables
+### Examples
+
+```hcl
+registry {
+    use "aws-ecr" {
+      region = "us-east-1"
+      tag = "latest"
+    }
+}
+```
+
+### Required Variables
+
+#### tag
+
+The docker tag to assign to the new image.
+
+- Type: **string**
+
+### Optional Variables
 
 #### region
 
 The AWS region the ECR repository is in.
 
+If not set uses the environment variable AWS_REGION or AWS_REGION_DEFAULT.
+
 - Type: **string**
+- **Optional**
 
 #### repository
 
@@ -24,21 +46,14 @@ This defaults to waypoint- then the application name. The repository will be aut
 - Type: **string**
 - **Optional**
 
-#### tag
+### Output Attributes
 
-The docker tag to assign to the new image.
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### image
 
 - Type: **string**
 
-### Examples
+#### tag
 
-```
-
-registry {
-    use "aws-ecr" {
-      region = "us-east-1"
-      tag = "latest"
-    }
-}
-
-```
+- Type: **string**

--- a/website/content/partials/components/registry-aws-ecr.mdx
+++ b/website/content/partials/components/registry-aws-ecr.mdx
@@ -18,7 +18,9 @@ registry {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### tag
 
@@ -26,7 +28,9 @@ The docker tag to assign to the new image.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### region
 

--- a/website/content/partials/components/registry-aws-ecs.mdx
+++ b/website/content/partials/components/registry-aws-ecs.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-aws-ecs.mdx
+++ b/website/content/partials/components/registry-aws-ecs.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecs (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-aws-ecs.mdx
+++ b/website/content/partials/components/registry-aws-ecs.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-azure-container-instance.mdx
+++ b/website/content/partials/components/registry-azure-container-instance.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## azure-container-instance (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-azure-container-instance.mdx
+++ b/website/content/partials/components/registry-azure-container-instance.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-azure-container-instance.mdx
+++ b/website/content/partials/components/registry-azure-container-instance.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-docker-pull.mdx
+++ b/website/content/partials/components/registry-docker-pull.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-docker-pull.mdx
+++ b/website/content/partials/components/registry-docker-pull.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## docker-pull (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-docker-pull.mdx
+++ b/website/content/partials/components/registry-docker-pull.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-docker.mdx
+++ b/website/content/partials/components/registry-docker.mdx
@@ -7,7 +7,39 @@ Push a Docker image to a Docker compatible registry.
 - Input: **docker.Image**
 - Output: **docker.Image**
 
-### Variables
+### Examples
+
+```hcl
+build {
+  use "docker" {}
+  registry {
+    use "docker" {
+      image = "hashicorp/http-echo"
+      tag   = "latest"
+    }
+  }
+}
+```
+
+### Required Variables
+
+#### image
+
+The image to push the local image to, fully qualified.
+
+This value must be the fully qualified name to the image. for example: gcr.io/waypoint-demo/demo.
+
+- Type: **string**
+
+#### tag
+
+The tag for the new image.
+
+This is added to image to provide the full image reference.
+
+- Type: **string**
+
+### Optional Variables
 
 #### encoded_auth
 
@@ -18,14 +50,6 @@ WARNING: be very careful to not leak the authentication information by hardcodin
 - Type: **string**
 - **Optional**
 
-#### image
-
-The image to push the local image to, fully qualified.
-
-This value must be the fully qualified name to the image. for example: gcr.io/waypoint-demo/demo.
-
-- Type: **string**
-
 #### local
 
 If set, the image will only be tagged locally and not pushed to a remote repository.
@@ -33,26 +57,14 @@ If set, the image will only be tagged locally and not pushed to a remote reposit
 - Type: **bool**
 - **Optional**
 
-#### tag
+### Output Attributes
 
-The tag for the new image.
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
 
-This is added to image to provide the full image reference.
+#### image
 
 - Type: **string**
 
-### Examples
+#### tag
 
-```
-
-build {
-  use "docker" {}
-  registry {
-    use "docker" {
-      image = "hashicorp/http-echo"
-      tag   = "latest"
-    }
-  }
-}
-
-```
+- Type: **string**

--- a/website/content/partials/components/registry-docker.mdx
+++ b/website/content/partials/components/registry-docker.mdx
@@ -21,7 +21,9 @@ build {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### image
 
@@ -39,7 +41,9 @@ This is added to image to provide the full image reference.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### encoded_auth
 

--- a/website/content/partials/components/registry-exec.mdx
+++ b/website/content/partials/components/registry-exec.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## exec (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-exec.mdx
+++ b/website/content/partials/components/registry-exec.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-exec.mdx
+++ b/website/content/partials/components/registry-exec.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-files.mdx
+++ b/website/content/partials/components/registry-files.mdx
@@ -4,18 +4,9 @@ Copies files to a specific directory.
 
 ### Interface
 
-### Variables
-
-#### path
-
-The filesystem path to store the files into.
-
-- Type: **string**
-
 ### Examples
 
-```
-
+```hcl
 build {
   use "files" {}
   registry {
@@ -24,5 +15,24 @@ build {
 	}
   }
 }
-
 ```
+
+### Required Variables
+
+#### path
+
+The filesystem path to store the files into.
+
+- Type: **string**
+
+### Optional Variables
+
+This plugin has no optional variables.
+
+### Output Attributes
+
+Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).
+
+#### path
+
+- Type: **string**

--- a/website/content/partials/components/registry-files.mdx
+++ b/website/content/partials/components/registry-files.mdx
@@ -17,7 +17,9 @@ build {
 }
 ```
 
-### Required Variables
+### Required Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### path
 
@@ -25,7 +27,7 @@ The filesystem path to store the files into.
 
 - Type: **string**
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.
 

--- a/website/content/partials/components/registry-files.mdx
+++ b/website/content/partials/components/registry-files.mdx
@@ -29,7 +29,7 @@ The filesystem path to store the files into.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.
 
 ### Output Attributes
 

--- a/website/content/partials/components/registry-google-cloud-run.mdx
+++ b/website/content/partials/components/registry-google-cloud-run.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## google-cloud-run (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-google-cloud-run.mdx
+++ b/website/content/partials/components/registry-google-cloud-run.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-google-cloud-run.mdx
+++ b/website/content/partials/components/registry-google-cloud-run.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-kubernetes.mdx
+++ b/website/content/partials/components/registry-kubernetes.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-kubernetes.mdx
+++ b/website/content/partials/components/registry-kubernetes.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## kubernetes (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-kubernetes.mdx
+++ b/website/content/partials/components/registry-kubernetes.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-netlify.mdx
+++ b/website/content/partials/components/registry-netlify.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-netlify.mdx
+++ b/website/content/partials/components/registry-netlify.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## netlify (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-netlify.mdx
+++ b/website/content/partials/components/registry-netlify.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-nomad.mdx
+++ b/website/content/partials/components/registry-nomad.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-nomad.mdx
+++ b/website/content/partials/components/registry-nomad.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## nomad (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-nomad.mdx
+++ b/website/content/partials/components/registry-nomad.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/registry-pack.mdx
+++ b/website/content/partials/components/registry-pack.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## pack (registry)
 
 ### Interface
 

--- a/website/content/partials/components/registry-pack.mdx
+++ b/website/content/partials/components/registry-pack.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/registry-pack.mdx
+++ b/website/content/partials/components/registry-pack.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-aws-alb.mdx
+++ b/website/content/partials/components/releasemanager-aws-alb.mdx
@@ -14,11 +14,13 @@ Release target groups by attaching them to an ALB.
 - Input: **ec2.Deployment**
 - Output: **alb.TargetGroup**
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### certificate
 

--- a/website/content/partials/components/releasemanager-aws-alb.mdx
+++ b/website/content/partials/components/releasemanager-aws-alb.mdx
@@ -14,7 +14,11 @@ Release target groups by attaching them to an ALB.
 - Input: **ec2.Deployment**
 - Output: **alb.TargetGroup**
 
-### Variables
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### certificate
 

--- a/website/content/partials/components/releasemanager-aws-alb.mdx
+++ b/website/content/partials/components/releasemanager-aws-alb.mdx
@@ -16,7 +16,7 @@ Release target groups by attaching them to an ALB.
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/releasemanager-aws-ami.mdx
+++ b/website/content/partials/components/releasemanager-aws-ami.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-aws-ami.mdx
+++ b/website/content/partials/components/releasemanager-aws-ami.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ami (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-aws-ami.mdx
+++ b/website/content/partials/components/releasemanager-aws-ami.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-aws-ec2.mdx
+++ b/website/content/partials/components/releasemanager-aws-ec2.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-aws-ec2.mdx
+++ b/website/content/partials/components/releasemanager-aws-ec2.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ec2 (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-aws-ec2.mdx
+++ b/website/content/partials/components/releasemanager-aws-ec2.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-aws-ecr.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecr.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-aws-ecr.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecr.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecr (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-aws-ecr.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecr.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-aws-ecs.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecs.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## aws-ecs (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-aws-ecs.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecs.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-aws-ecs.mdx
+++ b/website/content/partials/components/releasemanager-aws-ecs.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-azure-container-instance.mdx
+++ b/website/content/partials/components/releasemanager-azure-container-instance.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-azure-container-instance.mdx
+++ b/website/content/partials/components/releasemanager-azure-container-instance.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## azure-container-instance (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-azure-container-instance.mdx
+++ b/website/content/partials/components/releasemanager-azure-container-instance.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-docker-pull.mdx
+++ b/website/content/partials/components/releasemanager-docker-pull.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## docker-pull (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-docker-pull.mdx
+++ b/website/content/partials/components/releasemanager-docker-pull.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-docker-pull.mdx
+++ b/website/content/partials/components/releasemanager-docker-pull.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-docker.mdx
+++ b/website/content/partials/components/releasemanager-docker.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-docker.mdx
+++ b/website/content/partials/components/releasemanager-docker.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## docker (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-docker.mdx
+++ b/website/content/partials/components/releasemanager-docker.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-exec.mdx
+++ b/website/content/partials/components/releasemanager-exec.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-exec.mdx
+++ b/website/content/partials/components/releasemanager-exec.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## exec (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-exec.mdx
+++ b/website/content/partials/components/releasemanager-exec.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-files.mdx
+++ b/website/content/partials/components/releasemanager-files.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-files.mdx
+++ b/website/content/partials/components/releasemanager-files.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## files (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-files.mdx
+++ b/website/content/partials/components/releasemanager-files.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-google-cloud-run.mdx
+++ b/website/content/partials/components/releasemanager-google-cloud-run.mdx
@@ -4,10 +4,10 @@ Manipulates the Cloud Run APIs to make deployments active.
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-google-cloud-run.mdx
+++ b/website/content/partials/components/releasemanager-google-cloud-run.mdx
@@ -6,8 +6,8 @@ Manipulates the Cloud Run APIs to make deployments active.
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -4,7 +4,11 @@ Manipulates the Kubernetes Service activate Deployments.
 
 ### Interface
 
-### Variables
+### Required Variables
+
+This plugin has no required variables.
+
+### Optional Variables
 
 #### context
 
@@ -31,6 +35,15 @@ If the Kubernetes Service is not a LoadBalancer and node_port is not set, then t
 - Type: **bool**
 - **Optional**
 
+#### namespace
+
+Namespace to create Service in.
+
+Namespace is the name of the Kubernetes namespace to create the deployment in This is useful to create Services in non-default namespaces without creating kubeconfig contexts for each.
+
+- Type: **string**
+- **Optional**
+
 #### node_port
 
 The TCP port that the Service should consume as a NodePort.
@@ -47,9 +60,3 @@ The TCP port that the application is listening on.
 - Type: **int**
 - **Optional**
 - Default: 80
-
-#### namespace
-
-Namespace is the Kubernetes namespace to create the service in
-- Type: **string**
-- **Optional**

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -4,11 +4,13 @@ Manipulates the Kubernetes Service activate Deployments.
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
+
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### context
 

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -6,7 +6,7 @@ Manipulates the Kubernetes Service activate Deployments.
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/releasemanager-netlify.mdx
+++ b/website/content/partials/components/releasemanager-netlify.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-netlify.mdx
+++ b/website/content/partials/components/releasemanager-netlify.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## netlify (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-netlify.mdx
+++ b/website/content/partials/components/releasemanager-netlify.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-nomad.mdx
+++ b/website/content/partials/components/releasemanager-nomad.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-nomad.mdx
+++ b/website/content/partials/components/releasemanager-nomad.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## nomad (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-nomad.mdx
+++ b/website/content/partials/components/releasemanager-nomad.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.

--- a/website/content/partials/components/releasemanager-pack.mdx
+++ b/website/content/partials/components/releasemanager-pack.mdx
@@ -4,8 +4,8 @@
 
 ### Required Parameters
 
-This plugin has no required variables.
+This plugin has no required parameters.
 
 ### Optional Parameters
 
-This plugin has no optional variables.
+This plugin has no optional parameters.

--- a/website/content/partials/components/releasemanager-pack.mdx
+++ b/website/content/partials/components/releasemanager-pack.mdx
@@ -1,6 +1,4 @@
-## google-cloud-run (releasemanager)
-
-Manipulates the Cloud Run APIs to make deployments active.
+## pack (releasemanager)
 
 ### Interface
 

--- a/website/content/partials/components/releasemanager-pack.mdx
+++ b/website/content/partials/components/releasemanager-pack.mdx
@@ -2,10 +2,10 @@
 
 ### Interface
 
-### Required Variables
+### Required Parameters
 
 This plugin has no required variables.
 
-### Optional Variables
+### Optional Parameters
 
 This plugin has no optional variables.


### PR DESCRIPTION
Paired with: https://github.com/hashicorp/waypoint-plugin-sdk/pull/7

This adds docs for the new template attributes that builders/registries/platforms can emit. These are called "output attributes" in the docs since we don't call them "template attributes" anywhere in the docs and that can be confusing with templating functions and so on.

I took the liberty while I was here to make some other improvements (I believe):

  * Example moved up right after the description.
  * Example is now HCL syntax highlighted.
  * Separated required from optional fields and show required first
  * Added some small help text (that is repeated since its autogenerated) at the top of sections so folks can know how to use this a bit better.
  * Renamed "variables" to "parameters". This is the word we use in the `use` docs and I think limits the confusion since we now have HCL vars and will one day have user vars and so on.

Looks like this:

![CleanShot 2020-11-30 at 18 45 06@2x](https://user-images.githubusercontent.com/1299/100690813-311d7300-333c-11eb-8758-88cc4dbbf0c3.png)
