### PR TITLE
Closing issue 533 prevent incomplete deployments

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -366,7 +366,7 @@ func (p *Platform) Deploy(
 		reportedError bool
 	)
 
-	timeout := 30 * time.Second
+	timeout := 10 * time.Minute
 
 	cancelMu := &sync.Mutex{}
 	pollingComplete := false

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -156,11 +156,7 @@ func (op *deployOperation) Do(ctx context.Context, log hclog.Logger, app *App, m
 	if err := app.ConfigSync(ctx); err != nil {
 		return nil, err
 	}
-	// Upsert immediately so that if deployment fails we still have a reference to it in the db.
-	// TODO: Review this with the team. The rest of the solution seems to prevent this from happening, but it still seems
-	// like it might be useful to have the record. For instance, if we somehow do end up with a failed deployment, say
-	// on k8s, we could use pod metadata to delete the deployment even if we don't have the k8s deployment id. Perhaps
-	// we should add our own internal id as metadata to the pod so that we can cross reference ids. Maybe we are already.
+	// Upsert immediately so that if deployment fails we still have a reference to it in the db
 	if msg, err := op.Upsert(ctx, app.client, msg); err != nil {
 		log.Warn(fmt.Sprintf("Error with upsert: %+v \n%+v", msg, err))
 		return nil, err

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -150,9 +151,18 @@ func (op *deployOperation) Upsert(
 	return resp.Deployment, nil
 }
 
-func (op *deployOperation) Do(ctx context.Context, log hclog.Logger, app *App, _ proto.Message) (interface{}, error) {
+func (op *deployOperation) Do(ctx context.Context, log hclog.Logger, app *App, msg proto.Message) (interface{}, error) {
 	// Sync our config first
 	if err := app.ConfigSync(ctx); err != nil {
+		return nil, err
+	}
+	// Upsert immediately so that if deployment fails we still have a reference to it in the db.
+	// TODO: Review this with the team. The rest of the solution seems to prevent this from happening, but it still seems
+	// like it might be useful to have the record. For instance, if we somehow do end up with a failed deployment, say
+	// on k8s, we could use pod metadata to delete the deployment even if we don't have the k8s deployment id. Perhaps
+	// we should add our own internal id as metadata to the pod so that we can cross reference ids. Maybe we are already.
+	if msg, err := op.Upsert(ctx, app.client, msg); err != nil {
+		log.Warn(fmt.Sprintf("Error with upsert: %+v \n%+v", msg, err))
 		return nil, err
 	}
 

--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -29,7 +29,7 @@ func (a *App) CanDestroyDeploy() bool {
 	return ok
 }
 
-// DestroyDeploy destroyes a specific deployment.
+// DestroyDeploy destroys a specific deployment.
 func (a *App) DestroyDeploy(ctx context.Context, d *pb.Deployment) error {
 	// If the deploy is destroyed already then do nothing.
 	if d.State == pb.Operation_DESTROYED {
@@ -219,7 +219,7 @@ func (op *deployDestroyOperation) Do(ctx context.Context, log hclog.Logger, app 
 	}
 
 	if op.Deployment.Deployment == nil {
-		log.Error("Unable to destroy the Deployment as the proto message Deployment returned from the plugin's DeployFunc is nil. This situation occurs when the deployment process is interupted by the user.", "deployment", op.Deployment)
+		log.Error("Unable to destroy the Deployment as the proto message Deployment returned from the plugin's DeployFunc is nil. This situation occurs when the deployment process is interrupted by the user.", "deployment", op.Deployment)
 		return nil, nil // Fail silently for now, this will be fixed in v0.2
 	}
 


### PR DESCRIPTION
This PR does 4 things.

* Upsert the deployment immediately at the beginning of deployOperation.Do so that failed deployment are represented in the state.
* Adds a top-level Rollback function to the k8s platform module.
* Performs a rollback on deploy timeouts for k8s
* Performs a rollback on user cancellation for k8s