### PR TITLE
Add missing Region value from Deployment

### DIFF
--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -404,6 +404,7 @@ func (p *Platform) Deploy(
 
 	step.Done()
 
+	deployment.Region = p.config.Region
 	deployment.Id = id
 	deployment.FuncArn = funcarn
 	deployment.VerArn = verarn


### PR DESCRIPTION
We need the region, it's used by the ALB to figure out where to set things up.