### PR TITLE
remove excessive border decoration on links

### DIFF
--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -96,7 +96,7 @@ ul {
   padding: 0;
 }
 
-:any-link {
+:any-link, :any-link:not(.pds-button) {
   border-bottom: none;
 }
 


### PR DESCRIPTION
the way that the link underlines was applied changed from `text-decoration: underline` to using `border-bottom` in the latest version of the pds-addon, so our override wasn't applied anymore. This brings it back to normal. 

before: 

<img width="402" alt="Screen Shot 2021-03-11 at 15 57 35" src="https://user-images.githubusercontent.com/1416421/110806954-d8d30700-8282-11eb-83ba-c0e88226154a.png">

after: 

<img width="404" alt="Screen Shot 2021-03-11 at 15 57 41" src="https://user-images.githubusercontent.com/1416421/110806929-d2dd2600-8282-11eb-980d-e7d619c53bc3.png">



 