### PR TITLE
serverinstall/k8s: Allow using k8s context

### DIFF
--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -30,20 +30,6 @@ Usage: `waypoint install [options]`
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 
-#### kubernetes Options
-
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
-- `-k8s-annotate-service=<key=value>` - Annotations for the Service generated.
-- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
-- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
-- `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
-- `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
-- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes.
-
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
@@ -56,5 +42,20 @@ Usage: `waypoint install [options]`
 #### docker Options
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server.
+
+#### kubernetes Options
+
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-annotate-service=<key=value>` - Annotations for the Service generated.
+- `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
+- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
+- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
+- `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
+- `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
+- `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
+- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -34,6 +34,7 @@ Usage: `waypoint server install [options]`
 
 - `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
 - `-k8s-annotate-service=<key=value>` - Annotations for the Service generated.
+- `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -33,6 +33,8 @@ Usage: `waypoint server uninstall [options]`
 
 #### kubernetes Options
 
+- `-k8s-context=<string>` - The Kubernetes context to unisntall the Waypoint server from. If left unset, Waypoint will use the current Kubernetes context.
+
 #### nomad Options
 
 - `-nomad-purge` - Purge the Waypoint server job after deregistering as part of uninstall.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -31,13 +31,6 @@ Usage: `waypoint server upgrade [options]`
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
 
-#### kubernetes Options
-
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
-
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
@@ -50,5 +43,13 @@ Usage: `waypoint server upgrade [options]`
 #### docker Options
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server.
+
+#### kubernetes Options
+
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
 
 @include "commands/server-upgrade_more.mdx"


### PR DESCRIPTION
This commit introduces the ability for users to specify a kubernetes
context on install/upgrade/uninstall. If left unset, it will use the
current environment kubernetes context, but if set, it will attempt to
use the context specified for the given serverinstall operation.

Fixes #928