### PR TITLE
Fixes https://github.com/hashicorp/waypoint/issues/687

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -164,7 +164,7 @@ func (p *Platform) Deploy(
 	bindings := nat.PortMap{}
 	bindings[np] = []nat.PortBinding{
 		{
-			HostPort: "",
+			HostPort: port,
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/687 by specifying a host port (for Docker deployments) instead of an empty string (Which leads to random port assignment).