### PR TITLE
Fix panic from `waypoint hostname delete` with no hostname specified

### DIFF
--- a/internal/cli/hostname_delete.go
+++ b/internal/cli/hostname_delete.go
@@ -22,11 +22,11 @@ func (c *HostnameDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	hostname := c.args[0]
 	if len(c.args) == 0 {
 		c.ui.Output("hostname required for deletion", terminal.WithErrorStyle())
 		return 1
 	}
+	hostname := c.args[0]
 
 	_, err := c.project.Client().DeleteHostname(c.Ctx, &pb.DeleteHostnameRequest{
 		Hostname: hostname,


### PR DESCRIPTION
A lil order-of-operations issue resulted in an unsightly panic.

Before:

```
❯ waypoint hostname delete

panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
... trace ...
```

After:

```
❯ ./waypoint hostname delete
! hostname required for deletion
```