### PR TITLE
Flag to install runner, support installing runner with Docker

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -94,6 +94,10 @@ type baseCommand struct {
 
 	// options passed in at the global level
 	globalOptions []Option
+
+	// autoServer will be set to true if an automatic in-memory server
+	// is allowd.
+	autoServer bool
 }
 
 // Close cleans up any resources that the command created. This should be
@@ -127,6 +131,9 @@ func (c *baseCommand) Init(opts ...Option) error {
 	for _, opt := range opts {
 		opt(&baseCfg)
 	}
+
+	// Set some basic internal fields
+	c.autoServer = !baseCfg.NoAutoServer
 
 	// Init our UI first so we can write output to the user immediately.
 	ui := baseCfg.UI

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -92,7 +92,7 @@ func (c *baseCommand) initClient() (*clientpkg.Project, error) {
 		clientpkg.WithLabels(c.flagLabels),
 		clientpkg.WithSourceOverrides(c.flagRemoteSource),
 	}
-	if !c.flagRemote {
+	if !c.flagRemote && c.autoServer {
 		opts = append(opts, clientpkg.WithLocal())
 	}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -67,7 +67,10 @@ func (c *InstallCommand) Run(args []string) int {
 		return 1
 	}
 
-	contextConfig, advertiseAddr, httpAddr, err = p.Install(ctx, c.ui, log)
+	result, err := p.Install(ctx, &serverinstall.InstallOpts{
+		Log: log,
+		UI:  c.ui,
+	})
 	if err != nil {
 		c.ui.Output(
 			"Error installing server into %s: %s", c.platform, clierrors.Humanize(err),
@@ -76,6 +79,10 @@ func (c *InstallCommand) Run(args []string) int {
 
 		return 1
 	}
+
+	contextConfig = result.Context
+	advertiseAddr = result.AdvertiseAddr
+	httpAddr = result.HTTPAddr
 
 	sg := c.ui.StepGroup()
 	defer sg.Wait()
@@ -235,7 +242,7 @@ func (c *InstallCommand) Help() string {
 Usage: waypoint server install [options]
 Alias: waypoint install
 
-	Installs a Waypoint server to an existing platform. The platform should be 
+	Installs a Waypoint server to an existing platform. The platform should be
 	specified as kubernetes, nomad, or docker.
 
   By default, this will also automatically create a new default CLI context

--- a/internal/cli/option.go
+++ b/internal/cli/option.go
@@ -65,6 +65,14 @@ func WithUI(ui terminal.UI) Option {
 	}
 }
 
+// WithNoAutoServer configures the CLI to not automatically spin up
+// an in-memory server for this command.
+func WithNoAutoServer() Option {
+	return func(c *baseConfig) {
+		c.NoAutoServer = true
+	}
+}
+
 type baseConfig struct {
 	Args              []string
 	Flags             *flag.Sets
@@ -73,4 +81,7 @@ type baseConfig struct {
 	Client            bool
 	AppTargetRequired bool
 	UI                terminal.UI
+
+	// NoAutoServer is true if an in-memory server is not allowed.
+	NoAutoServer bool
 }

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -27,6 +27,7 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
+		WithNoAutoServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/serverconfig/config.go
+++ b/internal/serverconfig/config.go
@@ -29,7 +29,6 @@ type Client struct {
 
 // Env returns a slice of environment variables in key=value settings
 // that will authenticate to the server without a context set.
-// TODO: test
 func (c *Client) Env() []string {
 	result := []string{
 		"WAYPOINT_SERVER_ADDR=" + c.Address,

--- a/internal/serverconfig/config.go
+++ b/internal/serverconfig/config.go
@@ -1,5 +1,9 @@
 package serverconfig
 
+import (
+	"strconv"
+)
+
 // Client configures a client to connect to a server.
 type Client struct {
 	Address string `hcl:"address,attr"`
@@ -21,6 +25,23 @@ type Client struct {
 	// Note this will be stored plaintext on disk. You can also use the
 	// WAYPOINT_SERVER_TOKEN env var.
 	AuthToken string `hcl:"auth_token,optional"`
+}
+
+// Env returns a slice of environment variables in key=value settings
+// that will authenticate to the server without a context set.
+// TODO: test
+func (c *Client) Env() []string {
+	result := []string{
+		"WAYPOINT_SERVER_ADDR=" + c.Address,
+		"WAYPOINT_SERVER_TLS=" + strconv.FormatBool(c.Tls),
+		"WAYPOINT_SERVER_TLS_SKIP_VERIFY=" + strconv.FormatBool(c.TlsSkipVerify),
+	}
+
+	if c.RequireAuth {
+		result = append(result, "WAYPOINT_SERVER_TOKEN="+c.AuthToken)
+	}
+
+	return result
 }
 
 // Config is the configuration for the built-in server.

--- a/internal/serverconfig/config_test.go
+++ b/internal/serverconfig/config_test.go
@@ -1,0 +1,55 @@
+package serverconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientEnv(t *testing.T) {
+	listToMap := func(t *testing.T, vs []string) map[string]string {
+		result := map[string]string{}
+		for _, v := range vs {
+			idx := strings.Index(v, "=")
+			key := v[:idx]
+			value := v[idx+1:]
+			result[key] = value
+		}
+
+		return result
+	}
+
+	t.Run("no require auth, token set", func(t *testing.T) {
+		require := require.New(t)
+
+		env := listToMap(t, (&Client{
+			Address:       "foo",
+			Tls:           true,
+			TlsSkipVerify: true,
+			AuthToken:     "bar",
+		}).Env())
+
+		require.Equal(env["WAYPOINT_SERVER_ADDR"], "foo")
+		require.Equal(env["WAYPOINT_SERVER_TLS"], "true")
+		require.Equal(env["WAYPOINT_SERVER_TLS_SKIP_VERIFY"], "true")
+		require.Empty(env["WAYPOINT_SERVER_TOKEN"])
+	})
+
+	t.Run("require auth, token set", func(t *testing.T) {
+		require := require.New(t)
+
+		env := listToMap(t, (&Client{
+			Address:       "foo",
+			Tls:           true,
+			TlsSkipVerify: true,
+			AuthToken:     "bar",
+			RequireAuth:   true,
+		}).Env())
+
+		require.Equal(env["WAYPOINT_SERVER_ADDR"], "foo")
+		require.Equal(env["WAYPOINT_SERVER_TLS"], "true")
+		require.Equal(env["WAYPOINT_SERVER_TLS_SKIP_VERIFY"], "true")
+		require.Equal(env["WAYPOINT_SERVER_TOKEN"], "bar")
+	})
+}

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -531,6 +531,15 @@ func newService(c k8sConfig) (*apiv1.Service, error) {
 	}, nil
 }
 
+// InstallRunner implements Installer.
+func (i *K8sInstaller) InstallRunner(
+	ctx context.Context,
+	opts *InstallRunnerOpts,
+) error {
+	// TODO
+	return nil
+}
+
 func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 	set.BoolVar(&flag.BoolVar{
 		Name:   "k8s-advertise-internal",

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -54,8 +53,12 @@ type k8sConfig struct {
 // Install is a method of K8sInstaller and implements the Installer interface to
 // register a waypoint-server in a Kubernetes cluster
 func (i *K8sInstaller) Install(
-	ctx context.Context, ui terminal.UI, log hclog.Logger,
-) (*clicontext.Config, *pb.ServerConfig_AdvertiseAddr, string, error) {
+	ctx context.Context,
+	opts *InstallOpts,
+) (*InstallResults, error) {
+	ui := opts.UI
+	log := opts.Log
+
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
@@ -78,7 +81,7 @@ func (i *K8sInstaller) Install(
 				"Error getting namespace from client config: %s", clierrors.Humanize(err),
 				terminal.WithErrorStyle(),
 			)
-			return nil, nil, "", err
+			return nil, err
 		}
 		i.config.namespace = namespace
 	}
@@ -89,7 +92,7 @@ func (i *K8sInstaller) Install(
 			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	clientset, err := kubernetes.NewForConfig(clientconfig)
@@ -98,7 +101,7 @@ func (i *K8sInstaller) Install(
 			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	// If this is kind, then we want to warn the user that they need
@@ -122,7 +125,7 @@ func (i *K8sInstaller) Install(
 				"Error reading Kubernetes secret file: %s", clierrors.Humanize(err),
 				terminal.WithErrorStyle(),
 			)
-			return nil, nil, "", err
+			return nil, err
 		}
 
 		var secretData struct {
@@ -137,7 +140,7 @@ func (i *K8sInstaller) Install(
 				"Error reading Kubernetes secret file: %s", clierrors.Humanize(err),
 				terminal.WithErrorStyle(),
 			)
-			return nil, nil, "", err
+			return nil, err
 		}
 
 		if secretData.Metadata.Name == "" {
@@ -145,7 +148,7 @@ func (i *K8sInstaller) Install(
 				"Invalid secret, no metadata.name",
 				terminal.WithErrorStyle(),
 			)
-			return nil, nil, "", err
+			return nil, err
 		}
 
 		i.config.imagePullSecret = secretData.Metadata.Name
@@ -163,7 +166,7 @@ func (i *K8sInstaller) Install(
 				terminal.WithErrorStyle(),
 			)
 
-			return nil, nil, "", err
+			return nil, err
 		}
 
 		s.Done()
@@ -193,7 +196,7 @@ func (i *K8sInstaller) Install(
 			"Error generating statefulset configuration: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	service, err := newService(i.config)
@@ -202,7 +205,7 @@ func (i *K8sInstaller) Install(
 			"Error generating service configuration: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	s.Update("Creating Kubernetes resources...")
@@ -243,10 +246,7 @@ func (i *K8sInstaller) Install(
 		return true, nil
 	})
 	if err != nil {
-		return nil, nil, "", fmt.Errorf(
-			"error waiting for statefulset ready: %s",
-			err,
-		)
+		return nil, err
 	}
 
 	s.Update("Kubernetes StatefulSet reporting ready")
@@ -359,15 +359,16 @@ func (i *K8sInstaller) Install(
 		return true, nil
 	})
 	if err != nil {
-		return nil, nil, "", fmt.Errorf(
-			"error waiting for service ready: %s",
-			err,
-		)
+		return nil, err
 	}
 
 	s.Done()
 
-	return &contextConfig, &advertiseAddr, httpAddr, err
+	return &InstallResults{
+		Context:       &contextConfig,
+		AdvertiseAddr: &advertiseAddr,
+		HTTPAddr:      httpAddr,
+	}, nil
 }
 
 // newStatefulSet takes in a k8sConfig and creates a new Waypoint Statefulset

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -278,6 +278,15 @@ func getHTTPFromAllocID(allocID string, client *api.Client) (string, error) {
 	return "", nil
 }
 
+// InstallRunner implements Installer.
+func (i *NomadInstaller) InstallRunner(
+	ctx context.Context,
+	opts *InstallRunnerOpts,
+) error {
+	// TODO
+	return nil
+}
+
 func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	set.StringMapVar(&flag.StringMapVar{
 		Name:   "nomad-annotate-service",

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
@@ -31,9 +30,11 @@ type nomadConfig struct {
 // Install is a method of NomadInstaller and implements the Installer interface to
 // register a waypoint-server job with a Nomad cluster
 func (i *NomadInstaller) Install(
-	ctx context.Context, ui terminal.UI, log hclog.Logger) (
-	*clicontext.Config, *pb.ServerConfig_AdvertiseAddr, string, error,
-) {
+	ctx context.Context,
+	opts *InstallOpts,
+) (*InstallResults, error) {
+	ui := opts.UI
+
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
@@ -43,7 +44,7 @@ func (i *NomadInstaller) Install(
 	// Build api client from environment
 	client, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	s.Update("Checking for existing Waypoint server...")
@@ -51,7 +52,7 @@ func (i *NomadInstaller) Install(
 	// Check if waypoint-server has already been deployed
 	jobs, _, err := client.Jobs().PrefixList("waypoint-server")
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 	var serverDetected bool
 	for _, j := range jobs {
@@ -78,14 +79,14 @@ func (i *NomadInstaller) Install(
 	if serverDetected {
 		allocs, _, err := client.Jobs().Allocations("waypoint-server", false, nil)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, err
 		}
 		if len(allocs) == 0 {
-			return nil, nil, "", fmt.Errorf("waypoint-server job found but no running allocations available")
+			return nil, fmt.Errorf("waypoint-server job found but no running allocations available")
 		}
 		serverAddr, err := getAddrFromAllocID(allocs[0].ID, client)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, err
 		}
 
 		s.Update("Detected existing Waypoint server")
@@ -95,7 +96,11 @@ func (i *NomadInstaller) Install(
 		clicfg.Server.Address = serverAddr
 		addr.Addr = serverAddr
 		httpAddr = serverAddr
-		return &clicfg, &addr, httpAddr, nil
+		return &InstallResults{
+			Context:       &clicfg,
+			AdvertiseAddr: &addr,
+			HTTPAddr:      httpAddr,
+		}, nil
 	}
 
 	s.Update("Installing Waypoint server to Nomad")
@@ -106,7 +111,7 @@ func (i *NomadInstaller) Install(
 
 	resp, _, err := client.Jobs().RegisterOpts(job, jobOpts, nil)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	s.Update("Waiting for allocation to be scheduled")
@@ -117,7 +122,7 @@ EVAL:
 
 	eval, meta, err := client.Evaluations().Info(resp.EvalID, qopts)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 	qopts.WaitIndex = meta.LastIndex
 	switch eval.Status {
@@ -128,9 +133,9 @@ EVAL:
 	case "failed", "canceled", "blocked":
 		s.Update("Nomad failed to schedule the waypoint-server")
 		s.Status(terminal.StatusError)
-		return nil, nil, "", fmt.Errorf("nomad evaluation did not transition to 'complete'")
+		return nil, fmt.Errorf("nomad evaluation did not transition to 'complete'")
 	default:
-		return nil, nil, "", fmt.Errorf("unknown eval status: %q", eval.Status)
+		return nil, fmt.Errorf("unknown eval status: %q", eval.Status)
 	}
 
 	var allocID string
@@ -138,11 +143,11 @@ EVAL:
 	for {
 		allocs, qmeta, err := client.Evaluations().Allocations(eval.ID, qopts)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, err
 		}
 		qopts.WaitIndex = qmeta.LastIndex
 		if len(allocs) == 0 {
-			return nil, nil, "", fmt.Errorf("no allocations found after evaluation completed")
+			return nil, fmt.Errorf("no allocations found after evaluation completed")
 		}
 
 		switch allocs[0].ClientStatus {
@@ -153,7 +158,7 @@ EVAL:
 			s.Update(fmt.Sprintf("Waiting for allocation %q to start", allocs[0].ID))
 			// retry
 		default:
-			return nil, nil, "", fmt.Errorf("allocation failed")
+			return nil, fmt.Errorf("allocation failed")
 
 		}
 
@@ -164,17 +169,17 @@ EVAL:
 		select {
 		case <-time.After(500 * time.Millisecond):
 		case <-ctx.Done():
-			return nil, nil, "", ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 
 	serverAddr, err := getAddrFromAllocID(allocID, client)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 	hAddr, err := getHTTPFromAllocID(allocID, client)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 	httpAddr = hAddr
 	addr.Addr = serverAddr
@@ -189,7 +194,11 @@ EVAL:
 	s.Update("Nomad allocation ready")
 	s.Done()
 
-	return &clicfg, &addr, httpAddr, nil
+	return &InstallResults{
+		Context:       &clicfg,
+		AdvertiseAddr: &addr,
+		HTTPAddr:      httpAddr,
+	}, nil
 }
 
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -13,8 +13,36 @@ import (
 // Installer is implemented by the server platforms and is responsible for managing
 // the installation of the Waypoint server.
 type Installer interface {
-	Install(ctx context.Context, ui terminal.UI, log hclog.Logger) (*clicontext.Config, *pb.ServerConfig_AdvertiseAddr, string, error)
+	// Install expects the Waypoint server to be installed.
+	Install(context.Context, *InstallOpts) (*InstallResults, error)
+
+	// InstallFlags is called prior to Install and allows the installer to
+	// specify flags for the install CLI. The flags should be prefixed with
+	// the platform name to avoid conflicts with other flags.
 	InstallFlags(*flag.Set)
+}
+
+// InstallOpts are the options sent to Installer.Install.
+type InstallOpts struct {
+	Log hclog.Logger
+	UI  terminal.UI
+}
+
+// InstallResults are the results expected for a successful Installer.Install.
+type InstallResults struct {
+	// Context is the connection context that can be used to connect from
+	// the CLI to the server. This will be used to establish an API client.
+	Context *clicontext.Config
+
+	// AdvertiseAddr is the configuration for the advertised address
+	// that entrypoints (deployed workloads) will use to communicate back
+	// to the server. This may be different from the context info because this
+	// may be a private address.
+	AdvertiseAddr *pb.ServerConfig_AdvertiseAddr
+
+	// HTTPAddr is the address to the HTTP listener on the server. This generally
+	// is reachable from the CLI immediately and not a private address.
+	HTTPAddr string
 }
 
 var Platforms = map[string]Installer{

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/serverconfig"
 )
 
 // Installer is implemented by the server platforms and is responsible for managing
@@ -15,6 +16,9 @@ import (
 type Installer interface {
 	// Install expects the Waypoint server to be installed.
 	Install(context.Context, *InstallOpts) (*InstallResults, error)
+
+	// InstallRunner expects a Waypoint runner to be installed.
+	InstallRunner(context.Context, *InstallRunnerOpts) error
 
 	// InstallFlags is called prior to Install and allows the installer to
 	// specify flags for the install CLI. The flags should be prefixed with
@@ -43,6 +47,26 @@ type InstallResults struct {
 	// HTTPAddr is the address to the HTTP listener on the server. This generally
 	// is reachable from the CLI immediately and not a private address.
 	HTTPAddr string
+}
+
+// InstallRunnerOpts are the options sent to Installer.InstallRunner.
+type InstallRunnerOpts struct {
+	Log hclog.Logger
+	UI  terminal.UI
+
+	// AuthToken is an auth token that can be used for this runner.
+	AuthToken string
+
+	// AdvertiseAddr is the advertised address configuration currently set
+	// for the server. This is likely the same information you want to use
+	// for the runner to connect to the server, but doesn't have to be.
+	AdvertiseAddr *pb.ServerConfig_AdvertiseAddr
+
+	// AdvertiseClient is the serverconfig.Client information for connecting
+	// to the server via the AdvertiseAddr information. This also has the auth
+	// token already set. This is provided as a convenience since it is common
+	// to build this immediately.
+	AdvertiseClient *serverconfig.Client
 }
 
 var Platforms = map[string]Installer{


### PR DESCRIPTION
This adds a flag to `waypoint install` to install a runner. This is a hidden flag for now for dev work. I need this to work on runner-related functionality more easily for this release. 😄 

The `waypoint install` command grabs an auth token for the runner and calls a new `InstallRunner` platform installer function. This way the platform can install the runner and the runner can connect & auth to the server for registration.

Only Docker support for installing runners in this PR since this is still experimental. The K8S/Nomad implementation is a noop but would definitely be done prior to a release.