### PR TITLE
internal/{uninstall,upgrade}: Better error message for when server does not implement snapshots

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -448,8 +448,8 @@ so you can specify the app to target using the "-app" flag.
 	reAppTarget = regexp.MustCompile(`^(?P<project>[-0-9A-Za-z_]+)/(?P<app>[-0-9A-Za-z_]+)$`)
 
 	snapshotUnimplementedErr = strings.TrimSpace(`
-The server you are upgrading from does not support snapshots. Rerunning the
-upgrade command with '-snapshot=false' is required, and there will be no automatic
-data backups for the server.
+The current Waypoint server does not support snapshots. Rerunning the command
+with '-snapshot=false' is required, and there will be no automatic data backups
+for the server.
 `)
 )

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -446,4 +446,10 @@ so you can specify the app to target using the "-app" flag.
 `)
 
 	reAppTarget = regexp.MustCompile(`^(?P<project>[-0-9A-Za-z_]+)/(?P<app>[-0-9A-Za-z_]+)$`)
+
+	snapshotUnimplementedErr = strings.TrimSpace(`
+The server you are upgrading from does not support snapshots. Rerunning the
+upgrade command with '-snapshot=false' is required, and there will be no automatic
+data backups for the server.
+`)
 )

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -169,6 +169,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 			s.Done()
 
 			c.ui.Output(fmt.Sprintf("Error opening output: %s", err), terminal.WithErrorStyle())
+			os.Remove(snapshotName)
 			return 1
 		}
 
@@ -185,6 +186,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 			}
 
 			c.ui.Output(fmt.Sprintf("Error generating Snapshot: %s", err), terminal.WithErrorStyle())
+			os.Remove(snapshotName)
 			return 1
 		}
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -383,12 +383,6 @@ More information can be found by runninng 'waypoint server restore -help' or
 following the server maintenence guide for backups and restores:
 https://www.waypointproject.io/docs/server/run/maintenance#backup-restore
 `)
-
-	snapshotUnimplementedErr = strings.TrimSpace(`
-The server you are upgrading from does not support snapshots. Rerunning the
-upgrade command with '-snapshot=false' is required, and there will be no automatic
-data backups for the server.
-`)
 	addrSuccess = strings.TrimSpace(`
 Advertise Address: %[1]s
    Web UI Address: %[2]s

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/posener/complete"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -104,6 +106,10 @@ func (c *UninstallCommand) Run(args []string) int {
 			return 1
 		}
 		if err = clisnapshot.WriteSnapshot(ctx, c.project.Client(), w); err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				c.ui.Output(snapshotUnimplementedErr, terminal.WithErrorStyle())
+			}
+
 			fmt.Fprintf(os.Stderr, "Error generating snapshot: %s", err)
 			return 1
 		}
@@ -217,8 +223,7 @@ func (c *UninstallCommand) Flags() *flag.Sets {
 }
 
 var (
-	uninstallSnapshotName = "waypoint-server-snapshot"
-	autoApproveMsg        = strings.TrimSpace(`
+	autoApproveMsg = strings.TrimSpace(`
 Uninstalling Waypoint server requires approval.
 Rerun the command with -auto-approve to continue with the uninstall.
 `)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -102,15 +102,23 @@ func (c *UninstallCommand) Run(args []string) int {
 		s.Update("Taking snapshot of server with name: '%s'", snapshotName)
 		w, err := os.Create(snapshotName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating snapshot file: %s", err)
+			s.Update("Failed to take server snapshot\n")
+			s.Status(terminal.StatusError)
+			s.Done()
+
+			c.ui.Output("Error creating snapshot file: %s", err, terminal.WithErrorStyle())
 			return 1
 		}
 		if err = clisnapshot.WriteSnapshot(ctx, c.project.Client(), w); err != nil {
+			s.Update("Failed to take server snapshot\n")
+			s.Status(terminal.StatusError)
+			s.Done()
+
 			if status.Code(err) == codes.Unimplemented {
 				c.ui.Output(snapshotUnimplementedErr, terminal.WithErrorStyle())
 			}
 
-			fmt.Fprintf(os.Stderr, "Error generating snapshot: %s", err)
+			c.ui.Output("Error generating snapshot: %s", err, terminal.WithErrorStyle())
 			return 1
 		}
 		s.Update("Snapshot %q generated", snapshotName)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -107,6 +107,7 @@ func (c *UninstallCommand) Run(args []string) int {
 			s.Done()
 
 			c.ui.Output("Error creating snapshot file: %s", err, terminal.WithErrorStyle())
+			os.Remove(snapshotName)
 			return 1
 		}
 		if err = clisnapshot.WriteSnapshot(ctx, c.project.Client(), w); err != nil {
@@ -119,6 +120,7 @@ func (c *UninstallCommand) Run(args []string) int {
 			}
 
 			c.ui.Output("Error generating snapshot: %s", err, terminal.WithErrorStyle())
+			os.Remove(snapshotName)
 			return 1
 		}
 		s.Update("Snapshot %q generated", snapshotName)


### PR DESCRIPTION
This pull request adds better error messaging to the user if they attempt to uninstall or upgrade an old Waypoint server that does not support snapshots.

It also fixes the `clisnapshot` package to preserve the original grpc status codes while still wrapping them with the snapshot operation specific message.