### PR TITLE
Fix typo in ECS debug logging

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -672,7 +672,7 @@ func (p *Platform) Launch(
 		additionalContainers = append(additionalContainers, c)
 	}
 
-	L.Debug("registring task definition", "id", id)
+	L.Debug("registering task definition", "id", id)
 
 	var cpuShares int
 


### PR DESCRIPTION
Just a typo fix for "registring" -> "registering" in a debug statement.