### PR TITLE
internal/cli: flags to set a custom TLS cert for `server run`

### DIFF
--- a/website/content/docs/server/run/index.mdx
+++ b/website/content/docs/server/run/index.mdx
@@ -62,10 +62,6 @@ $ waypoint server run -db=data.db
 The `waypoint server run` command takes a variety of flags for configuration.
 See the CLI help output for more information.
 
--> **Note:** At the time of writing, Waypoint is limited to using self-signed
-TLS certificates and does not accept file-based configuration. This limitation
-will be fixed very soon.
-
 -> If you're manually running the server, we will assume that you know how
 to use a scheduler such as Nomad or service manager such as systemd to
 run this command in a production environment.

--- a/website/content/docs/server/run/production.mdx
+++ b/website/content/docs/server/run/production.mdx
@@ -63,6 +63,21 @@ For example, if you deploy a Kubernetes application with 5 replicas,
 then that would be 5 application instances (even though it is only one
 "deployment").
 
+## TLS
+
+Waypoint requires TLS for all inbound connections. TLS cannot be disabled.
+By default, Waypoint will generate a self-signed certificate on startup.
+
+Servers that are [run manually](/docs/server/run#manually-running-the-server)
+(_not_ installed using `waypoint install`) can specify custom TLS certificates
+using the `-tls-cert-file` and `-tls-key-file` flags on the `waypoint server run`
+command. These flags should point to a PEM-encoded certificate file and
+private key, respectively.
+
+-> **Note:** Servers installed using `waypoint install` currently don't
+support specifying a custom TLS certificate. This limitation will be fixed
+in the future.
+
 ## Limitations
 
 ### TLS Certs


### PR DESCRIPTION
This adds flags to `waypoint server run` to specify custom TLS certs.

This doesn't expose this yet to `waypoint install`, but we can't even work on that now if this doesn't support it!