### PR TITLE
Don't require app to exist on QueueJob

### DIFF
--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/go-argmapper"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/datadir"
@@ -142,9 +144,18 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 	return p, nil
 }
 
-// App initializes and returns the app with the given name.
+// App initializes and returns the app with the given name. This
+// returns an error with codes.NotFound if the app is not found.
 func (p *Project) App(name string) (*App, error) {
-	return p.apps[name], nil
+	if v, ok := p.apps[name]; ok {
+		return v, nil
+	}
+
+	return nil, status.Errorf(codes.NotFound,
+		"Application %q was not found in this project. Please ensure that "+
+			"you've created this project in the waypoint.hcl configuration.",
+		name,
+	)
 }
 
 // Client returns the API client for the backend server.

--- a/internal/core/project_test.go
+++ b/internal/core/project_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint/internal/config"
 )
@@ -15,9 +17,16 @@ func TestNewProject(t *testing.T) {
 		WithConfig(config.TestConfig(t, testNewProjectConfig)),
 	)
 
+	// App that exists
 	app, err := p.App("test")
 	require.NoError(err)
 	require.NotNil(app)
+
+	// App that doesn't exist
+	app, err = p.App("NO")
+	require.Error(err)
+	require.Nil(app)
+	require.Equal(status.Code(err), codes.NotFound)
 }
 
 const testNewProjectConfig = `

--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -74,18 +74,6 @@ func (s *service) QueueJob(
 		return nil, status.Errorf(codes.FailedPrecondition, err.Error())
 	}
 
-	// Validate the project/app pair exists.
-	if job.Application.Application != "" {
-		_, err := s.state.AppGet(job.Application)
-		if status.Code(err) == codes.NotFound {
-			return nil, status.Errorf(codes.NotFound,
-				"Application %s/%s was not found! Please ensure that 'waypoint init' was run with this project.",
-				job.Application.Project,
-				job.Application.Application,
-			)
-		}
-	}
-
 	// Verify the project exists and use that to set the default data source
 	project, err := s.state.ProjectGet(&pb.Ref_Project{Project: job.Application.Project})
 	if status.Code(err) == codes.NotFound {


### PR DESCRIPTION
We removed this check because it introduces a chicken/egg problem with
onboarding a new project: the user needs to have the waypoint.hcl loaded
to queue a job (to know what apps are defined), but with remote GitOps
style builds, we need to queue a job first to load the waypoint.hcl.

By removing this check, we move to a "late binding" approach where
non-existent applications will still error, but later in the process
after the job starts running.

This is one in a series of likely small PRs targeting a better CLI user
experience for remote runner based workflows.