### PR TITLE
Allow poll settings to be configured in `runner` stanza

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -303,11 +303,20 @@ func (c *InitCommand) validateProject() bool {
 			}
 		}
 
+		var poll *pb.Project_Poll
+		if v := c.cfg.Runner.Poll; v != nil {
+			poll = &pb.Project_Poll{
+				Enabled:  v.Enabled,
+				Interval: v.Interval,
+			}
+		}
+
 		resp, err := client.UpsertProject(c.Ctx, &pb.UpsertProjectRequest{
 			Project: &pb.Project{
-				Name:          ref.Project,
-				RemoteEnabled: c.cfg.Runner.Enabled,
-				DataSource:    ds,
+				Name:           ref.Project,
+				RemoteEnabled:  c.cfg.Runner.Enabled,
+				DataSource:     ds,
+				DataSourcePoll: poll,
 			},
 		})
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,12 +38,21 @@ type Runner struct {
 
 	// DataSource is the default data source when a remote job is queued.
 	DataSource *DataSource `hcl:"data_source,block"`
+
+	// Poll are the settings related to polling.
+	Poll *Poll `hcl:"poll,block"`
 }
 
 // DataSource configures the data source for the runner.
 type DataSource struct {
 	Type string   `hcl:",label"`
 	Body hcl.Body `hcl:",remain"`
+}
+
+// Poll configures the polling settings for a project.
+type Poll struct {
+	Enabled  bool   `hcl:"enabled,optional"`
+	Interval string `hcl:"interval,optional"`
 }
 
 // Load loads the configuration file from the given path.

--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -55,6 +55,7 @@ func (s *GitSource) ProjectSource(body hcl.Body, ctx *hcl.EvalContext) (*pb.Job_
 	result := &pb.Job_Git{
 		Url:  cfg.Url,
 		Path: cfg.Path,
+		Ref:  cfg.Ref,
 	}
 	switch {
 	case cfg.Username != "":
@@ -443,6 +444,7 @@ type gitConfig struct {
 	Password       string `hcl:"password,optional"`
 	SSHKey         string `hcl:"key,optional"`
 	SSHKeyPassword string `hcl:"key_password,optional"`
+	Ref            string `hcl:"ref,optional"`
 }
 
 var _ Sourcer = (*GitSource)(nil)

--- a/website/content/docs/waypoint-hcl/runner.mdx
+++ b/website/content/docs/waypoint-hcl/runner.mdx
@@ -14,6 +14,9 @@ The `runner` stanza configures a project for [remote operations](/docs/remote),
 including configuring how to source a project source code from Git and
 configuring polling.
 
+**The settings in this stanza only take effect when `waypoint init -update`
+is called.**
+
 The `runner` stanza is completely optional. The settings specified in the
 `runner `stanza can also be specified using the [`waypoint project apply`](/commands/project-apply)
 command or via the UI by creating or modifying a project.
@@ -75,6 +78,10 @@ The `runner` stanza has no required parameters.
 - `data_source` <code>([data_source][data_source]: nil)</code> - Configuration
   for how to fetch the source for this project, such as from Git.
 
+- `poll` <code>([poll][poll]: nil)</code> - Settings for polling the data
+  source for changes and automatically running `waypoint up`. By default
+  polling is disabled.
+
 ## `data_source` Parameters
 
 ### Label
@@ -120,4 +127,15 @@ other data source types.
   Git ref such as `refs/pulls/1234`. This defaults to pulling HEAD, the
   latest commit on the default branch.
 
+## `poll` Parameters
+
+### Optional Parameters
+
+- `enabled` `(boolean: false)` - True to enable [polling](/docs/projects/git#polling).
+  Polling requires that a valid datasource is configured.
+
+- `interval` `(string: "30s")` - The interval between polling for changes.
+  This defaults to 30 seconds.
+
 [data_source]: /docs/waypoint-hcl/config#data_source-parameters 'data_source Stanza'
+[poll]: /docs/waypoint-hcl/config#poll-parameters 'poll Stanza'

--- a/website/content/docs/waypoint-hcl/runner.mdx
+++ b/website/content/docs/waypoint-hcl/runner.mdx
@@ -115,4 +115,9 @@ other data source types.
 - `key_password` `(string: "")` - The password for the SSH private key if
   it is encrypted. This is only required if the private key is encrypted.
 
+- `ref` `(string: "HEAD")` - The Git ref that is pulled for operations on
+  this project. This can be a branch name, tag name, or a fully qualified
+  Git ref such as `refs/pulls/1234`. This defaults to pulling HEAD, the
+  latest commit on the default branch.
+
 [data_source]: /docs/waypoint-hcl/config#data_source-parameters 'data_source Stanza'


### PR DESCRIPTION
This was a small asymmetry I noticed when working on docs: we allow every other project setting to be configured in the waypoint.hcl file but didnt allow polling. This extends support for that and updates the docs.