### PR TITLE
feat: add support to env vars in hcl config files

### DIFF
--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,6 +11,9 @@ import (
 )
 
 func TestConfigApp_compare(t *testing.T) {
+	envVar := "test"
+	os.Setenv("APP_ENV", envVar)
+
 	cases := []struct {
 		File string
 		App  string
@@ -156,6 +160,15 @@ func TestConfigApp_compare(t *testing.T) {
 				vars, err := c.ConfigVars()
 				require.NoError(err)
 				require.Len(vars, 2)
+			},
+		},
+
+		{
+			"app_env.hcl",
+			"bar",
+			func(t *testing.T, c *App) {
+				require := require.New(t)
+				require.Equal(c.Labels["env"], envVar)
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,9 @@ func Load(path string, pwd string) (*Config, error) {
 
 	// Build our context
 	ctx := EvalContext(nil, pwd).NewChild()
+
 	addPathValue(ctx, pathData)
+	addEnvVars(ctx)
 
 	// Decode
 	var cfg hclConfig

--- a/internal/config/eval_context.go
+++ b/internal/config/eval_context.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"os"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -63,6 +66,19 @@ func addPathValue(ctx *hcl.EvalContext, v map[string]string) {
 	}
 
 	ctx.Variables["path"] = value
+}
+
+func addEnvVars(ctx *hcl.EvalContext) {
+	ctx.Variables = make(map[string]cty.Value)
+	env := make(map[string]cty.Value)
+
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		k, v := pair[0], pair[1]
+		env[k] = cty.StringVal(v)
+	}
+
+	ctx.Variables["env"] = cty.MapVal(env)
 }
 
 // finalizeContext should be called whenever an HCL context is being used

--- a/internal/config/testdata/compare/app_env.hcl
+++ b/internal/config/testdata/compare/app_env.hcl
@@ -1,0 +1,9 @@
+project = "foo"
+
+app "bar" {
+    path = "./bar"
+
+    labels = {
+        "env": env["APP_ENV"]
+    }
+}


### PR DESCRIPTION
This pull request exposes the environment vars so they can be used anywhere inside the hcl file.


```
...
registry {
  use "docker" {
    image = "hello-world-${env["APP_ENV"]}"
    tag   = "1"
    local = true
  }
}
```
or

```
app "bar" {
    path = "./bar"

    labels = {
        "env": env["APP_ENV"]
    }
}
```

```
APP_ENV=staging waypoint up
```

Bear in mind that I'm pretty neophyte with Go and the exposing approach could be considered incorrect as I am not familiar with the project internals.
Also, I saw that Terraform accepts only environment variables that start with the TF_VAR_ prefix and you might want to have a similar behaviour in the long term. 