### PR TITLE
builtin/k8s/release: Allow target_port to be int or string

### DIFF
--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -132,15 +132,29 @@ func (r *Releaser) Release(
 			port = DefaultPort
 		}
 
+		var target_port int
 		if sp["target_port"] == "" {
 			sp["target_port"] = "http"
+		} else {
+			target_port, err = strconv.Atoi(sp["target_port"])
+			if err != nil {
+				// it's a string label like 'http', not an integer
+				target_port = 0
+			}
 		}
 
 		servicePorts[i] = corev1.ServicePort{
-			Port:       int32(port),
-			TargetPort: intstr.FromString(sp["target_port"]),
-			Protocol:   corev1.ProtocolTCP,
-			NodePort:   int32(nodePort),
+			Port:     int32(port),
+			Protocol: corev1.ProtocolTCP,
+			NodePort: int32(nodePort),
+		}
+
+		// Because of the type TargetPort is expected to be, we can't pass along
+		// an int as a string, it expects the int to actually be an int
+		if target_port != 0 {
+			servicePorts[i].TargetPort = intstr.FromInt(target_port)
+		} else {
+			servicePorts[i].TargetPort = intstr.FromString(sp["target_port"])
 		}
 	}
 


### PR DESCRIPTION
When defining a ServicePort, TargetPort can be a string label _or_ it
can also be the port number. This commit fixes that by accounting for
when TargetPort is defined to be an int rather than a string label.

Fixes #987