### PR TITLE
internal/config: support waypoint.hcl.json for HCL-flavored JSON syntax

### DIFF
--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -38,7 +38,7 @@ func (c *baseCommand) initConfig(optional bool) (*configpkg.Config, error) {
 
 // initConfigPath returns the configuration path to load.
 func (c *baseCommand) initConfigPath() (string, error) {
-	path, err := configpkg.FindPath("", "")
+	path, err := configpkg.FindPath("", "", true)
 	if err != nil {
 		return "", fmt.Errorf("Error looking for a Waypoint configuration: %s", err)
 	}

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -29,7 +29,16 @@ func FindPath(start, filename string) (string, error) {
 	}
 
 	for {
+		// Look for HCL syntax
 		path := filepath.Join(start, filename)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		// Look for JSON
+		path += ".json"
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		} else if !os.IsNotExist(err) {

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -15,7 +15,11 @@ const Filename = "waypoint.hcl"
 //
 // If start is empty, start will be the current working directory. If
 // filename is empty, it will default to the Filename constant.
-func FindPath(start, filename string) (string, error) {
+//
+// If searchParent is false, then we will not search parent directories
+// and require the Waypoint configuration file be directly in the "start"
+// directory.
+func FindPath(start, filename string, searchParent bool) (string, error) {
 	var err error
 	if start == "" {
 		start, err = os.Getwd()
@@ -43,6 +47,10 @@ func FindPath(start, filename string) (string, error) {
 			return path, nil
 		} else if !os.IsNotExist(err) {
 			return "", err
+		}
+
+		if !searchParent {
+			return "", nil
 		}
 
 		next := filepath.Dir(start)

--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -31,9 +31,9 @@ func (r *Runner) executeJob(
 ) (*pb.Job_Result, error) {
 	// Eventually we'll need to extract the data source. For now we're
 	// just building for local exec so it is the working directory.
-	path := configpkg.Filename
-	if wd != "" {
-		path = filepath.Join(wd, path)
+	path, err := configpkg.FindPath(wd, "", false)
+	if err != nil {
+		return nil, err
 	}
 
 	// Determine the evaluation context we'll be using


### PR DESCRIPTION
The way we load (using the hclsimple package) will automatically use the
JSON loader if it ends in ".json", we just never accepted ".json"
before.