### PR TITLE
builtin/aws/ami: require []string for aws-ami filters

### DIFF
--- a/builtin/aws/ami/builder.go
+++ b/builtin/aws/ami/builder.go
@@ -34,7 +34,7 @@ type BuilderConfig struct {
 	Name string `hcl:"name,optional"`
 
 	// Specific filters to pass to the DescribeImages filter set
-	Filters map[string]interface{} `hcl:"filters,optional"`
+	Filters map[string][]string `hcl:"filters,optional"`
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
@@ -66,9 +66,7 @@ func (b *Builder) Documentation() (*docs.Documentation, error) {
 		"filters",
 		"DescribeImage specific filters to search with",
 		docs.Summary(
-			"the filters are always name => [value], but this api supports",
-			"the ability to pass a single value as a convience. Non string",
-			"values will be converted to strings",
+			"the filters are always name => [value]",
 		),
 	)
 
@@ -113,14 +111,7 @@ func (b *Builder) Build(
 	for k, v := range b.config.Filters {
 		var values []*string
 
-		switch sv := v.(type) {
-		case string:
-			values = append(values, aws.String(sv))
-		case []interface{}:
-			for _, iv := range sv {
-				values = append(values, aws.String(fmt.Sprintf("%s", iv)))
-			}
-		default:
+		for _, sv := range v {
 			values = append(values, aws.String(fmt.Sprintf("%s", sv)))
 		}
 

--- a/website/content/partials/components/builder-aws-ami.mdx
+++ b/website/content/partials/components/builder-aws-ami.mdx
@@ -26,7 +26,7 @@ DescribeImage specific filters to search with.
 
 The filters are always name => [value].
 
-- Type: **map[string]interface {}**
+- Type: **map[string][]string**
 - **Optional**
 
 #### name

--- a/website/content/partials/components/builder-aws-ami.mdx
+++ b/website/content/partials/components/builder-aws-ami.mdx
@@ -24,7 +24,7 @@ These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this
 
 DescribeImage specific filters to search with.
 
-The filters are always name => [value], but this api supports the ability to pass a single value as a convience. Non string values will be converted to strings.
+The filters are always name => [value].
 
 - Type: **map[string]interface {}**
 - **Optional**


### PR DESCRIPTION
Fixes #879 
Note: this bug moved from the `init` stage to the `build` stage. Verify by running `waypoint build`; you should see an output of `Resolved AMI: ami-04e229bcb91f0f16b`.