### PR TITLE
internal/server: fix send-after-close possibility in exec

### DIFF
--- a/internal/ceb/exec.go
+++ b/internal/ceb/exec.go
@@ -109,7 +109,11 @@ func (ceb *CEB) startExec(execConfig *pb.EntrypointConfig_Exec, env []string) {
 		for {
 			resp, err := client.Recv()
 			if err != nil {
-				log.Warn("error receiving from server stream", "err", err)
+				if err == io.EOF {
+					log.Info("exec stream ended by client")
+				} else {
+					log.Warn("error receiving from server stream", "err", err)
+				}
 				return
 			}
 

--- a/internal/server/singleprocess/service_entrypoint.go
+++ b/internal/server/singleprocess/service_entrypoint.go
@@ -264,6 +264,10 @@ func (s *service) EntrypointExecStream(
 	errCh := make(chan error, 1)
 	go func() {
 		defer cancel()
+
+		// Close the event channel we send to. This signals to the receiving
+		// side in StartExecStream (service_exec.go) that the entrypoint
+		// exited and it should also exit the client stream.
 		defer close(exec.EntrypointEventCh)
 
 		for {


### PR DESCRIPTION
I could never reproduce this bug nor write a test for it since it was
racey in nature but eyeball-tracing I belive this is the fix.

Prior to this change, there was a scenario that could exist where
EntrypointExecStream would exit before the recv goroutine. When
EntrypointExecStream exited, it would close the event channel that the
recv goroutine sends to. If the recv goroutine simultaneously had a
message buffered, it could try to send to the closed channel.

With this change, we moved the channel close into the recv goroutine.
This way there is never a send-after-close possibility.

The one important detail is that the event channel MUST ALWAYS be closed
when the EntrypointExecStream exits, because closing this channel
signals to the client side (typically a CLI) that they should exit
prematurely. Therefore, I moved the goroutine start up before we send
the Open message. This ensures that in every exit scenario, the
goroutine is running, recv should get an EOF, and we'll close the
channel.