### PR TITLE
internal/{ceb,cli,core,runner}: Plumb (optionally dynamic) config via env to the exec plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210121230149-423cbd96089d
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210202225000-326f71b85c70
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -783,8 +783,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef h1:YKouRHFf
 github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210121230149-423cbd96089d h1:k82G5Z1th6l05Gi4Xu2F9E8Y8wokRZ1hiM8XBNSNQxo=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210121230149-423cbd96089d/go.mod h1:+T5ugu6Dxv3uSe3EM5xBQ7u4Y1Em6zhHC0KTutBst84=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210202225000-326f71b85c70 h1:pzu3VEhpOJGfViLwI+jZDJnuVRakjPAirMgCdkHNBbE=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210202225000-326f71b85c70/go.mod h1:+T5ugu6Dxv3uSe3EM5xBQ7u4Y1Em6zhHC0KTutBst84=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d h1:W+SIwDdl3+jXWeidYySAgzytE3piq6GumXeBjFBG67c=

--- a/internal/ceb/virtual.go
+++ b/internal/ceb/virtual.go
@@ -21,6 +21,9 @@ type VirtualExecInfo struct {
 	// Command line arguments
 	Arguments []string
 
+	// The environment variables to set in the exec context
+	Environment []string
+
 	// Specifies if we and how we should allocate a pty to handle
 	// the command.
 	PTY *pb.ExecStreamRequest_PTY
@@ -57,6 +60,9 @@ type VirtualConfig struct {
 	// How to connect back to the server. Because Virtual is usually used in the context
 	// of a Runner, this can be the same Client the Runner is using.
 	Client pb.WaypointClient
+
+	// Support Dynamic Config
+	EnableDynamicConfig bool
 }
 
 // Virtual represents a virtual CEB instance. It is used to manifest an instance that
@@ -144,6 +150,11 @@ func (v *Virtual) RunExec(ctx context.Context, h VirtualExecHandler, count int) 
 		}
 
 		if msg.Config.Exec != nil {
+			if !v.cfg.EnableDynamicConfig {
+				dynamic = nil
+				dynamicSources = nil
+			}
+
 			env = buildAppConfig(ctx, v.log, configPlugins, static, dynamic, dynamicSources, prevVarsChanged)
 
 			idx := highestExec
@@ -220,11 +231,12 @@ func (v *Virtual) startExec(
 
 	// Spawn a new exec session for this exec config.
 	xsess, err := h.CreateSession(ctx, &VirtualExecInfo{
-		Input:     stdinR,
-		Output:    stdout,
-		Error:     stderr,
-		Arguments: execConfig.Args,
-		PTY:       execConfig.Pty,
+		Input:       stdinR,
+		Output:      stdout,
+		Error:       stderr,
+		Arguments:   execConfig.Args,
+		Environment: env,
+		PTY:         execConfig.Pty,
 	})
 	if err != nil {
 		return err

--- a/internal/core/app_exec_test.go
+++ b/internal/core/app_exec_test.go
@@ -84,7 +84,7 @@ func TestAppExec_happy(t *testing.T) {
 
 	// Exec
 	go func() {
-		app.Exec(context.Background(), instanceId, resp.Deployment)
+		app.Exec(context.Background(), instanceId, resp.Deployment, true)
 	}()
 
 	// We should get registered

--- a/internal/runner/operation_exec.go
+++ b/internal/runner/operation_exec.go
@@ -25,6 +25,6 @@ func (r *Runner) executeExecOp(
 		panic("operation not expected type")
 	}
 
-	err = app.Exec(ctx, op.Exec.InstanceId, op.Exec.Deployment)
+	err = app.Exec(ctx, op.Exec.InstanceId, op.Exec.Deployment, r.enableDynConfig)
 	return nil, err
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -52,6 +52,8 @@ type Runner struct {
 	local       bool
 	tempDir     string
 
+	enableDynConfig bool
+
 	closedVal int32
 	acceptWg  sync.WaitGroup
 
@@ -241,6 +243,13 @@ func WithLocal(ui terminal.UI) Option {
 func ByIdOnly() Option {
 	return func(r *Runner, cfg *config) error {
 		r.runner.ByIdOnly = true
+		return nil
+	}
+}
+
+func WithDynamicConfig(set bool) Option {
+	return func(r *Runner, cfg *config) error {
+		r.enableDynConfig = set
 		return nil
 	}
 }


### PR DESCRIPTION
This PR feeds configuration from the server to the exec plugin as a set of environment variables.

Unless configured as a flag in the runner, it does not provide any dynamic config variables because those require credentials to access, and it's not presumed that the runner is going to have the correct credentials.

Users that are using standalone runners and verify that their runner environment has the proper credentials can enable reading the dynamic config via the `-enable-dynamic-config` flag.