### PR TITLE
Bump react-section-header

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1335,12 +1335,11 @@
       }
     },
     "@hashicorp/react-section-header": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-section-header/-/react-section-header-3.0.1.tgz",
-      "integrity": "sha512-wqffNUyPzCHwdyPMZ+we4hj2Knn1zNxDCtU85Rk8iUgBcpArZF/pleCpIW5w65z6MgPniGAjxUhD0wt29Bc+Yw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-section-header/-/react-section-header-4.0.0.tgz",
+      "integrity": "sha512-6g36zzBq+55amtqGheXx0d3oqF280U/+YrVXXxv23Y4NgBYxYeajcCwg34FIENJtHjqcM2qFnb4rYjFZTdrfdA==",
       "requires": {
-        "@hashicorp/js-utils": "^1.0.10",
-        "marked": "^0.7.0"
+        "@hashicorp/js-utils": "^1.0.10"
       }
     },
     "@hashicorp/react-subnav": {
@@ -7638,11 +7637,6 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-head": "1.1.6",
     "@hashicorp/react-image": "3.0.3",
     "@hashicorp/react-product-downloader": "7.0.1",
-    "@hashicorp/react-section-header": "3.0.1",
+    "@hashicorp/react-section-header": "4.0.0",
     "@hashicorp/react-subnav": "7.1.0",
     "@hashicorp/react-tabs": "^2.0.0",
     "@hashicorp/react-vertical-text-block-list": "4.0.0",

--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -10,7 +10,6 @@
 @import '~@hashicorp/react-button/styles/index.css';
 @import '~@hashicorp/react-consent-manager/style.css';
 @import '~@hashicorp/react-toggle/style.css';
-@import '~@hashicorp/react-section-header/style.css';
 @import '~@hashicorp/react-vertical-text-block-list/style.css';
 @import '~@hashicorp/react-docs-sidenav/style.css';
 @import '~@hashicorp/react-search/style.css';


### PR DESCRIPTION
This PR bumps `@hashicorp/react-section-header` to a recently published version which does not process markdown within the component.

### Affected pages

- [`/community`](https://waypoint-git-zsbump-components.hashicorp.vercel.app/community), should be identical to [live site](https://waypointproject.io/community)