### PR TITLE
`waypoint project` CLI 

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -415,6 +415,12 @@ func Commands(
 				baseCommand: baseCommand,
 			}, nil
 		},
+
+		"project list": func() (cli.Command, error) {
+			return &ProjectListCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
 	}
 
 	// register our aliases

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -421,6 +421,11 @@ func Commands(
 				baseCommand: baseCommand,
 			}, nil
 		},
+		"project apply": func() (cli.Command, error) {
+			return &ProjectApplyCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
 	}
 
 	// register our aliases

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -79,9 +79,10 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 
 	// Setup our project that we're going to override
 	var proj *pb.Project
+	var updated bool
 	if resp != nil {
 		s.Update("Updating project %q...", name)
-		proj = resp.Project
+		updated = true
 	} else {
 		s.Update("Creating project %q...", name)
 		proj = &pb.Project{Name: name}

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/posener/complete"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+type ProjectApplyCommand struct {
+	*baseCommand
+
+	flagDataSource     string
+	flagGitURL         string
+	flagGitRef         string
+	flagGitAuthType    string
+	flagGitUsername    string
+	flagGitPassword    string
+	flagGitKeyPath     string
+	flagGitKeyPassword string
+}
+
+func (c *ProjectApplyCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	flagSet := c.Flags()
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(flagSet),
+		WithNoConfig(),
+	); err != nil {
+		return 1
+	}
+	args = flagSet.Args()
+	ctx := c.Ctx
+
+	if len(args) != 1 {
+		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		return 1
+	}
+
+	name := args[0]
+
+	sg := c.ui.StepGroup()
+	defer sg.Wait()
+
+	s := sg.Add("Checking for an existing project named: %s", name)
+	defer func() { s.Abort() }()
+
+	// Check for an existing project of the same name.
+	resp, err := c.project.Client().GetProject(ctx, &pb.GetProjectRequest{
+		Project: &pb.Ref_Project{
+			Project: name,
+		},
+	})
+	if status.Code(err) == codes.NotFound {
+		// If the error is a not found error, act as though there is no error
+		// and the project is nil so that we can handle that later.
+		resp = nil
+		err = nil
+	}
+	if err != nil {
+		c.ui.Output(
+			"Error checking for project: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return 1
+	}
+
+	// Setup our project that we're going to override
+	var proj *pb.Project
+	if resp != nil {
+		s.Update("Updating project %q...", name)
+		proj = resp.Project
+	} else {
+		s.Update("Creating project %q...", name)
+		proj = &pb.Project{Name: name}
+	}
+
+	// The logic throughout below has a ton of if checks cause we want to
+	// merge information rather than set it all new.
+
+	switch strings.ToLower(c.flagDataSource) {
+	case "git":
+		// Set remote enabled to true so users can run remote ops
+		proj.RemoteEnabled = true
+
+		// If the project existing datasource is Git, then we're overriding.
+		// If the existing datasource is not Git or not set, then we set it
+		// to Git and create new.
+		var gitInfo *pb.Job_Git
+		if proj.DataSource != nil {
+			if v, ok := proj.DataSource.Source.(*pb.Job_DataSource_Git); ok {
+				gitInfo = v.Git
+			}
+		}
+		if gitInfo == nil {
+			gitInfo = &pb.Job_Git{}
+			proj.DataSource = &pb.Job_DataSource{
+				Source: &pb.Job_DataSource_Git{Git: gitInfo},
+			}
+		}
+
+		if v := c.flagGitURL; v != "" {
+			gitInfo.Url = v
+		}
+		if v := c.flagGitRef; v != "" {
+			gitInfo.Ref = v
+		}
+
+		switch strings.ToLower(c.flagGitAuthType) {
+		case "basic":
+			authInfo, ok := gitInfo.Auth.(*pb.Job_Git_Basic_)
+			if !ok {
+				authInfo = &pb.Job_Git_Basic_{Basic: &pb.Job_Git_Basic{}}
+				gitInfo.Auth = authInfo
+			}
+
+			if v := c.flagGitUsername; v != "" {
+				authInfo.Basic.Username = v
+			}
+			if v := c.flagGitPassword; v != "" {
+				authInfo.Basic.Password = v
+			}
+
+		case "ssh":
+			authInfo, ok := gitInfo.Auth.(*pb.Job_Git_Ssh)
+			if !ok {
+				authInfo = &pb.Job_Git_Ssh{Ssh: &pb.Job_Git_SSH{}}
+				gitInfo.Auth = authInfo
+			}
+
+			if v := c.flagGitKeyPath; v != "" {
+				bs, err := ioutil.ReadFile(v)
+				if err != nil {
+					c.ui.Output(
+						"Error reading private key specified with -git-private-key-path: %s", err,
+						terminal.WithErrorStyle(),
+					)
+
+					return 1
+				}
+
+				authInfo.Ssh.PrivateKeyPem = bs
+			}
+			if v := c.flagGitKeyPassword; v != "" {
+				authInfo.Ssh.Password = v
+			}
+
+		case "":
+			gitInfo.Auth = nil
+
+		default:
+			c.ui.Output(
+				"Unknown value for -git-auth-type set. Must be either 'basic' or 'ssh' or unset.",
+				terminal.WithErrorStyle(),
+			)
+		}
+
+	case "local":
+		// Set the data source to local if it isn't set.
+		var localInfo *pb.Job_Local
+		if proj.DataSource != nil {
+			if v, ok := proj.DataSource.Source.(*pb.Job_DataSource_Local); ok {
+				localInfo = v.Local
+			}
+		}
+		if localInfo == nil {
+			localInfo = &pb.Job_Local{}
+			proj.DataSource = &pb.Job_DataSource{
+				Source: &pb.Job_DataSource_Local{Local: localInfo},
+			}
+		}
+
+		// We don't use localInfo yet since there is nothing to set.
+
+	case "":
+		// Do nothing, we aren't updating this information for this project.
+
+	default:
+		s.Abort()
+
+		c.ui.Output(
+			"Unknown value for -data-source set. Must be either 'git' or 'local' or unset.",
+			terminal.WithErrorStyle(),
+		)
+	}
+
+	// Upsert
+	_, err = c.project.Client().UpsertProject(ctx, &pb.UpsertProjectRequest{
+		Project: proj,
+	})
+	if err != nil {
+		c.ui.Output(
+			"Error upserting project: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return 1
+	}
+
+	s.Done()
+
+	return 0
+}
+
+func (c *ProjectApplyCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(sets *flag.Sets) {
+		f := sets.NewSet("Command Options")
+
+		f.StringVar(&flag.StringVar{
+			Name:    "data-source",
+			Target:  &c.flagDataSource,
+			Default: "",
+			Usage:   "The data source type to use (currently only supports 'git' or 'local').",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-url",
+			Target:  &c.flagGitURL,
+			Default: "",
+			Usage:   "URL of the Git repository to clone. This can be an HTTP or SSH URL.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-ref",
+			Target:  &c.flagGitRef,
+			Default: "",
+			Usage:   "Git ref (i.e. branch, tag, commit) to clone on new operations.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-auth-type",
+			Target:  &c.flagGitAuthType,
+			Default: "",
+			Usage: "Authentication type for Git. If set, must be one of 'basic' or 'ssh'. " +
+				"Basic auth is username/password and SSH uses an SSH key.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-username",
+			Target:  &c.flagGitUsername,
+			Default: "",
+			Usage: "Username for authentication when git-auth-type is 'basic'. " +
+				"For GitHub, this can be any value but it must be non-empty.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-password",
+			Target:  &c.flagGitPassword,
+			Default: "",
+			Usage: "Password for authentication when git-auth-type is 'basic'. " +
+				"For GitHub, this should be a personal access token (PAT).",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-private-key-path",
+			Target:  &c.flagGitKeyPath,
+			Default: "",
+			Usage:   "Path to a PEM-encoded private key for 'ssh'-based auth.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "git-private-key-password",
+			Target:  &c.flagGitKeyPassword,
+			Default: "",
+			Usage: "Password for the private key specified by git-private-key-path " +
+				"if the key requires a password to decode. This is not required if " +
+				"the private key doesn't require a password.",
+		})
+	})
+}
+
+func (c *ProjectApplyCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ProjectApplyCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *ProjectApplyCommand) Synopsis() string {
+	return "Create or update a project."
+}
+
+func (c *ProjectApplyCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint project apply [OPTIONS] NAME
+
+  Create or update a project.
+
+  This command should be used to create a new project pointing to a VCS
+  repo. If you have a "waypoint.hcl" file and a local repository, you can
+  also use "waypoint init" in the directory of the project.
+
+  This will create a new project with the given options. If a project with
+  the same name already exists, this will update the existing project using
+  the fields that are set.
+
+`)
+}

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -266,6 +266,11 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 		return 1
 	}
 
+	if updated {
+		s.Update("Project %q updated", name)
+	} else {
+		s.Update("Project %q created", name)
+	}
 	s.Done()
 
 	return 0

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -41,7 +41,7 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 	ctx := c.Ctx
 
 	if len(args) != 1 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output("Single argument required.\n\n"+c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -302,5 +302,6 @@ Usage: waypoint project apply [OPTIONS] NAME
   the same name already exists, this will update the existing project using
   the fields that are set.
 
-`)
+
+` + c.Flags().Help())
 }

--- a/internal/cli/project_list.go
+++ b/internal/cli/project_list.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"sort"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/posener/complete"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+)
+
+type ProjectListCommand struct {
+	*baseCommand
+}
+
+func (c *ProjectListCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+	); err != nil {
+		return 1
+	}
+
+	resp, err := c.project.Client().ListProjects(c.Ctx, &empty.Empty{})
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	var result []string
+	for _, p := range resp.Projects {
+		result = append(result, p.Project)
+	}
+
+	sort.Strings(result)
+	for _, p := range result {
+		c.ui.Output(p)
+	}
+
+	return 0
+}
+
+func (c *ProjectListCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
+}
+
+func (c *ProjectListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ProjectListCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *ProjectListCommand) Synopsis() string {
+	return "List all registered projects."
+}
+
+func (c *ProjectListCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint project list
+
+  List all registered projects.
+
+  Projects usually a single version control repository and contain
+  exactly one "waypoint.hcl" configuration. A project may contain multiple
+  applications.
+
+  A project is registered either via the web UI, "waypoint project apply",
+  or "waypoint init".
+
+`)
+}

--- a/internal/cli/project_list.go
+++ b/internal/cli/project_list.go
@@ -36,6 +36,10 @@ func (c *ProjectListCommand) Run(args []string) int {
 		result = append(result, p.Project)
 	}
 
+	if len(result) == 0 {
+		c.ui.Output("No projects found.")
+		return 0
+	}
 	sort.Strings(result)
 	for _, p := range result {
 		c.ui.Output(p)

--- a/internal/cli/project_list.go
+++ b/internal/cli/project_list.go
@@ -66,7 +66,7 @@ Usage: waypoint project list
 
   List all registered projects.
 
-  Projects usually a single version control repository and contain
+  Projects usually map to a single version control repository and contain
   exactly one "waypoint.hcl" configuration. A project may contain multiple
   applications.
 

--- a/internal/cli/project_list.go
+++ b/internal/cli/project_list.go
@@ -70,7 +70,7 @@ Usage: waypoint project list
   exactly one "waypoint.hcl" configuration. A project may contain multiple
   applications.
 
-  A project is registered either via the web UI, "waypoint project apply",
+  A project is registered via the web UI, "waypoint project apply",
   or "waypoint init".
 
 `)


### PR DESCRIPTION
This introduces `waypoint project list` and `waypoint project apply` CLIs.

(Note: there is no `waypoint project delete` cause we don't yet support project delete. Once we do, we'll add that.)

The "apply" CLI behaves as we described in the RFC, it merges wherever possible and everything is optional. We also have a `-waypoint-hcl` flag that can be used to specify a path to a `waypoint.hcl` file that we use to source config. Additional CLI flags can still be provided when using the HCL file mode to override values in there.

Example full CLI command to enable Git (no HCL file used):

```
waypoint project apply \
  -data-source=git \
  -git-url=https://github.com/mitchellh/waypoint-test-app.git \
  -git-auth-type=basic \
  -git-username=github \
  -git-password=abcd1234 \
  example-python
```