### PR TITLE
builtin/k8s: Include user defined labels on deploy and add name/version labels

### DIFF
--- a/builtin/k8s/deployment.go
+++ b/builtin/k8s/deployment.go
@@ -24,14 +24,14 @@ func (d *Deployment) newDeployment(name string) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"name": name,
+					"app": name,
 				},
 			},
 
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": name,
+						"app": name,
 					},
 
 					Annotations: map[string]string{},

--- a/builtin/k8s/deployment.go
+++ b/builtin/k8s/deployment.go
@@ -21,6 +21,8 @@ func (d *Deployment) newDeployment(name string) *appsv1.Deployment {
 			Name: name,
 		},
 
+		// Note both name and app are included here. 'app' is expected for certain
+		// k8s integrations, where as waypoint expepcts 'name' else where for release
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/builtin/k8s/deployment.go
+++ b/builtin/k8s/deployment.go
@@ -24,14 +24,16 @@ func (d *Deployment) newDeployment(name string) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": name,
+					"app":  name,
+					"name": name,
 				},
 			},
 
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": name,
+						"app":  name,
+						"name": name,
 					},
 
 					Annotations: map[string]string{},

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -182,6 +182,9 @@ func (p *Platform) Deploy(
 	// Set our ID on the label. We use this ID so that we can have a key
 	// to route to multiple versions during release management.
 	deployment.Spec.Template.Labels[labelId] = result.Id
+	// Version label duplicates "labelId" to support services like Istio that
+	// expect pods to be labled with 'version'
+	deployment.Spec.Template.Labels["version"] = result.Id
 
 	// Apply user defined labels
 	for k, v := range p.config.Labels {

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -183,6 +183,11 @@ func (p *Platform) Deploy(
 	// to route to multiple versions during release management.
 	deployment.Spec.Template.Labels[labelId] = result.Id
 
+	// Apply user defined labels
+	for k, v := range p.config.Labels {
+		deployment.Spec.Template.Labels[k] = v
+	}
+
 	// If the user is using the latest tag, then don't specify an overriding pull policy.
 	// This by default means kubernetes will always pull so that latest is useful.
 	pullPolicy := corev1.PullIfNotPresent
@@ -523,6 +528,9 @@ type Config struct {
 	// KubeconfigPath is the path to the kubeconfig file. If this is
 	// blank then we default to the home directory.
 	KubeconfigPath string `hcl:"kubeconfig,optional"`
+
+	// A map of key vals to label the deployed Pod and Deployment with.
+	Labels map[string]string `hcl:"labels,optional"`
 
 	// Namespace is the Kubernetes namespace to target the deployment to.
 	Namespace string `hcl:"namespace,optional"`

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -690,6 +690,11 @@ deploy "kubernetes" {
 	)
 
 	doc.SetField(
+		"labels",
+		"a map of key value labels to apply to the deployment pod",
+	)
+
+	doc.SetField(
 		"namespace",
 		"namespace to target deployment into",
 		docs.Summary(


### PR DESCRIPTION
This pull request introduces a couple of changes and enhancements for a kubeernetes deploy:

- Includes any user defined labels to apply to the app pod on deploy from the deploy stanza in a waypoint.hcl
- Duplicates the label `name` to be `app`. This fits with how we label `waypoint-server` pod, and will fit what is expected for other services that integrate with k8s such as Istio https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements
- Duplicates the namespaced waypoint id label as `version`, because `version` is an expected key that k8s integrations expect to have (also used by Istio).

Fixes #966