### PR TITLE
website: add http header to prevent tip indexing

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,4 +3,3 @@ node_modules
 .next
 out
 .env*.local
-public/robots.txt

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -5,12 +5,25 @@ const redirects = require('./redirects')
 console.log(`HASHI_ENV: ${process.env.HASHI_ENV}`)
 console.log(`NODE_ENV: ${process.env.NODE_ENV}`)
 
+// add a X-Robots-Tag noindex HTTP header
+// prevent indexing for tip.waypointproject.io
+let customHeaders = []
+if (process.env.VERCEL_GIT_COMMIT_REF == 'main') {
+  customHeaders.push({
+    source: '/:all*',
+    headers: [{ key: 'X-Robots-Tag', value: 'noindex' }],
+  })
+}
+
 module.exports = withHashicorp({
   defaultLayout: true,
   transpileModules: ['is-absolute-url', '@hashicorp/react-.*'],
 })({
   redirects() {
     return redirects
+  },
+  headers() {
+    return customHeaders
   },
   svgo: { plugins: [{ removeViewBox: false }] },
   env: {

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,6 @@
   },
   "main": "index.js",
   "scripts": {
-    "prebuild": "if [[ $VERCEL_GIT_COMMIT_REF = 'main' ]]; then echo 'User-agent: * Disallow: /' >> './public/robots.txt'; fi",
     "build": "node --max-old-space-size=2048 ./node_modules/.bin/next build",
     "export": "node --max-old-space-size=2048 ./node_modules/.bin/next export",
     "format": "next-hashicorp format",


### PR DESCRIPTION
this switches out our `robots.txt` approach for a `x-robots-tag` HTTP header to hide tip.waypointproject.io from search crawlers. in the near future, we'll clean up the implementation to be centrally managed by our `nextjs-scripts` package, but this direct implementation does the trick here. 