### PR TITLE
builtin/vault: nil check on freeport

### DIFF
--- a/builtin/vault/freeport/freeport.go
+++ b/builtin/vault/freeport/freeport.go
@@ -133,6 +133,10 @@ func checkFreedPortsOnce() {
 	mu.Lock()
 	defer mu.Unlock()
 
+	if pendingPorts == nil {
+		return
+	}
+
 	pending := pendingPorts.Len()
 	remove := make([]*list.Element, 0, pending)
 	for elem := pendingPorts.Front(); elem != nil; elem = elem.Next() {


### PR DESCRIPTION
I don't actually know how this happens and its not super important cause we only use this library for tests, but once in a very rare while we'd get a nil panic here so this fixes that.