### PR TITLE
Introduce go-changelog to Waypoint

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -4,6 +4,12 @@ Waypoint uses `go-changelog` to generate its changelog on release:
 
 * https://github.com/hashicorp/go-changelog
 
+To install, run the following command:
+
+```
+go get github.com/hashicorp/go-changelog/cmd/changelog-build
+```
+
 ## How to generate CHANGELOG entries for release
 
 Below is an example for running `go-changelog` to generate a collection of

--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,0 +1,79 @@
+# How To Use
+
+Waypoint uses `go-changelog` to generate its changelog on release:
+
+* https://github.com/hashicorp/go-changelog
+
+## How to generate CHANGELOG entries for release
+
+Below is an example for running `go-changelog` to generate a collection of
+entries. It will generate output that can be inserted into CHANGELOG.md.
+
+For more information as to what each flag does, make sure to run `changelog-build -help`.
+
+```
+changelog-build -last-release v0.5.0 -entries-dir .changelog/ -changelog-template changelog.tmpl -note-template note.tmpl -this-release 86b6b38faa7c69f26f1d4c71e271cd4285daadf9
+```
+
+## CHANGELOG entry examples
+
+CHANGELOG entries are expected to be txt files created inside this folder
+`.changelog`. The file name is expected to be the same issue number that will
+be linked when the CHANGELOG is generated. So for example, if your issue is
+\#1234, your file name would be `.changelog/1234.txt`.
+
+Below are some examples of how to generate a CHANGELOG entry with your pull
+request.
+
+### Improvement
+
+~~~
+```release-note:improvement
+internal/server: Add new option for configs
+```
+~~~
+
+### Feature
+
+~~~
+```release-note:feature
+platform/nomad: New feature integration
+```
+~~~
+
+### Bug
+
+~~~
+```release-note:bug
+platform/docker: Fix broken code
+```
+~~~
+
+### Multiple Entries
+
+~~~
+```release-note:bug
+platform/docker: Fix broken code
+```
+
+```release-note:bug
+platform/nomad: Fix broken code
+```
+
+```release-note:bug
+platform/k8s: Fix broken code
+```
+~~~
+
+### Long Description with Markdown
+
+~~~
+```release-note:feature
+main: Lorem ipsum dolor `sit amet`, _consectetur_ adipiscing elit, **sed** do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+```
+~~~

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -1,0 +1,47 @@
+{{- if index .NotesByType "breaking-change" -}}
+BREAKING CHANGES:
+
+{{range index .NotesByType "breaking-change" -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.security }}
+SECURITY:
+
+{{range .NotesByType.security -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.feature }}
+FEATURES:
+
+{{range .NotesByType.feature -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.improvement }}
+IMPROVEMENTS:
+
+{{range .NotesByType.improvement -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.deprecation }}
+DEPRECATIONS:
+
+{{range .NotesByType.deprecation -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.bug }}
+BUG FIXES:
+
+{{range .NotesByType.bug -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}

--- a/.changelog/note.tmpl
+++ b/.changelog/note.tmpl
@@ -1,0 +1,3 @@
+{{- define "note" -}}
+{{.Body}}{{if not (stringHasPrefix .Issue "_")}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/issues/{{- .Issue -}})]{{end}}
+{{- end -}}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,0 +1,36 @@
+# This workflow checks that there is either a 'pr/no-changelog' label applied to a PR
+# or there is a .changelog/<pr number>.txt file associated with a PR for a changelog entry
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    # Runs on PRs to main and all release branches
+    branches:
+      - main
+      - release/*
+
+jobs:
+  # checks that a .changelog entry is present for a PR
+  changelog-check:
+    # If there  a `pr/no-changelog` label we ignore this check
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
+      - name: Check for changelog entry in diff
+        run: |
+          # check if there is a diff in the .changelog directory
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- .changelog/${{ github.event.pull_request.number }}.txt)
+
+          # If we do not find a file in .changelog/, we fail the check
+          if [ -z "$changelog_files" ]; then
+            # Fail status check when no .changelog entry was found on the PR
+            echo "Did not find a .changelog entry and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/waypoint/blob/main/.changelog/README.md"
+            exit 1
+          else
+            echo "Found .changelog entry in PR!"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,15 @@ docker/evanphx:
 					-t waypoint:latest \
 					.
 
+# expected to be invoked by make gen/changelog LAST_RELEASE=gitref THIS_RELEASE=gitref
+.PHONY: gen/changelog
+gen/changelog:
+	@echo "Generating changelog diff..."
+	@echo
+	@changelog-build -last-release $(LAST_RELEASE) \
+		-entries-dir .changelog/ -changelog-template changelog.tmpl -note-template note.tmpl \
+		-this-release $(THIS_RELEASE)
+
 .PHONY: gen/ts
 gen/ts:
 	@rm -rf ./ui/lib/api-common-protos/google 2> /dev/null


### PR DESCRIPTION
This commit adds some essential template files for working with
`go-changelog`. It also includes a basic readme for how to generate the
proper CHANGELOG entries so that they can be generated with the tool.
Finally, it introduces a github workflow for checking when pull requests
forget to include a changelog file, with the option of being ignored if
the proper label is applied to the PR.