### PR TITLE
serverinstall/docker: Start waypoint server container if stopped

### DIFF
--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -97,12 +97,13 @@ func (i *DockerInstaller) Install(
 		s.Status(terminal.StatusWarn)
 		s.Done()
 
+		// In the case where waypoint server container isn't running, the installer
+		// will attempt to start the container. It does this for all containers
+		// that match the 'containerLabel'. In the future case where we support
+		// running multiple waypoint server containers, this loop will try to start
+		// each container.
 		for _, container := range containers {
-			if container.State == "running" {
-				s = sg.Add("Existing Waypoint server container is already running.")
-				s.Status(terminal.StatusWarn)
-				s.Done()
-			} else {
+			if container.State != "running" {
 				s = sg.Add("Attempting to start container...")
 
 				err = cli.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})


### PR DESCRIPTION
This commit updates the behavior of the docker server installer by
looking for any stopped waypoint server containers and attempting to
start it when the install command is invoked.

Fixes #925