### PR TITLE
use random serial number per cert

### DIFF
--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -499,7 +499,7 @@ func (c *ServerRunCommand) listenerForConfig(log hclog.Logger, cfg *serverconfig
 		}
 
 		template := x509.Certificate{
-			SerialNumber: big.NewInt(1),
+			SerialNumber: big.NewInt(time.Now().Unix()),
 			Subject: pkix.Name{
 				Organization: []string{"Waypoint"},
 			},


### PR DESCRIPTION
This change allows Firefox users to bypass the previous
`SEC_ERROR_REUSED_ISSUER_AND_SERIAL` error that blocked access to
the UI when a new server instance was installed or run locally.