### PR TITLE
Revert "Fixes https://github.com/hashicorp/waypoint/issues/687"

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -166,7 +166,7 @@ func (p *Platform) Deploy(
 	bindings := nat.PortMap{}
 	bindings[np] = []nat.PortBinding{
 		{
-			HostPort: "",
+			HostPort: "", // this is intentionally left empty for a random host port assignment
 		},
 	}
 

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -166,7 +166,7 @@ func (p *Platform) Deploy(
 	bindings := nat.PortMap{}
 	bindings[np] = []nat.PortBinding{
 		{
-			HostPort: port,
+			HostPort: "",
 		},
 	}
 


### PR DESCRIPTION
Reverts hashicorp/waypoint#918

This is required to allow `waypoint up` to continue to work beyond the first iteration. Without this, the second `waypoint up` fails with an error that there is already a container bound for the port requested.

For now we'll go back to leaving it randomly assigned, which supports waypoints deployment model here. We have plans in a future release for supporting mutable deployments, which should hopefully allow the original issue to be resolved. /cc @Wakeful-Cloud