### PR TITLE
cli: more specific error msgs on install

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -60,8 +60,17 @@ func (c *InstallCommand) Run(args []string) int {
 
 	p, ok := serverinstall.Platforms[strings.ToLower(c.platform)]
 	if !ok {
+		if c.platform == "" {
+			c.ui.Output(
+				"The -platform flag is required.",
+				terminal.WithErrorStyle(),
+			)
+
+			return 1
+		}
+
 		c.ui.Output(
-			"Error installing server into %s: invalid platform",
+			"Error installing server into %q: invalid platform",
 			c.platform,
 			terminal.WithErrorStyle(),
 		)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -70,7 +70,7 @@ func (c *InstallCommand) Run(args []string) int {
 		}
 
 		c.ui.Output(
-			"Error installing server into %q: invalid platform",
+			"Error installing server into %q: unsupported platform",
 			c.platform,
 			terminal.WithErrorStyle(),
 		)


### PR DESCRIPTION
Small PR to match the error messaging we give on `uninstall` if the `-platform` flag is missing.