### PR TITLE
builtin/aws/ecs: fix listener deletion check

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1198,7 +1198,7 @@ func destroyALB(
 		var tgs []*elbv2.TargetGroupTuple
 
 		// If there is only 1 target group, delete the listener
-		if len(def) == 1 {
+		if len(def) == 1 && len(def[0].ForwardConfig.TargetGroups) == 1 {
 			log.Debug("only 1 target group, deleting listener")
 			_, err = elbsrv.DeleteListener(&elbv2.DeleteListenerInput{
 				ListenerArn: listener.ListenerArn,


### PR DESCRIPTION
Makes this comment true
```
If there is only 1 target group, delete the listener
```

Closes #765
Smaller implementation of #795 and closes #795