### PR TITLE
cli: match k8s image pull policy to k8s defaults

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -577,7 +577,7 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-pull-policy",
 		Target:  &i.config.imagePullPolicy,
-		Usage:   "Set the pull policy ",
+		Usage:   "Set the pull policy for the Waypoint server image.",
 		Default: "",
 	})
 

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -578,7 +578,7 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 		Name:    "k8s-pull-policy",
 		Target:  &i.config.imagePullPolicy,
 		Usage:   "Set the pull policy ",
-		Default: "IfNotPresent",
+		Default: "",
 	})
 
 	set.StringVar(&flag.StringVar{

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -38,7 +38,7 @@ Usage: `waypoint install [options]`
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
 - `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-pull-policy=<string>` - Set the pull policy
+- `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -38,7 +38,7 @@ Usage: `waypoint server install [options]`
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
 - `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-pull-policy=<string>` - Set the pull policy
+- `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server.

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -14,6 +14,10 @@ One way to use the latest server is to [remove the existing
 server](/docs/troubleshooting#remove-the-waypoint-server) and then reinstall
 with `waypoint install`. Consider backing up `data.db` with `docker cp waypoint-server:/data/data.db ./data.db`, `kubectl cp waypoint-server-0:/data/data.db ./data.db` or similar.
 
+~> **Note:** Upgrading on a k8s cluster requires using the flag
+`-k8s-pull-policy=Always` when rerunning `waypoint install`. There is a known
+issue that will be resolved in 0.2.1.
+
 Waypoint is designed to be flexible and resilient when upgrading from
 one version to the next. We've carefully thought out an upgrade process
 so you can predict what will be involved when upgrading Waypoint.


### PR DESCRIPTION
This temporary note in our upgrade guide will help users work around the issue prior to the next release.