### PR TITLE
builtin/exec: Respect `dir` if defined for deploy command

### DIFF
--- a/builtin/exec/platform.go
+++ b/builtin/exec/platform.go
@@ -120,7 +120,11 @@ func (p *Platform) Deploy(
 	var cmd exec.Cmd
 	cmd.Path = args[0]
 	cmd.Args = args
-	cmd.Dir = src.Path
+	if p.config.Dir != "" {
+		cmd.Dir = p.config.Dir
+	} else {
+		cmd.Dir = src.Path
+	}
 	cmd.Stdout = s.TermOutput()
 	cmd.Stderr = cmd.Stdout
 


### PR DESCRIPTION
This commit ensures that the command configured to run for `exec`
respects the `dir` config option if defined, otherwise it will go back
to the default which is the src path.

Fixes #903 