### PR TITLE
internal/ceb/ssh: fix dropped test error

### DIFF
--- a/internal/ceb/ssh/server_test.go
+++ b/internal/ceb/ssh/server_test.go
@@ -79,6 +79,7 @@ func TestServer(t *testing.T) {
 	cfg.Timeout = 5 * time.Second
 
 	client, err := gossh.Dial("tcp", l.Addr().String(), &cfg)
+	require.NoError(t, err)
 
 	sess, err := client.NewSession()
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a dropped test error in `internal/ceb/ssh`.