### PR TITLE
Runner upgrade/uninstall machinery, default runner install to true

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -330,10 +330,10 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		})
 
 		f.BoolVar(&flag.BoolVar{
-			Name:    "x-runner",
+			Name:    "runner",
 			Target:  &c.flagRunner,
 			Usage:   "Install a runner in addition to the server",
-			Default: false,
+			Default: true,
 			Hidden:  true,
 		})
 
@@ -361,8 +361,12 @@ func (c *InstallCommand) Help() string {
 Usage: waypoint server install [options]
 Alias: waypoint install
 
-	Installs a Waypoint server to an existing platform. The platform should be
-	specified as kubernetes, nomad, or docker.
+  Installs a Waypoint server to an existing platform. The platform should be
+  specified as kubernetes, nomad, or docker.
+
+  This will also install a single Waypoint runner by default. This enables
+  remote operations out of the box, such as polling a Git repository. This can
+  be disabled by specifying "-runner=false".
 
   By default, this will also automatically create a new default CLI context
   (see "waypoint context") so the CLI will be configured to use the newly

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -282,7 +282,7 @@ func (c *InstallCommand) Run(args []string) int {
 	s.Done()
 
 	if c.flagRunner {
-		if code := installRunner(c.Ctx, log, client, c.ui, sg, p, advertiseAddr); code > 0 {
+		if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr); code > 0 {
 			return code
 		}
 	}
@@ -390,10 +390,12 @@ func installRunner(
 	log hclog.Logger,
 	client pb.WaypointClient,
 	ui terminal.UI,
-	sg terminal.StepGroup,
 	p serverinstall.Installer,
 	advertiseAddr *pb.ServerConfig_AdvertiseAddr,
 ) int {
+	sg := ui.StepGroup()
+	defer sg.Wait()
+
 	s := sg.Add("")
 	defer func() { s.Abort() }()
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -204,11 +205,13 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 	c.ui.Output("Waypoint server will now upgrade from version %q",
 		initServerVersion, terminal.WithInfoStyle())
 
-	// Upgrade in place
-	result, err := p.Upgrade(ctx, &serverinstall.InstallOpts{
+	installOpts := &serverinstall.InstallOpts{
 		Log: log,
 		UI:  c.ui,
-	}, originalCfg.Server)
+	}
+
+	// Upgrade in place
+	result, err := p.Upgrade(ctx, installOpts, originalCfg.Server)
 	if err != nil {
 		c.ui.Output(
 			"Error upgrading server on %s: %s", c.platform, clierrors.Humanize(err),
@@ -247,6 +250,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 
 	// Connect
 	c.ui.Output("Verifying upgrade...", terminal.WithHeaderStyle())
+
 	// New stepgroup to ensure output is after upgrade output
 	sg2 := c.ui.StepGroup()
 	defer sg2.Wait()
@@ -290,6 +294,13 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 	s2.Update("Server connection verified!")
 	s2.Done()
 
+	// Upgrade the runner
+	if code := c.upgradeRunner(
+		ctx, client, sg2, p, installOpts, advertiseAddr,
+	); code > 0 {
+		return code
+	}
+
 	c.ui.Output("\nServer upgrade for platform %q context %q complete!",
 		c.platform, ctxName, terminal.WithSuccessStyle())
 
@@ -300,6 +311,50 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 		terminal.WithSuccessStyle())
 
 	return 0
+}
+
+func (c *ServerUpgradeCommand) upgradeRunner(
+	ctx context.Context,
+	client pb.WaypointClient,
+	sg terminal.StepGroup,
+	p serverinstall.Installer,
+	installOpts *serverinstall.InstallOpts,
+	advertiseAddr *pb.ServerConfig_AdvertiseAddr,
+) int {
+	s := sg.Add("")
+	defer func() { s.Abort() }()
+
+	// Upgrade the runner
+	s.Update("Checking if a runner needs to be upgraded...")
+	hasRunner, err := p.HasRunner(ctx, installOpts)
+	if err != nil {
+		s.Update("Error checking for runner: %s", err)
+		s.Status(terminal.StatusError)
+		s.Done()
+		return 1
+	}
+
+	if !hasRunner {
+		s.Update("No runners to upgrade.")
+		s.Done()
+		return 0
+	}
+
+	s.Update("Runner found. Uninstalling previous runner...")
+	if err := p.UninstallRunner(ctx, installOpts); err != nil {
+		c.ui.Output(
+			"Error uninstalling runner from %s: %s\n\n"+
+				"The runner will not be upgraded.",
+			c.platform,
+			clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+
+		return 1
+	}
+	s.Done()
+
+	return installRunner(ctx, installOpts.Log, client, c.ui, sg, p, advertiseAddr)
 }
 
 func (c *ServerUpgradeCommand) Flags() *flag.Sets {
@@ -360,10 +415,14 @@ func (c *ServerUpgradeCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint server upgrade [options]
 
-	Upgrade Waypoint server in the current context to the latest version or the
-	server image version specified. By default, Waypoint will upgrade to server
-	version "hashicorp/waypoint:latest". Before upgrading, a snapshot of the
-	server will be taken in case of any upgrade failures.
+  Upgrade Waypoint server in the current context to the latest version or the
+  server image version specified. By default, Waypoint will upgrade to server
+  version "hashicorp/waypoint:latest". Before upgrading, a snapshot of the
+  server will be taken in case of any upgrade failures.
+
+  If a runner was installed via "waypoint install" then that runner will also
+  be upgraded to the latest version after the server is upgraded. Any other
+  manually installed runners will not be automatically upgraded.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -361,6 +361,9 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 	s.Update("Previous runner uninstalled")
 	s.Done()
 
+	// TODO(mitchellh): This creates a new auth token for the new runner.
+	// In the future, we need to invalidate the old token. We don't have
+	// the functionality to do this today.
 	return installRunner(ctx, installOpts.Log, client, c.ui, p, advertiseAddr)
 }
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -321,7 +321,6 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 	installOpts *serverinstall.InstallOpts,
 	advertiseAddr *pb.ServerConfig_AdvertiseAddr,
 ) int {
-	return 0
 	// Connect
 	c.ui.Output("Upgrading runner if required...", terminal.WithHeaderStyle())
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -214,6 +214,10 @@ Usage: waypoint server uninstall [options]
   This command does not destroy Waypoint resources, such as deployments and
   releases. Clear all workspaces prior to uninstall to prevent hanging resources.
 
+  If a runner was installed via "waypoint install", the runner will also be
+  uninstalled. Manually installed runners (outside of the "waypoint install"
+  command) will not be affected.
+
 ` + c.Flags().Help())
 }
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -38,6 +38,7 @@ func (c *UninstallCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
+		WithNoAutoServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -46,6 +46,14 @@ func (r *Runner) AcceptMany(ctx context.Context) {
 // Errors during job execution are expected (i.e. a project build is misconfigured)
 // and will be reported on the job.
 //
+// Two specific errors to watch out for are:
+//
+//   - ErrClosed (in this package) which means that the runner is closed
+//     and Accept can no longer be called.
+//   - code = NotFound which means that the runner was deregistered. This
+//     means the runner has to be fully recycled: Close called, a new runner
+//     started.
+//
 // This is safe to be called concurrently which can be used to execute
 // multiple jobs in parallel as a runner.
 func (r *Runner) Accept(ctx context.Context) error {

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -24,14 +24,29 @@ var heartbeatDuration = 5 * time.Second
 func (r *Runner) AcceptMany(ctx context.Context) {
 	for {
 		if err := r.Accept(ctx); err != nil {
-			switch {
-			case err == ErrClosed:
+			if err == ErrClosed {
 				return
-			case status.Code(err) == codes.Canceled:
+			}
+
+			switch status.Code(err) {
+			case codes.Canceled:
 				// Ideally we'd get ErrClosed, but there are cases where we'll observe
 				// the context being closed first, in which case we honor that as a valid
 				// reason to stop accepting jobs.
 				return
+
+			case codes.NotFound:
+				// This means the runner was deregistered and we must exit.
+				// This won't be fixed unless the runner is closed and restarted.
+				r.logger.Error("runner unexpectedly deregistered, exiting")
+				return
+
+			case codes.Unavailable:
+				// Server became unavailable. Let's just sleep to give the
+				// server time to come back.
+				r.logger.Warn("server unavailable, sleeping before retry")
+				time.Sleep(2 * time.Second)
+
 			default:
 				r.logger.Error("error running job", "error", err)
 			}

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -562,47 +562,6 @@ func (i *DockerInstaller) Uninstall(
 		s.Done()
 	}
 
-	// Find and delete any runners. There could be zero, 1, or more.
-	{
-		containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
-			Filters: filters.NewArgs(filters.KeyValuePair{
-				Key:   "label",
-				Value: containerKey + "=" + containerValueRunner,
-			}),
-		})
-		if err != nil {
-			return err
-		}
-
-		// It is not an error for there to be zero or more than one containers
-		// since runners are optional.
-		if len(containers) >= 1 {
-			s = sg.Add("Uninstalling runners...")
-
-			// There should only be one but let's just delete any that exist.
-			for _, c := range containers {
-				containerId := c.ID
-
-				s.Update("Stopping container: %s", containerId)
-
-				// Stop the container gracefully, respecting the Engine's default timeout.
-				if err := cli.ContainerStop(ctx, containerId, nil); err != nil {
-					return err
-				}
-
-				removeOptions := types.ContainerRemoveOptions{
-					RemoveVolumes: true,
-					Force:         true,
-				}
-				if err := cli.ContainerRemove(ctx, containerId, removeOptions); err != nil {
-					return err
-				}
-			}
-			s.Update("%d runner(s) uninstalled", len(containers))
-			s.Done()
-		}
-	}
-
 	s = sg.Add("")
 
 	imageList, err := cli.ImageList(ctx, types.ImageListOptions{
@@ -711,6 +670,71 @@ func (i *DockerInstaller) InstallRunner(
 	}
 
 	s.Update("Waypoint runner installed and started!")
+	s.Done()
+
+	return nil
+}
+
+// UninstallRunner implements Installer.
+func (i *DockerInstaller) UninstallRunner(
+	ctx context.Context,
+	opts *InstallOpts,
+) error {
+	sg := opts.UI.StepGroup()
+	defer sg.Wait()
+
+	s := sg.Add("Initializing Docker client...")
+	defer func() { s.Abort() }()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	cli.NegotiateAPIVersion(ctx)
+
+	// Find and delete any runners. There could be zero, 1, or more.
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{
+			Key:   "label",
+			Value: containerKey + "=" + containerValueRunner,
+		}),
+	})
+	if err != nil {
+		return err
+	}
+
+	// If there are no containers found, we do nothing.
+	if len(containers) == 0 {
+		s.Update("No runners found to uninstall.")
+		s.Done()
+		return nil
+	}
+
+	// It is not an error for there to be zero or more than one containers
+	// since runners are optional.
+	s.Update("Uninstalling runners...")
+
+	// There should only be one but let's just delete any that exist.
+	for _, c := range containers {
+		containerId := c.ID
+
+		s.Update("Stopping container: %s", containerId)
+
+		// Stop the container gracefully, respecting the Engine's default timeout.
+		if err := cli.ContainerStop(ctx, containerId, nil); err != nil {
+			return err
+		}
+
+		removeOptions := types.ContainerRemoveOptions{
+			RemoveVolumes: true,
+			Force:         true,
+		}
+		if err := cli.ContainerRemove(ctx, containerId, removeOptions); err != nil {
+			return err
+		}
+	}
+	s.Update("%d runner(s) uninstalled", len(containers))
 	s.Done()
 
 	return nil

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -62,11 +62,11 @@ func (i *DockerInstaller) Install(
 	s.Update("Checking for existing installation...")
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: containerLabel,
 		}),
-		All: true,
 	})
 	if err != nil {
 		return nil, err
@@ -294,6 +294,7 @@ func (i *DockerInstaller) Upgrade(
 
 	s.Update("Checking for an existing Waypoint server installation...")
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "waypoint-type=server",
@@ -494,6 +495,7 @@ func (i *DockerInstaller) Uninstall(
 	cli.NegotiateAPIVersion(ctx)
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: containerLabel,
@@ -618,6 +620,7 @@ func (i *DockerInstaller) InstallRunner(
 
 	s.Update("Checking for an existing runner...")
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: "waypoint-type=runner",
@@ -695,6 +698,7 @@ func (i *DockerInstaller) UninstallRunner(
 
 	// Find and delete any runners. There could be zero, 1, or more.
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: containerKey + "=" + containerValueRunner,
@@ -754,6 +758,7 @@ func (i *DockerInstaller) HasRunner(
 
 	// Find and delete any runners. There could be zero, 1, or more.
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true, // include stopped containers
 		Filters: filters.NewArgs(filters.KeyValuePair{
 			Key:   "label",
 			Value: containerKey + "=" + containerValueRunner,

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1088,6 +1088,14 @@ func (i *K8sInstaller) UninstallRunner(
 	return nil
 }
 
+// HasRunner implements Installer.
+func (i *K8sInstaller) HasRunner(
+	ctx context.Context,
+	opts *InstallOpts,
+) (bool, error) {
+	return false, nil
+}
+
 // newDeployment takes in a k8sConfig and creates a new Waypoint Deployment for
 // deploying Waypoint runners.
 func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, error) {

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1080,6 +1080,14 @@ func (i *K8sInstaller) InstallRunner(
 	return nil
 }
 
+// UninstallRunner implements Installer.
+func (i *K8sInstaller) UninstallRunner(
+	ctx context.Context,
+	opts *InstallOpts,
+) error {
+	return nil
+}
+
 // newDeployment takes in a k8sConfig and creates a new Waypoint Deployment for
 // deploying Waypoint runners.
 func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, error) {

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -70,49 +70,9 @@ func (i *K8sInstaller) Install(
 	s := sg.Add("Inspecting Kubernetes cluster...")
 	defer func() { s.Abort() }()
 
-	// Build our K8S client.
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if i.config.k8sContext != "" {
-		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: i.config.k8sContext,
-		}
-	}
-
-	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		configOverrides,
-	)
-
-	// Discover the current target namespace in the user's config so if they
-	// run kubectl commands waypoint will show up. If we use the default namespace
-	// they might not see the objects we've created.
-	if i.config.namespace == "" {
-		namespace, _, err := newCmdConfig.Namespace()
-		if err != nil {
-			ui.Output(
-				"Error getting namespace from client config: %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-			return nil, err
-		}
-		i.config.namespace = namespace
-	}
-
-	clientconfig, err := newCmdConfig.ClientConfig()
+	clientset, err := i.newClient()
 	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(clientconfig)
-	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
+		ui.Output(err.Error(), terminal.WithErrorStyle())
 		return nil, err
 	}
 
@@ -385,51 +345,12 @@ func (i *K8sInstaller) Upgrade(
 	s := sg.Add("Inspecting Kubernetes cluster...")
 	defer s.Abort()
 
-	// Build our K8S client.
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if i.config.k8sContext != "" {
-		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: i.config.k8sContext,
-		}
-	}
-
-	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		configOverrides,
-	)
-
-	// Discover the current target namespace in the user's config so if they
-	// run kubectl commands waypoint will show up. If we use the default namespace
-	// they might not see the objects we've created.
-	if i.config.namespace == "" {
-		namespace, _, err := newCmdConfig.Namespace()
-		if err != nil {
-			ui.Output(
-				"Error getting namespace from client config: %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-			return nil, err
-		}
-		i.config.namespace = namespace
-	}
-
-	clientconfig, err := newCmdConfig.ClientConfig()
+	clientset, err := i.newClient()
 	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
+		ui.Output(err.Error(), terminal.WithErrorStyle())
 		return nil, err
 	}
 
-	clientset, err := kubernetes.NewForConfig(clientconfig)
-	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return nil, err
-	}
 	// Do some probing to see if this is OpenShift. If so, we'll switch the config for the user.
 	// Setting the OpenShift flag will short circuit this.
 	if !i.config.openshift {
@@ -666,116 +587,10 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 	s := sg.Add("Inspecting Kubernetes cluster...")
 	defer func() { s.Abort() }()
 
-	// Build our k8s client
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if i.config.k8sContext != "" {
-		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: i.config.k8sContext,
-		}
-	}
-
-	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		configOverrides,
-	)
-
-	// Discover the current target namespace in the user's config so that we use
-	// the active kubectl target for the waypoint uninstall, mirroring what
-	// we do in Install.
-	if i.config.namespace == "" {
-		namespace, _, err := newCmdConfig.Namespace()
-		if err != nil {
-			ui.Output(
-				"Error getting namespace from client config: %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-		}
-		i.config.namespace = namespace
-	}
-
-	// initialize the k8s client
-	clientconfig, err := newCmdConfig.ClientConfig()
+	clientset, err := i.newClient()
 	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
+		ui.Output(err.Error(), terminal.WithErrorStyle())
 		return err
-	}
-
-	// init new clientset
-	clientset, err := kubernetes.NewForConfig(clientconfig)
-	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return err
-	}
-
-	deploymentClient := clientset.AppsV1().Deployments(i.config.namespace)
-	if list, err := deploymentClient.List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", runnerName),
-	}); err != nil {
-		ui.Output(
-			"Error looking up deployments: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return err
-	} else if len(list.Items) > 0 {
-		s.Update("Deleting any automatically installed runners...")
-
-		// create our wait channel to later poll for statefulset+pod deletion
-		w, err := deploymentClient.Watch(
-			ctx,
-			metav1.ListOptions{
-				LabelSelector: "app=" + runnerName,
-			},
-		)
-		if err != nil {
-			ui.Output(
-				"Error creating deployments watcher %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-			return err
-
-		}
-		// send DELETE to statefulset collection
-		if err = deploymentClient.DeleteCollection(
-			ctx,
-			metav1.DeleteOptions{},
-			metav1.ListOptions{
-				LabelSelector: "app=" + runnerName,
-			},
-		); err != nil {
-			ui.Output(
-				"Error deleting Waypoint deployment: %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-			return err
-		}
-
-		// wait for deletion to complete
-		err = wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-			select {
-			case wCh := <-w.ResultChan():
-				if wCh.Type == "DELETED" {
-					w.Stop()
-					return true, nil
-				}
-				log.Trace("deployment collection not fully removed, waiting")
-				return false, nil
-			default:
-				log.Trace("no message received on watch.ResultChan(), waiting for Event")
-				return false, nil
-			}
-		})
-		if err != nil {
-			return err
-		}
-		s.Update("Runner deployment deleted")
-		s.Done()
-		s = sg.Add("")
 	}
 
 	ssClient := clientset.AppsV1().StatefulSets(i.config.namespace)
@@ -986,48 +801,9 @@ func (i *K8sInstaller) InstallRunner(
 	s := sg.Add("Inspecting Kubernetes cluster...")
 	defer func() { s.Abort() }()
 
-	// Build our K8S client.
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if i.config.k8sContext != "" {
-		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: i.config.k8sContext,
-		}
-	}
-	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		configOverrides,
-	)
-
-	// Discover the current target namespace in the user's config so if they
-	// run kubectl commands waypoint will show up. If we use the default namespace
-	// they might not see the objects we've created.
-	if i.config.namespace == "" {
-		namespace, _, err := newCmdConfig.Namespace()
-		if err != nil {
-			ui.Output(
-				"Error getting namespace from client config: %s", clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
-			return err
-		}
-		i.config.namespace = namespace
-	}
-
-	clientconfig, err := newCmdConfig.ClientConfig()
+	clientset, err := i.newClient()
 	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return err
-	}
-
-	clientset, err := kubernetes.NewForConfig(clientconfig)
-	if err != nil {
-		ui.Output(
-			"Error initializing kubernetes client: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
+		ui.Output(err.Error(), terminal.WithErrorStyle())
 		return err
 	}
 
@@ -1063,12 +839,12 @@ func (i *K8sInstaller) InstallRunner(
 			return false, err
 		}
 
-		if ss.Status.ReadyReplicas != ss.Status.Replicas {
-			log.Trace("deployment not ready, waiting")
-			return false, nil
+		if ss.Status.ReadyReplicas > 0 {
+			return true, nil
 		}
 
-		return true, nil
+		log.Trace("deployment not ready, waiting")
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -1085,6 +861,114 @@ func (i *K8sInstaller) UninstallRunner(
 	ctx context.Context,
 	opts *InstallOpts,
 ) error {
+	ui := opts.UI
+	log := opts.Log
+
+	sg := ui.StepGroup()
+	defer sg.Wait()
+
+	s := sg.Add("Inspecting Kubernetes cluster...")
+	defer func() { s.Abort() }()
+
+	clientset, err := i.newClient()
+	if err != nil {
+		ui.Output(err.Error(), terminal.WithErrorStyle())
+		return err
+	}
+
+	deploymentClient := clientset.AppsV1().Deployments(i.config.namespace)
+	if list, err := deploymentClient.List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", runnerName),
+	}); err != nil {
+		ui.Output(
+			"Error looking up deployments: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return err
+	} else if len(list.Items) > 0 {
+		s.Update("Deleting any automatically installed runners...")
+
+		// Record various settings we can reuse for runner reinstallation
+		// if we're doing an upgrade. We need to do this because the upgrade
+		// flags don't contain the installation settings, and we prefer them
+		// not to; instead we just retain the old settings.
+		//
+		// Note we have lots of conditionals here to try to avoid weird
+		// panic situations if the remote side doesn't have the fields we
+		// expect.
+		podSpec := list.Items[0].Spec.Template.Spec
+		if secrets := podSpec.ImagePullSecrets; len(secrets) > 0 {
+			i.config.imagePullSecret = secrets[0].Name
+		}
+		if v := podSpec.Containers; len(v) > 0 {
+			c := v[0]
+
+			i.config.imagePullPolicy = string(c.ImagePullPolicy)
+			if m := c.Resources.Requests; len(m) > 0 {
+				if v, ok := m[apiv1.ResourceMemory]; ok {
+					i.config.memRequest = v.String()
+				}
+				if v, ok := m[apiv1.ResourceCPU]; ok {
+					i.config.cpuRequest = v.String()
+				}
+			}
+		}
+
+		// create our wait channel to later poll for statefulset+pod deletion
+		w, err := deploymentClient.Watch(
+			ctx,
+			metav1.ListOptions{
+				LabelSelector: "app=" + runnerName,
+			},
+		)
+		if err != nil {
+			ui.Output(
+				"Error creating deployments watcher %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
+
+		}
+		// send DELETE to statefulset collection
+		if err = deploymentClient.DeleteCollection(
+			ctx,
+			metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: "app=" + runnerName,
+			},
+		); err != nil {
+			ui.Output(
+				"Error deleting Waypoint deployment: %s", clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+			return err
+		}
+
+		// wait for deletion to complete
+		err = wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
+			select {
+			case wCh := <-w.ResultChan():
+				if wCh.Type == "DELETED" {
+					w.Stop()
+					return true, nil
+				}
+				log.Trace("deployment collection not fully removed, waiting")
+				return false, nil
+			default:
+				log.Trace("no message received on watch.ResultChan(), waiting for Event")
+				return false, nil
+			}
+		})
+		if err != nil {
+			return err
+		}
+		s.Update("Runner deployment deleted")
+		s.Done()
+	} else {
+		s.Update("No runners installed.")
+		s.Done()
+	}
+
 	return nil
 }
 
@@ -1093,7 +977,20 @@ func (i *K8sInstaller) HasRunner(
 	ctx context.Context,
 	opts *InstallOpts,
 ) (bool, error) {
-	return false, nil
+	clientset, err := i.newClient()
+	if err != nil {
+		return false, err
+	}
+
+	deploymentClient := clientset.AppsV1().Deployments(i.config.namespace)
+	list, err := deploymentClient.List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", runnerName),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(list.Items) > 0, nil
 }
 
 // newDeployment takes in a k8sConfig and creates a new Waypoint Deployment for
@@ -1520,6 +1417,54 @@ func int32Ptr(i int32) *int32 {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+// newClient creates a new K8S client based on the configured settings.
+func (i *K8sInstaller) newClient() (*kubernetes.Clientset, error) {
+	// Build our K8S client.
+	configOverrides := &clientcmd.ConfigOverrides{}
+	if i.config.k8sContext != "" {
+		configOverrides = &clientcmd.ConfigOverrides{
+			CurrentContext: i.config.k8sContext,
+		}
+	}
+	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		configOverrides,
+	)
+
+	// Discover the current target namespace in the user's config so if they
+	// run kubectl commands waypoint will show up. If we use the default namespace
+	// they might not see the objects we've created.
+	if i.config.namespace == "" {
+		namespace, _, err := newCmdConfig.Namespace()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error getting namespace from client config: %s",
+				clierrors.Humanize(err),
+			)
+		}
+
+		i.config.namespace = namespace
+	}
+
+	clientconfig, err := newCmdConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error initializing kubernetes client: %s",
+			clierrors.Humanize(err),
+		)
+	}
+
+	clientset, err := kubernetes.NewForConfig(clientconfig)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error initializing kubernetes client: %s",
+			clierrors.Humanize(err),
+		)
+	}
+
+	return clientset, nil
 }
 
 var (

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -484,6 +484,14 @@ func (i *NomadInstaller) UninstallRunner(
 	return nil
 }
 
+// HasRunner implements Installer.
+func (i *NomadInstaller) HasRunner(
+	ctx context.Context,
+	opts *InstallOpts,
+) (bool, error) {
+	return false, nil
+}
+
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the
 // Nomad API
 func waypointNomadJob(c nomadConfig) *api.Job {

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -476,6 +476,14 @@ func (i *NomadInstaller) InstallRunner(
 	return nil
 }
 
+// UninstallRunner implements Installer.
+func (i *NomadInstaller) UninstallRunner(
+	ctx context.Context,
+	opts *InstallOpts,
+) error {
+	return nil
+}
+
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the
 // Nomad API
 func waypointNomadJob(c nomadConfig) *api.Job {

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -119,72 +120,9 @@ func (i *NomadInstaller) Install(
 	}
 
 	s.Update("Installing Waypoint server to Nomad")
-	job := waypointNomadJob(i.config)
-	jobOpts := &api.RegisterOptions{
-		PolicyOverride: i.config.policyOverride,
-	}
-
-	resp, _, err := client.Jobs().RegisterOpts(job, jobOpts, nil)
+	allocID, err := i.runJob(ctx, s, client, waypointNomadJob(i.config))
 	if err != nil {
 		return nil, err
-	}
-
-	s.Update("Waiting for allocation to be scheduled")
-EVAL:
-	qopts := &api.QueryOptions{
-		WaitIndex: resp.EvalCreateIndex,
-	}
-
-	eval, meta, err := client.Evaluations().Info(resp.EvalID, qopts)
-	if err != nil {
-		return nil, err
-	}
-	qopts.WaitIndex = meta.LastIndex
-	switch eval.Status {
-	case "pending":
-		goto EVAL
-	case "complete":
-		s.Update("Nomad allocation created")
-	case "failed", "canceled", "blocked":
-		s.Update("Nomad failed to schedule the waypoint server ", serverName)
-		s.Status(terminal.StatusError)
-		return nil, fmt.Errorf("nomad evaluation did not transition to 'complete'")
-	default:
-		return nil, fmt.Errorf("unknown eval status: %q", eval.Status)
-	}
-
-	var allocID string
-
-	for {
-		allocs, qmeta, err := client.Evaluations().Allocations(eval.ID, qopts)
-		if err != nil {
-			return nil, err
-		}
-		qopts.WaitIndex = qmeta.LastIndex
-		if len(allocs) == 0 {
-			return nil, fmt.Errorf("no allocations found after evaluation completed")
-		}
-
-		switch allocs[0].ClientStatus {
-		case "running":
-			allocID = allocs[0].ID
-			s.Update("Nomad allocation running")
-		case "pending":
-			s.Update(fmt.Sprintf("Waiting for allocation %q to start", allocs[0].ID))
-			// retry
-		default:
-			return nil, fmt.Errorf("allocation failed")
-		}
-
-		if allocID != "" {
-			break
-		}
-
-		select {
-		case <-time.After(500 * time.Millisecond):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
 	}
 
 	serverAddr, err := getAddrFromAllocID(allocID, client)
@@ -206,7 +144,7 @@ EVAL:
 		},
 	}
 
-	s.Update("Nomad allocation ready")
+	s.Update("Waypoint server ready")
 	s.Done()
 
 	return &InstallResults{
@@ -472,7 +410,29 @@ func (i *NomadInstaller) InstallRunner(
 	ctx context.Context,
 	opts *InstallRunnerOpts,
 ) error {
-	// TODO
+	ui := opts.UI
+
+	sg := ui.StepGroup()
+	defer sg.Wait()
+
+	s := sg.Add("Initializing Nomad client...")
+	defer func() { s.Abort() }()
+
+	// Build api client from environment
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	// Install the runner
+	s.Update("Installing the Waypoint runner")
+	_, err = i.runJob(ctx, s, client, waypointRunnerNomadJob(i.config, opts))
+	if err != nil {
+		return err
+	}
+	s.Update("Waypoint runner installed")
+	s.Done()
+
 	return nil
 }
 
@@ -481,6 +441,72 @@ func (i *NomadInstaller) UninstallRunner(
 	ctx context.Context,
 	opts *InstallOpts,
 ) error {
+	ui := opts.UI
+
+	sg := ui.StepGroup()
+	defer sg.Wait()
+
+	s := sg.Add("Initializing Nomad client...")
+	defer func() { s.Abort() }()
+
+	// Build api client from environment
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	s.Update("Checking for existing Waypoint runner...")
+	jobs, _, err := client.Jobs().PrefixList(runnerName)
+	if err != nil {
+		return err
+	}
+	var detected bool
+	for _, j := range jobs {
+		if j.Name == runnerName {
+			detected = true
+			break
+		}
+	}
+	if !detected {
+		s.Update("No Waypoint runner detected.")
+		s.Done()
+		return nil
+	}
+
+	s.Update("Removing Waypoint runner...")
+	_, _, err = client.Jobs().Deregister(runnerName, i.config.serverPurge, &api.WriteOptions{})
+	if err != nil {
+		ui.Output(
+			"Error deregistering Waypoint runner job: %s", clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return err
+	}
+
+	allocs, _, err := client.Jobs().Allocations(serverName, true, nil)
+	if err != nil {
+		return err
+	}
+	for _, alloc := range allocs {
+		if alloc.DesiredStatus != "stop" {
+			a, _, err := client.Allocations().Info(alloc.ID, &api.QueryOptions{})
+			if err != nil {
+				return err
+			}
+			_, err = client.Allocations().Stop(a, &api.QueryOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if i.config.serverPurge {
+		s.Update("Waypoint runner job and allocations purged")
+	} else {
+		s.Update("Waypoint runner job and allocations stopped")
+	}
+	s.Done()
+
 	return nil
 }
 
@@ -489,7 +515,96 @@ func (i *NomadInstaller) HasRunner(
 	ctx context.Context,
 	opts *InstallOpts,
 ) (bool, error) {
+	// Build api client from environment
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return false, err
+	}
+
+	jobs, _, err := client.Jobs().PrefixList(runnerName)
+	if err != nil {
+		return false, err
+	}
+	for _, j := range jobs {
+		if j.Name == runnerName {
+			return true, nil
+		}
+	}
+
 	return false, nil
+}
+
+func (i *NomadInstaller) runJob(
+	ctx context.Context,
+	s terminal.Step,
+	client *api.Client,
+	job *api.Job,
+) (string, error) {
+	jobOpts := &api.RegisterOptions{
+		PolicyOverride: i.config.policyOverride,
+	}
+
+	resp, _, err := client.Jobs().RegisterOpts(job, jobOpts, nil)
+	if err != nil {
+		return "", err
+	}
+
+	s.Update("Waiting for allocation to be scheduled")
+EVAL:
+	qopts := &api.QueryOptions{
+		WaitIndex: resp.EvalCreateIndex,
+	}
+
+	eval, meta, err := client.Evaluations().Info(resp.EvalID, qopts)
+	if err != nil {
+		return "", err
+	}
+	qopts.WaitIndex = meta.LastIndex
+	switch eval.Status {
+	case "pending":
+		goto EVAL
+	case "complete":
+		s.Update("Nomad allocation created")
+	case "failed", "canceled", "blocked":
+		s.Update("Nomad failed to schedule the job")
+		s.Status(terminal.StatusError)
+		return "", fmt.Errorf("nomad evaluation did not transition to 'complete'")
+	default:
+		return "", fmt.Errorf("unknown eval status: %q", eval.Status)
+	}
+
+	var allocID string
+	for {
+		allocs, qmeta, err := client.Evaluations().Allocations(eval.ID, qopts)
+		if err != nil {
+			return "", err
+		}
+		qopts.WaitIndex = qmeta.LastIndex
+		if len(allocs) == 0 {
+			return "", fmt.Errorf("no allocations found after evaluation completed")
+		}
+
+		switch allocs[0].ClientStatus {
+		case "running":
+			allocID = allocs[0].ID
+			s.Update("Nomad allocation running")
+		case "pending":
+			s.Update(fmt.Sprintf("Waiting for allocation %q to start", allocs[0].ID))
+			// retry
+		default:
+			return "", fmt.Errorf("allocation failed")
+		}
+
+		if allocID != "" {
+			return allocID, nil
+		}
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
 }
 
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the
@@ -539,6 +654,49 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	}
 	task.Env = map[string]string{
 		"PORT": defaultGrpcPort,
+	}
+	tg.AddTask(task)
+
+	return job
+}
+
+// waypointRunnerNomadJob takes in a nomadConfig and returns a Nomad Job
+// for the Nomad API to run a Waypoint runner.
+func waypointRunnerNomadJob(c nomadConfig, opts *InstallRunnerOpts) *api.Job {
+	job := api.NewServiceJob(runnerName, runnerName, c.region, 50)
+	job.Namespace = &c.namespace
+	job.Datacenters = c.datacenters
+	job.Meta = c.serviceAnnotations
+	tg := api.NewTaskGroup(runnerName, 1)
+	tg.Networks = []*api.NetworkResource{
+		{
+			// Host mode so we can communicate to our server.
+			Mode: "host",
+		},
+	}
+	job.AddTaskGroup(tg)
+
+	task := api.NewTask("runner", "docker")
+	task.Config = map[string]interface{}{
+		"image": c.serverImage,
+		"args": []string{
+			"runner",
+			"agent",
+			"-vvv",
+		},
+	}
+
+	task.Env = map[string]string{}
+	for _, line := range opts.AdvertiseClient.Env() {
+		idx := strings.Index(line, "=")
+		if idx == -1 {
+			// Should never happen but let's not crash.
+			continue
+		}
+
+		key := line[:idx]
+		value := line[idx+1:]
+		task.Env[key] = value
 	}
 	tg.AddTask(task)
 

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -25,7 +25,9 @@ type Installer interface {
 	// the platform name to avoid conflicts with other flags.
 	InstallFlags(*flag.Set)
 
-	// Upgrade expects the Waypoint server to be upgraded from a previous install
+	// Upgrade expects the Waypoint server to be upgraded from a previous install.
+	// After upgrading the server, this should also upgrade the primary
+	// runner that was installed with InstallRunner, if it exists.
 	Upgrade(ctx context.Context, opts *InstallOpts, serverCfg serverconfig.Client) (*InstallResults, error)
 
 	// UpgradeFlags is called prior to Upgrade and allows the upgrader to
@@ -33,7 +35,10 @@ type Installer interface {
 	// the platform name to avoid conflicts with other flags.
 	UpgradeFlags(*flag.Set)
 
-	// Uninstall expects the Waypoint server to be uninstalled.
+	// Uninstall expects the Waypoint server to be uninstalled. This should
+	// also look up to see if any runners exist (installed via InstallRunner)
+	// and remove those as well. Runners manually installed outside of this
+	// interface should not be touched.
 	Uninstall(context.Context, *InstallOpts) error
 
 	// UninstallFlags is called prior to Uninstall and allows the Uninstaller to

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -14,6 +14,9 @@ import (
 // Installer is implemented by the server platforms and is responsible for managing
 // the installation of the Waypoint server.
 type Installer interface {
+	// HasRunner returns true if a runner is installed.
+	HasRunner(context.Context, *InstallOpts) (bool, error)
+
 	// Install expects the Waypoint server to be installed.
 	Install(context.Context, *InstallOpts) (*InstallResults, error)
 

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -41,6 +41,13 @@ type Installer interface {
 	// interface should not be touched.
 	Uninstall(context.Context, *InstallOpts) error
 
+	// UninstallRunner should remove the runner(s) installed via InstallRunner.
+	//
+	// No runners may exist. Runners installed manually by the user should be
+	// ignored (i.e. InstallRunner should set some identifiers that can be used
+	// to distinguish between automatically installed vs. manually installed).
+	UninstallRunner(context.Context, *InstallOpts) error
+
 	// UninstallFlags is called prior to Uninstall and allows the Uninstaller to
 	// specify flags for the uninstall CLI. The flags should be prefixed with the
 	// platform name to avoid conflicts with other flags.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6b1057b452c55bb3b463f0d7055bc4ec3fd1f381",
-        "sha256": "10qfg11g8m0q2k3ibcm0ivjq494gqynshm3smjl1rfn5ifjf5fz8",
+        "rev": "a2b0ea6865b2346ceb015259c76e111dcca039c5",
+        "sha256": "12dgwajv3w94p13scj68c24v01p055k9hcpcsn7w9i8fys72s99d",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6b1057b452c55bb3b463f0d7055bc4ec3fd1f381.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a2b0ea6865b2346ceb015259c76e111dcca039c5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -97,7 +97,10 @@ in pkgs.mkShell rec {
   ] ++ (with pkgs; [
     # Needed for website/
     pkgconfig autoconf automake libtool nasm autogen zlib libpng
-  ]);
+  ]) ++ (if stdenv.isLinux then [
+    # On Linux we use minikube as the primary k8s testing platform
+    pkgs.minikube
+  ] else []);
 
   # Extra env vars
   PGHOST = "localhost";


### PR DESCRIPTION
This formalizes the runner management machinery: `waypoint install`, `waypoint server upgrade`, `waypoint server uninstall`, etc. RFC is [WP-053](https://docs.google.com/document/d/1im3U7iYtZLhKSjJKtqadNxJA0Ur3U30l70krz-b1WH4/edit#). 

This PR focuses on the machinery and **does not** implement Kubernetes or Nomad completely yet. I will make subsequent PRs for that. Docker is fully working since I used that for testing.

This PR also fixes a couple major bugs that manifested themselves and affect `main`:

  * Runner accept loops (in two places) handle runner deregistration and server restarts more gracefully, namely by not DDoSing the server.
  * Upgrade and uninstall do not start local servers, which prevents a local runner from starting up during these operations and DDoSing the server from the previous bug.
  * Docker uninstall/upgrade works if the container is not running, whereas previously it detected this as "not installed".