### PR TITLE
chore: adds should build script for website

### DIFF
--- a/website/scripts/should-build.sh
+++ b/website/scripts/should-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This is run during the website build step to determine if we should skip the build or not.
+# More information: https://vercel.com/docs/platform/projects#ignored-build-step
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "stable-website"  ]] ; then
+  # Proceed with the build if the branch is stable-website
+  echo "✅ - Build can proceed"
+  exit 1;
+else
+  # Check for differences in the website directory
+  git diff --quiet HEAD^ HEAD ./
+fi


### PR DESCRIPTION
Adding a script to be run during the site build process to determine if we should actually build.

More information on the feature: https://vercel.com/docs/platform/projects#ignored-build-step