### PR TITLE
k8s install: Return error creating service/statefulset.

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -217,6 +217,7 @@ func (i *K8sInstaller) Install(
 			"Error creating service %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
+		return nil, err
 	}
 
 	statefulSetClient := clientset.AppsV1().StatefulSets(i.config.namespace)
@@ -226,6 +227,7 @@ func (i *K8sInstaller) Install(
 			"Error creating statefulset %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
+		return nil, err
 	}
 
 	s.Done()


### PR DESCRIPTION
When attempting to install Waypoint into a namespace that does not exist, the `waypoint install` command will hang indefinitely. Errors are printed to screen, but the process never exits.

```
$ waypoint install -accept-tos -k8s-namespace=waypoint -platform=kubernetes
✓ Creating Kubernetes resources...
⠧ Waiting for Kubernetes StatefulSet to be ready...
! Error creating service namespaces "waypoint" not found
! Error creating statefulset namespaces "waypoint" not found
```

The error is checked and used to populate `ui.Output`, but it is not actually returned.

With this change, it fails correctly:

```
$ ./waypoint install -accept-tos -k8s-namespace=waypoint -platform=kubernetes
❌ Creating Kubernetes resources...
! Error creating service namespaces "waypoint" not found
! Error installing server into kubernetes: namespaces "waypoint" not found
```

Looks to be the same issue as reported in https://github.com/hashicorp/waypoint/issues/934