### PR TITLE
Add input checking functions for both ALB and Route53 Zone ID

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -62,6 +62,47 @@ func (p *Platform) ValidateAuth() error {
 	return nil
 }
 
+func (p *Platform) ConfigurableNotify(config interface{}) error {
+	c, ok := config.(*Config)
+	if !ok {
+		return fmt.Errorf("Expected type Config")
+	}
+
+	if c.ALB != nil {
+		if c.ALB.ListenerARN != "" {
+			if c.ALB.ZoneId != "" || p.config.ALB.FQDN != "" {
+				return fmt.Errorf("When using an existing listener, Route53 setup is not available")
+			}
+
+			if c.ALB.CertificateId != "" {
+				return fmt.Errorf("When using an existing listener, certification configuration is not available")
+			}
+			validArn := IsValidArn(c.ALB.ListenerARN)
+			if !validArn {
+				return fmt.Errorf("The ALB Listener ARN provided is NOT a valid ARN.  Please double check the ARN to ensure it is a valid ARN.")
+			}
+			sess := CreateSession()
+			client := elbv2.New(sess)
+			albExists := DoesListenerExist(c.ALB.ListenerARN, client)
+			if !albExists {
+				return fmt.Errorf("The ALB Listener ARN does not exist in your environment.  Please double check to ensure the ARN is the ARN of the ALB Listner.")
+			}
+		}
+		if c.ALB.ZoneId != "" {
+			sess := CreateSession()
+			client := route53.New(sess)
+			validZone := DoesRoute53ZoneExist(c.ALB.ZoneId, client)
+			if !validZone {
+				return fmt.Errorf("The Zone ID supplied does not exist in subscription.  Please ensure the Zone ID exists.")
+			}
+
+		}
+	}
+
+	// config validated ok
+	return nil
+}
+
 // DefaultReleaserFunc implements component.PlatformReleaser
 func (p *Platform) DefaultReleaserFunc() interface{} {
 	return func() *Releaser { return &Releaser{p: p} }
@@ -207,18 +248,6 @@ func (p *Platform) Deploy(
 
 		err error
 	)
-
-	if p.config.ALB != nil {
-		if p.config.ALB.ListenerARN != "" {
-			if p.config.ALB.ZoneId != "" || p.config.ALB.FQDN != "" {
-				return nil, fmt.Errorf("When using an existing listener, Route53 setup is not available")
-			}
-
-			if p.config.ALB.CertificateId != "" {
-				return nil, fmt.Errorf("When using an existing listener, certification configuration is not available")
-			}
-		}
-	}
 
 	if p.config.ServicePort == 0 {
 		p.config.ServicePort = 3000
@@ -1325,13 +1354,13 @@ func (p *Platform) Destroy(
 
 type ALBConfig struct {
 	// Certificate ARN to attach to the load balancer
-	CertificateId string `hcl:"certificate"`
+	CertificateId string `hcl:"certificate,optional"`
 
 	// Route53 Zone to setup record in
-	ZoneId string `hcl:"zone_id"`
+	ZoneId string `hcl:"zone_id,optional"`
 
 	// Fully qualified domain name of the record to create in the target zone id
-	FQDN string `hcl:"domain_name"`
+	FQDN string `hcl:"domain_name,optional"`
 
 	// When set, waypoint will configure the target group into the specified
 	// ALB Listener ARN. This allows for usage of existing ALBs.

--- a/builtin/aws/ecs/validator.go
+++ b/builtin/aws/ecs/validator.go
@@ -1,0 +1,56 @@
+package ecs
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsarn "github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+type ALBListenerClient interface {
+	DescribeListeners(input *elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error)
+}
+
+type Route53Client interface {
+	GetHostedZone(input *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error)
+}
+
+func IsValidArn(arn string) bool {
+	return awsarn.IsARN(arn)
+}
+
+func DoesRoute53ZoneExist(hosted_zone_id string, client Route53Client) bool {
+
+	var input route53.GetHostedZoneInput
+	input.Id = aws.String(hosted_zone_id)
+	_, route53Error := client.GetHostedZone(&input)
+	if route53Error != nil {
+		return false
+	}
+	return true
+}
+
+func DoesListenerExist(arn string, client ALBListenerClient) bool {
+
+	var listnerArray []string
+	listnerArray = append(listnerArray, arn)
+
+	var input elbv2.DescribeListenersInput
+	input.ListenerArns = aws.StringSlice(append(listnerArray, arn))
+	result, err := client.DescribeListeners(&input)
+	if err != nil {
+		return false
+	}
+	fmt.Println(result)
+	return true
+
+}
+
+func CreateSession() *session.Session {
+	return session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+}

--- a/builtin/aws/ecs/validator_test.go
+++ b/builtin/aws/ecs/validator_test.go
@@ -1,0 +1,61 @@
+package ecs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+type MockRoute53Client struct {
+}
+
+func (c *MockRoute53Client) GetHostedZone(input *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error) {
+	var id string
+	id = "Z05223941XHIVUTZAMFED"
+	value := *input.Id
+	if id == value {
+		var output route53.GetHostedZoneOutput
+		return &output, nil
+	}
+	return nil, fmt.Errorf("Test failure:  Input is invalid")
+}
+
+type MockALBListenerClient struct {
+}
+
+func (c *MockALBListenerClient) DescribeListeners(input *elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
+	var listener string
+	listener = "arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21"
+	value := *input.ListenerArns[0]
+	if value == listener {
+		output := elbv2.DescribeListenersOutput{}
+		return &output, nil
+	}
+	return nil, fmt.Errorf("Test failure: Input is an invalid listener.")
+}
+
+func TestRoute53HostedZone(t *testing.T) {
+	mc := MockRoute53Client{}
+	result := DoesRoute53ZoneExist("Z05223941XHIVUTZAMFED", &mc)
+	if result == false {
+		t.Fatal("Error: Exiiting Route53 zone was not found.")
+	}
+
+}
+
+func TestLoadBalancerListener(t *testing.T) {
+	mc := MockALBListenerClient{}
+	result := DoesListenerExist("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21", &mc)
+	if result == false {
+		t.Fatal("Error: Loadblancer Listener does not exist.")
+	}
+}
+
+func TestLoadBalancerArn(t *testing.T) {
+	result := IsValidArn("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21")
+	if result == false {
+		t.Fatal("Error:  ARN supplied is not a valid ARN.")
+	}
+}

--- a/builtin/aws/ecs/validator_test.go
+++ b/builtin/aws/ecs/validator_test.go
@@ -1,44 +1,11 @@
 package ecs
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-type MockRoute53Client struct {
-}
-
-func (c *MockRoute53Client) GetHostedZone(input *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error) {
-	var id string
-	id = "Z05223941XHIVUTZAMFED"
-	value := *input.Id
-	if id == value {
-		var output route53.GetHostedZoneOutput
-		return &output, nil
-	}
-	return nil, fmt.Errorf("Test failure:  Input is invalid")
-}
-
-type MockALBListenerClient struct {
-}
-
-func (c *MockALBListenerClient) DescribeListeners(input *elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
-	var listener string
-	listener = "arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21"
-	value := *input.ListenerArns[0]
-	if value == listener {
-		output := elbv2.DescribeListenersOutput{}
-		return &output, nil
-	}
-	return nil, fmt.Errorf("Test failure: Input is an invalid listener.")
-}
-
 func TestRoute53HostedZone(t *testing.T) {
-	mc := MockRoute53Client{}
-	result := DoesRoute53ZoneExist("Z05223941XHIVUTZAMFED", &mc)
+	result := doesRoute53ZoneExist("Z05223941XHIVUTZAMFED", true)
 	if result == false {
 		t.Fatal("Error: Exiiting Route53 zone was not found.")
 	}
@@ -46,15 +13,14 @@ func TestRoute53HostedZone(t *testing.T) {
 }
 
 func TestLoadBalancerListener(t *testing.T) {
-	mc := MockALBListenerClient{}
-	result := DoesListenerExist("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21", &mc)
+	result := doesListenerExist("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21", true)
 	if result == false {
 		t.Fatal("Error: Loadblancer Listener does not exist.")
 	}
 }
 
 func TestLoadBalancerArn(t *testing.T) {
-	result := IsValidArn("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21")
+	result := isValidArn("arn:aws:elasticloadbalancing:us-east-1:003559363051:listener/app/EC2Co-EcsEl-Z0096VQ81O1L/a56215152ff76fb8/057269c8b4940c21")
 	if result == false {
 		t.Fatal("Error:  ARN supplied is not a valid ARN.")
 	}


### PR DESCRIPTION
Changed DNS, ALB, and Certificate HCL properties to "optional".  I added a function of ConfigNotify and run checks on the input in that function.  I also added unit tests for the various Listener, and Route53 API calls to ensure input is valid input. 