### PR TITLE
API Input Validation Foundations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl/v2 v2.7.1-0.20201023000745-3de61ecba298
 	github.com/hashicorp/horizon v0.0.0-20201203173320-fcefbe49771c

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -301,7 +301,7 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 			}
 
 		case ".json":
-			format = pb.Project_HCL
+			format = pb.Project_JSON
 			_, diag := hcljson.Parse(bs, "<waypoint-hcl>")
 			if diag.HasErrors() {
 				c.ui.Output(

--- a/internal/pkg/validationext/doc.go
+++ b/internal/pkg/validationext/doc.go
@@ -1,0 +1,6 @@
+// Package validationext provides helpers to extend the ozzo-validation.
+// There are two primary goals with this package: (1) to ease validating
+// deeply nested structures that are common with protobuf-based APIs and
+// (2) to convert errors from ozzo-validation into proto InvalidArgument
+// errors with field violation extra details.
+package validationext

--- a/internal/pkg/validationext/error.go
+++ b/internal/pkg/validationext/error.go
@@ -1,0 +1,71 @@
+package validationext
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error takes an error and turns an ozzo-validation.Errors into a
+// gRPC status error with field violations populated. If the error is
+// nil or not an ozzo-validation error, it is returned as-is.
+//
+// Note that validate.Validate doesn't return a validate.Errors. Only validation
+// on structs and other containers will return the proper structure that will
+// be wrapped by this call. This should be used against request structures.
+func Error(err error) error {
+	// Nil error returns nil directly
+	if err == nil {
+		return nil
+	}
+
+	// If it isn't a validation error, then return it as-is
+	verr, ok := err.(validation.Errors)
+	if !ok {
+		return err
+	}
+
+	// Build up the status and accumulate the errors.
+	st := status.New(codes.InvalidArgument, verr.Error())
+
+	// This should NEVER fail, we verified with the code that this should
+	// never fail. If it does, we panic because it should be impossible.
+	st, err = st.WithDetails(&errdetails.BadRequest{
+		FieldViolations: errorAppend(nil, "", verr),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return st.Err()
+}
+
+// errorAppend accumulates field violations by recursively nesting into the
+// validation errors. We have to recurse to get nested structs/maps/etc.
+// With each recursion, we prefix the errors with the field path to that
+// error.
+func errorAppend(
+	v []*errdetails.BadRequest_FieldViolation,
+	prefix string,
+	verr validation.Errors) []*errdetails.BadRequest_FieldViolation {
+	for k, err := range verr {
+		field := k
+		if prefix != "" {
+			field = prefix + "." + field
+		}
+
+		// If we have another validation error, then recurse
+		if verr, ok := err.(validation.Errors); ok {
+			v = errorAppend(v, field, verr)
+			continue
+		}
+
+		v = append(v, &errdetails.BadRequest_FieldViolation{
+			Field:       field,
+			Description: err.Error(),
+		})
+	}
+
+	return v
+}

--- a/internal/pkg/validationext/error_test.go
+++ b/internal/pkg/validationext/error_test.go
@@ -1,0 +1,133 @@
+package validationext
+
+import (
+	"fmt"
+	"testing"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/status"
+)
+
+func TestError(t *testing.T) {
+	type Address struct {
+		Number int
+		Street string
+	}
+	type AddressJSON struct {
+		Number int    `json:"number"`
+		Street string `json:"street"`
+	}
+
+	s1 := &struct{ Name string }{Name: ""}
+	s2 := &struct {
+		Name    string
+		Address *Address
+	}{
+		Name: "",
+		Address: &Address{
+			Number: 123,
+			Street: "",
+		},
+	}
+	s3 := &struct {
+		Name    string       `json:"name"`
+		Address *AddressJSON `json:"address"`
+	}{
+		Name: "",
+		Address: &AddressJSON{
+			Number: 123,
+			Street: "",
+		},
+	}
+
+	cases := []struct {
+		Name     string
+		Input    error
+		Expected map[string]string
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+
+		{
+			"non-validation error",
+			fmt.Errorf("hello"),
+			nil,
+		},
+
+		{
+			"basic validation error",
+			validation.ValidateStruct(s1,
+				validation.Field(&s1.Name, validation.Required),
+			),
+			map[string]string{
+				"Name": "cannot be blank",
+			},
+		},
+
+		{
+			"nested struct validation error",
+			validation.ValidateStruct(s2,
+				validation.Field(&s2.Name, validation.Required),
+				validation.Field(&s2.Address, validation.Required),
+				StructField(&s2.Address, func() []*validation.FieldRules {
+					return []*validation.FieldRules{
+						validation.Field(&s2.Address.Street, validation.Required),
+					}
+				}),
+			),
+			map[string]string{
+				"Name":           "cannot be blank",
+				"Address.Street": "cannot be blank",
+			},
+		},
+
+		{
+			"nested struct with json tags",
+			validation.ValidateStruct(s3,
+				validation.Field(&s3.Name, validation.Required),
+				validation.Field(&s3.Address, validation.Required),
+				StructField(&s3.Address, func() []*validation.FieldRules {
+					return []*validation.FieldRules{
+						validation.Field(&s3.Address.Street, validation.Required),
+					}
+				}),
+			),
+			map[string]string{
+				"name":           "cannot be blank",
+				"address.street": "cannot be blank",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			actual := Error(tt.Input)
+			if len(tt.Expected) == 0 {
+				require.Equal(actual, tt.Input)
+				return
+			}
+
+			st, ok := status.FromError(actual)
+			require.True(ok, fmt.Sprintf("%T", actual))
+
+			for _, errMessage := range tt.Expected {
+				require.Contains(st.Message(), errMessage)
+			}
+
+			require.Len(st.Details(), 1)
+			br := st.Details()[0].(*errdetails.BadRequest)
+			require.Len(br.FieldViolations, len(tt.Expected))
+			for _, fv := range br.FieldViolations {
+				require.Contains(tt.Expected, fv.Field)
+				require.Contains(fv.Description, tt.Expected[fv.Field])
+			}
+		})
+	}
+}

--- a/internal/pkg/validationext/rule_cidrblock.go
+++ b/internal/pkg/validationext/rule_cidrblock.go
@@ -1,0 +1,63 @@
+package validationext
+
+import (
+	"fmt"
+	"net"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// IsPrivateCIDRBlock implements validation.Rule to check if a value is a valid
+// IPv4 CIDR block within the ranges that are considered valid.
+var IsPrivateCIDRBlock validation.Rule = &isPrivateCIDRBlockRule{}
+
+// isPrivateCIDRBlockRule implements validation.Rule for IsPrivateCIDRBlock.
+type isPrivateCIDRBlockRule struct{}
+
+// validRanges contains the set of IP ranges considered valid.
+var validRanges = []net.IPNet{
+	{
+		// 10.*.*.*
+		IP:   net.IPv4(10, 0, 0, 0),
+		Mask: net.IPv4Mask(255, 0, 0, 0),
+	},
+	{
+		// 192.168.*.*
+		IP:   net.IPv4(192, 168, 0, 0),
+		Mask: net.IPv4Mask(255, 255, 0, 0),
+	},
+	{
+		// 172.[16-31].*.*
+		IP:   net.IPv4(172, 16, 0, 0),
+		Mask: net.IPv4Mask(255, 240, 0, 0),
+	},
+}
+
+// Validate validates if the provided value is a valid IPv4 CIDR
+// block contained within the valid ranges.
+func (r *isPrivateCIDRBlockRule) Validate(value interface{}) error {
+	// assert that value is of type string.
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("must be a valid string")
+	}
+
+	// parse the string as CIDR notation IP address and prefix length.
+	ip, net, err := net.ParseCIDR(s)
+	if err != nil {
+		return err
+	}
+
+	// validate if the IP address is contained in one of the expected ranges.
+	for _, validRange := range validRanges {
+		valueSize, _ := net.Mask.Size()
+		validRangeSize, _ := validRange.Mask.Size()
+		if validRange.Contains(ip) && valueSize >= validRangeSize {
+			return nil
+		}
+	}
+
+	// return an error if the IP address is not contained within expected ranges.
+	return fmt.Errorf("must match pattern of 10.*.*.* or 172.[16-31].*.* or " +
+		"192.168.*.*; where * is any number from [0-255]")
+}

--- a/internal/pkg/validationext/rule_cidrblock_test.go
+++ b/internal/pkg/validationext/rule_cidrblock_test.go
@@ -1,0 +1,130 @@
+package validationext
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCidrBlock(t *testing.T) {
+	cases := []struct {
+		Input interface{}
+		Valid bool
+	}{
+		{
+			nil,
+			false,
+		},
+		{
+			int32(4),
+			false,
+		},
+		{
+			"192.168.0/24",
+			false,
+		},
+		{
+			"someString",
+			false,
+		},
+		{
+			"10.0.0.0/24",
+			true,
+		},
+		{
+			"10.255.255.255/24",
+			true,
+		},
+		{
+			"10.256.0.0/24",
+			false,
+		},
+		{
+			"10.0.256.0/24",
+			false,
+		},
+		{
+			"10.255.255asdfasdfaqsd.250",
+			false,
+		},
+		{
+			"192.168.0.0/24",
+			true,
+		},
+		{
+			"192.168.255.255/24",
+			true,
+		},
+		{
+			"192.168.256.0/24",
+			false,
+		},
+		{
+			"192.0.0.0/24",
+			false,
+		},
+		{
+			"172.16.0.0/24",
+			true,
+		},
+		{
+			"172.17.0.0/24",
+			true,
+		},
+		{
+			"172.18.0.0/24",
+			true,
+		},
+		{
+			"172.30.0.0/24",
+			true,
+		},
+		{
+			"172.20.0.0/24",
+			true,
+		},
+		{
+			"172.31.0.0/24",
+			true,
+		},
+		{
+			"172.15.0.0/24",
+			false,
+		},
+		{
+			"172.32.0.0/24",
+			false,
+		},
+		{
+			"172.192.0.0/24",
+			false,
+		},
+		{
+			"172.255.0.0/24",
+			false,
+		},
+		{
+			"10.0.0.0/7",
+			false,
+		},
+		{
+			"192.168.0.0/15",
+			false,
+		},
+	}
+
+	cases = append(cases, struct {
+		Input interface{}
+		Valid bool
+	}{
+		nil, false,
+	})
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%#v", tt.Input), func(t *testing.T) {
+			err := IsPrivateCIDRBlock.Validate(tt.Input)
+			require.Equal(t, tt.Valid, err == nil)
+		})
+	}
+}

--- a/internal/pkg/validationext/rule_duration.go
+++ b/internal/pkg/validationext/rule_duration.go
@@ -1,0 +1,83 @@
+package validationext
+
+import (
+	"fmt"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/golang/protobuf/ptypes"
+	durationpb "github.com/golang/protobuf/ptypes/duration"
+)
+
+var (
+	// IsDuration implements validation.Rule to check if a value is a valid
+	// duration from a proto duration.
+	IsDuration validation.Rule = &isDurationRule{}
+)
+
+// IsDurationRange implements validation.Rule to check if a proto duration
+// is in the given range. Both ends of the duration are inclusive.
+func IsDurationRange(min, max time.Duration) validation.Rule {
+	return &isDurationRange{min: min, max: max}
+}
+
+// isDurationRule implements validation.Rule for IsDuration
+type isDurationRule struct{}
+
+func (r *isDurationRule) Validate(value interface{}) error {
+	_, err := r.duration(value)
+	return err
+}
+
+func (r *isDurationRule) duration(value interface{}) (time.Duration, error) {
+	switch v := value.(type) {
+	case *durationpb.Duration:
+		// Support non-required duration.
+		if v == nil {
+			return 0, nil
+		}
+		d, err := ptypes.Duration(v)
+		if err != nil {
+			return 0, fmt.Errorf("must be a valid duration: %s", err)
+		}
+		return d, nil
+	case string:
+		// Support non-required duration.
+		if v == "" {
+			return 0, nil
+		}
+
+		return time.ParseDuration(v)
+	case *time.Duration:
+		// Support non-required duration.
+		if v == nil {
+			return 0, nil
+		}
+
+		return *v, nil
+	case time.Duration:
+		return v, nil
+	}
+
+	return 0, fmt.Errorf("must be a valid duration")
+}
+
+// isDurationRange implements validation.Rule for IsDurationRange.
+type isDurationRange struct {
+	min, max time.Duration
+}
+
+func (r *isDurationRange) Validate(value interface{}) error {
+	var dr isDurationRule
+	d, err := dr.duration(value)
+	if err != nil {
+		return err
+	}
+	if d < r.min || d > r.max {
+		return fmt.Errorf(
+			"must be greater than %s and less than %s",
+			r.min.String(), r.max.String())
+	}
+
+	return nil
+}

--- a/internal/pkg/validationext/rule_duration_test.go
+++ b/internal/pkg/validationext/rule_duration_test.go
@@ -1,0 +1,114 @@
+package validationext
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDuration(t *testing.T) {
+	cases := []struct {
+		Input interface{}
+		Valid bool
+	}{
+		{
+			nil,
+			false,
+		},
+
+		{
+			"foo",
+			false,
+		},
+
+		{
+			ptypes.DurationProto(time.Second),
+			true,
+		},
+
+		{
+			"2s",
+			true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%#v", tt.Input), func(t *testing.T) {
+			err := IsDuration.Validate(tt.Input)
+			require.Equal(t, tt.Valid, err == nil)
+		})
+	}
+}
+
+func TestIsDurationRange(t *testing.T) {
+	cases := []struct {
+		Duration interface{}
+		Min, Max time.Duration
+		Valid    bool
+	}{
+		{
+			nil,
+			0, 0,
+			false,
+		},
+
+		{
+			"foo",
+			0, 0,
+			false,
+		},
+
+		{
+			ptypes.DurationProto(time.Second),
+			0, time.Minute,
+			true,
+		},
+
+		{
+			ptypes.DurationProto(time.Minute),
+			0, time.Second,
+			false,
+		},
+
+		{
+			ptypes.DurationProto(time.Second),
+			time.Second, time.Minute,
+			true,
+		},
+
+		{
+			ptypes.DurationProto(time.Minute),
+			time.Second, time.Minute,
+			true,
+		},
+
+		{
+			"1m",
+			0, time.Second,
+			false,
+		},
+
+		{
+			"1s",
+			time.Second, time.Minute,
+			true,
+		},
+
+		{
+			"1m",
+			time.Second, time.Minute,
+			true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%#v", tt.Duration), func(t *testing.T) {
+			r := IsDurationRange(tt.Min, tt.Max)
+			err := r.Validate(tt.Duration)
+			require.Equal(t, tt.Valid, err == nil)
+		})
+	}
+}

--- a/internal/pkg/validationext/rule_version.go
+++ b/internal/pkg/validationext/rule_version.go
@@ -1,0 +1,77 @@
+package validationext
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+var (
+	// MeetsVersionConstraint implements validation.Rule to check if a
+	// supplied version is a valid according to the constraints supplied.
+	MeetsVersionConstraint validation.Rule = &ConstraintVersionRule{}
+	// IsVersion implements validation.Rule to check if the supplied string
+	// is considered a valid Semantic Versioning (semver) string.
+	IsVersion validation.Rule = &ParseVersionRule{}
+)
+
+type ParseVersionRule struct{}
+
+func (v *ParseVersionRule) Validate(value interface{}) error {
+	valueVersion, err := extractVersionString(value)
+	if err != nil {
+		return err
+	}
+
+	_, err = goversion.NewVersion(valueVersion)
+	return err
+}
+
+type ConstraintVersionRule struct {
+	Constraint goversion.Constraints
+}
+
+func MeetsConstraints(constraints ...string) validation.Rule {
+	constraintString := strings.Join(constraints, ",")
+	constraint, err := goversion.NewConstraint(constraintString)
+	if err != nil {
+		panic(err)
+	}
+	return &ConstraintVersionRule{
+		Constraint: constraint,
+	}
+}
+
+func (v *ConstraintVersionRule) Validate(value interface{}) error {
+	valueVersion, err := extractVersionString(value)
+	if err != nil {
+		return err
+	}
+
+	goVer, err := goversion.NewVersion(valueVersion)
+	if err != nil {
+		return err
+	}
+
+	if !v.Constraint.Check(goVer) {
+		return fmt.Errorf("%s does not satisfy constraint: %s", goVer, v.Constraint)
+	}
+
+	return nil
+}
+
+func extractVersionString(value interface{}) (string, error) {
+	rv := reflect.ValueOf(value)
+	kind := rv.Kind()
+	switch kind {
+	case reflect.String:
+		return value.(string), nil
+	default:
+		return "", fmt.Errorf("type not supported: %v, must be string", rv.Type())
+	}
+
+}

--- a/internal/pkg/validationext/rule_version_test.go
+++ b/internal/pkg/validationext/rule_version_test.go
@@ -1,0 +1,141 @@
+package validationext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IsVersion(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			// This is weird but forced by ozzo-validation, so users should
+			// pair that with validation.Required.
+			"",
+			false,
+		},
+
+		{
+			"bob",
+			false,
+		},
+
+		{
+			"1",
+			true,
+		},
+
+		{
+			"1.0",
+			true,
+		},
+
+		{
+			"1.0.1",
+			true,
+		},
+
+		{
+			"v1",
+			true,
+		},
+
+		{
+			"v1.0",
+			true,
+		},
+
+		{
+			"v1.0.1",
+			true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Input, func(t *testing.T) {
+			err := IsVersion.Validate(tt.Input)
+			require.Equal(t, tt.Valid, err == nil)
+		})
+	}
+}
+
+func Test_MeetsConstraints(t *testing.T) {
+	cases := []struct {
+		Input      string
+		Constraint []string
+		Valid      bool
+	}{
+		{
+			// This is weird but forced by ozzo-validation, so users should
+			// pair that with validation.Required.
+			"",
+			[]string{"< 1"},
+			false,
+		},
+
+		{
+			"bob",
+			[]string{"< 1"},
+			false,
+		},
+
+		{
+			"1",
+			[]string{"< 2"},
+			true,
+		},
+
+		{
+			"1.0",
+			[]string{"<1"},
+			false,
+		},
+
+		{
+			"1.0.1",
+			[]string{">0", "<2"},
+			true,
+		},
+
+		{
+			"v1.0.1",
+			[]string{">0", "<2"},
+			true,
+		},
+
+		{
+			"1.0.2",
+			[]string{">v0", "<v2"},
+			true,
+		},
+
+		{
+			"v1.0.3",
+			[]string{">v2"},
+			false,
+		},
+
+		{
+			"v1.0.4",
+			[]string{">2"},
+			false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Input, func(t *testing.T) {
+			f := MeetsConstraints(tt.Constraint...)
+			err := f.Validate(tt.Input)
+			require.Equal(t, tt.Valid, err == nil)
+		})
+	}
+
+	testPanic := func() { MeetsConstraints("not a constraint") }
+	// If a bad constraint is passed, we explode.
+	t.Run("check we panic on bad constraint", func(t *testing.T) {
+		require.Panics(t, testPanic)
+	})
+}

--- a/internal/pkg/validationext/struct.go
+++ b/internal/pkg/validationext/struct.go
@@ -1,0 +1,245 @@
+package validationext
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+)
+
+// StructField returns a *validation.FieldRules (can be used as an arg to
+// validation.ValidateStruct) that validates a nested struct value only if
+// the struct value is non-nil.
+//
+// This is useful to apply validation to nested pointer structs all within
+// a single call to validation.ValidateStruct. Otherwise, nil-checks with
+// complex field rule slice building is necessary.
+//
+// The struct value (sv) parameter needs to be a _pointer to the struct
+// field_, even if that's a pointer. So it should always be in the form
+// `&s.Field`. Otherwise, you'll get a "field #N not in struct" internal
+// error from ozzo-validation.
+//
+// Full example:
+//
+//   s := &Person{
+//     Address: &Address{Number: 0},
+//   }
+//
+//   validation.ValidateStruct(&s,
+//     validation.Field(&s.Address, validation.Required),
+//     StructField(&s.Address, func() []*validation.FieldRules {
+//       return []*validation.FieldRules{
+//         validation.Field(&s.Address.Number, validation.Required),
+//       }
+//     }),
+//   )
+//
+// In this example, the address number will be required, but will only
+// be checked if the address is non-nil. Without StructField, you either
+// have to do nil-checks outside of the validation call or you get a crash.
+func StructField(sv interface{}, f func() []*validation.FieldRules) *validation.FieldRules {
+	return validation.Field(sv, &structFieldRule{s: sv, rules: f})
+}
+
+// StructInterface is similar to StructField but validates interface-type
+// fields that are non-nil and match the type t exactly. This is useful for
+// "oneof" fields created by protobufs.
+//
+// If the function f is called, it is guaranteed that the field pointed to by
+// sv is of type t. You can type assert it without ok-checking safely.
+//
+// See the docs for StructField for additional details on how this works.
+func StructInterface(sv, t interface{}, f func() []*validation.FieldRules) *validation.FieldRules {
+	return validation.Field(sv, &structFieldRule{s: sv, rules: f, iface: t})
+}
+
+// StructOneof is a special-case helper to validate struct values within
+// a oneof field from a protobuf-generated struct. This behaves like
+// StructInterface but automatically sets up validation directly into the
+// nested oneof value. The returned fieldrules from f can be directly on the
+// nested value which is implicitly required to be set.
+//
+// For oneof values that are NOT message types (structs) and are primitives
+// like string, int, etc. then you should use StructInterface directly.
+//
+// Example:
+//
+// Given the protobuf of:
+//
+//   message Employee {
+//     oneof role {
+//       Eng eng = 1;
+//       Sales sales = 2;
+//     }
+//   }
+//
+// The generated types look something lke this:
+//
+//   type Employee { Role Role }
+//   type Role interface{}
+//   type Role_Eng struct { Eng *Eng }
+//   type Role_Sales struct { Sales *Sales }
+//   type Eng { Language string }
+//   ...
+//
+// To validate this, you can do this:
+//
+//   var e *Employee
+//   validation.ValidateStruct(&e,
+//     StructOneof(&e.Role, (*Eng)(nil), func() []*validation.FieldRules {
+//       v := e.Role.(*Role_Eng)
+//       return []*validation.FieldRules{
+//         validation.Field(&v.Eng.Language, validation.Required),
+//       }
+//     }),
+//   )
+//
+// Notice how the callback sets validation on the nested `e.Role.Eng` directly.
+// This helper saves a few lines of boilerplate and complicated pointer
+// addressing to make this possible.
+//
+// The existence and non-emptiness of `e.Role.Eng` is validated automatically
+// and does not need to be verified in the consumer code. This is done because
+// the protobuf compiler adds these intermediate structs for type-safety
+// reasons, but there is no use-case for the specific value to be nil if the
+// intermediate wrapper struct is set. This results in the following cases:
+//
+// Valid:
+//   Employee{ Role: nil }
+//   Employee{ Role: &Role_Eng{ Eng: &Eng {} } }
+//
+// Invalid (a validation error is produced):
+//   Employee{ Role: &Role_Eng{ Eng: nil } }
+//
+func StructOneof(sv, t interface{}, f func() []*validation.FieldRules) *validation.FieldRules {
+	return validation.Field(sv, &structFieldRule{s: sv, rules: f, iface: t, oneof: true})
+}
+
+// StructJSONPB validates a jsonpb-encoded field (type []byte) within a struct.
+// This will decode the value sv into the proto struct v and validate it with
+// the rules returned by f.
+//
+// A validation error will be returned if jsonpb-decoding fails or if the value
+// is not a byte slice.
+//
+// A side effect of this validation is that the field is decoded into v. After
+// validation, you can continue to use this decoded value. Prior to decoding,
+// we call v.Reset() so that the values are fully reset.
+//
+// Example:
+//
+//
+//   req := struct{
+//     Employee []byte
+//   }
+//
+//   var e pb.Employee
+//   validation.ValidateStruct(&req,
+//     StructJSONPB(&req.Employee, &e, func() []*validation.FieldRules {
+//       return []*validation.FieldRules{
+//         validation.Field(&e.Name, validation.Required),
+//       }
+//     }),
+//   )
+//
+func StructJSONPB(sv interface{}, v proto.Message, f func() []*validation.FieldRules) *validation.FieldRules {
+	return validation.Field(sv, &structJSONPBRule{s: sv, v: v, rules: f})
+}
+
+// structJSONPBRule implements validation.Rule for StructJSONPB.
+type structJSONPBRule struct {
+	s     interface{}   // field pointer
+	v     proto.Message // value to decode into
+	rules func() []*validation.FieldRules
+}
+
+func (s *structJSONPBRule) Validate(v interface{}) error {
+	// Should be bytes
+	bs, ok := v.([]byte)
+	if !ok {
+		return errors.New("should be byte slice")
+	}
+
+	// Reset the value so we're empty then decode
+	s.v.Reset()
+	if err := jsonpb.Unmarshal(bytes.NewReader(bs), s.v); err != nil {
+		return err
+	}
+
+	// Call our rules
+	return validation.ValidateStruct(
+		s.v,
+		s.rules()...,
+	)
+}
+
+// structFieldRule implements validation.Rule. See StructField.
+type structFieldRule struct {
+	s     interface{}
+	rules func() []*validation.FieldRules
+	iface interface{}
+	oneof bool
+}
+
+func (s *structFieldRule) Validate(interface{}) error {
+	// The struct given to the StructField must be a pointer to that
+	// struct, but we need a pointer to the field in the struct. This
+	// bit of reflection checks if we have a pointer to a pointer and
+	// if so, unwraps it. Otherwise we leave it as-is. This handles both
+	// possible cases.
+	sv := reflect.ValueOf(s.s)
+	if sv.Kind() == reflect.Ptr {
+		nested := reflect.Indirect(sv)
+		if nested.Kind() == reflect.Ptr {
+			sv = nested
+		}
+
+		// If iface is set then we want to actually validate the specific
+		// type pointed to. ValidateStruct doesn't work with interface types
+		// so we need to dereference it.
+		if s.iface != nil {
+			// This checks that the interface value is non-nil and its type
+			// matches the specified concrete type directly.
+			elem := nested.Elem()
+			if !elem.IsValid() || elem.Type() != reflect.TypeOf(s.iface) {
+				return nil
+			}
+
+			sv = elem
+		}
+	}
+	direct := reflect.Indirect(sv)
+	if !direct.IsValid() {
+		return nil
+	}
+
+	// If this is a protobuf oneof, then we dereference the first field
+	// in the struct
+	if s.oneof {
+		// We need to pointer to the first field in the struct.
+		field := direct.Field(0).Addr().Interface()
+
+		// This first field must be set. This is a requirement for all oneofs
+		// and aligns with the logic of the protobuf compiler's code generation.
+		if err := validation.Validate(field, validation.Required); err != nil {
+			return err
+		}
+
+		// We next call ValidateStruct with our current field followed by
+		// a StructField on our nested field (since protobufs inserts
+		// exactly one field in a oneof value). This lets us build rules
+		// on the nested value.
+		return validation.ValidateStruct(
+			sv.Interface(),
+			StructField(
+				field,
+				s.rules,
+			))
+	}
+
+	return validation.ValidateStruct(sv.Interface(), s.rules()...)
+}

--- a/internal/pkg/validationext/struct_test.go
+++ b/internal/pkg/validationext/struct_test.go
@@ -1,0 +1,382 @@
+package validationext
+
+import (
+	"bytes"
+	"testing"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructField(t *testing.T) {
+	var called bool
+	type Person struct {
+		Name string
+	}
+
+	s1 := &struct {
+		P Person
+	}{
+		P: Person{Name: "alice"},
+	}
+
+	s2 := &struct {
+		P *Person
+	}{
+		P: &Person{Name: "alice"},
+	}
+
+	s3 := &struct {
+		P *Person
+	}{
+		P: nil,
+	}
+
+	cases := []struct {
+		Name        string
+		Value       interface{}
+		StructField *validation.FieldRules
+		Called      bool
+	}{
+		{
+			"non-pointer nested struct",
+			s1,
+			StructField(&s1.P, func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{
+					validation.Field(&s1.P.Name, validation.Required),
+				}
+			}),
+			true,
+		},
+
+		{
+			"pointer nested struct, non-nil",
+			s2,
+			StructField(&s2.P, func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{
+					validation.Field(&s2.P.Name, validation.Required),
+				}
+			}),
+			true,
+		},
+
+		{
+			"pointer nested struct, nil",
+			s3,
+			StructField(&s3.P, func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{
+					validation.Field(&s3.P.Name, validation.Required),
+				}
+			}),
+			false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Reset
+			called = false
+
+			require.NoError(validation.ValidateStruct(
+				tt.Value,
+				tt.StructField,
+			))
+			require.Equal(tt.Called, called)
+		})
+	}
+}
+
+func TestStructInterface(t *testing.T) {
+	var called bool
+
+	type Oneof interface{}
+	type OneofA struct{ A string }
+	type OneofB struct{ B int }
+
+	s1 := &struct {
+		V Oneof
+	}{
+		V: &OneofA{A: "hello"},
+	}
+
+	s2 := &struct {
+		V Oneof
+	}{
+		// Unset
+	}
+
+	s3 := &struct {
+		V Oneof
+	}{
+		V: &OneofB{B: 42},
+	}
+
+	cases := []struct {
+		Name   string
+		Value  interface{}
+		Rules  *validation.FieldRules
+		Called bool
+	}{
+		{
+			"oneof field set",
+			s1,
+			StructInterface(&s1.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				v := s1.V.(*OneofA)
+				return []*validation.FieldRules{
+					validation.Field(&v.A, validation.Required),
+				}
+			}),
+			true,
+		},
+
+		{
+			"oneof field nil",
+			s2,
+			StructInterface(&s2.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{}
+			}),
+			false,
+		},
+
+		{
+			"oneof field other type",
+			s3,
+			StructInterface(&s3.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{}
+			}),
+			false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Reset
+			called = false
+
+			require.NoError(validation.ValidateStruct(
+				tt.Value,
+				tt.Rules,
+			))
+			require.Equal(tt.Called, called)
+		})
+	}
+}
+
+func TestStructOneof(t *testing.T) {
+	var called bool
+
+	// These types mimic the types setup by a oneof in protobuf
+	type A struct{ A string }
+	type B struct{ B int }
+	type Oneof interface{}
+	type OneofA struct{ A *A }
+	type OneofB struct{ B *B }
+
+	s1 := &struct {
+		V Oneof
+	}{
+		V: &OneofA{A: &A{A: "hello"}},
+	}
+
+	s2 := &struct {
+		V Oneof
+	}{
+		// Unset
+	}
+
+	s3 := &struct {
+		V Oneof
+	}{
+		V: &OneofA{A: nil},
+	}
+
+	s4 := &struct {
+		V Oneof
+	}{
+		V: &OneofB{B: &B{B: 42}},
+	}
+
+	cases := []struct {
+		Name   string
+		Value  interface{}
+		Rules  *validation.FieldRules
+		Called bool
+		Valid  bool
+	}{
+		{
+			"oneof field set",
+			s1,
+			StructOneof(&s1.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				v := s1.V.(*OneofA)
+				return []*validation.FieldRules{
+					validation.Field(&v.A.A, validation.Required),
+				}
+			}),
+			true,
+			true,
+		},
+
+		{
+			"oneof field not set",
+			s2,
+			StructOneof(&s2.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				v := s2.V.(*OneofA)
+				return []*validation.FieldRules{
+					validation.Field(&v.A.A, validation.Required),
+				}
+			}),
+			false,
+			true,
+		},
+
+		{
+			"oneof field nested value nil",
+			s3,
+			StructOneof(&s3.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				v := s3.V.(*OneofA)
+				return []*validation.FieldRules{
+					validation.Field(&v.A.A, validation.Required),
+				}
+			}),
+			false,
+			false,
+		},
+
+		{
+			"oneof field set to different type",
+			s4,
+			StructOneof(&s4.V, (*OneofA)(nil), func() []*validation.FieldRules {
+				called = true
+				v := s4.V.(*OneofA)
+				return []*validation.FieldRules{
+					validation.Field(&v.A.A, validation.Required),
+				}
+			}),
+			false, // should not be called!
+			true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Reset
+			called = false
+
+			err := validation.ValidateStruct(
+				tt.Value,
+				tt.Rules,
+			)
+			require.Equal(tt.Called, called)
+			if tt.Valid {
+				require.NoError(err)
+			} else {
+				require.Error(err)
+			}
+		})
+	}
+}
+
+func TestStructJSONPB(t *testing.T) {
+	m := func(p *PersonPB) []byte {
+		var m jsonpb.Marshaler
+		var buf bytes.Buffer
+		require.NoError(t, m.Marshal(&buf, p))
+		return buf.Bytes()
+	}
+
+	s1 := &struct {
+		P []byte
+	}{
+		P: m(&PersonPB{Name: "bob", Pronoun: "they"}),
+	}
+	s2 := &struct {
+		P []byte
+	}{
+		P: m(&PersonPB{Name: "", Pronoun: "they"}),
+	}
+
+	var called bool
+	var p PersonPB
+	cases := []struct {
+		Name        string
+		Value       interface{}
+		StructField *validation.FieldRules
+		Called      bool
+		Error       string
+	}{
+		{
+			"valid",
+			s1,
+			StructJSONPB(&s1.P, &p, func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{
+					validation.Field(&p.Name, validation.Required),
+				}
+			}),
+			true,
+			"",
+		},
+
+		{
+			"error",
+			s2,
+			StructJSONPB(&s2.P, &p, func() []*validation.FieldRules {
+				called = true
+				return []*validation.FieldRules{
+					validation.Field(&p.Name, validation.Required),
+				}
+			}),
+			true,
+			"name: cannot be blank",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Reset
+			called = false
+			p = PersonPB{}
+
+			err := validation.ValidateStruct(
+				tt.Value,
+				tt.StructField,
+			)
+			require.Equal(tt.Called, called)
+			if tt.Error == "" {
+				require.NoError(err)
+				return
+			}
+			require.Error(err)
+			require.Contains(err.Error(), tt.Error)
+		})
+	}
+}
+
+// PersonPB is a proto.Message used for testing.
+type PersonPB struct {
+	Name    string `protobuf:"bytes,2,opt,name=name,json=name,proto3" json:"name,omitempty"`
+	Pronoun string `protobuf:"bytes,3,opt,name=pronoun,json=pronoun,proto3" json:"pronoun,omitempty"`
+}
+
+// Implement proto.Message with dummy implementation
+func (p *PersonPB) ProtoMessage()  {}
+func (p *PersonPB) Reset()         { *p = PersonPB{} }
+func (p *PersonPB) String() string { return "" }

--- a/internal/server/ptypes/job.go
+++ b/internal/server/ptypes/job.go
@@ -2,13 +2,16 @@ package ptypes
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
@@ -56,10 +59,76 @@ func ValidateJob(job *pb.Job) error {
 	)
 }
 
+// ValidateJobDataSourceRules
+func ValidateJobDataSourceRules(v *pb.Job_DataSource) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Source, validation.Required),
+
+		validationext.StructOneof(&v.Source, (*pb.Job_DataSource_Git)(nil),
+			func() []*validation.FieldRules {
+				v := v.Source.(*pb.Job_DataSource_Git)
+				return validateJobDataSourceGitRules(v)
+			}),
+	}
+}
+
+// validateJobDataSourceGitRules
+func validateJobDataSourceGitRules(v *pb.Job_DataSource_Git) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Git.Url, validation.Required),
+		validation.Field(&v.Git.Path, validation.By(hasNoDotDot)),
+
+		validationext.StructOneof(&v.Git.Auth, (*pb.Job_Git_Basic_)(nil),
+			func() []*validation.FieldRules {
+				v := v.Git.Auth.(*pb.Job_Git_Basic_)
+				return []*validation.FieldRules{
+					validation.Field(&v.Basic.Username, validation.Required),
+					validation.Field(&v.Basic.Password, validation.Required),
+				}
+			}),
+
+		validationext.StructOneof(&v.Git.Auth, (*pb.Job_Git_Ssh)(nil),
+			func() []*validation.FieldRules {
+				v := v.Git.Auth.(*pb.Job_Git_Ssh)
+				return []*validation.FieldRules{
+					validation.Field(&v.Ssh.PrivateKeyPem,
+						validation.Required, isSSHKey(v)),
+				}
+			}),
+	}
+}
+
 func isEmpty(v interface{}) error {
 	if reflect.ValueOf(v).IsZero() {
 		return nil
 	}
 
 	return errors.New("must be empty")
+}
+
+// isGitSSHKey validates the SSH key given.
+func isSSHKey(v *pb.Job_Git_Ssh) validation.Rule {
+	return validation.By(func(_ interface{}) error {
+		if len(v.Ssh.PrivateKeyPem) == 0 {
+			return nil
+		}
+
+		_, err := ssh.NewPublicKeys(
+			"git",
+			[]byte(v.Ssh.PrivateKeyPem),
+			v.Ssh.Password,
+		)
+
+		return err
+	})
+}
+
+func hasNoDotDot(v interface{}) error {
+	for _, part := range filepath.SplitList(v.(string)) {
+		if part == ".." {
+			return errors.New("must not contain '..'")
+		}
+	}
+
+	return nil
 }

--- a/internal/server/ptypes/project_test.go
+++ b/internal/server/ptypes/project_test.go
@@ -1,0 +1,95 @@
+package ptypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+func TestValidateProject(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Modify func(*pb.Project)
+		Error  string
+	}{
+		{
+			"valid",
+			nil,
+			"",
+		},
+
+		{
+			"name is not set",
+			func(v *pb.Project) {
+				v.Name = ""
+			},
+			"name: cannot be blank",
+		},
+
+		{
+			"polling set but disabled",
+			func(v *pb.Project) {
+				v.DataSourcePoll = &pb.Project_Poll{Enabled: false}
+			},
+			"",
+		},
+
+		{
+			"polling interval is invalid",
+			func(v *pb.Project) {
+				v.DataSourcePoll = &pb.Project_Poll{
+					Enabled:  true,
+					Interval: "very long",
+				}
+			},
+			"invalid duration",
+		},
+
+		{
+			"polling interval is valid",
+			func(v *pb.Project) {
+				v.DataSourcePoll = &pb.Project_Poll{
+					Enabled:  true,
+					Interval: "5m",
+				}
+			},
+			"",
+		},
+
+		{
+			"data source git with no URL",
+			func(v *pb.Project) {
+				v.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url: "",
+						},
+					},
+				}
+			},
+			"url: cannot be blank",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			value := TestProject(t, nil)
+			if f := tt.Modify; f != nil {
+				f(value)
+			}
+
+			err := ValidateProject(value)
+			if tt.Error == "" {
+				require.NoError(err)
+				return
+			}
+
+			require.Error(err)
+			require.Contains(err.Error(), tt.Error)
+		})
+	}
+}

--- a/internal/server/ptypes/project_test.go
+++ b/internal/server/ptypes/project_test.go
@@ -71,6 +71,24 @@ func TestValidateProject(t *testing.T) {
 			},
 			"url: cannot be blank",
 		},
+
+		{
+			"invalid Waypoint HCL",
+			func(v *pb.Project) {
+				v.WaypointHcl = []byte("i am not valid")
+				v.WaypointHclFormat = pb.Project_HCL
+			},
+			"waypoint_hcl",
+		},
+
+		{
+			"valid Waypoint HCL",
+			func(v *pb.Project) {
+				v.WaypointHcl = []byte("foo = 42")
+				v.WaypointHclFormat = pb.Project_HCL
+			},
+			"",
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/server/ptypes/ref.go
+++ b/internal/server/ptypes/ref.go
@@ -1,0 +1,14 @@
+package ptypes
+
+import (
+	"github.com/go-ozzo/ozzo-validation/v4"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// ValidateRefWorkspaceRules
+func ValidateRefWorkspaceRules(v *pb.Ref_Workspace) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Workspace, validation.Required),
+	}
+}

--- a/internal/server/ptypes/workspace.go
+++ b/internal/server/ptypes/workspace.go
@@ -1,0 +1,37 @@
+package ptypes
+
+import (
+	"github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+func TestGetWorkspaceRequest(t testing.T, src *pb.GetWorkspaceRequest) *pb.GetWorkspaceRequest {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.GetWorkspaceRequest{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.GetWorkspaceRequest{
+		Workspace: &pb.Ref_Workspace{
+			Workspace: "w_test",
+		},
+	}))
+
+	return src
+}
+
+// ValidateGetWorkspaceRequest
+func ValidateGetWorkspaceRequest(v *pb.GetWorkspaceRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Workspace, validation.Required),
+		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
+			return ValidateRefWorkspaceRules(v.Workspace)
+		}),
+	))
+}

--- a/internal/server/ptypes/workspace_test.go
+++ b/internal/server/ptypes/workspace_test.go
@@ -1,0 +1,59 @@
+package ptypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+func TestValidateGetWorkspaceRequest(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Modify func(*pb.GetWorkspaceRequest)
+		Error  string
+	}{
+		{
+			"valid",
+			nil,
+			"",
+		},
+
+		{
+			"ref is not set",
+			func(v *pb.GetWorkspaceRequest) {
+				v.Workspace = nil
+			},
+			"workspace: cannot be blank",
+		},
+
+		{
+			"ref set, blank workspace value",
+			func(v *pb.GetWorkspaceRequest) {
+				v.Workspace = &pb.Ref_Workspace{Workspace: ""}
+			},
+			"workspace: cannot be blank",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			value := TestGetWorkspaceRequest(t, nil)
+			if f := tt.Modify; f != nil {
+				f(value)
+			}
+
+			err := ValidateGetWorkspaceRequest(value)
+			if tt.Error == "" {
+				require.NoError(err)
+				return
+			}
+
+			require.Error(err)
+			require.Contains(err.Error(), tt.Error)
+		})
+	}
+}

--- a/internal/server/singleprocess/service_project.go
+++ b/internal/server/singleprocess/service_project.go
@@ -14,6 +14,10 @@ func (s *service) UpsertProject(
 	ctx context.Context,
 	req *pb.UpsertProjectRequest,
 ) (*pb.UpsertProjectResponse, error) {
+	if err := serverptypes.ValidateUpsertProjectRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.Project
 	if err := s.state.ProjectPut(result); err != nil {
 		return nil, err

--- a/internal/server/singleprocess/service_workspace.go
+++ b/internal/server/singleprocess/service_workspace.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/ptypes"
 )
 
 // TODO: test
@@ -13,6 +14,10 @@ func (s *service) GetWorkspace(
 	ctx context.Context,
 	req *pb.GetWorkspaceRequest,
 ) (*pb.GetWorkspaceResponse, error) {
+	if err := ptypes.ValidateGetWorkspaceRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.WorkspaceGet(req.Workspace.Workspace)
 	if err != nil {
 		return nil, err

--- a/shell.nix
+++ b/shell.nix
@@ -86,6 +86,7 @@ in pkgs.mkShell rec {
     pkgs.docker-compose
     pkgs.go
     pkgs.go-bindata
+    pkgs.grpcurl
     pkgs.niv
     pkgs.nodejs-12_x
     pkgs.protobuf3_11


### PR DESCRIPTION
This brings in the foundation for API input validation.

This copies in the `internal/pkg/validationext` package that we've extracted out of our other projects. This package helps to format validation errors in proto `status` formats using `InvalidArgument` and `fieldViolations` so callers can break down individual errors. This package also adds helpers for `ozzo-validation` to work nicely with deeply nested structs and proto-style "oneof" fields.

I've implemented workspace and project validation in this PR, but stopped there so we can PR the foundation and add more validation as we go.

An example of the format is below. This should be inspectable by UIs (@gregone) to provide nicer error formatting:

<img width="1279" alt="CleanShot 2021-03-08 at 10 12 17@2x" src="https://user-images.githubusercontent.com/1299/110363033-e5dbc600-7ff6-11eb-9173-578aa821a8f5.png">
