### PR TITLE
Fix empty gitreftag response (#978)

### DIFF
--- a/internal/config/funcs/vcs_git.go
+++ b/internal/config/funcs/vcs_git.go
@@ -153,12 +153,15 @@ func (s *VCSGit) refTagFunc(args []cty.Value, retType cty.Type) (cty.Value, erro
 	}
 
 	var tagRefStr string
-	_ = iter.ForEach(func(t *plumbing.Reference) error {
+	err = iter.ForEach(func(t *plumbing.Reference) error {
 		if t.Hash() == ref.Hash() {
 			tagRefStr = t.Name().Short()
 		}
 		return nil
 	})
+	if err != nil {
+		return cty.UnknownVal(cty.String), err
+	}
 
 	if tagRefStr != "" {
 		return cty.StringVal(tagRefStr), nil

--- a/internal/config/funcs/vcs_git.go
+++ b/internal/config/funcs/vcs_git.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -150,18 +151,17 @@ func (s *VCSGit) refTagFunc(args []cty.Value, retType cty.Type) (cty.Value, erro
 	if err != nil {
 		return cty.UnknownVal(cty.String), err
 	}
-	defer iter.Close()
-	for {
-		tagRef, err := iter.Next()
-		if err == io.EOF {
-			break
+
+	var tagRefStr string
+	_ = iter.ForEach(func(t *plumbing.Reference) error {
+		if t.Hash() == ref.Hash() {
+			tagRefStr = t.Name().Short()
 		}
-		if err != nil {
-			return cty.UnknownVal(cty.String), err
-		}
-		if tagRef.Hash() == ref.Hash() {
-			return cty.StringVal(tagRef.Name().Short()), nil
-		}
+		return nil
+	})
+
+	if tagRefStr != "" {
+		return cty.StringVal(tagRefStr), nil
 	}
 
 	return cty.StringVal(""), nil


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/978

I was able to reproduce #978 with this config and a local git repo with 2 tags, one in the past and one on the current `HEAD` :

<details>

```hcl
project = "example-nodejs"

app "example-nodejs" {
  labels = {
    "service" = "example-nodejs"
    "env"     = "dev"
  }

  config {
    env = {
      TEST = "hiya"

      # REFTAG    = gitreftag()
      REFHASH   = gitrefhash()
      REFPRETTY = gitrefpretty()
    }
  }

  build {
    use "pack" {}
  }

  deploy {
    # use "docker" {}
    use "exec" {
      command = [ "echo", gitreftag() ]
      # command = [ "echo", gitrefhash() ]
    }
  }
  
}

```

</details>

The deploy output was always `echo ` (empty)

I dug in an found that `refTagFunc` was always hitting an `EOF` here (L157):

- https://github.com/hashicorp/waypoint/blob/298ec9289ea651bc80ca2c757bde7d325e1e70c7/internal/config/funcs/vcs_git.go#L148-L168

I dug in more and found a built-in iterator for tag references (https://github.com/go-git/go-git/blob/024d62b96ac19b40473f04931f9c12c8e24e0f7a/plumbing/object/tag.go#L339). Switching to that in this PR resolved the issue and started showing me the tag I was expecting. 

Unfortunately, I couldn't figure out why the tests pass on `main` with the time I had 🤔 

- https://github.com/hashicorp/waypoint/blob/c4d2a01aa5c13a2a0f8ab53e6420c6e50561df14/internal/config/funcs/vcs_git_test.go#L21