### PR TITLE
internal/runner: Fix race condition around runner shutdown

### DIFF
--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -42,9 +42,9 @@ func (r *Runner) AcceptExact(ctx context.Context, id string) error {
 var testRecvDelay time.Duration
 
 func (r *Runner) accept(ctx context.Context, id string) error {
-	r.runningMu.Lock()
+	r.runningCond.L.Lock()
 	shutdown := r.shutdown
-	r.runningMu.Unlock()
+	r.runningCond.L.Unlock()
 
 	if shutdown {
 		return ErrClosed
@@ -105,12 +105,12 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 	// since prior to this, if Close() were called, we could go ahead
 	// and return.
 
-	r.runningMu.Lock()
+	r.runningCond.L.Lock()
 	shutdown = r.shutdown
 	if !shutdown {
 		r.runningJobs++
 	}
-	r.runningMu.Unlock()
+	r.runningCond.L.Unlock()
 
 	if shutdown {
 		return errors.Wrapf(ErrClosed, "runner shutdown, dropped job: %s", assignment.Assignment.Job.Id)

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/pkg/errors"
 )
 
 var heartbeatDuration = 5 * time.Second
@@ -38,8 +39,14 @@ func (r *Runner) AcceptExact(ctx context.Context, id string) error {
 	return r.accept(ctx, id)
 }
 
+var testRecvDelay time.Duration
+
 func (r *Runner) accept(ctx context.Context, id string) error {
-	if r.closed() {
+	r.runningMu.Lock()
+	shutdown := r.shutdown
+	r.runningMu.Unlock()
+
+	if shutdown {
 		return ErrClosed
 	}
 
@@ -49,7 +56,7 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 	// since if the context is cancelled we want to continue reporting
 	// errors.
 	log.Debug("opening job stream")
-	client, err := r.client.RunnerJobStream(context.Background())
+	client, err := r.client.RunnerJobStream(r.runningCtx)
 	if err != nil {
 		return err
 	}
@@ -69,6 +76,10 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 
 	// Wait for an assignment
 	log.Info("waiting for job assignment")
+
+	// NOTE: if r.runningCtx is canceled, because the runner has finished closing,
+	// any job sent won't be acked, but the server will see an error on waiting
+	// for us to ack the job, and auto-nack it.
 	resp, err := client.Recv()
 	if err != nil {
 		return err
@@ -84,12 +95,34 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 	log = log.With("job_id", assignment.Assignment.Job.Id)
 	log.Info("job assignment received")
 
-	// We increment the waitgroup at this point since prior to this if we're
-	// forcefully quit, we shouldn't have acked. This is somewhat brittle so
-	// a todo here is to build a better notification mechanism that we've quit
-	// and exit here.
-	r.acceptWg.Add(1)
-	defer r.acceptWg.Done()
+	// Used to test the behavior of accepting a job while
+	// the runner is shutting down.
+	if testRecvDelay != 0 {
+		time.Sleep(testRecvDelay)
+	}
+
+	// We need to register ourselves as being worthy to be waited on
+	// since prior to this, if Close() were called, we could go ahead
+	// and return.
+
+	r.runningMu.Lock()
+	shutdown = r.shutdown
+	if !shutdown {
+		r.runningJobs++
+	}
+	r.runningMu.Unlock()
+
+	if shutdown {
+		return errors.Wrapf(ErrClosed, "runner shutdown, dropped job: %s", assignment.Assignment.Job.Id)
+	}
+
+	defer func() {
+		r.runningCond.L.Lock()
+		defer r.runningCond.L.Unlock()
+
+		r.runningJobs--
+		r.runningCond.Broadcast()
+	}()
 
 	// If this isn't the job we expected then we nack and error.
 	if id != "" {

--- a/internal/runner/accept_test.go
+++ b/internal/runner/accept_test.go
@@ -165,9 +165,9 @@ func TestRunnerAccept_closeWaits(t *testing.T) {
 		close(noopCh)
 	})
 
-	runner.runningMu.Lock()
+	runner.runningCond.L.Lock()
 	count := runner.runningJobs
-	runner.runningMu.Unlock()
+	runner.runningCond.L.Unlock()
 
 	require.Equal(1, count)
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -51,7 +51,6 @@ type Runner struct {
 	tempDir     string
 
 	// protects whether or not the runner is active or not.
-	runningMu   sync.Mutex
 	runningCond *sync.Cond
 	shutdown    bool
 	runningJobs int
@@ -94,7 +93,7 @@ func New(opts ...Option) (*Runner, error) {
 		},
 	}
 
-	runner.runningCond = sync.NewCond(&runner.runningMu)
+	runner.runningCond = sync.NewCond(new(sync.Mutex))
 	runner.runningCtx, runner.runningCancel = context.WithCancel(context.Background())
 
 	// Build our config

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/codes"
@@ -44,7 +43,6 @@ type Runner struct {
 	id          string
 	logger      hclog.Logger
 	client      pb.WaypointClient
-	ctx         context.Context
 	cleanupFunc func()
 	runner      *pb.Runner
 	factories   map[component.Type]*factory.Factory
@@ -52,8 +50,14 @@ type Runner struct {
 	local       bool
 	tempDir     string
 
-	closedVal int32
-	acceptWg  sync.WaitGroup
+	// protects whether or not the runner is active or not.
+	runningMu   sync.Mutex
+	runningCond *sync.Cond
+	shutdown    bool
+	runningJobs int
+
+	runningCtx    context.Context
+	runningCancel func()
 
 	// config is the current runner config.
 	config      *pb.RunnerConfig
@@ -80,7 +84,6 @@ func New(opts ...Option) (*Runner, error) {
 	runner := &Runner{
 		id:     id,
 		logger: hclog.L(),
-		ctx:    context.Background(),
 		runner: &pb.Runner{Id: id},
 		factories: map[component.Type]*factory.Factory{
 			component.MapperType:         plugin.BaseFactories[component.MapperType],
@@ -90,6 +93,9 @@ func New(opts ...Option) (*Runner, error) {
 			component.ReleaseManagerType: plugin.BaseFactories[component.ReleaseManagerType],
 		},
 	}
+
+	runner.runningCond = sync.NewCond(&runner.runningMu)
+	runner.runningCtx, runner.runningCancel = context.WithCancel(context.Background())
 
 	// Build our config
 	var cfg config
@@ -122,7 +128,7 @@ func (r *Runner) Id() string {
 // server. This will spawn goroutines for management. This will return after
 // registration so this should not be executed in a goroutine.
 func (r *Runner) Start() error {
-	if r.closed() {
+	if r.shutdown {
 		return ErrClosed
 	}
 
@@ -130,7 +136,7 @@ func (r *Runner) Start() error {
 
 	// Register
 	log.Debug("registering runner")
-	client, err := r.client.RunnerConfig(r.ctx)
+	client, err := r.client.RunnerConfig(r.runningCtx)
 	if err != nil {
 		return err
 	}
@@ -162,7 +168,7 @@ func (r *Runner) Start() error {
 	go r.watchConfig(ch)
 
 	// Start the goroutine that waits for all other configs
-	go r.recvConfig(r.ctx, client, ch)
+	go r.recvConfig(r.runningCtx, client, ch)
 
 	log.Info("runner registered with server")
 	return nil
@@ -173,13 +179,16 @@ func (r *Runner) Start() error {
 // this is called, Start and Accept will no longer function and will
 // return errors immediately.
 func (r *Runner) Close() error {
-	// If we can't swap, we're already closed.
-	if !atomic.CompareAndSwapInt32(&r.closedVal, 0, 1) {
-		return nil
+	r.runningCond.L.Lock()
+	defer r.runningCond.L.Unlock()
+
+	for r.runningJobs > 0 {
+		r.runningCond.Wait()
 	}
 
-	// Wait for our jobs to complete
-	r.acceptWg.Wait()
+	r.shutdown = true
+
+	r.runningCancel()
 
 	// Run any cleanup necessary
 	if f := r.cleanupFunc; f != nil {
@@ -187,10 +196,6 @@ func (r *Runner) Close() error {
 	}
 
 	return nil
-}
-
-func (r *Runner) closed() bool {
-	return atomic.LoadInt32(&r.closedVal) > 0
 }
 
 type config struct{}

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -214,10 +214,12 @@ func (s *service) RunnerJobStream(
 				err = status.Errorf(codes.FailedPrecondition,
 					"ack expected, got: %T", req.Event)
 			}
+		} else {
+			ack = false
 		}
 	}
 
-	// Send the ack.
+	// Send the ack OR nack, based on the value of +ack+.
 	job, ackerr := s.state.JobAck(job.Id, ack)
 	if ackerr != nil {
 		// If this fails, we just log, there is nothing more we can do.


### PR DESCRIPTION
The old code had a race condition where it was possible to shutdown the runner while a job had just started and would have continued to run.

Because of the behavior around executing the runner within the client package as a local runner inside the CLI, this bug has likely never been hit. But a busy system running a standalone runner certainly would have.