### PR TITLE
feat: Additional configuration for Google Cloud Run

### DIFF
--- a/.changelog/1123.txt
+++ b/.changelog/1123.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+builtin/google/cloudrun: Add VPC and Cloud SQL config options
+```

--- a/builtin/google/cloudrun/validation.go
+++ b/builtin/google/cloudrun/validation.go
@@ -65,6 +65,7 @@ var ErrInvalidCPUCount = fmt.Errorf("Invalid value for CPUCount, it is currently
 var ErrInvalidRequestTimetout = fmt.Errorf("RequestTimeout must be greater than 0 and lets than 900\n")
 var ErrInvalidMaxRequests = fmt.Errorf("MaxRequestsPerContainer must be greater than 0\n")
 var ErrInvalidAutoscalingMax = fmt.Errorf("AutoScaling maximum must be larger than 0\n")
+var ErrInvalidVPCAccessEgress = fmt.Errorf("Invalid value for Egress, possible values: 'all' and 'private-ranges-only'\n")
 
 // ValidateConfig checks the deployment configuration for errors
 func validateConfig(c Config) error {
@@ -86,6 +87,8 @@ func validateConfig(c Config) error {
 				errorMessage += ErrInvalidMaxRequests.Error()
 			case "Config.AutoScaling.Max":
 				errorMessage += ErrInvalidAutoscalingMax.Error()
+			case "Config.VPCAccess.Egress":
+				errorMessage += ErrInvalidVPCAccessEgress.Error()
 			default:
 				errorMessage += fmt.Sprintf("%s\n", err.Value())
 			}

--- a/builtin/google/cloudrun/validation_test.go
+++ b/builtin/google/cloudrun/validation_test.go
@@ -157,6 +157,26 @@ func TestConfigValidation(t *testing.T) {
 			},
 			false,
 		},
+		"Egress invalid": {
+			Config{
+				Project:  "waypoint-286812",
+				Location: "europe-north1",
+				VPCAccess: &VPCAccess{
+					Egress: "invalid value for egress",
+				},
+			},
+			false,
+		},
+		"Egress valid": {
+			Config{
+				Project:  "waypoint-286812",
+				Location: "europe-north1",
+				VPCAccess: &VPCAccess{
+					Egress: "all",
+				},
+			},
+			true,
+		},
 	}
 
 	for name, tc := range tests {

--- a/website/content/partials/components/platform-google-cloud-run.mdx
+++ b/website/content/partials/components/platform-google-cloud-run.mdx
@@ -139,6 +139,35 @@ Is public unauthenticated access allowed for the Cloud Run instance?.
 - Type: **bool**
 - **Optional**
 
+#### cloudsql_instances
+
+List of CloudSQL instances that the Cloud Run instance will have access to.
+
+- Type: **[]string**
+- **Optional**
+
+#### vpc_access
+
+VPC (Virtual Private Cloud) configuration for the Cloud Run instance granting
+access to reqsources by their internal IPs.
+
+- Type: **\*cloudrun.VPCAccess**
+
+#### vpc_access.connector
+
+Name of the VPC Access Connector to use for this Cloud Run instance.
+
+- Type: **string**
+- **Optional**
+
+#### vpc_access.egress
+
+VPC egress type. Supported values are 'all' (route all traffic through the VPC connctor)
+and 'private-ranges-only' (only route requsts to internal IPs throgh the connector).
+
+- Type: **string**
+- **Optional**
+
 ### Output Attributes
 
 Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).


### PR DESCRIPTION
Add additional configuration for Google Cloud Run.
Specifically, add options to specify connectible
CloudSQL instances, VPC Access Connector and the
type of the connector.

Reference: https://cloud.google.com/run/docs/reference/rest/v1/RevisionTemplate