### PR TITLE
Backport of internal/serverinstall: fix dropped errors into release/0.2.x

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -721,6 +721,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 			LabelSelector: "app=" + serverName,
 		},
 	)
+	if err != nil {
+		ui.Output(
+			"Error creating statefulsets watcher %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return err
+	}
 
 	// send DELETE to statefulset collection
 	if err = clientset.AppsV1().StatefulSets(i.config.namespace).DeleteCollection(
@@ -768,6 +775,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 			LabelSelector: "app=" + serverName,
 		},
 	)
+	if err != nil {
+		ui.Output(
+			"Error creating persistent volume claims watcher %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return err
+	}
 
 	// delete persistent volume claims
 	if err = clientset.CoreV1().PersistentVolumeClaims(i.config.namespace).DeleteCollection(
@@ -815,6 +829,13 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 			LabelSelector: "app=" + serverName,
 		},
 	)
+	if err != nil {
+		ui.Output(
+			"Error creating services watcher %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return err
+	}
 
 	// delete waypoint service
 	if err = clientset.CoreV1().Services(i.config.namespace).Delete(

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -432,6 +432,9 @@ func (i *NomadInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error
 	s.Update("Removing Waypoint server from Nomad...")
 
 	_, _, err = client.Jobs().Deregister(serverName, i.config.serverPurge, &api.WriteOptions{})
+	if err != nil {
+		return err
+	}
 	allocs, _, err := client.Jobs().Allocations(serverName, true, nil)
 	if err != nil {
 		return err

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clicontext"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverconfig"
@@ -433,6 +434,10 @@ func (i *NomadInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error
 
 	_, _, err = client.Jobs().Deregister(serverName, i.config.serverPurge, &api.WriteOptions{})
 	if err != nil {
+		ui.Output(
+			"Error deregistering waypoint server job: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
 		return err
 	}
 	allocs, _, err := client.Jobs().Allocations(serverName, true, nil)


### PR DESCRIPTION
Overrides https://github.com/hashicorp/waypoint/pull/1144. Had to redo a commit because the original PR rebased code that wasn't meant for backport.