### PR TITLE
Update readme with dependency instructions for the gen/ts command

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -57,7 +57,7 @@ Then run the authentication steps above again.
 
 if you've made API changes in `/internal/server` and want to use those on the frontend, you'll need to generate the type definitions again: 
 
-#### required dependencies for this build step
+#### Required dependencies for build step
 
 - MacOS only: `brew install gnu-sed` then follow the instructions to replace the default `sed`
 - Download [the 1.1.2 release of `mockery`](https://github.com/vektra/mockery/releases/tag/v1.1.2) and install in your `/go/bin` directory

--- a/ui/README.md
+++ b/ui/README.md
@@ -57,6 +57,15 @@ Then run the authentication steps above again.
 
 if you've made API changes in `/internal/server` and want to use those on the frontend, you'll need to generate the type definitions again: 
 
+#### required dependencies for this build step
+
+- MacOS only: `brew install gnu-sed` then follow the instructions to replace the default `sed`
+- Download [the 1.1.2 release of `mockery`](https://github.com/vektra/mockery/releases/tag/v1.1.2) and install in your `/go/bin` directory
+- use node 12.x: `nvm use 12`
+- install `ts-protoc-gen`: `yarn global add ts-protoc-gen` or `npm i -g ts-protoc-gen`
+
+#### Generate the API definitions
+
 - `go generate ./internal/server`
 - `make gen/ts`
 


### PR DESCRIPTION
We had a few undocumented dependency requirements to build the server and the API ts definitions. This PR updates the UI README to make this process more consistent. I chose to keep them in the section rather than the `Prerequisites`, as one can start ramping up on the repo without those.