### PR TITLE
internal/server: More descriptive error for unknown application deploys

### DIFF
--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -323,7 +323,7 @@ func (op *appOperation) Latest(
 		}
 	}
 
-	return nil, status.Error(codes.NotFound, "none available")
+	return nil, status.Errorf(codes.NotFound, "No application named %q to deploy!", ref.Application)
 }
 
 // dbGet reads the value from the database.

--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -323,7 +323,7 @@ func (op *appOperation) Latest(
 		}
 	}
 
-	return nil, status.Errorf(codes.NotFound, "No application named %q to deploy!", ref.Application)
+	return nil, status.Errorf(codes.NotFound, "No application named %q is available!", ref.Application)
 }
 
 // dbGet reads the value from the database.


### PR DESCRIPTION
This commit returns a more descriptive error message when a non-existent
application is attempted to be deployed.

Fixes #973

Before:

```
brian@localghost:go % waypoint deploy -plain -app=FOO]
! none available
```

After:

```
brian@localghost:go % waypoint deploy -plain -app=FOO
! No application named "FOO" is available!
```