### PR TITLE
Honor the ALB config's port, but use the correct auto-calculated port

### DIFF
--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -65,6 +65,11 @@ func (r *Releaser) Release(
 		})
 	}
 
+	// If there is a port defined, honor it.
+	if r.config.Port != 0 {
+		port = int64(r.config.Port)
+	}
+
 	var (
 		lb               *elbv2.LoadBalancer
 		listener         *elbv2.Listener
@@ -147,7 +152,7 @@ func (r *Releaser) Release(
 				vpc = subnetInfo.Subnets[0].VpcId
 			}
 
-			sg, err := utils.CreateSecurityGroup(ctx, sess, fmt.Sprintf("%s-incoming", lbName), vpc, r.config.Port)
+			sg, err := utils.CreateSecurityGroup(ctx, sess, fmt.Sprintf("%s-incoming", lbName), vpc, int(port))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The automatically created security group is created incorrectly if we use the auto-calculated port value, but we were also not honoring the Port value that the ALB defined.