### PR TITLE
internal/client: use given context so it can be cancelled

### DIFF
--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -58,7 +58,7 @@ func New(ctx context.Context, opts ...Option) (*Project, error) {
 	// package or spinning up an in-process server.
 	if client.client == nil {
 		client.logger.Trace("no API client provided, initializing connection if possible")
-		conn, err := client.initServerClient(context.Background(), &cfg)
+		conn, err := client.initServerClient(ctx, &cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
While attempting to connect to a server, Ctrl-C was not working. This is
because we were using `context.Background` rather than the passed in
context when attempting to connect.

I don't know why we did this, it looks like a simple mistake from dev.
Verified that this makes Ctrl-C work properly for server connection.

Labeling for backport to 0.2.x.