### PR TITLE
UI: upgrade pds-addon to 0.4.2

### DIFF
--- a/ui/app/components/app-breadcrumbs/index.hbs
+++ b/ui/app/components/app-breadcrumbs/index.hbs
@@ -1,5 +1,5 @@
 {{#each this.breadcrumbs as |breadcrumb index|}}
-  <li class="{{if (eq (inc index) this.breadcrumbs.length) "is-active"}}">
+  <li class="pds-breadcrumbs__crumb {{if (eq (inc index) this.breadcrumbs.length) "is-active"}}">
     {{#if breadcrumb.isPending}}
       <a href="#" aria-label="loading" data-test-breadcrumb="loading">&hellip;</a>
     {{else}}

--- a/ui/app/components/app-breadcrumbs/index.js
+++ b/ui/app/components/app-breadcrumbs/index.js
@@ -6,7 +6,7 @@ import classic from 'ember-classic-decorator';
 
 @classic
 @tagName('ul')
-@classNames('breadcrumbs')
+@classNames('breadcrumbs', 'pds-breadcrumbs')
 export default class AppBreadcrumbs extends Component {
   @service('breadcrumbs') breadcrumbsService;
 

--- a/ui/app/styles/_breadcrumbs.scss
+++ b/ui/app/styles/_breadcrumbs.scss
@@ -37,8 +37,7 @@ ul.breadcrumbs {
       content: '/';
       color: rgb(var(--outline));
       font-weight: normal;
-      margin-left: scale.$sm-2;
-      margin-right: scale.$sm-2;
+      margin-inline-start: 0.5rem;
     }
 
     &:last-child::after {

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/pds-ember": "^0.3.0",
+    "@hashicorp/pds-ember": "^0.4.2",
     "@hashicorp/structure-icons": "^1.8.1",
     "@types/ember": "^3.16.0",
     "@types/ember-qunit": "^3.4.9",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2016,10 +2016,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@hashicorp/pds-ember@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/pds-ember/-/pds-ember-0.3.0.tgz#790d53ed42851ad3b030e85106babfe8fcbcdb49"
-  integrity sha512-3o4TEtmukRmeBwnGOpca8sj2Izkz0UV/dVSmo/NQM/aozwNPJAeccK5HxBpiVq0+8T+xVnAnSEfx8nw8/FllWQ==
+"@hashicorp/pds-ember@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@hashicorp/pds-ember/-/pds-ember-0.4.2.tgz#4d6a35335a64e5853ea926553414db2742203d9d"
+  integrity sha512-NqiEgSEHJyCN1s2+59WtlOh4LyzOWK/dpaNLmv6QUx1ln7+9qIWBxGT0EaFjLH+L7bS/5/OU5TXqTueZBY0IjQ==
   dependencies:
     "@ember/render-modifiers" "^1.0.2"
     "@hashicorp/structure-icons" "1.9.0-0"


### PR DESCRIPTION
@meirish released v0.4.2 of the `@hashicorp/pds-ember` addon with a large improvement to the production payload size. 

This PR upgrades the addon and fixes a minor regression with the breadcrumbs styles (and adopts the addon's styles for that component)