### PR TITLE
Add Connect item to UI header

### DIFF
--- a/ui/app/components/actions/context.hbs
+++ b/ui/app/components/actions/context.hbs
@@ -1,0 +1,13 @@
+<span class="hint-link connect-link" {{on "click" this.toggleHint}}>
+  {{inline-svg "bolt" class="nav-icon"}}
+  Connect
+</span>
+
+{{#if this.hintIsVisible}}
+  <div class="cli-hint">
+    <p>Connect to your Waypoint instance by running the following command in the CLI</p>
+    <ContextCreate></ContextCreate>
+    <small><ExternalLink href="https://waypointproject.io/commands/context-create">Read more in our documentation</ExternalLink></small>
+  </div>
+  <div class="cli-hint-overlay" {{on "click" this.toggleHint}}></div>
+{{/if}}

--- a/ui/app/components/actions/context.hbs
+++ b/ui/app/components/actions/context.hbs
@@ -1,6 +1,6 @@
 <span class="hint-link connect-link" {{on "click" this.toggleHint}}>
   {{inline-svg "bolt" class="nav-icon"}}
-  Connect
+  CLI
 </span>
 
 {{#if this.hintIsVisible}}

--- a/ui/app/components/actions/context.ts
+++ b/ui/app/components/actions/context.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ActionsRelease extends Component {
+  @tracked hintIsVisible = false;
+
+  @action
+  toggleHint() {
+    if (this.hintIsVisible === true) {
+      return this.hintIsVisible = false;
+    } else {
+      return this.hintIsVisible = true;
+    };
+  }
+}

--- a/ui/app/components/actions/invite.hbs
+++ b/ui/app/components/actions/invite.hbs
@@ -1,4 +1,4 @@
-<span class="invite-link" {{on "click" this.toggleHint}}>
+<span class="hint-link" {{on "click" this.toggleHint}}>
   {{inline-svg "plus-circle-outline" class="nav-icon"}}
   Invite
 </span>

--- a/ui/app/components/header/index.hbs
+++ b/ui/app/components/header/index.hbs
@@ -9,7 +9,9 @@
       Documentation
     </ExternalLink>
     {{#if this.canLogout}}
-    <Actions::Invite />
+      <hr />
+      <Actions::Context />
+      <Actions::Invite />
     {{/if}}
     <hr />
     <Logout @canLogout={{this.canLogout}} />

--- a/ui/app/styles/_header.scss
+++ b/ui/app/styles/_header.scss
@@ -45,7 +45,7 @@
     a {
       display: flex;
       align-items: center;
-      margin-left: scale.$lg-2;
+      margin: 0 scale.$sm-2;
       text-decoration: none;
     }
 
@@ -55,11 +55,11 @@
       height: scale.$base;
     }
 
-    .invite-link {
+    .hint-link {
       display: flex;
       align-items: center;
       position: relative;
-      margin-left: scale.$lg-2;
+      margin: 0 scale.$sm-2;
       cursor: pointer;
 
       & + .cli-hint {
@@ -72,13 +72,19 @@
           margin: 0;
         }
       }
+
+      &.connect-link {
+        @media only screen and (max-width: 600px) {
+          display: none;
+        }
+      }
     }
 
     hr {
       height: scale.$lg-1;
       border: none;
       border-right: 1px solid rgb(var(--header-border));
-      margin: 0 scale.$lg-2;
+      margin: 0 scale.$sm-2;
     }
 
     .auth-link {
@@ -87,7 +93,7 @@
       background: none;
       border: none;
       padding: 0;
-      margin: 0;
+      margin: 0 0 0 scale.$sm-2;
       cursor: pointer;
       outline: 0;
       @include Typography.Interface(L);

--- a/ui/app/styles/_header.scss
+++ b/ui/app/styles/_header.scss
@@ -72,12 +72,6 @@
           margin: 0;
         }
       }
-
-      &.connect-link {
-        @media only screen and (max-width: 600px) {
-          display: none;
-        }
-      }
     }
 
     hr {
@@ -105,7 +99,9 @@
       margin-left: 0;
       margin: scale.$base 0 0;
 
-      hr, > a, .invite-link {
+      hr,
+      > a,
+      .invite-link {
         margin: 0 scale.$sm-2;
       }
 


### PR DESCRIPTION
Adds a new "Connect" button to the UI header that displays a popover containing the `context create` CLI command that is shown during the initial onboarding flow. This resolves #781.

#### New menu item for `Connect`

<img width="755" alt="Connect Link" src="https://user-images.githubusercontent.com/717867/100786866-ad7e8780-340a-11eb-9ead-aee505656e7a.png">

#### Displays a popover containing the `<ContextCreate>` component

<img width="755" alt="Connect Popover" src="https://user-images.githubusercontent.com/717867/100786872-afe0e180-340a-11eb-9f97-aeeeb0c5c0ec.png">
