### PR TITLE
website: add robots.txt for deploys from master

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .next
 out
 .env*.local
+public/robots.txt

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "git rev-parse --abbrev-ref HEAD",
+    "prebuild": "git name-rev --name-only $VERCEL_GIT_COMMIT_SHA",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF = 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
+    "prebuild": "echo $VERCEL_GIT_COMMIT_REF",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "prebuild": "git rev-parse --abbrev-ref HEAD",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF != 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
+    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF = 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "if [[ $VERCEL_ENV != 'production' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
+    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF = 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "git name-rev --name-only $VERCEL_GIT_COMMIT_SHA",
+    "prebuild": "if [[ $VERCEL_ENV != 'production' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "echo $VERCEL_GIT_COMMIT_REF",
+    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF != 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",


### PR DESCRIPTION
> 🙇‍♂️ i will squash all my tmp commits on merge. needed to test out some ENV variables on our build machines before i came to the correct ones.

this creates a `prebuild` script which runs prior to our `build` script on vercel's build machines, and injects a `robots.txt` file that prevents crawling for all deployments based on our `main` branch. 

this logic is a predecessor to creating a [tip.waypointproject.io](https://tip.waypointproject.io) branch domain, which will continuously build a preview of docs content on `main`. 

⚠️ at the time of this PR, the DNS is not yet in place for the `tip` subdomain. 

you can verify this worked via a [commit](https://github.com/hashicorp/waypoint/pull/865/commits/eacde5393f90764de11e54e665734d2c502f4de2) where i used the inverse of the conditional to test - https://waypoint-qq3wdzocj.vercel.app/robots.txt 