### PR TITLE
serverinstall/k8s: Use k8s client over execing kubectl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elazarl/go-bindata-assetfs v1.0.1
 	github.com/fatih/color v1.9.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/gliderlabs/ssh v0.3.1
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-openapi/runtime v0.19.15
@@ -106,7 +107,7 @@ require (
 	google.golang.org/grpc v1.32.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	k8s.io/api v0.19.4
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1,13 +1,11 @@
 package serverinstall
 
 import (
-	"bytes"
 	"context"
 	json "encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -140,11 +138,7 @@ func (i *K8sInstaller) Install(
 			return nil, err
 		}
 
-		var secretData struct {
-			Metadata struct {
-				Name string `yaml:"name"`
-			} `yaml:"metadata"`
-		}
+		var secretData apiv1.Secret
 
 		err = yaml.Unmarshal(data, &secretData)
 		if err != nil {
@@ -155,29 +149,17 @@ func (i *K8sInstaller) Install(
 			return nil, err
 		}
 
-		if secretData.Metadata.Name == "" {
-			ui.Output(
-				"Invalid secret, no metadata.name",
-				terminal.WithErrorStyle(),
-			)
-			return nil, err
-		}
-
-		i.config.imagePullSecret = secretData.Metadata.Name
+		i.config.imagePullSecret = secretData.ObjectMeta.Name
 
 		ui.Output("Installing kubernetes secret...")
 
-		cmd := exec.Command("kubectl", "create", "-f", "-")
-		cmd.Stdin = bytes.NewReader(data)
-		cmd.Stdout = s.TermOutput()
-		cmd.Stderr = cmd.Stdout
-
-		if err = cmd.Run(); err != nil {
+		secretsClient := clientset.CoreV1().Secrets(i.config.namespace)
+		_, err = secretsClient.Create(context.TODO(), &secretData, metav1.CreateOptions{})
+		if err != nil {
 			ui.Output(
-				"Error executing kubectl to install secret: %s", clierrors.Humanize(err),
+				"Error creating Kubernetes secret from file: %s", clierrors.Humanize(err),
 				terminal.WithErrorStyle(),
 			)
-
 			return nil, err
 		}
 

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"


### PR DESCRIPTION
This commit removes the instance of using kubectl in favor of just using
the k8s client for installing a secrets file.