### PR TITLE
feature: Add CEB Virtual instance type

### DIFF
--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -129,19 +129,7 @@ func Run(ctx context.Context, os ...Option) error {
 	defer ceb.Close()
 
 	// Setup our default config sourcers.
-	// NOTE(mitchellh): In the future, we will dynamically load these via
-	// a plugin system, Initially, we hardcode what we support.
-	ceb.configPlugins = map[string]*plugin.Instance{
-		"aws-ssm": {
-			Component: &pluginAWSSSM.ConfigSourcer{},
-		},
-		"kubernetes": {
-			Component: &pluginK8s.ConfigSourcer{},
-		},
-		"vault": {
-			Component: &pluginVault.ConfigSourcer{},
-		},
-	}
+	ceb.configPlugins = loadPlugins()
 
 	// Set our options
 	var cfg config
@@ -208,6 +196,22 @@ func Run(ctx context.Context, os ...Option) error {
 	}
 
 	return nil
+}
+
+// In the future, this will load plugins from disk as true plugin instances,
+// but for now, they're hard coded.
+func loadPlugins() map[string]*plugin.Instance {
+	return map[string]*plugin.Instance{
+		"aws-ssm": {
+			Component: &pluginAWSSSM.ConfigSourcer{},
+		},
+		"kubernetes": {
+			Component: &pluginK8s.ConfigSourcer{},
+		},
+		"vault": {
+			Component: &pluginVault.ConfigSourcer{},
+		},
+	}
 }
 
 // waitState waits for the given state boolean to go true. This boolean

--- a/internal/ceb/exec.go
+++ b/internal/ceb/exec.go
@@ -10,7 +10,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-hclog"
-	"github.com/mitchellh/go-grpc-net-conn"
+	grpc_net_conn "github.com/mitchellh/go-grpc-net-conn"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -123,8 +123,8 @@ func (ceb *CEB) startExec(execConfig *pb.EntrypointConfig_Exec, env []string) {
 
 	// We need to modify our command so the input/output is all over gRPC
 	cmd.Stdin = stdinR
-	cmd.Stdout = ceb.execOutputWriter(client, pb.EntrypointExecRequest_Output_STDOUT)
-	cmd.Stderr = ceb.execOutputWriter(client, pb.EntrypointExecRequest_Output_STDERR)
+	cmd.Stdout = execOutputWriter(client, pb.EntrypointExecRequest_Output_STDOUT)
+	cmd.Stderr = execOutputWriter(client, pb.EntrypointExecRequest_Output_STDERR)
 
 	// PTY
 	var ptyFile *os.File
@@ -301,7 +301,7 @@ func (ceb *CEB) handleExecProcessExit(
 	}
 }
 
-func (ceb *CEB) execOutputWriter(
+func execOutputWriter(
 	client grpc.ClientStream,
 	channel pb.EntrypointExecRequest_Output_Channel,
 ) io.Writer {

--- a/internal/ceb/plugin.go
+++ b/internal/ceb/plugin.go
@@ -11,7 +11,7 @@ import (
 //
 // If error is nil, then the result is guaranteed to not be erroneous. Callers
 // do NOT need to check result.Err().
-func (ceb *CEB) callDynamicFunc(
+func callDynamicFunc(
 	log hclog.Logger,
 	f interface{},
 	args ...argmapper.Arg,

--- a/internal/ceb/virtual.go
+++ b/internal/ceb/virtual.go
@@ -1,0 +1,309 @@
+package ceb
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// VirtualExecInfo contains values to run an exec session.
+type VirtualExecInfo struct {
+	Input  io.Reader // stdin
+	Output io.Writer // stdout
+	Error  io.Writer // stderr
+
+	// Command line arguments
+	Arguments []string
+
+	// Specifies if we and how we should allocate a pty to handle
+	// the command.
+	PTY *pb.ExecStreamRequest_PTY
+}
+
+// VirtualExecSession represents a running exec, spawned by VirtualExecHandler.
+type VirtualExecSession interface {
+	// Called to start the session. Should block until the session is finished.
+	Run(ctx context.Context) error
+
+	// Close the running session down. Called concurrently to Run.
+	Close() error
+
+	// Resize the PTY according to the given window information.
+	// Called concurrently to Run.
+	PTYResize(*pb.ExecStreamRequest_WindowSize) error
+}
+
+// VirtualExecHandler represents the ability to spawn exec sessions.
+// It is the abstraction layer Virtual uses for creating exec sessions.
+type VirtualExecHandler interface {
+	CreateSession(ctx context.Context, sess *VirtualExecInfo) (VirtualExecSession, error)
+}
+
+// VirtualConfig is the configuration of the CEB Virtual value
+type VirtualConfig struct {
+	// The deployment id that this virtual session is for. The server
+	// will validate this value.
+	DeploymentId string
+
+	// The instance id for this virtual instance.
+	InstanceId string
+
+	// How to connect back to the server. Because Virtual is usually used in the context
+	// of a Runner, this can be the same Client the Runner is using.
+	Client pb.WaypointClient
+}
+
+// Virtual represents a virtual CEB instance. It is used to manifest an instance that
+// performs exec operations via a Go interface rather than just running a command.
+type Virtual struct {
+	cfg VirtualConfig
+	log hclog.Logger
+}
+
+// NewVirtual creates a new Virtual value based on the logger and config.
+func NewVirtual(log hclog.Logger, cfg VirtualConfig) (*Virtual, error) {
+	virt := &Virtual{
+		cfg: cfg,
+		log: log,
+	}
+	return virt, nil
+}
+
+// RunExec connects to the server and handles any inbound Exec requests via the
+// VirtualExecHandler. The count parameter inidcates how many exec sessions to handle
+// before returning. If count is less than 0, it handles sessions forever.
+func (v *Virtual) RunExec(ctx context.Context, h VirtualExecHandler, count int) error {
+	v.log.Info("connecting virtual instance")
+
+	// A quick heads up: gRPC provides to ability to let the client of a recieve stream
+	// tell the remote side "hey, I'm done now, don't send me anything else.". So instead
+	// we wire up a context to the call and cancel it when we are done. This cancelation
+	// will propogate to the server and they'll see that we have gone away.
+	//
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// On the server side, EntrypointConfig is what registers an instance. Keeping
+	// the epclient alive is what controls if the instance is registered or not.
+	//
+	epclient, err := v.cfg.Client.EntrypointConfig(ctx, &pb.EntrypointConfigRequest{
+		DeploymentId: v.cfg.DeploymentId,
+		InstanceId:   v.cfg.InstanceId,
+		Type:         pb.Instance_VIRTUAL,
+	})
+	if err != nil {
+		return err
+	}
+
+	// We never send anything
+	epclient.CloseSend()
+
+	v.log.Info("virtual instance connected")
+
+	dynamicSources := map[string]*pb.ConfigSource{}
+
+	var (
+		static  []string
+		dynamic map[string][]*component.ConfigRequest
+		env     []string
+
+		highestExec int64
+	)
+
+	// They can be used for config sources that we might be sent.
+	configPlugins := loadPlugins()
+
+	prevVarsChanged := map[string]bool{}
+
+	// This is much more paired down than the version in the official CEB because the
+	// expectation is that a virtual instance is used for a single operation and then
+	// exits. So we only need to see a single view of the config variables before we
+	// can continue on.
+
+	for {
+		msg, err := epclient.Recv()
+		if err != nil {
+			return err
+		}
+
+		// The idea here is that we're going to gather up all the configs sent down
+		// and then use them in an exec session when it's requested.
+
+		for _, src := range msg.Config.ConfigSources {
+			dynamicSources[src.Type] = src
+		}
+
+		if msg.Config.EnvVars != nil {
+			static, dynamic = splitAppConfig(v.log, msg.Config.EnvVars)
+		}
+
+		if msg.Config.Exec != nil {
+			env = buildAppConfig(ctx, v.log, configPlugins, static, dynamic, dynamicSources, prevVarsChanged)
+
+			idx := highestExec
+
+			for _, exec := range msg.Config.Exec {
+				// Skip sessions we already know about. Normal CEB does this too, I guess beacuse
+				// the server can resend exec info.
+				if exec.Index <= highestExec {
+					continue
+				}
+
+				if exec.Index > idx {
+					idx = exec.Index
+				}
+
+				err = v.startExec(ctx, h, exec, env)
+				if count > 0 {
+					count--
+					if count == 0 {
+						v.log.Info("virtual instance stopping")
+						return nil
+					}
+				}
+			}
+
+			highestExec = idx
+		}
+	}
+}
+
+// startExec launches and manages a ExecStream for the given exec config. It will
+// spawn an exec session from the handler and then shuffle the data between gRPC
+// and the VirtualExecSession and VirtualExecInfo interfaces.
+func (v *Virtual) startExec(
+	ctx context.Context,
+	h VirtualExecHandler,
+	execConfig *pb.EntrypointConfig_Exec,
+	env []string,
+) error {
+	v.log.Info("starting exec stream", "args", execConfig.Args)
+	defer v.log.Info("exec stream finished")
+
+	client, err := v.cfg.Client.EntrypointExecStream(ctx)
+	if err != nil {
+		v.log.Warn("error opening exec stream", "err", err)
+		return nil
+	}
+
+	defer client.CloseSend()
+
+	// Send our open message
+	v.log.Trace("sending open message")
+	if err := client.Send(&pb.EntrypointExecRequest{
+		Event: &pb.EntrypointExecRequest_Open_{
+			Open: &pb.EntrypointExecRequest_Open{
+				InstanceId: v.cfg.InstanceId,
+				Index:      execConfig.Index,
+			},
+		},
+	}); err != nil {
+		v.log.Warn("error opening exec stream", "err", err)
+		return nil
+	}
+
+	// Create our pipe for stdin so that we can send data
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	// We need to modify our command so the input/output is all over gRPC
+	stdout := execOutputWriter(client, pb.EntrypointExecRequest_Output_STDOUT)
+	stderr := execOutputWriter(client, pb.EntrypointExecRequest_Output_STDERR)
+
+	done := make(chan error, 1)
+
+	// Spawn a new exec session for this exec config.
+	xsess, err := h.CreateSession(ctx, &VirtualExecInfo{
+		Input:     stdinR,
+		Output:    stdout,
+		Error:     stderr,
+		Arguments: execConfig.Args,
+		PTY:       execConfig.Pty,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Start our receive data loop. We use this loop so that our
+	// main processing loop can select on multiple channels.
+
+	respCh := make(chan *pb.EntrypointExecResponse)
+	go func() {
+		defer close(respCh)
+
+		for {
+			resp, err := client.Recv()
+			if err != nil {
+				if err == io.EOF || err == context.Canceled {
+					v.log.Info("exec stream ended by client")
+				} else {
+					v.log.Warn("error receiving from server stream", "err", err)
+				}
+				return
+			}
+
+			respCh <- resp
+		}
+	}()
+
+	// We don't block on Run in the main goroutine so that we can just shuffle
+	// and orchestrate the data there.
+	go func() {
+		done <- xsess.Run(ctx)
+	}()
+
+	for {
+		select {
+
+		// Run has finished.
+		case err := <-done:
+			v.log.Info("command has finished", "error", err)
+			exitCode := 0
+			if err != nil {
+				exitCode = 1
+			}
+
+			if err := client.Send(&pb.EntrypointExecRequest{
+				Event: &pb.EntrypointExecRequest_Exit_{
+					Exit: &pb.EntrypointExecRequest_Exit{
+						Code: int32(exitCode),
+					},
+				},
+			}); err != nil {
+				v.log.Warn("error sending exit message", "err", err)
+			}
+			return err
+
+		// The server sent new info
+		case resp, ok := <-respCh:
+			if !ok {
+				// channel is closed, we should terminate our child process.
+				v.log.Info("exec recv stream closed")
+				return xsess.Close()
+			}
+
+			switch event := resp.Event.(type) {
+			case *pb.EntrypointExecResponse_Input:
+				// Copy the input to stdin
+				v.log.Trace("input received", "data", event.Input)
+				io.Copy(stdinW, bytes.NewReader(event.Input))
+
+			case *pb.EntrypointExecResponse_InputEof:
+				v.log.Trace("input EOF, closing stdin")
+				stdinW.Close()
+
+			case *pb.EntrypointExecResponse_Winch:
+				v.log.Debug("window size change event, changing")
+
+				if err := xsess.PTYResize(event.Winch); err != nil {
+					v.log.Warn("error changing window size, this doesn't quit the stream",
+						"err", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/ceb/virtual_test.go
+++ b/internal/ceb/virtual_test.go
@@ -1,0 +1,137 @@
+package ceb
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/waypoint/internal/server"
+	"github.com/hashicorp/waypoint/internal/server/execclient"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testVirtualHandler struct {
+	info   *VirtualExecInfo
+	closed int
+
+	stdin bytes.Buffer
+}
+
+func (t *testVirtualHandler) Run(ctx context.Context) error {
+	io.Copy(&t.stdin, t.info.Input)
+	fmt.Fprintf(t.info.Output, "test output\n")
+	fmt.Fprintf(t.info.Error, "test error\n")
+	time.Sleep(time.Second)
+
+	return nil
+}
+
+func (t *testVirtualHandler) Close() error {
+	t.closed++
+	return nil
+}
+
+func (t *testVirtualHandler) PTYResize(_ *pb.ExecStreamRequest_WindowSize) error {
+	return nil
+}
+
+func (t *testVirtualHandler) CreateSession(ctx context.Context, sess *VirtualExecInfo) (VirtualExecSession, error) {
+	t.info = sess
+	return t, nil
+}
+
+func TestVirtual_exec(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	L := hclog.New(&hclog.LoggerOptions{
+		Level:           hclog.Trace,
+		IncludeLocation: true,
+	})
+
+	// Start up the server
+	restartCh := make(chan struct{})
+	impl := singleprocess.TestImpl(t)
+	client := server.TestServer(t, impl,
+		server.TestWithContext(ctx),
+		server.TestWithRestart(restartCh),
+	)
+
+	resp, err := client.UpsertDeployment(ctx, &pb.UpsertDeploymentRequest{
+		Deployment: serverptypes.TestValidDeployment(t, nil),
+	})
+	require.NoError(err)
+
+	virt, err := NewVirtual(L, VirtualConfig{
+		DeploymentId: resp.Deployment.Id,
+		InstanceId:   "A",
+		Client:       client,
+	})
+
+	require.NoError(err)
+
+	var th testVirtualHandler
+
+	go virt.RunExec(ctx, &th, 1)
+
+	// We should get registered
+	require.Eventually(func() bool {
+		resp, err := client.ListInstances(ctx, &pb.ListInstancesRequest{
+			Scope: &pb.ListInstancesRequest_DeploymentId{
+				DeploymentId: resp.Deployment.Id,
+			},
+		})
+		require.NoError(err)
+		return len(resp.Instances) == 1
+	}, 2*time.Second, 25*time.Millisecond)
+
+	var stderr, stdout bytes.Buffer
+
+	ec := &execclient.Client{
+		Logger:  L,
+		Context: ctx,
+		Client:  client,
+		Args:    []string{"date"},
+		Stdin:   ioutil.NopCloser(strings.NewReader("input data\n")),
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+
+		InstanceId: "A",
+	}
+
+	code, err := ec.Run()
+	require.NoError(err)
+
+	assert.Equal(0, code)
+
+	assert.Equal("input data\n", th.stdin.String())
+	assert.Equal("test output\n", stdout.String())
+	assert.Equal("test error\n", stderr.String())
+
+	assert.Equal([]string{"date"}, th.info.Arguments)
+
+	// We should get deregistered
+	require.Eventually(func() bool {
+		resp, err := client.ListInstances(ctx, &pb.ListInstancesRequest{
+			Scope: &pb.ListInstancesRequest_DeploymentId{
+				DeploymentId: resp.Deployment.Id,
+			},
+		})
+		require.NoError(err)
+		return len(resp.Instances) == 0
+	}, time.Second, 100*time.Millisecond)
+
+}

--- a/internal/server/execclient/client.go
+++ b/internal/server/execclient/client.go
@@ -250,10 +250,12 @@ func (c *Client) Run() (int, error) {
 		case resp := <-recvCh:
 			switch event := resp.Event.(type) {
 			case *pb.ExecStreamResponse_Output_:
-				// TODO: stderr
-				out := c.Stdout
-				io.Copy(out, bytes.NewReader(event.Output.Data))
-
+				switch event.Output.Channel {
+				case pb.ExecStreamResponse_Output_STDOUT:
+					io.Copy(c.Stdout, bytes.NewReader(event.Output.Data))
+				case pb.ExecStreamResponse_Output_STDERR:
+					io.Copy(c.Stderr, bytes.NewReader(event.Output.Data))
+				}
 			case *pb.ExecStreamResponse_Exit_:
 				return int(event.Exit.Code), nil
 

--- a/internal/server/singleprocess/service_exec.go
+++ b/internal/server/singleprocess/service_exec.go
@@ -38,6 +38,7 @@ func (s *service) StartExecStream(
 		Pty:               start.Start.Pty,
 		ClientEventCh:     clientEventCh,
 		EntrypointEventCh: eventCh,
+		Context:           srv.Context(),
 	}
 
 	// Register the exec session

--- a/internal/server/singleprocess/state/instance_exec.go
+++ b/internal/server/singleprocess/state/instance_exec.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/hashicorp/go-memdb"
@@ -58,6 +59,11 @@ type InstanceExec struct {
 	ClientEventCh     <-chan *pb.ExecStreamRequest
 	EntrypointEventCh chan<- *pb.EntrypointExecRequest
 	Connected         uint32
+
+	// This is the context that the client side is running inside.
+	// It is used by the entrypoint side to detect if the client is still
+	// around or not.
+	Context context.Context
 }
 
 func (s *State) InstanceExecCreateByTargetedInstance(id string, exec *InstanceExec) error {


### PR DESCRIPTION
This work lays the groundwork for the exec plugin, which will use the virtual CEB running inside a runner, with a VirtualExecHandler wired up to an exec function provided by the Deploy plugin.