### PR TITLE
test-e2e/{nomad,k8s}: smoke tests for remaining server platforms

### DIFF
--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -61,10 +61,3 @@ func TestWaypointAvailable(t *testing.T) {
 
 The `util.go` file inside this directory offers a simple way to execute any
 binary.
-
-## TODO
-
-Include additional tests for the following supported server platforms:
-
-- Nomad
-- Kubernetes

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -3,8 +3,8 @@
 ## Requirements
 
 For now, these tests assume that you already have Waypoint available on the path,
-as well as Docker installed. In the future, the `run-tests.sh` script will
-set these up in a CI environment.
+as well as Docker, K8s, and Nomad  installed and running. In the future, the
+`run-tests.sh` script will set these up in a CI environment.
 
 ## How to run
 

--- a/test-e2e/cli_smoke.test.go
+++ b/test-e2e/cli_smoke.test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWaypointInstall(t *testing.T) {
+	t.Logf("Testing waypoint is available...")
+	wp := NewBinary(wpBinary, ".")
+	stdout, stderr, err := wp.Run("version")
+	if err != nil {
+		t.Errorf("unexpected error getting version: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output getting version: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint v") {
+		t.Errorf("No version output detected:\n%s", stdout)
+	}
+}

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -10,23 +10,6 @@ var (
 	dockerTestDir = fmt.Sprintf("%s/docker/go", examplesRootDir)
 )
 
-func TestWaypointInstall(t *testing.T) {
-	t.Logf("Testing waypoint is available...")
-	wp := NewBinary(wpBinary, ".")
-	stdout, stderr, err := wp.Run("version")
-	if err != nil {
-		t.Errorf("unexpected error getting version: %s", err)
-	}
-
-	if stderr != "" {
-		t.Errorf("unexpected stderr output getting version: %s", err)
-	}
-
-	if !strings.Contains(stdout, "Waypoint v") {
-		t.Errorf("No version output detected:\n%s", stdout)
-	}
-}
-
 func TestWaypointDockerInstall(t *testing.T) {
 	wp := NewBinary(wpBinary, dockerTestDir)
 	stdout, stderr, err := wp.Run("install", "-platform=docker", "-accept-tos", fmt.Sprintf("-docker-server-image=%s", wpServerImage))

--- a/test-e2e/k8s_smoke_test.go
+++ b/test-e2e/k8s_smoke_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	kubernetesTestDir = fmt.Sprintf("%s/kubernetes/nodejs", examplesRootDir)
+)
+
+func TestWaypointKubernetesInstall(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("install", "-platform=kubernetes", "-accept-tos", fmt.Sprintf("-k8s-server-image=%s", wpServerImage))
+
+	if err != nil {
+		t.Errorf("unexpected error installing server to kubernetes: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output installing server to kubernetes: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
+		t.Errorf("No success message detected after kubernetes server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointKubernetesUp(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("init")
+
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
+
+	stdout, stderr, err = wp.Run("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointKubernetesUpgrade(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("server", "upgrade", "-platform=kubernetes", "-auto-approve", fmt.Sprintf("-k8s-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error upgrading server in kubernetes: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output upgrading server in kubernetes: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
+		t.Errorf("No success message detected after kubernetes server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointKubernetesUpAfterUpgrade(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointKubernetesDestroy(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("destroy")
+
+	if err != nil {
+		t.Errorf("unexpected error destroying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Destroy successful!") {
+		t.Errorf("No success message detected after destroying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointKubernetesUninstall(t *testing.T) {
+	wp := NewBinary(wpBinary, kubernetesTestDir)
+	stdout, stderr, err := wp.Run("server", "uninstall", "-platform=kubernetes", "-auto-approve", "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error uninstalling waypoint server: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {
+		t.Errorf("No success message detected after uninstalling server:\n%s", stdout)
+	}
+}

--- a/test-e2e/nomad_smoke_test.go
+++ b/test-e2e/nomad_smoke_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	nomadTestDir = fmt.Sprintf("%s/nomad/nodejs", examplesRootDir)
+)
+
+func TestWaypointNomadInstall(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("install", "-platform=nomad", "-accept-tos", fmt.Sprintf("-nomad-server-image=%s", wpServerImage))
+
+	if err != nil {
+		t.Errorf("unexpected error installing server to nomad: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output installing server to nomad: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
+		t.Errorf("No success message detected after nomad server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointNomadUp(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("init")
+
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
+
+	stdout, stderr, err = wp.Run("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointNomadUpgrade(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("server", "upgrade", "-platform=nomad", "-auto-approve", fmt.Sprintf("-nomad-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error upgrading server in nomad: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output upgrading server in nomad: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
+		t.Errorf("No success message detected after nomad server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointNomadUpAfterUpgrade(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointNomadDestroy(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("destroy")
+
+	if err != nil {
+		t.Errorf("unexpected error destroying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Destroy successful!") {
+		t.Errorf("No success message detected after destroying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointNomadUninstall(t *testing.T) {
+	wp := NewBinary(wpBinary, nomadTestDir)
+	stdout, stderr, err := wp.Run("server", "uninstall", "-platform=nomad", "-auto-approve", "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error uninstalling waypoint server: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {
+		t.Errorf("No success message detected after uninstalling server:\n%s", stdout)
+	}
+}

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -87,7 +87,7 @@ if [[ ! -v CI_ENV ]]; then
   trap "kill -9 $SPIN_PID" `seq 0 15`
 fi
 
-go test "github.com/hashicorp/waypoint/test-e2e"
+go test -v "github.com/hashicorp/waypoint/test-e2e"
 testResult=$?
 
 if [[ "$testResult" -eq 0 ]]; then

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -9,7 +9,7 @@ import (
 // Test config settings used by the tests
 var (
 	wpBinary             = Getenv("WP_BINARY", "waypoint")
-	wpServerImage        = Getenv("WP_SERVERIMAGE", "hashicorp/waypoint:latest")
+	wpServerImage        = Getenv("WP_SERVERIMAGE", "hashicorp/waypoint:0.2.0")
 	wpServerImageUpgrade = Getenv("WP_SERVERIMAGE_UPGRADE", "hashicorp/waypoint:latest")
 
 	examplesRootDir = Getenv("WP_EXAMPLES_PATH", "waypoint-examples")


### PR DESCRIPTION
This pull request adds the remaining supported server platforms for smoke tests. It also moves out the basic CLI test into its own file instead of living in just the docker tests.