### PR TITLE
Resolve polling flash in UI

### DIFF
--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -5,7 +5,7 @@ import { Ref, Deployment, Build, Release, Project } from 'waypoint-pb';
 import PollModelService from 'waypoint/services/poll-model';
 import ObjectProxy from '@ember/object/proxy';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
-import { resolve } from 'rsvp';
+import { resolve, hash } from 'rsvp';
 
 interface AppModelParams {
   app_id: string;
@@ -47,7 +47,7 @@ export default class App extends Route {
 
     let ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
-    return {
+    return hash({
       application: appRef.toObject(),
       deployments: ObjectPromiseProxy.create({
         promise: resolve(this.api.listDeployments(wsRef, appRef)),
@@ -58,7 +58,7 @@ export default class App extends Route {
       builds: ObjectPromiseProxy.create({
         promise: resolve(this.api.listBuilds(wsRef, appRef)),
       }),
-    };
+    });
   }
 
   afterModel() {


### PR DESCRIPTION
Issue: https://github.com/hashicorp/waypoint/issues/783 

I initially went down the rabbit hole of changing the polling pattern to avoid calling `model.refresh()`, and instead creating an Ember Concurrency task to wrap the model fetching instead. 

Then while debugging I realized the issue was probably caused by the model resolving partial data (creating "gaps" in the state as the UI refreshes). It turn out that using [`rsvp.hash`](https://api.emberjs.com/ember/release/classes/rsvp/methods/hash?anchor=hash), to wait for all promises to resolve, works just fine. 