### PR TITLE
cli/main: Add -version flag for CLI version

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -59,6 +59,13 @@ func Main(args []string) int {
 	// up plugin processes by calling Close on all the resources we use.
 	defer plugin.CleanupClients()
 
+	// NOTE: This is only for running `waypoint -v` and expecting it to return
+	// a version. Any other subcommand will expect `-v` to be around verbose
+	// logging rather than printing a version
+	if len(args) == 2 && args[1] == "-v" {
+		args[1] = "-version"
+	}
+
 	// Initialize our logger based on env vars
 	args, log, logOutput, err := logger(args)
 	if err != nil {
@@ -87,6 +94,7 @@ func Main(args []string) int {
 	cli := &cli.CLI{
 		Name:                       args[0],
 		Args:                       args[1:],
+		Version:                    vsn.FullVersionNumber(true),
 		Commands:                   commands,
 		Autocomplete:               true,
 		AutocompleteNoDefaultFlags: true,


### PR DESCRIPTION
This commit introduces a `-version` flag to `waypoint -version`. It also
overrides `-v` to print version instead of being verbose only in the
case where there is 1 arg.