### PR TITLE
Validate in CLI and serverside that exec gets at least one arg

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -107,6 +107,14 @@ func (c *ExecCommand) Run(args []string) int {
 	}
 
 	args = flagSet.Args()
+	if len(args) == 0 {
+		c.ui.Output(
+			"At least one argument expected.\n\n"+c.Help(),
+			terminal.WithErrorStyle(),
+		)
+
+		return 1
+	}
 
 	var exitCode int
 	client := c.project.Client()

--- a/internal/server/ptypes/exec.go
+++ b/internal/server/ptypes/exec.go
@@ -1,0 +1,37 @@
+package ptypes
+
+import (
+	"github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+func TestExecStreamRequestStart(t testing.T, src *pb.ExecStreamRequest_Start) *pb.ExecStreamRequest_Start {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.ExecStreamRequest_Start{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.ExecStreamRequest_Start{
+		Target: &pb.ExecStreamRequest_Start_DeploymentId{
+			DeploymentId: "1",
+		},
+
+		Args: []string{"/bin/bash"},
+	}))
+
+	return src
+}
+
+// ValidateExecStreamRequestStart
+func ValidateExecStreamRequestStart(v *pb.ExecStreamRequest_Start) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Target, validation.Required),
+		validation.Field(&v.Args, validation.Required),
+	))
+}

--- a/internal/server/ptypes/exec_test.go
+++ b/internal/server/ptypes/exec_test.go
@@ -1,0 +1,51 @@
+package ptypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+func TestValidateExecStreamRequestStart(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Modify func(*pb.ExecStreamRequest_Start)
+		Error  string
+	}{
+		{
+			"valid",
+			nil,
+			"",
+		},
+
+		{
+			"args must not be blank",
+			func(v *pb.ExecStreamRequest_Start) {
+				v.Args = []string{}
+			},
+			"args: cannot be blank",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			value := TestExecStreamRequestStart(t, nil)
+			if f := tt.Modify; f != nil {
+				f(value)
+			}
+
+			err := ValidateExecStreamRequestStart(value)
+			if tt.Error == "" {
+				require.NoError(err)
+				return
+			}
+
+			require.Error(err)
+			require.Contains(err.Error(), tt.Error)
+		})
+	}
+}

--- a/internal/server/ptypes/job.go
+++ b/internal/server/ptypes/job.go
@@ -50,13 +50,13 @@ func TestJobNew(t testing.T, src *pb.Job) *pb.Job {
 
 // ValidateJob validates the job structure.
 func ValidateJob(job *pb.Job) error {
-	return validation.ValidateStruct(job,
+	return validationext.Error(validation.ValidateStruct(job,
 		validation.Field(&job.Id, validation.By(isEmpty)),
 		validation.Field(&job.Application, validation.Required),
 		validation.Field(&job.Workspace, validation.Required),
 		validation.Field(&job.TargetRunner, validation.Required),
 		validation.Field(&job.Operation, validation.Required),
-	)
+	))
 }
 
 // ValidateJobDataSourceRules

--- a/internal/server/singleprocess/service_exec.go
+++ b/internal/server/singleprocess/service_exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
+	"github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -31,6 +32,9 @@ func (s *service) StartExecStream(
 	if !ok {
 		return status.Errorf(codes.FailedPrecondition,
 			"first message must be start type")
+	}
+	if err := ptypes.ValidateExecStreamRequestStart(start.Start); err != nil {
+		return err
 	}
 
 	// Create our exec. We have to populate everything here first because


### PR DESCRIPTION
One argument (the command to execute) is required. This validates it.

Without this, users would get exec just terminated with no message.