### PR TITLE
Fix slice panic in serviceName

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -773,7 +773,7 @@ func (p *Platform) Launch(
 	}
 
 	s.Update("Registered Task definition: %s", family)
-	rand := id[len(id)-(31-len(app.App)):]
+	rand = id[:len(id)-len(app.App)]
 
 	serviceName := fmt.Sprintf("%s-%s", app.App, rand)
 

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -773,7 +773,7 @@ func (p *Platform) Launch(
 	}
 
 	s.Update("Registered Task definition: %s", family)
-	rand = id[:len(id)-len(app.App)]
+	rand := id[:len(id)-len(app.App)]
 
 	serviceName := fmt.Sprintf("%s-%s", app.App, rand)
 


### PR DESCRIPTION
Fix slice panic when app name is 5 characters or less. 