### PR TITLE
Add a generic build target for waypoint server container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ test: # run tests
 format: # format go code
 	gofmt -s -w ./
 
+.PHONY: docker/server
+docker/server:
+	DOCKER_BUILDKIT=1 docker build \
+					--ssh default \
+					--secret id=ssh.config,src="${HOME}/.ssh/config" \
+					--secret id=ssh.key,src="${HOME}/.ssh/config" \
+					-t waypoint:dev \
+					.
+
 .PHONY: docker/mitchellh
 docker/mitchellh:
 	DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
Including the make target for the generic docker server on our 0.2.x branch