### PR TITLE
clean up error msgs for snapshots on uninstall

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -98,11 +98,19 @@ func (c *UninstallCommand) Run(args []string) int {
 		// take the snapshot
 		w, err := os.Create(c.snapshotName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating snapshot file: %s", err)
+			s.Update("Error generating server snapshot")
+			s.Status(terminal.StatusError)
+			s.Done()
+
+			c.ui.Output(fmt.Sprintf("Error creating snapshot file: %s", err), terminal.WithErrorStyle())
 			return 1
 		}
 		if err = clisnapshot.WriteSnapshot(ctx, c.project.Client(), w); err != nil {
-			fmt.Fprintf(os.Stderr, "Error generating snapshot: %s", err)
+			s.Update("Error generating server snapshot")
+			s.Status(terminal.StatusError)
+			s.Done()
+
+			c.ui.Output(fmt.Sprintf("Error generating snapshot: %s", err), terminal.WithErrorStyle())
 			return 1
 		}
 		s.Update("Snapshot %q generated", c.snapshotName)


### PR DESCRIPTION
Before
```
Uninstalling Waypoint server with context "install-1611076865"
⠙ Generating server snapshot...Error generating snapshot: failed to receive snapshot start message: rpc error: code = Unimplemented desc = unknown method CreateSnapshot for servi❌ Generating server snapshot...
```

After
```
Uninstalling Waypoint server with context "install-1611076865"
❌ Error generating server snapshot
! Error generating snapshot: failed to receive snapshot start message: rpc error: code = Unimplemented desc = unknown method CreateSnapshot for service
hashicorp.waypoint.Waypoint
```