### PR TITLE
contrib/serverinstall: Setup local registry for kind

### DIFF
--- a/contrib/serverinstall/kind-k8s/README.md
+++ b/contrib/serverinstall/kind-k8s/README.md
@@ -46,13 +46,13 @@ the kubernetes platform!
 
 #### Manual
 
-_this section is a work in progress_
-
-1) kind create cluster --config configs/cluster-config.yaml
-2) kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
-3) kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-4) kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
-5) Get docker subnet from networked container `docker ps -a`, then `docker inspect <container_id>`, and update metallb addresses range in `configs/metallb-config.yaml` to represent your local docker subnet
+1) docker run -d --restart=always -p "127.0.0.1:5000:5000" --name "kind-registry"
+2) kind create cluster --config configs/cluster-config.yaml
+3) docker network connect "kind" "kind-registry"
+4) kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+5) kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+6) kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+7) Get docker subnet from networked container `docker ps -a`, then `docker inspect <container_id>`, and update metallb addresses range in `configs/metallb-config.yaml` to represent your local docker subnet
   * `docker ps -a`
   ```
   CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS                       NAMES
@@ -65,7 +65,7 @@ _this section is a work in progress_
   * `docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' CONTAINER_ID_GOES_HERE`
   * Update the range inside the `configs/metallb-config.yaml` file. If your
   container IP Address was `172.18.0.4` for example, you might set the range to `172.18.0.20-172.18.0.50`.
-6) kubectl apply -f configs/metallb-config.yaml
+8) kubectl apply -f configs/metallb-config.yaml
 
 ### Setup waypoint
 

--- a/contrib/serverinstall/kind-k8s/configs/cluster-config.yaml
+++ b/contrib/serverinstall/kind-k8s/configs/cluster-config.yaml
@@ -1,8 +1,7 @@
 # three node (two workers) cluster config
 # https://kind.sigs.k8s.io/docs/user/quick-start/#multinode-clusters
-kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-- role: worker
-- role: worker
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]

--- a/contrib/serverinstall/kind-k8s/destroy-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/destroy-k8s.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kind delete cluster
+docker rm kind-registry -f

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -1,18 +1,61 @@
 #!/bin/bash
+set -o errexit
+
+echo "Setting up local docker registry..."
+echo
+
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2 | 2>/dev/null
+fi
 
 echo "Setting up kubernetes with kind and metallb..."
 echo
 
 echo "Creating kind cluster with cluster-config.yaml..."
-kind create cluster --config configs/cluster-config.yaml
+echo
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+      endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+echo "Connecting registry to cluster network..."
+echo
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
 
 echo "Applying metallb namespace..."
+echo
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
 
 echo "Create secret for metallb-system node..."
+echo
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
 echo "Applying metallb manifest..."
+echo
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
 
 echo


### PR DESCRIPTION
This pull request updates the automated kind-k8s install to include a local registry container. This allows waypoint to push the app it builds locally and have k8s pull from the local registry.