### PR TITLE
builtin/docker-pull: support daemonless image pulls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apk add --no-cache \
 
 RUN git clone https://github.com/mitchellh/img.git /img
 WORKDIR /img
-RUN git checkout inspect
+RUN git checkout pull-config
 RUN go get github.com/go-bindata/go-bindata/go-bindata
 RUN make static && mv img /usr/bin/img
 

--- a/builtin/docker/auth.go
+++ b/builtin/docker/auth.go
@@ -1,0 +1,100 @@
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/distribution/reference"
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TempDockerConfig creates a new Docker configuration with the
+// configured auth in it. It saves this Docker config to a temporary path
+// and returns the path to that Docker file.
+//
+// We have to do this because `img` doesn't support setting auth for
+// a single operation. Therefore, we must set auth in the Docker config,
+// but we don't want to pollute any concurrent runs or the main file. So
+// we create a copy.
+//
+// This can return ("", nil) if there is no custom Docker config necessary.
+//
+// Callers should defer file deletion for this temporary file.
+func TempDockerConfig(
+	log hclog.Logger,
+	target *Image,
+	encodedAuth string,
+) (string, error) {
+	if encodedAuth == "" {
+		return "", nil
+	}
+
+	// Create a reader that base64 decodes our encoded auth and then
+	// JSON decodes that.
+	var authCfg types.AuthConfig
+	var rdr io.Reader = strings.NewReader(encodedAuth)
+	rdr = base64.NewDecoder(base64.URLEncoding, rdr)
+	dec := json.NewDecoder(rdr)
+	if err := dec.Decode(&authCfg); err != nil {
+		return "", status.Errorf(codes.FailedPrecondition,
+			"Failed to decode encoded_auth: %s", err)
+	}
+
+	// Determine the host that we're setting auth for. We have to parse the
+	// image for this cause it may not contain a host. Luckily Docker has
+	// libs to normalize this all for us.
+	log.Trace("determining host for auth configuration", "image", target.Name())
+	ref, err := reference.ParseNormalizedNamed(target.Name())
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "unable to parse image name: %s", err)
+	}
+	host := reference.Domain(ref)
+	log.Trace("auth host", "host", host)
+
+	// Parse our old Docker config and add the auth.
+	log.Trace("loading Docker configuration")
+	file, err := config.Load(config.Dir())
+	if err != nil {
+		return "", err
+	}
+
+	if file.AuthConfigs == nil {
+		file.AuthConfigs = map[string]types.AuthConfig{}
+	}
+	file.AuthConfigs[host] = authCfg
+
+	// Create a temporary directory for our config
+	td, err := ioutil.TempDir("", "wp-docker-config")
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"Failed to create temporary directory for Docker config: %s", err)
+	}
+
+	// Create a temporary file and write our Docker config to it
+	f, err := os.Create(filepath.Join(td, "config.json"))
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"Failed to create temporary file for Docker config: %s", err)
+	}
+	defer f.Close()
+	if err := file.SaveToWriter(f); err != nil {
+		return "", status.Errorf(codes.Internal,
+			"Failed to create temporary file for Docker config: %s", err)
+	}
+
+	log.Info("temporary Docker config created for auth",
+		"auth_host", host,
+		"path", td,
+	)
+
+	return td, nil
+}

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -171,7 +171,7 @@ func (b *Builder) Build(
 		log.Warn("error during check if we should use Docker fallback", "err", err)
 		return nil, status.Errorf(codes.Internal,
 			"error validating Docker connection: %s", err)
-	} else if fallback && hasImg() {
+	} else if fallback && HasImg() {
 		// If we're falling back and have "img" available, use that. If we
 		// don't have "img" available, we continue to try to use Docker. We'll
 		// fail but that error message should help the user.

--- a/builtin/docker/img.go
+++ b/builtin/docker/img.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
-// hasImg returns true if "img" is available on the PATH.
+// HasImg returns true if "img" is available on the PATH.
 //
 // This doesn't do any fancy checking that "img" is the "img" we expect.
 // We can make the checking here more advanced later.
-func hasImg() bool {
+func HasImg() bool {
 	_, err := exec.LookPath("img")
 	return err == nil
 }

--- a/builtin/docker/pull/builder.go
+++ b/builtin/docker/pull/builder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"os"
+	"os/exec"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution/reference"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -64,6 +66,9 @@ can disable this with the "disable_entrypoint" configuration.
 If you wish to rename or retag an image, use this along with the
 "docker" registry option which will rename/retag the image and then
 push it to the specified registry.
+
+If Docker isn't available (the Docker daemon isn't running or a DOCKER_HOST
+isn't set), a daemonless solution will be used instead.
 `)
 
 	doc.Example(`
@@ -127,18 +132,19 @@ func (b *Builder) Build(
 	src *component.Source,
 	log hclog.Logger,
 ) (*wpdocker.Image, error) {
-	stdout, _, err := ui.OutputWriters()
-	if err != nil {
-		return nil, err
-	}
-
 	sg := ui.StepGroup()
+	defer sg.Wait()
 	step := sg.Add("Initializing Docker client...")
-	defer step.Abort()
+	defer func() {
+		if step != nil {
+			step.Abort()
+		}
+	}()
 
 	result := &wpdocker.Image{
-		Image: b.config.Image,
-		Tag:   b.config.Tag,
+		Image:    b.config.Image,
+		Tag:      b.config.Tag,
+		Location: &wpdocker.Image_Docker{Docker: &empty.Empty{}},
 	}
 
 	cli, err := wpdockerclient.NewClientWithOpts(client.FromEnv)
@@ -147,11 +153,97 @@ func (b *Builder) Build(
 	}
 	cli.NegotiateAPIVersion(ctx)
 
-	step.Done()
+	// We now test if Docker is actually functional. We do this here because we
+	// need all of the above to complete the actual build.
+	log.Debug("testing if we should use a Docker fallback")
+	useImg := false
+	if fallback, err := wpdockerclient.Fallback(ctx, log, cli); err != nil {
+		log.Warn("error during check if we should use Docker fallback", "err", err)
+		return nil, status.Errorf(codes.Internal,
+			"error validating Docker connection: %s", err)
+	} else if fallback && wpdocker.HasImg() {
+		// If we're falling back and have "img" available, use that. If we
+		// don't have "img" available, we continue to try to use Docker. We'll
+		// fail but that error message should help the user.
+		step.Update("Docker isn't available. Falling back to daemonless image pull...")
+		step.Done()
+		step = nil
+		if err := b.buildWithImg(
+			ctx, log, sg, result,
+		); err != nil {
+			return nil, err
+		}
 
+		// Our image is in the img registry now. We set this so that
+		// future users of this result type know where to look.
+		result.Location = &wpdocker.Image_Img{Img: &empty.Empty{}}
+
+		// We set this to true so we use the img-based injector later
+		useImg = true
+	} else {
+		// No fallback, build with Docker
+		step.Done()
+		step = nil
+		if err := b.buildWithDocker(
+			ctx, log, ui, sg, cli, result,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if !b.config.DisableCEB {
+		step = sg.Add("Injecting Waypoint Entrypoint...")
+
+		asset, err := assets.Asset("ceb/ceb")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
+		}
+
+		assetInfo, err := assets.AssetInfo("ceb/ceb")
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
+		}
+
+		callback := func(cur []string) (*epinject.NewEntrypoint, error) {
+			ep := &epinject.NewEntrypoint{
+				Entrypoint: append([]string{"/waypoint-entrypoint"}, cur...),
+				InjectFiles: map[string]epinject.InjectFile{
+					"/waypoint-entrypoint": {
+						Reader: bytes.NewReader(asset),
+						Info:   assetInfo,
+					},
+				},
+			}
+
+			return ep, nil
+		}
+
+		if !useImg {
+			_, err = epinject.AlterEntrypoint(ctx, result.Name(), callback)
+		} else {
+			_, err = epinject.AlterEntrypointImg(ctx, result.Name(), callback)
+		}
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to set modify Docker entrypoint: %s", err)
+		}
+
+		step.Done()
+	}
+
+	return result, nil
+}
+
+func (b *Builder) buildWithDocker(
+	ctx context.Context,
+	log hclog.Logger,
+	ui terminal.UI,
+	sg terminal.StepGroup,
+	cli *client.Client,
+	result *wpdocker.Image,
+) error {
 	ref, err := reference.ParseNormalizedNamed(result.Name())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to parse image name: %s", err)
+		return status.Errorf(codes.Internal, "unable to parse image name: %s", err)
 	}
 
 	encodedAuth := b.config.EncodedAuth
@@ -159,7 +251,7 @@ func (b *Builder) Build(
 		// Resolve the Repository name from fqn to RepositoryInfo
 		repoInfo, err := registry.ParseRepositoryInfo(ref)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to parse repository info from image name: %s", err)
+			return status.Errorf(codes.Internal, "unable to parse repository info from image name: %s", err)
 		}
 
 		var server string
@@ -185,20 +277,26 @@ func (b *Builder) Build(
 		authConfig, _ := cf.GetAuthConfig(server)
 		buf, err := json.Marshal(authConfig)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to generate authentication info for registry: %s", err)
+			return status.Errorf(codes.Internal, "unable to generate authentication info for registry: %s", err)
 		}
 		encodedAuth = base64.URLEncoding.EncodeToString(buf)
 	}
 
-	step = sg.Add("Pulling image...")
+	step := sg.Add("Pulling image...")
+	defer step.Abort()
 
 	resp, err := cli.ImagePull(ctx, reference.FamiliarString(ref), types.ImagePullOptions{
 		RegistryAuth: encodedAuth,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error pulling image: %s", err)
+		return status.Errorf(codes.Internal, "error pulling image: %s", err)
 	}
 	defer resp.Close()
+
+	stdout, _, err := ui.OutputWriters()
+	if err != nil {
+		return err
+	}
 
 	var termFd uintptr
 	if f, ok := stdout.(*os.File); ok {
@@ -207,44 +305,51 @@ func (b *Builder) Build(
 
 	err = jsonmessage.DisplayJSONMessagesStream(resp, step.TermOutput(), termFd, true, nil)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to stream pull logs to the terminal: %s", err)
+		return status.Errorf(codes.Internal, "unable to stream pull logs to the terminal: %s", err)
 	}
 
 	step.Done()
+	return nil
+}
 
-	if !b.config.DisableCEB {
-		step = sg.Add("Injecting Waypoint Entrypoint...")
-
-		asset, err := assets.Asset("ceb/ceb")
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
+func (b *Builder) buildWithImg(
+	ctx context.Context,
+	log hclog.Logger,
+	sg terminal.StepGroup,
+	target *wpdocker.Image,
+) error {
+	var step terminal.Step
+	defer func() {
+		if step != nil {
+			step.Abort()
 		}
+	}()
 
-		assetInfo, err := assets.AssetInfo("ceb/ceb")
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
-		}
-
-		_, err = epinject.AlterEntrypoint(ctx, result.Name(), func(cur []string) (*epinject.NewEntrypoint, error) {
-			ep := &epinject.NewEntrypoint{
-				Entrypoint: append([]string{"/waypoint-entrypoint"}, cur...),
-				InjectFiles: map[string]epinject.InjectFile{
-					"/waypoint-entrypoint": {
-						Reader: bytes.NewReader(asset),
-						Info:   assetInfo,
-					},
-				},
-			}
-
-			return ep, nil
-		})
-
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to modify Docker entrypoint: %s", err)
-		}
-
-		step.Done()
+	step = sg.Add("Preparing Docker configuration...")
+	env := os.Environ()
+	if path, err := wpdocker.TempDockerConfig(log, target, b.config.EncodedAuth); err != nil {
+		return err
+	} else if path != "" {
+		defer os.RemoveAll(path)
+		env = append(env, "DOCKER_CONFIG="+path)
 	}
 
-	return result, nil
+	step.Done()
+	step = sg.Add("Pulling Docker image with img...")
+
+	// NOTE(mitchellh): we can probably use the img Go pkg directly one day.
+	cmd := exec.CommandContext(ctx,
+		"img",
+		"pull",
+		target.Name(),
+	)
+	cmd.Env = env
+	cmd.Stdout = step.TermOutput()
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	step.Done()
+	return nil
 }

--- a/builtin/docker/registry_img.go
+++ b/builtin/docker/registry_img.go
@@ -3,18 +3,10 @@ package docker
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/config/types"
-	"github.com/docker/distribution/reference"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"google.golang.org/grpc/codes"
@@ -39,7 +31,7 @@ func (r *Registry) pushWithImg(
 
 	step = sg.Add("Preparing Docker configuration...")
 	env := os.Environ()
-	if path, err := r.createDockerConfig(log, target); err != nil {
+	if path, err := TempDockerConfig(log, target, r.config.EncodedAuth); err != nil {
 		return err
 	} else if path != "" {
 		defer os.RemoveAll(path)
@@ -90,85 +82,4 @@ func (r *Registry) pushWithImg(
 
 	step.Done()
 	return nil
-}
-
-// createDockerConfig creates a new Docker configuration with the
-// configured auth in it. It saves this Docker config to a temporary path
-// and returns the path to that Docker file.
-//
-// We have to do this because `img` doesn't support setting auth for
-// a single operation. Therefore, we must set auth in the Docker config,
-// but we don't want to pollute any concurrent runs or the main file. So
-// we create a copy.
-//
-// This can return ("", nil) if there is no custom Docker config necessary.
-//
-// Callers should defer file deletion for this temporary file.
-func (r *Registry) createDockerConfig(
-	log hclog.Logger,
-	target *Image,
-) (string, error) {
-	if r.config.EncodedAuth == "" {
-		return "", nil
-	}
-
-	// Create a reader that base64 decodes our encoded auth and then
-	// JSON decodes that.
-	var authCfg types.AuthConfig
-	var rdr io.Reader = strings.NewReader(r.config.EncodedAuth)
-	rdr = base64.NewDecoder(base64.URLEncoding, rdr)
-	dec := json.NewDecoder(rdr)
-	if err := dec.Decode(&authCfg); err != nil {
-		return "", status.Errorf(codes.FailedPrecondition,
-			"Failed to decode encoded_auth: %s", err)
-	}
-
-	// Determine the host that we're setting auth for. We have to parse the
-	// image for this cause it may not contain a host. Luckily Docker has
-	// libs to normalize this all for us.
-	log.Trace("determining host for auth configuration", "image", target.Name())
-	ref, err := reference.ParseNormalizedNamed(target.Name())
-	if err != nil {
-		return "", status.Errorf(codes.Internal, "unable to parse image name: %s", err)
-	}
-	host := reference.Domain(ref)
-	log.Trace("auth host", "host", host)
-
-	// Parse our old Docker config and add the auth.
-	log.Trace("loading Docker configuration")
-	file, err := config.Load(config.Dir())
-	if err != nil {
-		return "", err
-	}
-
-	if file.AuthConfigs == nil {
-		file.AuthConfigs = map[string]types.AuthConfig{}
-	}
-	file.AuthConfigs[host] = authCfg
-
-	// Create a temporary directory for our config
-	td, err := ioutil.TempDir("", "wp-docker-config")
-	if err != nil {
-		return "", status.Errorf(codes.Internal,
-			"Failed to create temporary directory for Docker config: %s", err)
-	}
-
-	// Create a temporary file and write our Docker config to it
-	f, err := os.Create(filepath.Join(td, "config.json"))
-	if err != nil {
-		return "", status.Errorf(codes.Internal,
-			"Failed to create temporary file for Docker config: %s", err)
-	}
-	defer f.Close()
-	if err := file.SaveToWriter(f); err != nil {
-		return "", status.Errorf(codes.Internal,
-			"Failed to create temporary file for Docker config: %s", err)
-	}
-
-	log.Info("temporary Docker config created for auth",
-		"auth_host", host,
-		"path", td,
-	)
-
-	return td, nil
 }


### PR DESCRIPTION
The diff is deceiving, this is more or less just copying similar logic from the Docker builder into the registry but calling `img pull` instead of `img build`. I also updated the Dockerfile to use an updated fork which has fixes for `img pull`