### PR TITLE
internal/server/state: project put should not modify applications

### DIFF
--- a/internal/server/singleprocess/state/project.go
+++ b/internal/server/singleprocess/state/project.go
@@ -21,11 +21,25 @@ func init() {
 }
 
 // ProjectPut creates or updates the given project.
+//
+// Application changes will be ignored, you must use the Application APIs.
 func (s *State) ProjectPut(p *pb.Project) error {
 	memTxn := s.inmem.Txn(true)
 	defer memTxn.Abort()
 
 	err := s.db.Update(func(dbTxn *bolt.Tx) error {
+		prev, err := s.projectGet(dbTxn, memTxn, &pb.Ref_Project{
+			Project: p.Name,
+		})
+		if err != nil && status.Code(err) != codes.NotFound {
+			// We ignore NotFound since this function is used to create projects.
+			return err
+		}
+		if err == nil {
+			// If we have a previous project, preserve the applications.
+			p.Applications = prev.Applications
+		}
+
 		return s.projectPut(dbTxn, memTxn, p)
 	})
 	if err == nil {
@@ -239,6 +253,8 @@ func projectIndexSchema() *memdb.TableSchema {
 const (
 	projectIndexTableName   = "project-index"
 	projectIndexIdIndexName = "id"
+
+	projectWaypointHclMaxSize = 5 * 1024 // 5 MB
 )
 
 type projectIndexRecord struct {

--- a/internal/server/singleprocess/state/project_test.go
+++ b/internal/server/singleprocess/state/project_test.go
@@ -64,6 +64,51 @@ func TestProject(t *testing.T) {
 		}
 	})
 
+	t.Run("Put does not modify applications", func(t *testing.T) {
+		require := require.New(t)
+
+		const name = "AbCdE"
+		ref := &pb.Ref_Project{Project: name}
+
+		s := TestState(t)
+		defer s.Close()
+
+		// Set
+		proj := serverptypes.TestProject(t, &pb.Project{Name: name})
+		err := s.ProjectPut(proj)
+		require.NoError(err)
+		_, err = s.AppPut(serverptypes.TestApplication(t, &pb.Application{
+			Project: ref,
+		}))
+		require.NoError(err)
+
+		// Get exact
+		{
+			resp, err := s.ProjectGet(&pb.Ref_Project{
+				Project: "AbCdE",
+			})
+			require.NoError(err)
+			require.NotNil(resp)
+			require.False(resp.RemoteEnabled)
+			require.Len(resp.Applications, 1)
+		}
+
+		// Update the project
+		proj.RemoteEnabled = true
+		require.NoError(s.ProjectPut(proj))
+
+		// Get exact
+		{
+			resp, err := s.ProjectGet(&pb.Ref_Project{
+				Project: "AbCdE",
+			})
+			require.NoError(err)
+			require.NotNil(resp)
+			require.True(resp.RemoteEnabled)
+			require.Len(resp.Applications, 1)
+		}
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		require := require.New(t)
 

--- a/internal/server/singleprocess/state/project_test.go
+++ b/internal/server/singleprocess/state/project_test.go
@@ -78,6 +78,12 @@ func TestProject(t *testing.T) {
 		err := s.ProjectPut(proj)
 		require.NoError(err)
 		_, err = s.AppPut(serverptypes.TestApplication(t, &pb.Application{
+			Name:    "test",
+			Project: ref,
+		}))
+		require.NoError(err)
+		_, err = s.AppPut(serverptypes.TestApplication(t, &pb.Application{
+			Name:    "test2",
 			Project: ref,
 		}))
 		require.NoError(err)
@@ -90,7 +96,7 @@ func TestProject(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(resp)
 			require.False(resp.RemoteEnabled)
-			require.Len(resp.Applications, 1)
+			require.Len(resp.Applications, 2)
 		}
 
 		// Update the project
@@ -105,7 +111,7 @@ func TestProject(t *testing.T) {
 			require.NoError(err)
 			require.NotNil(resp)
 			require.True(resp.RemoteEnabled)
-			require.Len(resp.Applications, 1)
+			require.Len(resp.Applications, 2)
 		}
 	})
 


### PR DESCRIPTION
We document that project-related APIs cannot be used for applications,
but previously we didn't preserve existing applications. If a user
called UpsertProject to modify an existing project it'd blow away all
their applications.

This couldn't be hit in the real world unless the user was using the API
directly, since `waypoint init -update` is the only thing that calls
this API and it always registers applications again.

But with future changes such as introducing server side waypoint.hcl and
future UI changes to modify projects, this would've become a big issue.