### PR TITLE
internal/server/state: CalculateInstanceExec picks least loaded

### DIFF
--- a/internal/server/singleprocess/state/instance_exec.go
+++ b/internal/server/singleprocess/state/instance_exec.go
@@ -134,6 +134,12 @@ func (s *State) CalculateInstanceExecByDeployment(did string) (*Instance, error)
 
 		// Otherwise we keep track of the lowest "load" exec which we just
 		// choose by the minimum number of registered sessions.
+		if len(execs) < minCount {
+			// If we're less than the min count we've seen before, then
+			// we reset the slice of candidates because we only want
+			// candidates with this count.
+			min = nil
+		}
 		if min == nil || len(execs) <= minCount {
 			min = append(min, rec)
 			minCount = len(execs)

--- a/internal/server/singleprocess/state/instance_exec_test.go
+++ b/internal/server/singleprocess/state/instance_exec_test.go
@@ -157,6 +157,7 @@ func TestCalculateInstanceExecByDeployment(t *testing.T) {
 	virt.Type = gen.Instance_VIRTUAL
 	require.NoError(s.InstanceCreate(virt))
 
+	// Should get an error because there are no long running instances
 	_, err := s.CalculateInstanceExecByDeployment(od.DeploymentId)
 	require.Error(err)
 
@@ -177,6 +178,7 @@ func TestCalculateInstanceExecByDeployment(t *testing.T) {
 	lr.Type = gen.Instance_LONG_RUNNING
 	require.NoError(s.InstanceCreate(lr))
 
+	// Get an instance, it should be one of the long running ones
 	reserve, err := s.CalculateInstanceExecByDeployment(instance.DeploymentId)
 	require.NoError(err)
 
@@ -184,9 +186,7 @@ func TestCalculateInstanceExecByDeployment(t *testing.T) {
 	require.NoError(s.InstanceExecCreateByTargetedInstance(reserve.Id, &exec))
 
 	// ok, now see that on the next time, we get the other long running instance
-
 	reserve2, err := s.CalculateInstanceExecByDeployment(instance.DeploymentId)
 	require.NoError(err)
-
 	assert.NotEqual(reserve.Id, reserve2.Id)
 }


### PR DESCRIPTION
This fixes an issue where if we looped over instances in the order of
most to least loaded, they would ALL be candidates. We need to reset the
candidate list when we find a lower loaded value.