### PR TITLE
internal/cli: colorize flags in help text and nested subcommands

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -166,7 +166,7 @@ func (c *helpCommand) HelpTemplate() string {
 var (
 	reHelpHeader = regexp.MustCompile(`^[a-zA-Z0-9_-].*:$`)
 	reCommand    = regexp.MustCompile(`"waypoint (\w\s?)+"`)
-	reFlag       = regexp.MustCompile(`(\s|^)(-[\w-]+)(\s|$)`)
+	reFlag       = regexp.MustCompile(`(\s|^|")(-[\w-]+)(\s|$|")`)
 )
 
 const helpTemplate = `

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -27,6 +27,9 @@ func formatHelp(v string) string {
 		Cols: 180,
 	})
 
+	// seenHeader is flipped to true once we see any reHelpHeader match.
+	seenHeader := false
+
 	for _, line := range strings.Split(v, "\n") {
 		// Usage: prefix lines
 		prefix := "Usage: "
@@ -58,6 +61,8 @@ func formatHelp(v string) string {
 
 		// A header line
 		if reHelpHeader.MatchString(line) {
+			seenHeader = true
+
 			d.Append(glint.Style(
 				glint.Text(line),
 				glint.Bold(),
@@ -91,6 +96,38 @@ func formatHelp(v string) string {
 
 			d.Append(glint.Layout(cs...).Row())
 			continue
+		}
+
+		// The styles in this block we only want to apply before any headers.
+		if !seenHeader {
+			// If we have a flag in the line, then highlight that.
+			if matches := reFlag.FindAllStringSubmatchIndex(line, -1); len(matches) > 0 {
+				const matchGroup = 2 // the subgroup that has the actual flag
+
+				var cs []glint.Component
+				idx := 0
+				for _, match := range matches {
+					start := match[matchGroup*2]
+					end := match[matchGroup*2+1]
+
+					cs = append(
+						cs,
+						glint.Text(line[idx:start]),
+						glint.Style(
+							glint.Text(line[start:end]),
+							glint.Color("lightMagenta"),
+						),
+					)
+
+					idx = end
+				}
+
+				// Add the rest of the text
+				cs = append(cs, glint.Text(line[idx:]))
+
+				d.Append(glint.Layout(cs...).Row())
+				continue
+			}
 		}
 
 		// Normal line
@@ -128,7 +165,8 @@ func (c *helpCommand) HelpTemplate() string {
 
 var (
 	reHelpHeader = regexp.MustCompile(`^[a-zA-Z0-9_-].*:$`)
-	reCommand    = regexp.MustCompile(`"waypoint \w+"`)
+	reCommand    = regexp.MustCompile(`"waypoint (\w\s?)+"`)
+	reFlag       = regexp.MustCompile(`(\s|^)(-[\w-]+)(\s|$)`)
 )
 
 const helpTemplate = `


### PR DESCRIPTION
This modifies our CLI help output to do two things:

  1. We always highlighted commands such as "waypoint foo", but nested
     subcommands "waypoint foo bar" weren't highlighted. This fixes
     that.

  2. Flags in the help text body such as -foo and -foo-bar are now
     highlighted as well. This is only in the help text summary and not
     the flag documentation itself.

Screenshots (sorry my colors are very muted so its hard to see):

Flag highlight (see -waypoint-hcl):

<img width="613" alt="CleanShot 2021-01-19 at 12 19 45@2x" src="https://user-images.githubusercontent.com/1299/105088559-e91ff000-5a50-11eb-8e8c-ec7ffcbded6d.png">

Nested subcommand highlight:

<img width="594" alt="CleanShot 2021-01-19 at 12 19 57@2x" src="https://user-images.githubusercontent.com/1299/105088571-ec1ae080-5a50-11eb-8a77-3d436ef63dbc.png">
