### PR TITLE
Fix a couple minor bugs in SSH auth with Git

### DIFF
--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/mitchellh/mapstructure"
+	cryptossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -411,6 +412,11 @@ func (s *GitSource) auth(
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"Failed to load private key for Git auth: %s", err)
 		}
+
+		// We do not do any host key verification for now.
+		// NOTE(mitchellh): in the future we should expose a way to
+		// configure enabling this in some way.
+		auth.HostKeyCallback = cryptossh.InsecureIgnoreHostKey()
 
 		return auth, nil
 

--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -402,9 +402,15 @@ func (s *GitSource) auth(
 		}, nil
 
 	case *pb.Job_Git_Ssh:
+		// Default the user to "git" which is typically what is used.
+		user := authcfg.Ssh.User
+		if user == "" {
+			user = "git"
+		}
+
 		ui.Output("Auth: ssh", terminal.WithInfoStyle())
 		auth, err := ssh.NewPublicKeys(
-			authcfg.Ssh.User,
+			user,
 			authcfg.Ssh.PrivateKeyPem,
 			authcfg.Ssh.Password,
 		)


### PR DESCRIPTION
This fixes two bugs that prevented SSH auth from properly working with Git:

* If no "user" is specified, use "git" (which is what every public Git host I found uses)
* We have to disable host key verification since we have no way to set that up in runners.

With these changes, I verified locally that polling setup to use SSH with GitHub works.