### PR TITLE
internal/{ceb,core,server/singleprocess}: Fix exec stream closure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/vektra/mockery v1.1.2
 	github.com/zclconf/go-cty v1.5.1
 	github.com/zclconf/go-cty-yaml v1.0.2
+	go.uber.org/goleak v1.1.10
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d

--- a/go.sum
+++ b/go.sum
@@ -1350,6 +1350,8 @@ go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.starlark.net v0.0.0-20200707032745-474f21a9602d/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277/go.mod h1:2X8KaoNd1J0lZV+PxJk/5+DGbO/tpwLR1m++a7FnB/Y=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -1552,6 +1554,7 @@ golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/core/app_exec_test.go
+++ b/internal/core/app_exec_test.go
@@ -17,6 +17,7 @@ import (
 	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	componentmocks "github.com/hashicorp/waypoint-plugin-sdk/component/mocks"
@@ -96,6 +97,10 @@ func TestAppExec_happy(t *testing.T) {
 		require.NoError(err)
 		return len(resp.Instances) == 1
 	}, 2*time.Second, 25*time.Millisecond)
+
+	// Make sure that with all the exec stream tracking we don't leak
+	// goroutines
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	var stderr, stdout bytes.Buffer
 

--- a/internal/server/singleprocess/service_entrypoint.go
+++ b/internal/server/singleprocess/service_entrypoint.go
@@ -327,6 +327,7 @@ func (s *service) EntrypointExecStream(
 				errCh <- err
 				return
 			}
+			log.Trace("entrypoint event received", "event", hclog.Fmt("%#v", req.Event))
 
 			// If this is an exit or error event track that so we don't synthesize one.
 			// We synthesize an Error value if this loop is going to returning without

--- a/internal/server/singleprocess/service_entrypoint.go
+++ b/internal/server/singleprocess/service_entrypoint.go
@@ -256,8 +256,14 @@ func (s *service) EntrypointExecStream(
 	}
 	log.Debug("exec stream open")
 
-	// Create a context we can use to cancel
-	ctx, cancel := context.WithCancel(server.Context())
+	// Create a new context that we'll use manage the below go routine.
+	// We use a new context rather than server.Context() so that we don't
+	// exit too early because we see the context Done(). Specificly we want
+	// to allow server.Recv() to return any buffered messages even if the
+	// server.Context() is Done().
+	// This fresh context will only be canceled we are no longer able to
+	// process any client messages.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Create a goroutine that just waits for events from the entrypoint
@@ -273,11 +279,16 @@ func (s *service) EntrypointExecStream(
 		// sawExit indicates that we observed either an Exit or Error message
 		// flow through. We use this to control if we should synthesizes a Error
 		// message about an improper closure.
-		var backgroundRetry, sawExit bool
+		var sawExit bool
 
-		// Pulled out to a closure because we call it in the "proper" shutdown path
-		// as well as the case where we're doing one last message send in the background.
-		sendExit := func() {
+		// Close the event channel we send to. This signals to the receiving
+		// side in StartExecStream (service_exec.go) that the entrypoint
+		// exited and it should also exit the client stream.
+		defer func() {
+			// We defer the close again here so that if sendExit fails, we always
+			// manage to get the channel closed.
+			defer close(exec.EntrypointEventCh)
+
 			// If we observed a Exit or Error event, we don't need to do this.
 			if sawExit {
 				return
@@ -286,7 +297,7 @@ func (s *service) EntrypointExecStream(
 			req := &pb.EntrypointExecRequest{
 				Event: &pb.EntrypointExecRequest_Error_{
 					Error: &pb.EntrypointExecRequest_Error{
-						Error: status.New(codes.Aborted, "server side exitted unexpectedly").Proto(),
+						Error: status.New(codes.Aborted, "server side exited unexpectedly").Proto(),
 					},
 				},
 			}
@@ -295,28 +306,13 @@ func (s *service) EntrypointExecStream(
 			// client's context to decide if we should give up.
 			select {
 			case exec.EntrypointEventCh <- req:
-				log.Info("entrypoint event dispatched")
+				log.Debug("entrypoint event for improper closure dispatched")
 			case <-exec.Context.Done():
 			}
-		}
-
-		// Close the event channel we send to. This signals to the receiving
-		// side in StartExecStream (service_exec.go) that the entrypoint
-		// exited and it should also exit the client stream.
-		defer func() {
-			// If there is a background retry, it will handle the cleanup, so we shouldn't
-			if backgroundRetry {
-				return
-			}
-
-			// We defer the close again here so that if sendExit fails, we always
-			// manage to get the channel closed.
-			defer close(exec.EntrypointEventCh)
-			sendExit()
 		}()
 
 		for {
-			log.Trace("waiting for entrypoint exec event")
+			log.Debug("waiting for entrypoint exec event")
 			req, err := server.Recv()
 			if err == io.EOF {
 				// On EOF, this means the client closed their write side.
@@ -331,7 +327,6 @@ func (s *service) EntrypointExecStream(
 				errCh <- err
 				return
 			}
-			log.Trace("entrypoint event received", "event", hclog.Fmt("%#v", req.Event))
 
 			// If this is an exit or error event track that so we don't synthesize one.
 			// We synthesize an Error value if this loop is going to returning without
@@ -341,36 +336,16 @@ func (s *service) EntrypointExecStream(
 				sawExit = true
 			}
 
-			// Send the event along
+			// Send the event along. We if the reciever is gone (ie it's context is Done())
+			// then we don't bother. We don't depend on server.Context() here because
+			// that is done within server.Recv() and we want to allow it to returned buffered
+			// messages even if it's internal context is Done().
 			select {
 			case exec.EntrypointEventCh <- req:
-				// ok
-			case <-ctx.Done():
-				// The situation here is that we have a message in `req` but we also
-				// detected that the context has been canceled. This happens because of
-				// the way events flow through gRPC and arrive at the server stream handler
-				// when the client has canceled the context right after sending a message.
-				//
-				// We are disabling direct cleanup by setting backgroundRetry.
-				backgroundRetry = true
-
-				// Rather than block the server stream handler, we spawn off a goroutine
-				// to try and deliver `req`. This also then cleans up the activities of
-				// this stream handler function.
-				go func() {
-					defer close(exec.EntrypointEventCh)
-
-					select {
-					case exec.EntrypointEventCh <- req:
-						// ok
-					case <-exec.Context.Done():
-						// ok
-					}
-
-					sendExit()
-				}()
-
-				return
+			// ok
+			case <-exec.Context.Done():
+				// oops, guess they went away. Keep reading req's so we don't
+				// block though.
 			}
 
 			// If this is an exit or error event then we also exit this loop now.
@@ -402,12 +377,23 @@ func (s *service) EntrypointExecStream(
 	// Loop through our receive loop
 	for {
 		select {
-		case <-ctx.Done():
-			return nil
 
+		// Wait on the above goroutine.
+		case <-ctx.Done():
+
+			// Double check and see if there was an error and if so, return it.
+			select {
+			case err = <-errCh:
+				return err
+			default:
+				return nil
+			}
+
+		// The above goroutine has errored.
 		case err := <-errCh:
 			return err
 
+		// The client goroutine has finished.
 		case req, active := <-exec.ClientEventCh:
 			if !active {
 				log.Debug("client event channel closed, exiting")
@@ -426,7 +412,7 @@ func (s *service) handleClientExecRequest(
 	srv pb.Waypoint_EntrypointExecStreamServer,
 	req *pb.ExecStreamRequest,
 ) error {
-	log.Trace("event received from client", "event", req.Event)
+	log.Debug("event received from client", "event", req.Event)
 	var send *pb.EntrypointExecResponse
 	switch event := req.Event.(type) {
 	case *pb.ExecStreamRequest_Input_:

--- a/internal/server/singleprocess/service_exec.go
+++ b/internal/server/singleprocess/service_exec.go
@@ -155,6 +155,18 @@ func (s *service) handleEntrypointExecRequest(
 				},
 			},
 		}
+	case *pb.EntrypointExecRequest_Error_:
+		log.Warn("error observed processing entrypoint exec stream", "error", event.Error.Error)
+		exit = true
+		send = &pb.ExecStreamResponse{
+			Event: &pb.ExecStreamResponse_Exit_{
+				Exit: &pb.ExecStreamResponse_Exit{
+					Code: 1,
+				},
+			},
+		}
+	default:
+		log.Warn("unimplemented exec entrypoint message seen", "event", hclog.Fmt("%T", event))
 	}
 
 	// Send our response

--- a/internal/server/singleprocess/service_exec_test.go
+++ b/internal/server/singleprocess/service_exec_test.go
@@ -170,6 +170,81 @@ func TestServiceStartExecStream_eventExit(t *testing.T) {
 	require.False(active)
 }
 
+func TestServiceStartExecStream_eventError(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+
+	// Create our server
+	impl, err := New(WithDB(testDB(t)))
+	require.NoError(err)
+	client := server.TestServer(t, impl)
+
+	// Create an instance
+	instanceId, deploymentId, closer := TestEntrypoint(t, client)
+	defer closer()
+
+	// Start stream
+	stream, err := client.StartExecStream(ctx)
+	require.NoError(err)
+	require.NoError(stream.Send(&pb.ExecStreamRequest{
+		Event: &pb.ExecStreamRequest_Start_{
+			Start: &pb.ExecStreamRequest_Start{
+				Target: &pb.ExecStreamRequest_Start_DeploymentId{
+					DeploymentId: deploymentId,
+				},
+				Args: []string{"foo", "bar"},
+			},
+		},
+	}))
+	defer stream.CloseSend()
+
+	// Should open
+	{
+		resp, err := stream.Recv()
+		require.NoError(err)
+		open, ok := resp.Event.(*pb.ExecStreamResponse_Open_)
+		require.True(ok, "should be an open")
+		require.NotNil(open)
+	}
+
+	// Get the record
+	ws := memdb.NewWatchSet()
+	list, err := testServiceImpl(impl).state.InstanceExecListByInstanceId(instanceId, ws)
+	require.NoError(err)
+	if len(list) == 0 {
+		ws.Watch(time.After(1 * time.Second))
+		list, err = impl.(*service).state.InstanceExecListByInstanceId(instanceId, ws)
+		require.NoError(err)
+	}
+	require.Len(list, 1)
+	exec := list[0]
+
+	// Send an exit event
+	exec.EntrypointEventCh <- &pb.EntrypointExecRequest{
+		Event: &pb.EntrypointExecRequest_Error_{
+			Error: &pb.EntrypointExecRequest_Error{
+				Error: status.New(codes.DataLoss, "this is a bad thing").Proto(),
+			},
+		},
+	}
+
+	// The above should trigger an exit event
+	resp, err := stream.Recv()
+	require.NoError(err)
+	exitResp, ok := resp.Event.(*pb.ExecStreamResponse_Exit_)
+	require.True(ok)
+	require.Equal(int32(1), exitResp.Exit.Code)
+
+	// Then we should get a close
+	_, err = stream.Recv()
+	require.Error(err)
+	require.Equal(io.EOF, err)
+
+	// The event channel should be closed
+	_, active := <-exec.ClientEventCh
+	require.False(active)
+}
+
 // When the InstanceExec EntrypointEventCh closes, we should exit.
 func TestServiceStartExecStream_entrypointEventChClose(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
This fixes a very specific edgecase where if the virtual side of the
exec handler sends an Exit message and then cancels the context in quick
succession, the server side may not see the message, only the context
cancelation. gRPC seems to prioritize the cancelation above pending
events, possibly because message sends are not guaranteed (the docs
state this).

The change then is to wait for the server side to close the stream after
the virtual side sends it's exit code. This means that the server side
is in control of seeing the messages and shutting down the stream.

We also can now simplify the handling of the ExecStream messages by
allowing server.Recv() to return any buffered messages even if the
context has already been canceled. Effectively, if we check that the
context the server stream is using has been canceled on our own, we
don't allow the server stream to return any buffered messages.

The entrypoint exec code is also simplified by having it depend only on
the execclient/exec side by checking exec.Context for readiness when
trying to relay messages back to the execclient.