### PR TITLE
internal/{client,runner}: start a single runner at the start of the CLI

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -59,66 +59,27 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 // The receiver must be careful to not block sending to mon as it will block
 // the job state processing loop.
 func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.UI, monCh chan pb.Job_State) (*pb.Job_Result, error) {
-	log := c.logger
-
 	// Be sure that the monitor is closed so the reciever knows for sure the job isn't going
 	// anymore.
 	if monCh != nil {
 		defer close(monCh)
 	}
 
-	// cb is used in local mode only to get a callback of the job ID
-	// so we can tell our runner what ID to expect.
-	var cb func(string)
-
 	// In local mode we have to start a runner.
 	if c.local {
-		log.Info("local mode, starting local runner")
-		r, err := c.startRunner()
-		if err != nil {
-			return nil, err
-		}
-
-		log.Info("runner started", "runner_id", r.Id())
-
-		// We defer the close so that we clean up resources. Local mode
-		// always blocks and streams the full output so when doJob exits
-		// the job is complete.
-		defer r.Close()
-
-		var jobCh chan struct{}
-
-		defer func() {
-			if jobCh != nil {
-				log.Info("waiting for accept to finish")
-				<-jobCh
-				log.Debug("finished waiting for job accept")
-			}
-		}()
-
-		// Set our callback up so that we will accept a job once it is queued
-		// so that we can accept exactly this job.
-		cb = func(id string) {
-			jobCh = make(chan struct{})
-			go func() {
-				defer close(jobCh)
-				if err := r.AcceptExact(ctx, id); err != nil {
-					log.Error("runner job accept error", "err", err)
-				}
-			}()
-		}
-
 		// Modify the job to target this runner and use the local data source.
+		// The runner will have been started when we created the Project value and be
+		// used for all local jobs.
 		job.TargetRunner = &pb.Ref_Runner{
 			Target: &pb.Ref_Runner_Id{
 				Id: &pb.Ref_RunnerId{
-					Id: r.Id(),
+					Id: c.activeRunner.Id(),
 				},
 			},
 		}
 	}
 
-	return c.queueAndStreamJob(ctx, job, ui, cb, monCh)
+	return c.queueAndStreamJob(ctx, job, ui, nil, monCh)
 }
 
 // queueAndStreamJob will queue the job. If the client is configured to watch the job,

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -79,7 +79,7 @@ func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.U
 		}
 	}
 
-	return c.queueAndStreamJob(ctx, job, ui, nil, monCh)
+	return c.queueAndStreamJob(ctx, job, ui, monCh)
 }
 
 // queueAndStreamJob will queue the job. If the client is configured to watch the job,
@@ -88,7 +88,6 @@ func (c *Project) queueAndStreamJob(
 	ctx context.Context,
 	job *pb.Job,
 	ui terminal.UI,
-	jobIdCallback func(string),
 	monCh chan pb.Job_State,
 ) (*pb.Job_Result, error) {
 	log := c.logger
@@ -111,11 +110,6 @@ func (c *Project) queueAndStreamJob(
 		return nil, err
 	}
 	log = log.With("job_id", queueResp.JobId)
-
-	// Call our callback if it was given
-	if jobIdCallback != nil {
-		jobIdCallback(queueResp.JobId)
-	}
 
 	// Get the stream
 	log.Debug("opening job stream")

--- a/internal/client/noop_test.go
+++ b/internal/client/noop_test.go
@@ -21,6 +21,7 @@ func TestProjectNoop(t *testing.T) {
 
 	// Build our client
 	c := TestProject(t, WithClient(client), WithLocal())
+	defer c.Close()
 	app := c.App(TestApp(t, c))
 
 	// TODO(mitchellh): once we have an API to list jobs, verify we have

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -36,7 +36,7 @@ type Project struct {
 	// in a goroutine.
 	wg           sync.WaitGroup
 	bg           context.Context
-	cancel       func()
+	bgCancel     func()
 	activeRunner *runner.Runner
 }
 
@@ -63,7 +63,7 @@ func New(ctx context.Context, opts ...Option) (*Project, error) {
 	}
 
 	// Used by any background goroutines that we'll spawn (like runner job processing)
-	client.bg, client.cancel = context.WithCancel(context.Background())
+	client.bg, client.bgCancel = context.WithCancel(context.Background())
 
 	// If a client was explicitly provided, we use that. Otherwise, we
 	// have to establish a connection either through the serverclient
@@ -142,7 +142,7 @@ func (c *Project) Close() error {
 	}
 
 	// Forces any background goroutines to stop
-	c.cancel()
+	c.bgCancel()
 
 	// Now wait on those goroutines to finish up.
 	c.wg.Wait()


### PR DESCRIPTION
This moves runners from being spawn per job to creating a single runner that runs for the lifetime of a client Project value. The reason for this change to make it possible for a server to spawn jobs on a CLI client in response to a client RPC call, rather than just when the CLI client queues the job itself.

We're going to be using this server spawned jobs function (future PR) to cleanup the API for exec and logs plugin functionality, allowing the server to decide if the plugin needs to be spawned or not, rather than the client.