### PR TITLE
Add waypoint-entrypoint to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,12 @@ WORKDIR /tmp/wp-src
 RUN apk add --no-cache make
 RUN go get github.com/kevinburke/go-bindata/...
 RUN --mount=type=cache,target=/root/.cache/go-build make bin
+RUN --mount=type=cache,target=/root/.cache/go-build make bin/entrypoint
 
 FROM hashicorp.jfrog.io/docker/alpine
 
 COPY --from=builder /tmp/wp-src/waypoint /usr/bin/waypoint
+COPY --from=builder /tmp/wp-src/waypoint-entrypoint /usr/bin/waypoint-entrypoint
 
 VOLUME ["/data"]
 

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ bin/windows: # create windows binaries
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint.exe ./cmd/waypoint
 
-.PHONY: bin/linux
-bin/linux: # create Linux binaries
-	GOOS=linux GOARCH=amd64 $(MAKE) bin
+.PHONY: bin/entrypoint
+bin/entrypoint: # create the entrypoint for the current platform
+	CGO_ENABLED=0 go build -tags assetsembedded -o ./waypoint-entrypoint ./cmd/waypoint-entrypoint
 
 .PHONY: test
 test: # run tests


### PR DESCRIPTION
This introduces a dedicated Make task to build the entrypoint and
modifies the Dockerfile to build it and copy it into our final image.