### PR TITLE
Add a generic build target for waypoint server container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,15 @@ test: # run tests
 format: # format go code
 	gofmt -s -w ./
 
+.PHONY: docker/server
+docker/server:
+	DOCKER_BUILDKIT=1 docker build \
+					--ssh default \
+					--secret id=ssh.config,src="${HOME}/.ssh/config" \
+					--secret id=ssh.key,src="${HOME}/.ssh/config" \
+					-t waypoint:dev \
+					.
+
 .PHONY: docker/mitchellh
 docker/mitchellh:
 	DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
This pull request just copies the `docker/mitchellh` make target to something more generic for building a waypoint server. I'm happy to remove the other targets if they aren't going to be used, but don't want to mess up anyones workflow by removing them yet :smile: 