### PR TITLE
Include libseccomp-static and pkgconfig for building wp/server with img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM hashicorp.jfrog.io/docker/golang:alpine AS builder
 
-RUN apk add --no-cache git gcc libc-dev openssh
+RUN apk add --no-cache git gcc libc-dev openssh make
 
 RUN mkdir -p /tmp/wp-prime
 COPY go.sum /tmp/wp-prime
@@ -20,13 +20,11 @@ RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
 RUN --mount=type=ssh --mount=type=secret,id=ssh.config --mount=type=secret,id=ssh.key \
     GIT_SSH_COMMAND="ssh -o \"ControlMaster auto\" -F \"/run/secrets/ssh.config\"" \
     go mod download
+RUN go get github.com/kevinburke/go-bindata/...
 
 COPY . /tmp/wp-src
-
 WORKDIR /tmp/wp-src
 
-RUN apk add --no-cache make
-RUN go get github.com/kevinburke/go-bindata/...
 RUN --mount=type=cache,target=/root/.cache/go-build make bin
 RUN --mount=type=cache,target=/root/.cache/go-build make bin/entrypoint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN git clone https://github.com/mitchellh/img.git /img
 WORKDIR /img
 RUN git checkout pull-config
 RUN go get github.com/go-bindata/go-bindata/go-bindata
-RUN make static && mv img /usr/bin/img
+RUN make BUILDTAGS="seccomp noembed" && mv img /usr/bin/img
 
 # Copied from img repo, see notes for specific reasons:
 # https://github.com/genuinetools/img/blob/d858ac71f93cc5084edd2ba2d425b90234cf2ead/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,6 @@ RUN apk add --no-cache \
 	gcc \
 	git \
 	libseccomp-dev \
-	libseccomp-static \
-	pkgconfig \
 	linux-headers \
 	make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ RUN apk add --no-cache \
 	gcc \
 	git \
 	libseccomp-dev \
+	libseccomp-static \
+	pkgconfig \
 	linux-headers \
 	make
 


### PR DESCRIPTION
With the recent img additions to waypoint server, gcc needs libseccomp
static available as well as pkg-config to properly build runc for img
against our forked copy.

Before these changes, the server fails to build:

```
=> CANCELED [imgbase 6/6] RUN ./autogen.sh --disable-nls --disable-man --without-audit     --without-selinux --without-acl --without-attr --without-tcb     --without-nscd     && make     14.0s
 => ERROR [imgbuilder 7/7] RUN make static && mv img /usr/bin/img                                                                                                                           13.8s
 => CACHED [builder  2/15] RUN apk add --no-cache git gcc libc-dev openssh                                                                                                                   0.0s
 => CACHED [builder  3/15] RUN mkdir -p /tmp/wp-prime                                                                                                                                        0.0s
 => CACHED [builder  4/15] COPY go.sum /tmp/wp-prime                                                                                                                                         0.0s
 => CACHED [builder  5/15] COPY go.mod /tmp/wp-prime                                                                                                                                         0.0s
 => CACHED [builder  6/15] WORKDIR /tmp/wp-prime                                                                                                                                             0.0s
 => CACHED [builder  7/15] RUN mkdir -p -m 0600 ~/.ssh     && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts                                                                            0.0s
 => CACHED [builder  8/15] RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/                                                                                   0.0s
 => CANCELED [builder  9/15] RUN --mount=type=ssh --mount=type=secret,id=ssh.config --mount=type=secret,id=ssh.key     GIT_SSH_COMMAND="ssh -o "ControlMaster auto" -F "/run/secrets/ssh.c  14.1s
------
 > [imgbuilder 7/7] RUN make static && mv img /usr/bin/img:
#14 0.752 git clone -c advice.detachedHead=false https://github.com/opencontainers/runc.git "/img/cross/src/github.com/opencontainers/runc"
#14 0.753 Cloning into '/img/cross/src/github.com/opencontainers/runc'...
#14 2.612 ( cd /img/cross/src/github.com/opencontainers/runc ; git checkout 56aca5aa50d07548d5db8fd33e9dc562f70f3208 )
#14 2.794 HEAD is now at 56aca5aa Merge pull request #2295 from kolyshkin/integration-cgroups
#14 2.796 make -C "/img/cross/src/github.com/opencontainers/runc" static BUILDTAGS="seccomp apparmor"
#14 2.797 make[1]: Entering directory '/img/cross/src/github.com/opencontainers/runc'
#14 3.468 CGO_ENABLED=1 go build  -tags "seccomp apparmor netgo osusergo" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit="56aca5aa50d07548d5db8fd33e9dc562f70f3208" -X main.version=1.0.0-rc10+dev " -o runc .
#14 13.58 # github.com/opencontainers/runc
#14 13.58 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
#14 13.58 /usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lseccomp
#14 13.58 collect2: error: ld returned 1 exit status
#14 13.58
#14 13.61 make[1]: *** [Makefile:44: static] Error 2
#14 13.61 make[1]: Leaving directory '/img/cross/src/github.com/opencontainers/runc'
#14 13.61 make: *** [Makefile:23: /img/cross/bin/runc] Error 2
------
executor failed running [/bin/sh -c make static && mv img /usr/bin/img]: exit code: 2
Makefile:41: recipe for target 'docker/server' failed

```