### PR TITLE
internal/ceb: quiet ceb log disconnection messages

### DIFF
--- a/internal/ceb/log.go
+++ b/internal/ceb/log.go
@@ -145,12 +145,15 @@ func (ceb *CEB) initLogStreamSender(
 				Lines:      []*pb.LogBatch_Entry{entry},
 			})
 			if err == io.EOF || status.Code(err) == codes.Unavailable {
-				log.Error("log stream disconnected from server, attempting reconnect",
+				log.Debug("log stream disconnected from server, attempting reconnect",
 					"err", err)
 				err = ceb.initLogStreamSender(log, ctx)
 				if err == nil {
 					return
 				}
+
+				log.Error("log stream disconnected from server, reconnect failed",
+					"err", err)
 			}
 			if err != nil {
 				log.Warn("error sending logs", "error", err)


### PR DESCRIPTION
This changes the ERROR message to a DEBUG and adds a new ERROR-level
message only if we failed to reconnect the log stream.

It is expected that long-running streams such as the log stream will be
disconnected periodically due to any number of reasons, but most
commonly a load balancer in the middle limiting connection times. In
this scenario, we quickly reconnect and its not an issue. It creates too
much noise to log every disconnect as an error.

However, if we fail to reconnect the log stream, it is an error that
should be noted.