### PR TITLE
Don't block server startup on URL service

### DIFF
--- a/internal/pkg/grpcready/grpcready.go
+++ b/internal/pkg/grpcready/grpcready.go
@@ -1,0 +1,47 @@
+package grpcready
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/status"
+)
+
+// Conn returns nil if the connection is in the ready state. If wait is
+// set, this will wait for the connection to become ready or until the context
+// is cancelled.
+//
+// This is useful over `WithBlock` when connecting because it allows a
+// fail-fast first attempt to connect. This makes it easily to synchronously
+// attempt connection once before falling back to a retry loop in the background.
+func Conn(
+	ctx context.Context,
+	log hclog.Logger,
+	conn *grpc.ClientConn,
+	wait bool,
+) error {
+	for {
+		s := conn.GetState()
+		log.Trace("connection state", "state", s.String())
+
+		// If we're ready then we're done!
+		if s == connectivity.Ready {
+			log.Debug("connection is ready")
+			return nil
+		}
+
+		// If we have a transient error and we're not retrying, then we're done.
+		if s == connectivity.TransientFailure && !wait {
+			log.Warn("failed to connect to the server, temporary network error")
+			conn.Close()
+			return status.Errorf(codes.Unavailable, "server is unavailable")
+		}
+
+		if !conn.WaitForStateChange(ctx, s) {
+			return ctx.Err()
+		}
+	}
+}

--- a/internal/server/singleprocess/service_deploy.go
+++ b/internal/server/singleprocess/service_deploy.go
@@ -41,7 +41,7 @@ func (s *service) UpsertDeployment(
 	// This requires: (1) URL service is enabled (2) auto hostname isn't
 	// explicitly set to false in the request and (3) either the server
 	// default is true or we explicitly ask for it.
-	if s.urlClient != nil &&
+	if s.urlClient() != nil &&
 		req.AutoHostname != pb.UpsertDeploymentRequest_FALSE &&
 		(s.urlConfig.AutomaticAppHostname || req.AutoHostname == pb.UpsertDeploymentRequest_TRUE) {
 		// Our hostname target. We need this to automatically create a hostname.

--- a/internal/server/singleprocess/service_hostname.go
+++ b/internal/server/singleprocess/service_hostname.go
@@ -24,7 +24,8 @@ func (s *service) CreateHostname(
 	ctx context.Context,
 	req *pb.CreateHostnameRequest,
 ) (*pb.CreateHostnameResponse, error) {
-	if s.urlClient == nil {
+	urlClient := s.urlClient()
+	if urlClient == nil {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"server doesn't have the URL service enabled")
 	}
@@ -53,7 +54,7 @@ func (s *service) CreateHostname(
 	}
 
 	// Make the request
-	resp, err := s.urlClient.RegisterHostname(ctx, hostnameReq)
+	resp, err := urlClient.RegisterHostname(ctx, hostnameReq)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,8 @@ func (s *service) ListHostnames(
 	ctx context.Context,
 	req *pb.ListHostnamesRequest,
 ) (*pb.ListHostnamesResponse, error) {
-	if s.urlClient == nil {
+	urlClient := s.urlClient()
+	if urlClient == nil {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"server doesn't have the URL service enabled")
 	}
@@ -94,7 +96,7 @@ func (s *service) ListHostnames(
 		targetMap = s.hostnameLabelSetToMap(labels)
 	}
 
-	resp, err := s.urlClient.ListHostnames(ctx, &wphznpb.ListHostnamesRequest{})
+	resp, err := urlClient.ListHostnames(ctx, &wphznpb.ListHostnamesRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -124,12 +126,13 @@ func (s *service) DeleteHostname(
 	ctx context.Context,
 	req *pb.DeleteHostnameRequest,
 ) (*empty.Empty, error) {
-	if s.urlClient == nil {
+	urlClient := s.urlClient()
+	if urlClient == nil {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"server doesn't have the URL service enabled")
 	}
 
-	_, err := s.urlClient.DeleteHostname(ctx, &wphznpb.DeleteHostnameRequest{
+	_, err := urlClient.DeleteHostname(ctx, &wphznpb.DeleteHostnameRequest{
 		Hostname: req.Hostname,
 	})
 	if err != nil {

--- a/internal/server/singleprocess/service_url.go
+++ b/internal/server/singleprocess/service_url.go
@@ -5,37 +5,154 @@ import (
 	"crypto/tls"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	grpctoken "github.com/hashicorp/horizon/pkg/grpc/token"
 	wphznpb "github.com/hashicorp/waypoint-hzn/pkg/pb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/waypoint/internal/pkg/grpcready"
+	"github.com/hashicorp/waypoint/internal/serverconfig"
 )
 
-func (s *service) initURLGuestAccount(acceptURLTerms bool) error {
+// urlClient returns the URL service client. This may return nil if the
+// client isn't yet ready.
+func (s *service) urlClient() wphznpb.WaypointHznClient {
+	s.urlClientMu.Lock()
+	defer s.urlClientMu.Unlock()
+	return s.urlClientVal
+}
+
+// initURLClient initializes the URL service client. This will get a guest
+// account token if necessary, and will retry in the background on failure.
+// If the URL service is not available, then `s.urlClient()` may be nil.
+//
+// Prior to retrying in the background, this attempts once to synchronously
+// connect and initialize the client. Therefore, the happy path expects
+// that `urlClient()` never returns nil if the URL service is enabled.
+func (s *service) initURLClient(
+	log hclog.Logger,
+	isRetry bool,
+	acceptURLTerms bool,
+	cfg *serverconfig.URL,
+) error {
+	if cfg == nil || !cfg.Enabled {
+		log.Info("URL service is not configured or explicitly disabled")
+		return nil
+	}
+
+	// We don't currently have a context here to thread through. The
+	// remainder of the logic is context-aware so when we do have one, we
+	// just need to replace this and everything will just work.
+	ctx := context.Background()
+
+	// Perform the blocking attempt to initialize.
+	err := s.initURLClientBlocking(ctx, log, isRetry, acceptURLTerms, cfg)
+	if status.Code(err) == codes.Unavailable {
+		// Start a goroutine to keep retrying in the background.
+		log.Warn("URL service unavailable, will retry in the background")
+		go s.initURLClient(log, true, acceptURLTerms, cfg)
+		return nil
+	}
+
+	log.Warn("failed to initialize URL service", "err", err)
+	return err
+}
+
+func (s *service) initURLClientBlocking(
+	ctx context.Context,
+	log hclog.Logger,
+	isRetry bool,
+	acceptURLTerms bool,
+	cfg *serverconfig.URL,
+) error {
+	// If we have no API token, get our guest account token.
+	if cfg.APIToken == "" {
+		token, err := s.initURLGuestAccount(ctx, log, isRetry, acceptURLTerms, cfg)
+		if err != nil {
+			return err
+		}
+
+		// Set the API token, if logic later in this func fails and we retry
+		// we will reuse the API token we already have.
+		cfg.APIToken = token
+	}
+
+	// Now that we have a token, connect to the API service with that token.
+	opts := []grpc.DialOption{
+		grpc.WithPerRPCCredentials(grpctoken.Token(cfg.APIToken)),
+	}
+	if cfg.APIInsecure {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+	}
+
+	conn, err := grpc.Dial(cfg.APIAddress, opts...)
+	if err != nil {
+		return err
+	}
+	if err := grpcready.Conn(ctx, log, conn, isRetry); err != nil {
+		return err
+	}
+
+	s.urlClientMu.Lock()
+	defer s.urlClientMu.Unlock()
+	s.urlClientVal = wphznpb.NewWaypointHznClient(conn)
+	return nil
+}
+
+func (s *service) initURLGuestAccount(
+	ctx context.Context,
+	log hclog.Logger,
+	isRetry bool,
+	acceptURLTerms bool,
+	cfg *serverconfig.URL,
+) (string, error) {
 	// Check if URL Token already exists, if so, no reason to
 	// re-register and generate a new hostname
 	urlToken, err := s.state.ServerURLTokenGet()
 	if err != nil {
-		return err
+		return "", err
 	} else if urlToken != "" {
-		// url token already set, guest account already exists
-		s.urlConfig.APIToken = urlToken
-		return nil
+		return urlToken, nil
 	}
 
 	// Connect without auth to our API client
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(10*time.Second))
-	if s.urlConfig.APIInsecure {
+	opts = append(opts, grpc.WithTimeout(10*time.Second))
+	if cfg.APIInsecure {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
 		// If it isn't insecure, then we have to specify that we're using TLS
-		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+		opts = append(opts, grpc.WithTransportCredentials(
+			credentials.NewTLS(&tls.Config{}),
+		))
 	}
 
-	conn, err := grpc.Dial(s.urlConfig.APIAddress, opts...)
+	log.Debug("connecting to URL service to retrieve guest token",
+		"addr", cfg.APIAddress,
+		"tls", !cfg.APIInsecure,
+	)
+	conn, err := grpc.DialContext(ctx, cfg.APIAddress, opts...)
 	if err != nil {
-		return err
+		// This error should NOT happen on connection failure, since
+		// we connect in the background. This should happen if there is
+		// a local configuration error.
+		log.Warn("failed to connect to the URL service", "err", err)
+		return "", err
 	}
+
+	// Verify we're connected. We do this loop so that we can
+	// fail fast in the non-isRetry case.
+	log.Debug("waiting on server connection state to become ready")
+	if err := grpcready.Conn(ctx, log, conn, isRetry); err != nil {
+		return "", err
+	}
+
+	// Init our client
 	client := wphznpb.NewWaypointHznClient(conn)
 
 	// Request a guest account
@@ -47,13 +164,12 @@ func (s *service) initURLGuestAccount(acceptURLTerms bool) error {
 		},
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	s.urlConfig.APIToken = accountResp.Token
 	if err := s.state.ServerURLTokenSet(accountResp.Token); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return accountResp.Token, nil
 }

--- a/internal/server/singleprocess/service_url_test.go
+++ b/internal/server/singleprocess/service_url_test.go
@@ -1,0 +1,43 @@
+package singleprocess
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/serverconfig"
+)
+
+func TestServerURLService(t *testing.T) {
+	t.Run("with URL service disabled", func(t *testing.T) {
+		// Our default TestImpl doesn't have a URL service.
+		impl := testServiceImpl(TestImpl(t))
+		require.Nil(t, impl.urlClient())
+	})
+
+	t.Run("with URL service enabled", func(t *testing.T) {
+		impl := testServiceImpl(TestImpl(t, TestWithURLService(t, nil)))
+		require.NotNil(t, impl.urlClient())
+	})
+
+	t.Run("with URL service enabled, but down", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:")
+		require.NoError(t, err)
+		ln.Close()
+
+		impl := testServiceImpl(TestImpl(t, WithConfig(&serverconfig.Config{
+			URL: &serverconfig.URL{
+				Enabled:              true,
+				APIAddress:           ln.Addr().String(),
+				APIInsecure:          true,
+				APIToken:             "",
+				ControlAddress:       fmt.Sprintf("dev://%s", ln.Addr().String()),
+				AutomaticAppHostname: true,
+			},
+		})))
+
+		require.Nil(t, impl.urlClient())
+	})
+}


### PR DESCRIPTION
If the URL service is down, the server fails to startup. We should not behave this way.

This changes the server to attempt a blocking connection _once_. If that fails, we move to background retries. This will enable the server to come up when the URL service is down (though it may try the first blocking attempt for ~10 seconds). Additionally, logging is much improved here.