### PR TITLE
Refactor snapshot cli commands

### DIFF
--- a/internal/cli/server_config_set.go
+++ b/internal/cli/server_config_set.go
@@ -78,7 +78,7 @@ func (c *ServerConfigSetCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ServerConfigSetCommand) Synopsis() string {
-	return "Set the server online configuration."
+	return "Set the server online configuration"
 }
 
 func (c *ServerConfigSetCommand) Help() string {

--- a/internal/cli/snapshot_backup.go
+++ b/internal/cli/snapshot_backup.go
@@ -8,8 +8,8 @@ import (
 	"github.com/posener/complete"
 	sshterm "golang.org/x/crypto/ssh/terminal"
 
-	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/clisnapshot"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
 )
 
 type SnapshotBackupCommand struct {

--- a/internal/cli/snapshot_backup.go
+++ b/internal/cli/snapshot_backup.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/posener/complete"
 	sshterm "golang.org/x/crypto/ssh/terminal"
-	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/clisnapshot"
 )
 
 type SnapshotBackupCommand struct {
@@ -51,8 +51,6 @@ func (c *SnapshotBackupCommand) Run(args []string) int {
 		return 1
 	}
 
-	client := c.project.Client()
-
 	w, closer, err := c.initWriter(args)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open output: %s", err)
@@ -63,45 +61,12 @@ func (c *SnapshotBackupCommand) Run(args []string) int {
 		defer closer.Close()
 	}
 
-	stream, err := client.CreateSnapshot(c.Ctx, &emptypb.Empty{})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to generate snapshot: %s", err)
-		return 1
+	config := snapshot.Config{
+		Client: c.project.Client(),
 	}
-
-	resp, err := stream.Recv()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to receive snapshot start message: %s", err)
+	if err = config.WriteSnapshot(c.Ctx, w); err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating Snapshot: %s", err)
 		return 1
-	}
-
-	if _, ok := resp.Event.(*pb.CreateSnapshotResponse_Open_); !ok {
-		fmt.Fprintf(os.Stderr, "failed to receive snapshot start message: %s", err)
-		return 1
-	}
-
-	for {
-		ev, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-
-			fmt.Fprintf(os.Stderr, "error receiving snapshot data: %s", err)
-			return 1
-		}
-
-		chunk, ok := ev.Event.(*pb.CreateSnapshotResponse_Chunk)
-		if ok {
-			_, err = w.Write(chunk.Chunk)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error writing snapshot data: %s", err)
-				return 1
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "unexpected protocol value: %T", ev.Event)
-			return 1
-		}
 	}
 
 	if w != os.Stdout {
@@ -124,16 +89,16 @@ func (c *SnapshotBackupCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *SnapshotBackupCommand) Synopsis() string {
-	return "Write a backup of the server data."
+	return "Write a backup of the server data"
 }
 
 func (c *SnapshotBackupCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint server snapshot [<filenamp>]
+Usage: waypoint server snapshot [<filename>]
 
 	Generate a snapshot from the current server and write it to a file specified
 	by the given name. If no name is specified and standard out is not a terminal,
-	the backup will written to standard out. Using a name of '-' will force writing
+	the backup will be written to standard out. Using a name of '-' will force writing
 	to standard out.
 
 ` + c.Flags().Help())

--- a/internal/cli/snapshot_backup.go
+++ b/internal/cli/snapshot_backup.go
@@ -61,10 +61,7 @@ func (c *SnapshotBackupCommand) Run(args []string) int {
 		defer closer.Close()
 	}
 
-	config := snapshot.Config{
-		Client: c.project.Client(),
-	}
-	if err = config.WriteSnapshot(c.Ctx, w); err != nil {
+	if err = clisnapshot.WriteSnapshot(c.Ctx, c.project.Client(), w); err != nil {
 		fmt.Fprintf(os.Stderr, "Error generating Snapshot: %s", err)
 		return 1
 	}

--- a/internal/cli/snapshot_restore.go
+++ b/internal/cli/snapshot_restore.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/clisnapshot"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/posener/complete"
 	sshterm "golang.org/x/crypto/ssh/terminal"
 )

--- a/internal/cli/snapshot_restore.go
+++ b/internal/cli/snapshot_restore.go
@@ -63,10 +63,7 @@ func (c *SnapshotRestoreCommand) Run(args []string) int {
 		defer closer.Close()
 	}
 
-	config := snapshot.Config{
-		Client: c.project.Client(),
-	}
-	if err := config.ReadSnapshot(c.Ctx, r, c.flagExit); err != nil {
+	if err := clisnapshot.ReadSnapshot(c.Ctx, c.project.Client(), r, c.flagExit); err != nil {
 		fmt.Fprintf(os.Stderr, "Error restoring Snapshot: %s", err)
 		return 1
 	}

--- a/internal/clisnapshot/snapshot.go
+++ b/internal/clisnapshot/snapshot.go
@@ -1,4 +1,6 @@
-package snapshot
+package clisnapshot
+// Package clisnapshot provides access to our CLI commands to create and
+// restore snapshots
 
 import (
 	"context"
@@ -10,13 +12,11 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-type Config struct {
-	// This Client points to a project's client, as set in the baseCommand
-	Client pb.WaypointClient
-}
-
-func (c *Config) WriteSnapshot(ctx context.Context, w io.Writer) error {
-	stream, err := c.Client.CreateSnapshot(ctx, &emptypb.Empty{})
+// WriteSnapshot accepts a context, WaypointClient, and io.Writer, and returns
+// an error. It uses the Client to create a snapshot and write it to the 
+// provided writer.
+func WriteSnapshot(ctx context.Context, client pb.WaypointClient, w io.Writer) error {
+	stream, err := client.CreateSnapshot(ctx, &emptypb.Empty{})
 	if err != nil {
 		return fmt.Errorf("failed to generate snapshot: %s", err)
 	}
@@ -52,8 +52,11 @@ func (c *Config) WriteSnapshot(ctx context.Context, w io.Writer) error {
 	return nil
 }
 
-func (c *Config) ReadSnapshot(ctx context.Context, r io.Reader, exit bool) error {
-	stream, err := c.Client.RestoreSnapshot(ctx)
+// ReadSnapshot accepts a context, WaypointClient, io.Reader, and an exit value,
+// and returns an error. It uses the Client to restore a snapshot from the 
+// provided reader, and sends an exit signal to the server if 'exit' is true.
+func ReadSnapshot(ctx context.Context, client pb.WaypointClient, r io.Reader, exit bool) error {
+	stream, err := client.RestoreSnapshot(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to restore snapshot: %s", err)
 	}

--- a/internal/clisnapshot/snapshot.go
+++ b/internal/clisnapshot/snapshot.go
@@ -1,4 +1,5 @@
 package clisnapshot
+
 // Package clisnapshot provides access to our CLI commands to create and
 // restore snapshots
 
@@ -13,7 +14,7 @@ import (
 )
 
 // WriteSnapshot accepts a context, WaypointClient, and io.Writer, and returns
-// an error. It uses the Client to create a snapshot and write it to the 
+// an error. It uses the Client to create a snapshot and write it to the
 // provided writer.
 func WriteSnapshot(ctx context.Context, client pb.WaypointClient, w io.Writer) error {
 	stream, err := client.CreateSnapshot(ctx, &emptypb.Empty{})
@@ -53,7 +54,7 @@ func WriteSnapshot(ctx context.Context, client pb.WaypointClient, w io.Writer) e
 }
 
 // ReadSnapshot accepts a context, WaypointClient, io.Reader, and an exit value,
-// and returns an error. It uses the Client to restore a snapshot from the 
+// and returns an error. It uses the Client to restore a snapshot from the
 // provided reader, and sends an exit signal to the server if 'exit' is true.
 func ReadSnapshot(ctx context.Context, client pb.WaypointClient, r io.Reader, exit bool) error {
 	stream, err := client.RestoreSnapshot(ctx)

--- a/internal/clisnapshot/snapshot.go
+++ b/internal/clisnapshot/snapshot.go
@@ -1,7 +1,6 @@
-package clisnapshot
-
-// Package clisnapshot provides access to our CLI commands to create and
+// Package clisnapshot provides access for our CLI commands to create and
 // restore snapshots
+package clisnapshot
 
 import (
 	"context"
@@ -13,9 +12,9 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-// WriteSnapshot accepts a context, WaypointClient, and io.Writer, and returns
-// an error. It uses the Client to create a snapshot and write it to the
-// provided writer.
+// WriteSnapshot requests a snapshot from the client and writes it to the
+// provided writer. Cancelling the context will prematurely cancel the snapshot.
+// This may result in partial writes to the writer.
 func WriteSnapshot(ctx context.Context, client pb.WaypointClient, w io.Writer) error {
 	stream, err := client.CreateSnapshot(ctx, &emptypb.Empty{})
 	if err != nil {
@@ -53,9 +52,10 @@ func WriteSnapshot(ctx context.Context, client pb.WaypointClient, w io.Writer) e
 	return nil
 }
 
-// ReadSnapshot accepts a context, WaypointClient, io.Reader, and an exit value,
-// and returns an error. It uses the Client to restore a snapshot from the
-// provided reader, and sends an exit signal to the server if 'exit' is true.
+// ReadSnapshot stages a snapshot for restore from the provided reader, and
+// sends an exit signal to the server if 'exit' is true. Cancelling the context
+// will prematurely cancel the snapshot restore. This may result in a partial
+// restore from the reader being staged.
 func ReadSnapshot(ctx context.Context, client pb.WaypointClient, r io.Reader, exit bool) error {
 	stream, err := client.RestoreSnapshot(ctx)
 	if err != nil {

--- a/internal/clisnapshot/snapshot.go
+++ b/internal/clisnapshot/snapshot.go
@@ -1,0 +1,104 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+type Config struct {
+	// This Client points to a project's client, as set in the baseCommand
+	Client pb.WaypointClient
+}
+
+func (c *Config) WriteSnapshot(ctx context.Context, w io.Writer) error {
+	stream, err := c.Client.CreateSnapshot(ctx, &emptypb.Empty{})
+	if err != nil {
+		return fmt.Errorf("failed to generate snapshot: %s", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("failed to receive snapshot start message: %s", err)
+	}
+
+	if _, ok := resp.Event.(*pb.CreateSnapshotResponse_Open_); !ok {
+		return fmt.Errorf("failed to receive snapshot start message: %s", err)
+	}
+
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("error receiving snapshot data: %s", err)
+		}
+
+		chunk, ok := ev.Event.(*pb.CreateSnapshotResponse_Chunk)
+		if ok {
+			_, err = w.Write(chunk.Chunk)
+			if err != nil {
+				return fmt.Errorf("error writing snapshot data: %s", err)
+			}
+		} else {
+			return fmt.Errorf("unexpected protocol value: %T", ev.Event)
+		}
+	}
+	return nil
+}
+
+func (c *Config) ReadSnapshot(ctx context.Context, r io.Reader, exit bool) error {
+	stream, err := c.Client.RestoreSnapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to restore snapshot: %s", err)
+	}
+
+	err = stream.Send(&pb.RestoreSnapshotRequest{
+		Event: &pb.RestoreSnapshotRequest_Open_{
+			Open: &pb.RestoreSnapshotRequest_Open{
+				Exit: exit,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send start message: %s", err)
+	}
+
+	// Write the data in smaller chunks so we don't overwhelm the grpc stream
+	// processing machinary.
+	var buf [1024]byte
+
+	for {
+		// use ReadFull here because if r is an OS pipe, each bare call to Read()
+		// can result in just one or two bytes per call, so we want to batch those
+		// up before sending them off for better performance.
+		n, err := io.ReadFull(r, buf[:])
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			err = nil
+		}
+
+		if n == 0 {
+			break
+		}
+
+		err = stream.Send(&pb.RestoreSnapshotRequest{
+			Event: &pb.RestoreSnapshotRequest_Chunk{
+				Chunk: buf[:n],
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to write snapshot data: %s", err)
+		}
+	}
+
+	_, err = stream.CloseAndRecv()
+	if err != nil && !exit {
+		return fmt.Errorf("failed to receive snapshot close message: %s", err)
+	}
+	return nil
+}

--- a/internal/clisnapshot/snapshot_test.go
+++ b/internal/clisnapshot/snapshot_test.go
@@ -1,4 +1,4 @@
-package snapshot
+package clisnapshot
 
 import (
 	"context"
@@ -17,9 +17,6 @@ func TestServerSnapshot(t *testing.T) {
 	require := require.New(t)
 	// create our server
 	client := singleprocess.TestServer(t)
-	config := Config{
-		Client: client,
-	}
 
 	// Create a temporary directory for our test
 	td, err := ioutil.TempDir("", "test")
@@ -28,16 +25,18 @@ func TestServerSnapshot(t *testing.T) {
 	path := filepath.Join(td, "fancyserver")
 
 	w, err := os.Create(path)
+	defer w.Close()
 	require.NoError(err)
 
-	err = config.WriteSnapshot(ctx, w)
+	err = WriteSnapshot(ctx, client, w)
 	require.NoError(err)
 
 	require.FileExists(path)
 
 	r, err := os.Open(path)
+	defer r.Close()
 	require.NoError(err)
 
-	err = config.ReadSnapshot(ctx, r, false)
+	err = ReadSnapshot(ctx, client, r, false)
 	require.NoError(err)
 }

--- a/internal/clisnapshot/snapshot_test.go
+++ b/internal/clisnapshot/snapshot_test.go
@@ -1,0 +1,88 @@
+package snapshot
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/server"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess"
+)
+
+func TestServerSnapshot(t *testing.T) {
+	ctx := context.Background()
+	t.Run("base create and restore", func(t *testing.T) {
+		require := require.New(t)
+		// create our server
+		client := singleprocess.TestServer(t)
+
+		config := Config{
+			Client: client,
+		}
+
+		// Create a temporary directory for our test
+		td, err := ioutil.TempDir("", "test")
+		require.NoError(err)
+		defer os.RemoveAll(td)
+		path := filepath.Join(td, "fancyserver")
+
+		w, err := os.Create(path)
+		require.NoError(err)
+
+		err = config.WriteSnapshot(ctx, w)
+		require.NoError(err)
+
+		require.FileExists(path)
+
+		r, err := os.Open(path)
+		require.NoError(err)
+
+		err = config.ReadSnapshot(ctx, r, false)
+		require.NoError(err)
+
+	})
+
+	// probably need to further abstract ReadSnapshot as this test fails out
+	// immediately when it hits `[WARN]  grpc: restore requested exit, closing database and exiting NOW`
+	t.Run("restore with server exit", func(t *testing.T) {
+		require := require.New(t)
+		// start the server with restart channel
+		restartCh := make(chan struct{})
+		impl := singleprocess.TestImpl(t)
+		client := server.TestServer(t, impl,
+			server.TestWithContext(ctx),
+			server.TestWithRestart(restartCh),
+		)
+
+		config := Config{
+			Client: client,
+		}
+
+		// Create a temporary directory for our test
+		td, err := ioutil.TempDir("", "test")
+		require.NoError(err)
+		defer os.RemoveAll(td)
+		path := filepath.Join(td, "fancyserver")
+
+		w, err := os.Create(path)
+		require.NoError(err)
+
+		err = config.WriteSnapshot(ctx, w)
+		require.NoError(err)
+
+		require.FileExists(path)
+
+		r, err := os.Open(path)
+		require.NoError(err)
+
+		err = config.ReadSnapshot(ctx, r, true)
+
+		// require.NoError(err)
+
+	})
+
+}

--- a/internal/clisnapshot/snapshot_test.go
+++ b/internal/clisnapshot/snapshot_test.go
@@ -9,80 +9,35 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/waypoint/internal/server"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess"
 )
 
 func TestServerSnapshot(t *testing.T) {
 	ctx := context.Background()
-	t.Run("base create and restore", func(t *testing.T) {
-		require := require.New(t)
-		// create our server
-		client := singleprocess.TestServer(t)
+	require := require.New(t)
+	// create our server
+	client := singleprocess.TestServer(t)
+	config := Config{
+		Client: client,
+	}
 
-		config := Config{
-			Client: client,
-		}
+	// Create a temporary directory for our test
+	td, err := ioutil.TempDir("", "test")
+	require.NoError(err)
+	defer os.RemoveAll(td)
+	path := filepath.Join(td, "fancyserver")
 
-		// Create a temporary directory for our test
-		td, err := ioutil.TempDir("", "test")
-		require.NoError(err)
-		defer os.RemoveAll(td)
-		path := filepath.Join(td, "fancyserver")
+	w, err := os.Create(path)
+	require.NoError(err)
 
-		w, err := os.Create(path)
-		require.NoError(err)
+	err = config.WriteSnapshot(ctx, w)
+	require.NoError(err)
 
-		err = config.WriteSnapshot(ctx, w)
-		require.NoError(err)
+	require.FileExists(path)
 
-		require.FileExists(path)
+	r, err := os.Open(path)
+	require.NoError(err)
 
-		r, err := os.Open(path)
-		require.NoError(err)
-
-		err = config.ReadSnapshot(ctx, r, false)
-		require.NoError(err)
-
-	})
-
-	// probably need to further abstract ReadSnapshot as this test fails out
-	// immediately when it hits `[WARN]  grpc: restore requested exit, closing database and exiting NOW`
-	t.Run("restore with server exit", func(t *testing.T) {
-		require := require.New(t)
-		// start the server with restart channel
-		restartCh := make(chan struct{})
-		impl := singleprocess.TestImpl(t)
-		client := server.TestServer(t, impl,
-			server.TestWithContext(ctx),
-			server.TestWithRestart(restartCh),
-		)
-
-		config := Config{
-			Client: client,
-		}
-
-		// Create a temporary directory for our test
-		td, err := ioutil.TempDir("", "test")
-		require.NoError(err)
-		defer os.RemoveAll(td)
-		path := filepath.Join(td, "fancyserver")
-
-		w, err := os.Create(path)
-		require.NoError(err)
-
-		err = config.WriteSnapshot(ctx, w)
-		require.NoError(err)
-
-		require.FileExists(path)
-
-		r, err := os.Open(path)
-		require.NoError(err)
-
-		err = config.ReadSnapshot(ctx, r, true)
-
-		// require.NoError(err)
-
-	})
-
+	err = config.ReadSnapshot(ctx, r, false)
+	require.NoError(err)
 }


### PR DESCRIPTION
This pulls out the core snapshot logic from the CLI into its own package, so we can use the snapshot creation in our uninstall and upgrade functions.