### PR TITLE
internal/serverinstall: fix dropped errors

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -732,7 +732,14 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 				LabelSelector: "app=" + runnerName,
 			},
 		)
+		if err != nil {
+			ui.Output(
+				"Error creating deployments watcher %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
 
+		}
 		// send DELETE to statefulset collection
 		if err = deploymentClient.DeleteCollection(
 			ctx,
@@ -790,7 +797,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 				LabelSelector: "app=" + serverName,
 			},
 		)
-
+		if err != nil {
+			ui.Output(
+				"Error creating stateful set watcher: %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
+		}
 		// send DELETE to statefulset collection
 		if err = ssClient.DeleteCollection(
 			ctx,
@@ -848,7 +861,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 				LabelSelector: "app=" + serverName,
 			},
 		)
-
+		if err != nil {
+			ui.Output(
+				"Error creating persistent volume claims watcher: %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
+		}
 		// delete persistent volume claims
 		if err = pvcClient.DeleteCollection(
 			ctx,
@@ -906,7 +925,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 				LabelSelector: "app=" + serverName,
 			},
 		)
-
+		if err != nil {
+			ui.Output(
+				"Error creating service client watcher: %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
+		}
 		// delete waypoint service
 		if err = svcClient.Delete(
 			ctx,

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -432,6 +432,9 @@ func (i *NomadInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error
 	s.Update("Removing Waypoint server from Nomad...")
 
 	_, _, err = client.Jobs().Deregister(serverName, i.config.serverPurge, &api.WriteOptions{})
+	if err != nil {
+		return err
+	}
 	allocs, _, err := client.Jobs().Allocations(serverName, true, nil)
 	if err != nil {
 		return err

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverconfig"
@@ -433,6 +434,10 @@ func (i *NomadInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error
 
 	_, _, err = client.Jobs().Deregister(serverName, i.config.serverPurge, &api.WriteOptions{})
 	if err != nil {
+		ui.Output(
+			"Error deregistering waypoint server job: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
 		return err
 	}
 	allocs, _, err := client.Jobs().Allocations(serverName, true, nil)


### PR DESCRIPTION
This fixes both Kubernetes and Nomad dropped errors in `internal/serverinstall`.