### PR TITLE
internal/server: send entrypoint URL config only when we get a token

### DIFF
--- a/internal/ceb/config.go
+++ b/internal/ceb/config.go
@@ -112,6 +112,8 @@ func (ceb *CEB) watchConfig(
 			return
 
 		case config := <-ch:
+			// TODO(mitchellh): we need to handle changes to the URL settings
+			// and stop/restart the URL service gracefully.
 			if !didInitURL {
 				didInitURL = true
 

--- a/internal/server/singleprocess/service_deploy.go
+++ b/internal/server/singleprocess/service_deploy.go
@@ -55,7 +55,7 @@ func (s *service) UpsertDeployment(
 		}
 
 		// Create a context that will timeout relatively quickly
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		// Create the hostname. We ignore errors.

--- a/internal/server/singleprocess/service_url.go
+++ b/internal/server/singleprocess/service_url.go
@@ -78,6 +78,14 @@ func (s *service) initURLClientBlocking(
 		// Set the API token, if logic later in this func fails and we retry
 		// we will reuse the API token we already have.
 		cfg.APIToken = token
+
+		// Set our URL CEB settings. It is always initialized with the API
+		// token if it is set so we only have to do this on this code path.
+		s.urlCEBMu.Lock()
+		s.urlCEB.Token = token
+		close(s.urlCEBWatchCh) // notify any watchers we have changes
+		s.urlCEBWatchCh = make(chan struct{})
+		s.urlCEBMu.Unlock()
 	}
 
 	// Now that we have a token, connect to the API service with that token.

--- a/internal/server/singleprocess/service_url.go
+++ b/internal/server/singleprocess/service_url.go
@@ -57,7 +57,12 @@ func (s *service) initURLClient(
 		return nil
 	}
 
-	log.Warn("failed to initialize URL service", "err", err)
+	if err != nil {
+		log.Warn("failed to initialize URL service", "err", err)
+	} else {
+		log.Info("URL service client successfully initialized")
+	}
+
 	return err
 }
 
@@ -70,6 +75,7 @@ func (s *service) initURLClientBlocking(
 ) error {
 	// If we have no API token, get our guest account token.
 	if cfg.APIToken == "" {
+		log.Debug("API token not set in config, initializing guest account")
 		token, err := s.initURLGuestAccount(ctx, log, isRetry, acceptURLTerms, cfg)
 		if err != nil {
 			return err
@@ -125,6 +131,7 @@ func (s *service) initURLGuestAccount(
 	if err != nil {
 		return "", err
 	} else if urlToken != "" {
+		log.Debug("using saved URL guest token")
 		return urlToken, nil
 	}
 

--- a/internal/server/singleprocess/testing.go
+++ b/internal/server/singleprocess/testing.go
@@ -108,6 +108,18 @@ func TestWithURLService(t testing.T, out *hzntest.DevSetup) Option {
 	}
 }
 
+// TestWithURLServiceGuestAccount sets the API token to empty to force
+// getting a guest account with the URL service. This can ONLY be set if
+// TestWithURLService is set before this.
+func TestWithURLServiceGuestAccount(t testing.T) Option {
+	return func(s *service, cfg *config) error {
+		// Set the API token to empty which will force a guest account registration.
+		cfg.serverConfig.URL.APIToken = ""
+
+		return nil
+	}
+}
+
 func TestEntrypoint(t testing.T, client pb.WaypointClient) (string, string, func()) {
 	instanceId, err := server.Id()
 	require.NoError(t, err)


### PR DESCRIPTION
At the server level, this sets us up completely for any scenario where
the URL service configuration changes. However, the CEB doesn't yet
support changing URL configurations (it ignores them once it has
initialized) so we only send down the URL config once we are ready.
Future changes will just be ignored.