### PR TITLE
website(style): Update gray brand colors

### DIFF
--- a/website/components/animated-steps-list/steps-indicator/StepsIndicator.module.css
+++ b/website/components/animated-steps-list/steps-indicator/StepsIndicator.module.css
@@ -6,7 +6,7 @@
   & li {
     font-size: 17px;
     line-height: 28px;
-    color: var(--gray-4);
+    color: var(--gray-3);
     margin-bottom: 16px;
 
     &.active {

--- a/website/components/branded-cta/branded-cta.module.css
+++ b/website/components/branded-cta/branded-cta.module.css
@@ -42,7 +42,7 @@
 .content {
   max-width: 647px;
   margin: 0;
-  color: var(--gray-3);
+  color: var(--gray-2);
 }
 
 .content-and-links {

--- a/website/components/features/Features.module.css
+++ b/website/components/features/Features.module.css
@@ -29,7 +29,7 @@
   & .pagingDots {
     & :global(.paging-item:not(.active) > button) {
       opacity: 1 !important;
-      fill: var(--gray-6) !important;
+      fill: var(--gray-5) !important;
     }
   }
 }
@@ -49,7 +49,7 @@
 
 .feature {
   border-left: 2px solid;
-  border-color: var(--gray-6);
+  border-color: var(--gray-5);
   padding-left: 44px;
   margin: 28px 0;
   min-height: auto;
@@ -96,7 +96,7 @@
   line-height: 28px;
   font-family: var(--font-display);
   font-weight: bold;
-  color: var(--gray-4);
+  color: var(--gray-3);
   cursor: pointer;
 }
 

--- a/website/components/footer/style.module.css
+++ b/website/components/footer/style.module.css
@@ -3,7 +3,7 @@
   flex-shrink: 0;
 
   & a {
-    color: var(--gray-4);
+    color: var(--gray-3);
     transition: color 0.25s ease;
     cursor: pointer;
     display: inline-block;

--- a/website/components/homepage-section/HomepageSection.module.css
+++ b/website/components/homepage-section/HomepageSection.module.css
@@ -4,7 +4,7 @@
     background: var(--white);
   }
   &.gray {
-    background: var(--gray-7);
+    background: var(--gray-6);
   }
   &.dark {
     background: var(--black);

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1038,9 +1038,9 @@
       "integrity": "sha512-59AS4kK3EURCTU9ibJmk8MVT8i3qc5tEHv985dxECZrWTL4+3kKr45u/13OPpcRlpUSIKeWEsN9FL1f5/ztHww=="
     },
     "@hashicorp/mktg-global-styles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.0.tgz",
-      "integrity": "sha512-REr07tPJDKpyTh/u9tUS3sf29LnkDrWFVgY7FTvDJfbJ60IJ/R1TYNmcE7QKREGJ8j0p43QWEDabqVWOWvOXFA=="
+      "version": "2.1.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.1-canary.0.tgz",
+      "integrity": "sha512-P/PtJNKU8SQPwiVM4FAXT28D3IQqQCtm1CuyP/5uJvZCljzHQ8bTWqQuoV0wVw5ceAPbYoQyACB9fait9eCm7Q=="
     },
     "@hashicorp/nextjs-scripts": {
       "version": "16.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "HashiCorp",
   "dependencies": {
-    "@hashicorp/mktg-global-styles": "2.1.0",
+    "@hashicorp/mktg-global-styles": "2.1.1-canary.0",
     "@hashicorp/nextjs-scripts": "16.0.1",
     "@hashicorp/react-alert-banner": "5.0.0",
     "@hashicorp/react-button": "4.0.0",


### PR DESCRIPTION
Removes references to deprecated gray CSS properties and maps all gray colors to new brand values.

[_Created by Sourcegraph campaign `kstraut/product-sites-migrate-v3-gray-colors`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/product-sites-migrate-v3-gray-colors)

## **Important**
Due to old imports of `react-global-styles` within `react-components`, the proper gray values will not show until we update `react-components` later on because the old style sheets are taking precedent.

## The Map
```
// v2 gray css properties to new v3 values
"--gray-3" --> "--gray-2" 
 
"--gray-4" --> "--gray-3" 
 
"--gray-5" --> "--gray-4" 
 
"--gray-6" --> "--gray-5" 
 
"--gray-7" --> "--gray-6" 
 

// Replace Deprecated Gray Value references
"DEPRECATED-gray-:[~1|2]" --> "gray-1" 
 
"DEPRECATED-gray-:[~3|4]" --> "gray-2" 
 
"DEPRECATED-gray-:[~5|6]" --> "gray-3" 
 
"DEPRECATED-gray-7" --> "gray-4" 
 
"DEPRECATED-gray-:[~8|9]" --> "gray-5" 
 
"DEPRECATED-gray-10" --> "gray-6" 
```