### PR TITLE
internal/server: backoff on URL service not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.5
 	github.com/boltdb/bolt v1.3.1
 	github.com/buildpacks/pack v0.11.1
+	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
 	github.com/containerd/console v1.0.1
 	github.com/creack/pty v1.1.11

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -109,7 +109,7 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 
 		if err := s.initURLClient(
 			log.Named("url_service"),
-			false,
+			nil,
 			cfg.acceptUrlTerms,
 			&cfgCopy,
 		); err != nil {


### PR DESCRIPTION
This introduces an exponential backoff (up to 60s max wait) when the URL
service can't be initialized. Without this, we were spinning at nearly
100% CPU trying to reconnect, and I'm sure that's causing quite a lot of
network load on the service as well.

![CleanShot 2021-03-08 at 08 56 34@2x](https://user-images.githubusercontent.com/1299/110353885-6fd26180-7fec-11eb-952c-09b9e00d1e97.png)
