### PR TITLE
builtin/aws/ecr: use the ecr mapper

### DIFF
--- a/builtin/aws/ecr/ecr.go
+++ b/builtin/aws/ecr/ecr.go
@@ -9,4 +9,5 @@ import (
 // Options are the SDK options to use for instantiation.
 var Options = []sdk.Option{
 	sdk.WithComponents(&Registry{}),
+	sdk.WithMappers(ECRImageMapper),
 }


### PR DESCRIPTION
This does not need to be backported; it is only on `main`.
This resolves the error `argument cannot be satisfied: type *anypb.Any` received when using the `aws-ecr` registry.