### PR TITLE
builtin/docker: Add Binds, Labels and Networks config options

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -350,10 +350,21 @@ func makeImageCanonical(image string) string {
 
 // Config is the configuration structure for the Platform.
 type PlatformConfig struct {
+	// ClientConfig allow the user to specify the connection to the Docker
+	// engine. By default we try to load this from env vars:
+	// DOCKER_HOST to set the url to the docker server.
+	// DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
+	// DOCKER_CERT_PATH to load the TLS certificates from.
+	// DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
+	ClientConfig *ClientConfig `hcl:"client_config,block"`
+
 	// The command to run in the container. This is an array of arguments
 	// that are executed directly. These are not executed in the context of
 	// a shell. If you want to use a shell, add that to this command manually.
 	Command []string `hcl:"command,optional"`
+
+	// Force pull the image from the remote repository
+	ForcePull bool `hcl:"force_pull,optional"`
 
 	// A path to a directory that will be created for the service to store
 	// temporary data.
@@ -370,17 +381,6 @@ type PlatformConfig struct {
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port.
 	ServicePort uint `hcl:"service_port,optional"`
-
-	// Force pull the image from the remote repository
-	ForcePull bool `hcl:"force_pull,optional"`
-
-	// ClientConfig allow the user to specify the connection to the Docker
-	// engine. By default we try to load this from env vars:
-	// DOCKER_HOST to set the url to the docker server.
-	// DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
-	// DOCKER_CERT_PATH to load the TLS certificates from.
-	// DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
-	ClientConfig *ClientConfig `hcl:"client_config,block"`
 }
 
 type ClientConfig struct {

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -168,8 +168,14 @@ func (p *Platform) Deploy(
 		},
 	}
 
+	// default container binds
+	containerBinds := []string{src.App + "-scratch" + ":/input"}
+	if p.config.Binds != nil {
+		containerBinds = append(containerBinds, p.config.Binds...)
+	}
+
 	hostconfig := container.HostConfig{
-		Binds:        []string{src.App + "-scratch" + ":/input"},
+		Binds:        containerBinds,
 		PortBindings: bindings,
 	}
 
@@ -380,6 +386,9 @@ func makeImageCanonical(image string) string {
 
 // Config is the configuration structure for the Platform.
 type PlatformConfig struct {
+	// A list of folders to mount to the container.
+	Binds []string `hcl:"binds,optional"`
+
 	// ClientConfig allow the user to specify the connection to the Docker
 	// engine. By default we try to load this from env vars:
 	// DOCKER_HOST to set the url to the docker server.
@@ -457,6 +466,16 @@ deploy {
 
 	doc.Input("docker.Image")
 	doc.Output("docker.Deployment")
+
+	doc.SetField(
+		"binds",
+		"A 'source:destination' list of folders to mount onto the container from the host.",
+		docs.Summary(
+			"A list of folders to mount onto the container from the host. The expected",
+			"format for each string entry in the list is `source:destination`. So",
+			"for example: `binds: [\"host_folder/scripts:/scripts\"]",
+		),
+	)
 
 	doc.SetField(
 		"command",


### PR DESCRIPTION
This pull request introduces three new config options for the docker platform for deploys:

- Labels
- Networks
- Binds

It allows users to label their deployed container, as well as connect additional networks.

Fixes https://github.com/hashicorp/waypoint/issues/1064