### PR TITLE
check for nil logging opts; remove endpoint

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -824,26 +824,36 @@ func createALB(
 	return lbArn, tgArn, err
 }
 
-func buildLoggingOptions(conf *Logging, region string, logGroup string, defaultStreamPrefix string) map[string]*string {
-
-	var streamPrefix = conf.StreamPrefix
-	if streamPrefix == "" {
-		streamPrefix = defaultStreamPrefix
-	}
+func buildLoggingOptions(
+	lo *Logging,
+	region string,
+	logGroup string,
+	defaultStreamPrefix string,
+	isEC2 bool,
+) map[string]*string {
 
 	result := map[string]*string{
-		"awslogs-region":            aws.String(region),
-		"awslogs-group":             aws.String(logGroup),
-		"awslogs-endpoint":          aws.String(conf.Endpoint),
-		"awslogs-stream-prefix":     aws.String(streamPrefix),
-		"awslogs-datetime-format":   aws.String(conf.DateTimeFormat),
-		"awslogs-multiline-pattern": aws.String(conf.MultilinePattern),
-		"mode":                      aws.String(conf.Mode),
-		"max-buffer-size":           aws.String(conf.MaxBufferSize),
+		"awslogs-region":        aws.String(region),
+		"awslogs-group":         aws.String(logGroup),
+		"awslogs-stream-prefix": aws.String(defaultStreamPrefix),
 	}
 
-	if conf.CreateGroup {
-		result["awslogs-create-group"] = aws.String("true")
+	if lo != nil {
+		// We receive the error `Log driver awslogs disallows options: awslogs-endpoint`
+		// when setting `awslogs-endpoint`, so that is not included here of the
+		// available options
+		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+		result["awslogs-datetime-format"] = aws.String(lo.DateTimeFormat)
+		result["awslogs-multiline-pattern"] = aws.String(lo.MultilinePattern)
+		result["mode"] = aws.String(lo.Mode)
+		result["max-buffer-size"] = aws.String(lo.MaxBufferSize)
+
+		if lo.CreateGroup {
+			result["awslogs-create-group"] = aws.String("true")
+		}
+		if lo.StreamPrefix != "" {
+			result["awslogs-stream-prefix"] = aws.String(lo.StreamPrefix)
+		}
 	}
 
 	for k, v := range result {
@@ -904,7 +914,13 @@ func (p *Platform) Launch(
 		})
 	}
 
-	logOptions := buildLoggingOptions(p.config.Logging, p.config.Region, logGroup, defaultStreamPrefix)
+	logOptions := buildLoggingOptions(
+		p.config.Logging,
+		p.config.Region,
+		logGroup,
+		defaultStreamPrefix,
+		p.config.EC2Cluster,
+	)
 
 	def := ecs.ContainerDefinition{
 		Essential: aws.Bool(true),
@@ -1358,8 +1374,6 @@ type HealthCheckConfig struct {
 type Logging struct {
 	CreateGroup bool `hcl:"create_group,optional"`
 
-	Endpoint string `hcl:"endpoint,optional"`
-
 	StreamPrefix string `hcl:"stream_prefix,optional"`
 
 	DateTimeFormat string `hcl:"datetime_format,optional"`
@@ -1611,11 +1625,6 @@ deploy {
 		"logging.region",
 		"The region the logs are to be shipped to.",
 		docs.Default("The same region the task is to be running."),
-	)
-
-	doc.SetField(
-		"logging.endpoint",
-		"Override the endpoint the logs are shipped to",
 	)
 
 	doc.SetField(

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -829,7 +829,6 @@ func buildLoggingOptions(
 	region string,
 	logGroup string,
 	defaultStreamPrefix string,
-	isEC2 bool,
 ) map[string]*string {
 
 	result := map[string]*string{
@@ -919,7 +918,6 @@ func (p *Platform) Launch(
 		p.config.Region,
 		logGroup,
 		defaultStreamPrefix,
-		p.config.EC2Cluster,
 	)
 
 	def := ecs.ContainerDefinition{

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1609,25 +1609,25 @@ deploy {
 
 	doc.SetField(
 		"logging",
-		"Provides additional configuration for logging flags for ECS.",
+		"Provides additional configuration for logging flags for ECS",
 		docs.Summary("Part of the ecs task definition.  These configuration flags help",
 			"control how the awslogs log driver is configured."),
 	)
 
 	doc.SetField(
 		"logging.create_group",
-		"Should the task attempt to create the aws logs group if not present?",
+		"Enables creation of the aws logs group if not present",
 	)
 
 	doc.SetField(
 		"logging.region",
-		"The region the logs are to be shipped to.",
-		docs.Default("The same region the task is to be running."),
+		"The region the logs are to be shipped to",
+		docs.Default("The same region the task is to be running"),
 	)
 
 	doc.SetField(
 		"logging.stream_prefix",
-		"prefix for application in cloudwatch logs path",
+		"Prefix for application in cloudwatch logs path",
 		docs.Default("Generated based off timestamp"),
 	)
 

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -58,7 +58,7 @@ Part of the ecs task definition. These configuration flags help control how the 
 
 #### logging.create_group
 
-Should the task attempt to create the aws logs group if not present?.
+Enables creation of the aws logs group if not present.
 
 #### logging.datetime_format
 

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -64,10 +64,6 @@ Should the task attempt to create the aws logs group if not present?.
 
 Defines the multiline start pattern in Python strftime format.
 
-#### logging.endpoint
-
-Override the endpoint the logs are shipped to.
-
 #### logging.max_buffer_size
 
 When using non-blocking logging mode, this is the buffer size for message storage.

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -48,6 +48,46 @@ Route53 ZoneID to create a DNS record into.
 
 Set along with alb.domain_name to have DNS automatically setup for the ALB.
 
+#### logging
+
+Provides additional configuration for logging flags for ECS.
+
+Part of the ecs task definition. These configuration flags help control how the awslogs log driver is configured.
+
+- Type: **\*ecs.Logging**
+
+#### logging.create_group
+
+Should the task attempt to create the aws logs group if not present?.
+
+#### logging.datetime_format
+
+Defines the multiline start pattern in Python strftime format.
+
+#### logging.endpoint
+
+Override the endpoint the logs are shipped to.
+
+#### logging.max_buffer_size
+
+When using non-blocking logging mode, this is the buffer size for message storage.
+
+#### logging.mode
+
+Delivery method for log messages, either 'blocking' or 'non-blocking'.
+
+#### logging.multiline_pattern
+
+Defines the multiline start pattern using a regular expression.
+
+#### logging.region
+
+The region the logs are to be shipped to.
+
+#### logging.stream_prefix
+
+Prefix for application in cloudwatch logs path.
+
 #### memory
 
 How much memory to assign to the container running the application.
@@ -163,6 +203,13 @@ On Fargate, possible values for this are configured by the amount of memory the 
 30720MB: 4096.
 
 - Type: **int**
+- **Optional**
+
+#### disable_alb
+
+Do not create a load balancer assigned to the service.
+
+- Type: **bool**
 - **Optional**
 
 #### ec2_cluster

--- a/website/content/partials/components/platform-docker.mdx
+++ b/website/content/partials/components/platform-docker.mdx
@@ -38,6 +38,15 @@ This config block can be used to configure a remote Docker engine. By default Wa
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
+#### binds
+
+A 'source:destination' list of folders to mount onto the container from the host.
+
+A list of folders to mount onto the container from the host. The expected format for each string entry in the list is `source:destination`. So for example: `binds: ["host_folder/scripts:/scripts"].
+
+- Type: **[]string**
+- **Optional**
+
 #### command
 
 The command to run to start the application in the container.
@@ -53,6 +62,25 @@ Always pull the docker container from the registry.
 - Type: **bool**
 - **Optional**
 - Default: false
+
+#### labels
+
+A map of key/value pairs to label the docker container with.
+
+A map of key/value pair(s), stored in docker as a string. Each key/value pair must be unique. Validiation occurs at the docker layer, not in Waypoint. Label keys are alphanumeric strings which may contain periods (.) and hyphens (-).
+
+- Type: **map[string]string**
+- **Optional**
+
+#### networks
+
+An list of strings with network names to connect the container to.
+
+A list of networks to connect the container to. By default the container will always connect to the `waypoint` network.
+
+- Type: **[]string**
+- **Optional**
+- Default: waypoint
 
 #### scratch_path
 

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -60,9 +60,18 @@ By default uses from current user's home directory.
 
 Namespace to target deployment into.
 
-Namespace is the name of the Kubernetes namespace to apply the deployment in This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each.
+Namespace is the name of the Kubernetes namespace to apply the deployment in. This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each.
 
 - Type: **string**
+- **Optional**
+
+#### ports
+
+A map of ports and options that the application is listening on.
+
+Used to define and expose multiple ports that the application is listening on for the container in use. Available keys are 'port', 'name' , 'host_port', and 'host_ip'. Ports defined will be TCP protocol.
+
+- Type: **[]map[string]string**
 - **Optional**
 
 #### probe_path
@@ -81,6 +90,15 @@ The number of replicas to maintain.
 If the replica count is maintained outside waypoint, for instance by a pod autoscaler, do not set this variable.
 
 - Type: **int32**
+- **Optional**
+
+#### resources
+
+A map of resource limits and requests to apply to a pod on deploy.
+
+Resource limits and requests for a pod. limits and requests options must start with either 'limits*' or 'requests*'. Any other options will be ignored.
+
+- Type: **map[string]string**
 - **Optional**
 
 #### scratch_path
@@ -104,6 +122,8 @@ Service account is the name of the Kubernetes service account to add to the pod.
 #### service_port
 
 The TCP port that the application is listening on.
+
+By default, this config variable is used for exposing a single port for the container in use. For multi-port configuration, use 'ports' instead.
 
 - Type: **uint**
 - **Optional**

--- a/website/content/partials/components/releasemanager-kubernetes.mdx
+++ b/website/content/partials/components/releasemanager-kubernetes.mdx
@@ -52,13 +52,22 @@ The TCP port that the Service should consume as a NodePort.
 
 If this is set but load_balancer is not, the service will be NodePort type, but if load_balancer is also set, it will be LoadBalancer.
 
-- Type: **int**
+- Type: **uint**
 - **Optional**
 
 #### port
 
 The TCP port that the application is listening on.
 
-- Type: **int**
+- Type: **uint**
 - **Optional**
 - Default: 80
+
+#### ports
+
+A map of ports and options that the application is listening on.
+
+Used to define and configure multiple ports that the application is listening on. Available keys are 'port', 'node_port', and 'target_port'. If 'node_port' is set but 'load_balancer' is not, the service will be NodePort type. If 'load_balancer' is also set, it will be LoadBalancer. Ports defined will be TCP protocol.
+
+- Type: **[]map[string]string**
+- **Optional**


### PR DESCRIPTION
This fixes two bugs.
One was our lack of a nil check on `logging` options in waypoint hcl.
The other was the aws error message we receive for `awslogs-endpoint`. I've submitted a ticket via their docs page and will update if/when I hear back. Until then, I don't want to hold up this bug fix.