### PR TITLE
builtin/k8s: support in-cluster auth

### DIFF
--- a/builtin/k8s/config_sourcer.go
+++ b/builtin/k8s/config_sourcer.go
@@ -68,7 +68,7 @@ func (cs *ConfigSourcer) read(
 		cs.secretCache = map[string]*cachedSecret{}
 	}
 
-	clientset, ns, err := clientsetInCluster()
+	clientset, ns, _, err := clientsetInCluster()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This attempts to auth with K8S using in-cluster auth by default, unless
a kubeconfig file is explicitly specified. If we detect we're not in a
cluster, then we fall back to out of cluster auth.

This is particularly important for a GitOps and runner-based future where
we expect to be deploying to platforms like this from potentially within
the target cluster.