### PR TITLE
website: Update docs from components for release

### DIFF
--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -23,8 +23,4 @@ Usage: `waypoint exec [options]`
 - `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-workspace=<string>` - Workspace to operate in.
 
-#### Command Options
-
-- `-instance=<string>` - Start an exec session on this specific instance
-
 @include "commands/exec_more.mdx"

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -30,19 +30,6 @@ Usage: `waypoint install [options]`
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 
-#### nomad Options
-
-- `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
-- `-nomad-dc=<string>` - Datacenters to install to for Nomad.
-- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad.
-- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
-- `-nomad-region=<string>` - Region to install to for Nomad.
-- `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-
-#### docker Options
-
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
-
 #### kubernetes Options
 
 - `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
@@ -57,5 +44,18 @@ Usage: `waypoint install [options]`
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server.
 - `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes.
+
+#### nomad Options
+
+- `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
+- `-nomad-dc=<string>` - Datacenters to install to for Nomad.
+- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad.
+- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
+- `-nomad-region=<string>` - Region to install to for Nomad.
+- `-nomad-server-image=<string>` - Docker image for the Waypoint server.
+
+#### docker Options
+
+- `-docker-server-image=<string>` - Docker image for the Waypoint server.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -30,6 +30,10 @@ Usage: `waypoint server install [options]`
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 
+#### docker Options
+
+- `-docker-server-image=<string>` - Docker image for the Waypoint server.
+
 #### kubernetes Options
 
 - `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
@@ -53,9 +57,5 @@ Usage: `waypoint server install [options]`
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
 - `-nomad-region=<string>` - Region to install to for Nomad.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-
-#### docker Options
-
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
 
 @include "commands/server-install_more.mdx"

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -31,14 +31,14 @@ Usage: `waypoint server uninstall [options]`
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to uninstall.
 
-#### kubernetes Options
-
-- `-k8s-context=<string>` - The Kubernetes context to unisntall the Waypoint server from. If left unset, Waypoint will use the current Kubernetes context.
-
 #### nomad Options
 
 - `-nomad-purge` - Purge the Waypoint server job after deregistering as part of uninstall.
 
 #### docker Options
+
+#### kubernetes Options
+
+- `-k8s-context=<string>` - The Kubernetes context to unisntall the Waypoint server from. If left unset, Waypoint will use the current Kubernetes context.
 
 @include "commands/server-uninstall_more.mdx"

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -31,6 +31,14 @@ Usage: `waypoint server upgrade [options]`
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
 
+#### kubernetes Options
+
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
+
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
@@ -43,13 +51,5 @@ Usage: `waypoint server upgrade [options]`
 #### docker Options
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server.
-
-#### kubernetes Options
-
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
-- `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
 
 @include "commands/server-upgrade_more.mdx"

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -26,12 +26,6 @@ easiest way to install it is to use our official signed packages for Homebrew,
 
 Start the Docker Desktop application.
 
-Pull the `hashicorp/waypoint` Docker image.
-
-```shell-session
-$ docker pull hashicorp/waypoint:latest
-```
-
 Install the Waypoint server to Docker with the `install` command. The
 `-accept-tos` flag is required to use the `waypoint.run` URL publishing service.
 

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -48,6 +48,46 @@ Route53 ZoneID to create a DNS record into.
 
 Set along with alb.domain_name to have DNS automatically setup for the ALB.
 
+#### logging
+
+Provides additional configuration for logging flags for ECS.
+
+Part of the ecs task definition. These configuration flags help control how the awslogs log driver is configured.
+
+- Type: **\*ecs.Logging**
+
+#### logging.create_group
+
+Should the task attempt to create the aws logs group if not present?.
+
+#### logging.datetime_format
+
+Defines the multiline start pattern in Python strftime format.
+
+#### logging.endpoint
+
+Override the endpoint the logs are shipped to.
+
+#### logging.max_buffer_size
+
+When using non-blocking logging mode, this is the buffer size for message storage.
+
+#### logging.mode
+
+Delivery method for log messages, either 'blocking' or 'non-blocking'.
+
+#### logging.multiline_pattern
+
+Defines the multiline start pattern using a regular expression.
+
+#### logging.region
+
+The region the logs are to be shipped to.
+
+#### logging.stream_prefix
+
+Prefix for application in cloudwatch logs path.
+
 #### memory
 
 How much memory to assign to the container running the application.
@@ -163,6 +203,13 @@ On Fargate, possible values for this are configured by the amount of memory the 
 30720MB: 4096.
 
 - Type: **int**
+- **Optional**
+
+#### disable_alb
+
+Do not create a load balancer assigned to the service.
+
+- Type: **bool**
 - **Optional**
 
 #### ec2_cluster

--- a/website/content/partials/components/platform-docker.mdx
+++ b/website/content/partials/components/platform-docker.mdx
@@ -38,6 +38,15 @@ This config block can be used to configure a remote Docker engine. By default Wa
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
+#### binds
+
+A 'source:destination' list of folders to mount onto the container from the host.
+
+A list of folders to mount onto the container from the host. The expected format for each string entry in the list is `source:destination`. So for example: `binds: ["host_folder/scripts:/scripts"].
+
+- Type: **[]string**
+- **Optional**
+
 #### command
 
 The command to run to start the application in the container.
@@ -53,6 +62,25 @@ Always pull the docker container from the registry.
 - Type: **bool**
 - **Optional**
 - Default: false
+
+#### labels
+
+A map of key/value pairs to label the docker container with.
+
+A map of key/value pair(s), stored in docker as a string. Each key/value pair must be unique. Validiation occurs at the docker layer, not in Waypoint. Label keys are alphanumeric strings which may contain periods (.) and hyphens (-).
+
+- Type: **map[string]string**
+- **Optional**
+
+#### networks
+
+An list of strings with network names to connect the container to.
+
+A list of networks to connect the container to. By default the container will always connect to the `waypoint` network.
+
+- Type: **[]string**
+- **Optional**
+- Default: waypoint
 
 #### scratch_path
 

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -60,9 +60,18 @@ By default uses from current user's home directory.
 
 Namespace to target deployment into.
 
-Namespace is the name of the Kubernetes namespace to apply the deployment in This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each.
+Namespace is the name of the Kubernetes namespace to apply the deployment in. This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each.
 
 - Type: **string**
+- **Optional**
+
+#### ports
+
+A map of ports and options that the application is listening on.
+
+Used to define and expose multiple ports that the application is listening on for the container in use. Available keys are 'port', 'name' , 'host_port', and 'host_ip'. Ports defined will be TCP protocol.
+
+- Type: **[]map[string]string**
 - **Optional**
 
 #### probe_path
@@ -81,6 +90,15 @@ The number of replicas to maintain.
 If the replica count is maintained outside waypoint, for instance by a pod autoscaler, do not set this variable.
 
 - Type: **int32**
+- **Optional**
+
+#### resources
+
+A map of resource limits and requests to apply to a pod on deploy.
+
+Resource limits and requests for a pod. limits and requests options must start with either 'limits*' or 'requests*'. Any other options will be ignored.
+
+- Type: **map[string]string**
 - **Optional**
 
 #### scratch_path
@@ -104,6 +122,8 @@ Service account is the name of the Kubernetes service account to add to the pod.
 #### service_port
 
 The TCP port that the application is listening on.
+
+By default, this config variable is used for exposing a single port for the container in use. For multi-port configuration, use 'ports' instead.
 
 - Type: **uint**
 - **Optional**

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -52,13 +52,22 @@ The TCP port that the Service should consume as a NodePort.
 
 If this is set but load_balancer is not, the service will be NodePort type, but if load_balancer is also set, it will be LoadBalancer.
 
-- Type: **int**
+- Type: **uint**
 - **Optional**
 
 #### port
 
 The TCP port that the application is listening on.
 
-- Type: **int**
+- Type: **uint**
 - **Optional**
 - Default: 80
+
+#### ports
+
+A map of ports and options that the application is listening on.
+
+Used to define and configure multiple ports that the application is listening on. Available keys are 'port', 'node_port', and 'target_port'. If 'node_port' is set but 'load_balancer' is not, the service will be NodePort type. If 'load_balancer' is also set, it will be LoadBalancer. Ports defined will be TCP protocol.
+
+- Type: **[]map[string]string**
+- **Optional**

--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,5 +1,5 @@
 // This is current version of the software available for download
-export default '0.2.0'
+export default '0.2.2'
 
 // HashiCorp officially supported package managers
 // NOTE: This information will be moving into the releases API


### PR DESCRIPTION
This PR generates all of the various component docs for the website off of the `release/0.2.x` branch. It also cherry-picks a docs update that should be included in stable website from main.