### PR TITLE
internal/cli: fall back to legacy "up" if server doesn't support op up

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strings"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -27,6 +30,12 @@ func (c *UpCommand) Run(args []string) int {
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		result, err := app.Up(ctx, &pb.Job_UpOp{})
+		if c.legacyRequired(err) {
+			// An older Waypoint server version that doesn't support the
+			// "up" operation, so fall back.
+			c.Log.Warn("server doesn't support 'up' operation, falling back")
+			return c.legacyUp(ctx, app)
+		}
 		if err != nil {
 			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
@@ -68,6 +77,116 @@ func (c *UpCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+
+// legacyRequired returns true if we need to execute the legacy "up" logic.
+func (c *UpCommand) legacyRequired(err error) bool {
+	switch status.Code(err) {
+	case codes.Unimplemented:
+		// Waypoint 0.3+ returns this.
+		return true
+
+	case codes.FailedPrecondition:
+		// Waypoint 0.2 the only way we can detect is this error message
+		// since operation will be seen as "nil" to an older server since
+		// it can't understand our newer op type.
+		return err != nil && strings.Contains(strings.ToLower(err.Error()), "operation")
+
+	default:
+		return false
+	}
+}
+
+// legacyUp implements the exact "up" logic from WP 0.2.x. In WP 0.3.0 we
+// introduced a remote "up" job type that we use instead. If the user uses
+// a new client but an old server that doesn't support the up job type, this
+// will be executed instead.
+func (c *UpCommand) legacyUp(
+	ctx context.Context,
+	app *clientpkg.App,
+) error {
+	client := c.project.Client()
+
+	// Build it
+	app.UI.Output("Building...", terminal.WithHeaderStyle())
+
+	_, err := app.Build(ctx, &pb.Job_BuildOp{})
+	if err != nil {
+		app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return ErrSentinel
+	}
+
+	// Get the most recent pushed artifact
+	push, err := client.GetLatestPushedArtifact(ctx, &pb.GetLatestPushedArtifactRequest{
+		Application: app.Ref(),
+		Workspace:   c.project.WorkspaceRef(),
+	})
+	if err != nil {
+		app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return ErrSentinel
+	}
+
+	// Push it
+	app.UI.Output("Deploying...", terminal.WithHeaderStyle())
+
+	result, err := app.Deploy(ctx, &pb.Job_DeployOp{
+		Artifact: push,
+	})
+	if err != nil {
+		app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return ErrSentinel
+	}
+	deployUrl := result.Deployment.Preload.DeployUrl
+
+	// Try to get the hostname
+	var hostname *pb.Hostname
+	hostnamesResp, err := client.ListHostnames(ctx, &pb.ListHostnamesRequest{
+		Target: &pb.Hostname_Target{
+			Target: &pb.Hostname_Target_Application{
+				Application: &pb.Hostname_TargetApp{
+					Application: result.Deployment.Application,
+					Workspace:   result.Deployment.Workspace,
+				},
+			},
+		},
+	})
+	if err == nil && len(hostnamesResp.Hostnames) > 0 {
+		hostname = hostnamesResp.Hostnames[0]
+	}
+
+	// We're releasing, do that too.
+	app.UI.Output("Releasing...", terminal.WithHeaderStyle())
+	releaseResult, err := app.Release(ctx, &pb.Job_ReleaseOp{
+		Deployment: result.Deployment,
+		Prune:      true,
+	})
+	if err != nil {
+		app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return ErrSentinel
+	}
+
+	releaseUrl := releaseResult.Release.Url
+
+	// Output
+	app.UI.Output("")
+	switch {
+	case releaseUrl != "":
+		app.UI.Output(strings.TrimSpace(deployURLService)+"\n", terminal.WithSuccessStyle())
+		app.UI.Output("   Release URL: %s", releaseUrl, terminal.WithSuccessStyle())
+		if deployUrl != "" {
+			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+		}
+
+	case hostname != nil && deployUrl != "":
+		app.UI.Output(strings.TrimSpace(deployURLService)+"\n", terminal.WithSuccessStyle())
+		app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
+		app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+
+	default:
+		app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
+	}
+
+	return nil
 }
 
 func (c *UpCommand) Flags() *flag.Sets {

--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -70,6 +70,12 @@ func (s *service) QueueJob(
 	if job == nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "job must be set")
 	}
+	if job.Operation == nil {
+		// We special case this check and return "Unimplemented" because
+		// the primary case where operation is nil is if a client is sending
+		// us an unsupported operation.
+		return nil, status.Errorf(codes.Unimplemented, "operation is nil or unknown")
+	}
 	if err := serverptypes.ValidateJob(job); err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, err.Error())
 	}


### PR DESCRIPTION
This just adds back the old "up" logic from 0.2.x as a fallback. Over
time, it is possible that the UX of these two diverge but I expect that
we'll see less and less of the old behavior as people upgrade.