### PR TITLE
internal/server/singleprocess/state: Add ability to prune jobs and deployments

### DIFF
--- a/.changelog/1193.txt
+++ b/.changelog/1193.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+server: Prune old deployments and jobs from server memory. This limits the number
+of deployments and jobs to 10,000. The data for the old entries is still stored on disk
+but it is not indexed in memory, to allow data recovery should it be needed.
+```

--- a/internal/server/singleprocess/prune.go
+++ b/internal/server/singleprocess/prune.go
@@ -1,0 +1,35 @@
+package singleprocess
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func (s *service) runPrune(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	funclog hclog.Logger,
+) {
+	defer wg.Done()
+
+	funclog.Info("starting")
+	defer funclog.Info("exiting")
+
+	tk := time.NewTicker(10 * time.Minute)
+	defer tk.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tk.C:
+			err := s.state.Prune()
+			if err != nil {
+				funclog.Error("error pruning data", "error", err)
+			}
+		}
+	}
+}

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -144,6 +144,11 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 	s.bgWg.Add(1)
 	go s.runPollQueuer(s.bgCtx, &s.bgWg, log.Named("poll_queuer"))
 
+	// Start out state pruning background goroutine. This calls
+	// Prune on the state every 10 minutes.
+	s.bgWg.Add(1)
+	go s.runPrune(s.bgCtx, &s.bgWg, log.Named("prune"))
+
 	return &s, nil
 }
 

--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -100,8 +100,9 @@ func (op *appOperation) register() {
 	schemas = append(schemas, op.memSchema)
 
 	if op.MaximumIndexedRecords > 0 {
-		pruneFns = append(pruneFns, func(memTxn *memdb.Txn) (int, error) {
-			return op.pruneOld(memTxn, op.MaximumIndexedRecords)
+		pruneFns = append(pruneFns, func(memTxn *memdb.Txn) (string, int, error) {
+			cnt, err := op.pruneOld(memTxn, op.MaximumIndexedRecords)
+			return op.memTableName(), cnt, err
 		})
 	}
 }

--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -61,9 +61,6 @@ type appOperation struct {
 	seq map[string]map[string]*uint64
 }
 
-// By default, we allow 10000 records
-const DefaultMaximumIndexedRecords = 10000
-
 // Test validates that the operation struct is setup properly. This
 // is expected to be called in a unit test.
 func (op *appOperation) Test(t testing.T) {

--- a/internal/server/singleprocess/state/deployment.go
+++ b/internal/server/singleprocess/state/deployment.go
@@ -7,6 +7,8 @@ import (
 var deploymentOp = &appOperation{
 	Struct: (*pb.Deployment)(nil),
 	Bucket: []byte("deployment"),
+
+	MaximumIndexedRecords: 10000,
 }
 
 func init() {

--- a/internal/server/singleprocess/state/deployment_test.go
+++ b/internal/server/singleprocess/state/deployment_test.go
@@ -2,8 +2,53 @@ package state
 
 import (
 	"testing"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeployment(t *testing.T) {
 	deploymentOp.Test(t)
+}
+
+func TestDeploymentPrune(t *testing.T) {
+	t.Run("prunes old records", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		require.NoError(s.DeploymentPut(false, serverptypes.TestValidDeployment(t, &pb.Deployment{
+			Id: "A",
+		})))
+
+		require.NoError(s.DeploymentPut(false, serverptypes.TestValidDeployment(t, &pb.Deployment{
+			Id: "B",
+		})))
+
+		require.NoError(s.DeploymentPut(false, serverptypes.TestValidDeployment(t, &pb.Deployment{
+			Id: "C",
+		})))
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		cnt, err := deploymentOp.pruneOld(memTxn, 2)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(1, cnt)
+		require.Equal(2, deploymentOp.indexedRecords)
+
+		dep, err := s.DeploymentGet(&pb.Ref_Operation{
+			Target: &pb.Ref_Operation_Id{
+				Id: "A",
+			},
+		})
+
+		require.Error(err)
+		require.Nil(dep)
+	})
 }

--- a/internal/server/singleprocess/state/job_test.go
+++ b/internal/server/singleprocess/state/job_test.go
@@ -1461,7 +1461,7 @@ func TestJobsPrune(t *testing.T) {
 		memTxn := s.inmem.Txn(true)
 		defer memTxn.Abort()
 
-		cnt, err := s.jobsPruneOld(memTxn, 2)
+		cnt, err := s.jobsPruneOld(memTxn, 1)
 		require.NoError(err)
 
 		memTxn.Commit()

--- a/internal/server/singleprocess/state/job_test.go
+++ b/internal/server/singleprocess/state/job_test.go
@@ -1357,3 +1357,220 @@ func TestJobUpdateRef(t *testing.T) {
 		require.Equal(ref.Commit, "hello")
 	})
 }
+
+func TestJobsPrune(t *testing.T) {
+	t.Run("removes only completed jobs", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		// Create a build
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		// Cancel it
+		require.NoError(s.JobCancel("A", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "B",
+		})))
+
+		// Leave B running
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		cnt, err := s.jobsPruneOld(memTxn, 0)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(1, cnt)
+		require.Equal(1, s.indexedJobs)
+
+		val, err := s.JobById("A", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("B", nil)
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("does nothing there are fewer than the maximum", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		// Create a build
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		// Cancel it
+		require.NoError(s.JobCancel("A", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "B",
+		})))
+
+		// Leave B running
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		require.Equal(2, s.indexedJobs)
+		cnt, err := s.jobsPruneOld(memTxn, 10)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(0, cnt)
+		require.Equal(2, s.indexedJobs)
+
+		val, err := s.JobById("A", nil)
+		require.NoError(err)
+		require.NotNil(val)
+
+		val, err = s.JobById("B", nil)
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("stops when the maximum are pruned", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		require.NoError(s.JobCancel("A", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "B",
+		})))
+
+		require.NoError(s.JobCancel("B", false))
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		cnt, err := s.jobsPruneOld(memTxn, 2)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(1, cnt)
+		require.Equal(1, s.indexedJobs)
+
+		val, err := s.JobById("A", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("B", nil)
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("prunes according to the queue time", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		require.NoError(s.JobCancel("A", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "B",
+		})))
+
+		require.NoError(s.JobCancel("B", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "C",
+		})))
+
+		require.NoError(s.JobCancel("C", false))
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		cnt, err := s.jobsPruneOld(memTxn, 1)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(2, cnt)
+		require.Equal(1, s.indexedJobs)
+
+		val, err := s.JobById("A", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("B", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("C", nil)
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("can prune all jobs", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		require.NoError(s.JobCancel("A", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "B",
+		})))
+
+		require.NoError(s.JobCancel("B", false))
+
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "C",
+		})))
+
+		require.NoError(s.JobCancel("C", false))
+
+		memTxn := s.inmem.Txn(true)
+		defer memTxn.Abort()
+
+		cnt, err := s.jobsPruneOld(memTxn, 0)
+		require.NoError(err)
+
+		memTxn.Commit()
+
+		require.Equal(3, cnt)
+		require.Equal(0, s.indexedJobs)
+
+		val, err := s.JobById("A", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("B", nil)
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = s.JobById("C", nil)
+		require.NoError(err)
+		require.Nil(val)
+	})
+}

--- a/internal/server/singleprocess/state/prune.go
+++ b/internal/server/singleprocess/state/prune.go
@@ -1,0 +1,85 @@
+package state
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-memdb"
+)
+
+type pruneOp struct {
+	lock         *sync.Mutex
+	table, index string
+	indexArgs    []interface{}
+	max          int
+	cur          *int
+	check        func(val interface{}) bool
+}
+
+// pruneOld uses the types in op to scan the table indicated and prune old records.
+// The op's check function can allow the process to skip records that shouldn't be
+// pruned regardless of their age.
+func pruneOld(memTxn *memdb.Txn, op pruneOp) (int, error) {
+	op.lock.Lock()
+
+	// Easy enough, just exit if we haven't hit the maximum
+	if *op.cur < op.max {
+		op.lock.Unlock()
+		return 0, nil
+	}
+
+	// Calculate how many jobs we need to prune to get back to the maximum.
+	pruneCnt := *op.cur - op.max
+
+	// Unlock the prune lock for the bulk of the work so we don't prevent new work
+	// from starting while the prune is taking place.
+	op.lock.Unlock()
+
+	// Now we iterate the jobs, starting we the queue time that is furtherest in the past
+	// (ie, delete the oldest records first).
+	iter, err := memTxn.LowerBound(op.table, op.index, op.indexArgs...)
+	if err != nil {
+		return 0, err
+	}
+
+	// Track the total values deleted separately because we can exit early
+	// and so we might want to prune, say, 100 we might only be able to prune 50
+	// and need to know the exact number.
+	var deleted int
+
+pruning:
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+
+		if op.check != nil && op.check(raw) {
+			continue pruning
+		}
+
+		// otherwise, prune this job! Once we've pruned enough jobs to get back
+		// to the maximum, we stop pruning.
+		pruneCnt--
+
+		err = memTxn.Delete(op.table, raw)
+		if err != nil {
+			return 0, err
+		}
+
+		deleted++
+		if pruneCnt <= 0 {
+			break
+		}
+	}
+
+	// Grab the lock and update indexedJobs value
+	op.lock.Lock()
+	defer op.lock.Unlock()
+
+	// We subject the diff here because while prune was running, new jobs
+	// can get scheduled and thusly we might not actually remove the same
+	// percentage of jobs as we expect.
+	*op.cur -= deleted
+
+	return deleted, nil
+}

--- a/internal/server/singleprocess/state/prune.go
+++ b/internal/server/singleprocess/state/prune.go
@@ -36,7 +36,7 @@ func pruneOld(memTxn *memdb.Txn, op pruneOp) (int, error) {
 	op.lock.Lock()
 
 	// Easy enough, just exit if we haven't hit the maximum
-	if *op.cur < op.max {
+	if *op.cur <= op.max {
 		op.lock.Unlock()
 		return 0, nil
 	}

--- a/internal/server/singleprocess/state/prune_test.go
+++ b/internal/server/singleprocess/state/prune_test.go
@@ -1,0 +1,217 @@
+package state
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/require"
+)
+
+type pti struct {
+	Id string
+}
+
+func TestPruneOld(t *testing.T) {
+	schema := &memdb.DBSchema{
+		Tables: map[string]*memdb.TableSchema{
+			"items": {
+				Name: "items",
+				Indexes: map[string]*memdb.IndexSchema{
+					jobIdIndexName: {
+						Name:         "id",
+						AllowMissing: false,
+						Unique:       true,
+						Indexer: &memdb.StringFieldIndex{
+							Field: "Id",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("prunes none when there is enough room", func(t *testing.T) {
+		require := require.New(t)
+
+		inmem, err := memdb.NewMemDB(schema)
+		require.NoError(err)
+
+		txn := inmem.Txn(true)
+		defer txn.Abort()
+
+		require.NoError(txn.Insert("items", &pti{"B"}))
+		require.NoError(txn.Insert("items", &pti{"C"}))
+		require.NoError(txn.Insert("items", &pti{"A"}))
+		require.NoError(txn.Insert("items", &pti{"D"}))
+
+		// Weird order on purpose to validate lexical ordering on pruning.
+
+		txn.Commit()
+
+		txn = inmem.Txn(true)
+		defer txn.Abort()
+
+		var (
+			mu      sync.Mutex
+			indexed int = 4
+		)
+
+		cnt, err := pruneOld(txn, pruneOp{
+			lock:      &mu,
+			table:     "items",
+			index:     "id",
+			indexArgs: []interface{}{""},
+			cur:       &indexed,
+			max:       4,
+		})
+		require.NoError(err)
+
+		txn.Commit()
+
+		require.Equal(0, cnt)
+		require.Equal(4, indexed)
+
+		txn = inmem.Txn(false)
+		defer txn.Abort()
+
+		val, err := txn.First("items", "id", "A")
+		require.NoError(err)
+		require.NotNil(val)
+
+		val, err = txn.First("items", "id", "B")
+		require.NoError(err)
+		require.NotNil(val)
+
+		val, err = txn.First("items", "id", "C")
+		require.NoError(err)
+		require.NotNil(val)
+
+		val, err = txn.First("items", "id", "D")
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("deletes a subset of records", func(t *testing.T) {
+		require := require.New(t)
+
+		inmem, err := memdb.NewMemDB(schema)
+		require.NoError(err)
+
+		txn := inmem.Txn(true)
+		defer txn.Abort()
+
+		require.NoError(txn.Insert("items", &pti{"B"}))
+		require.NoError(txn.Insert("items", &pti{"C"}))
+		require.NoError(txn.Insert("items", &pti{"A"}))
+		require.NoError(txn.Insert("items", &pti{"D"}))
+
+		// Weird order on purpose to validate lexical ordering on pruning.
+
+		txn.Commit()
+
+		txn = inmem.Txn(true)
+		defer txn.Abort()
+
+		var (
+			mu      sync.Mutex
+			indexed int = 4
+		)
+
+		cnt, err := pruneOld(txn, pruneOp{
+			lock:      &mu,
+			table:     "items",
+			index:     "id",
+			indexArgs: []interface{}{""},
+			cur:       &indexed,
+			max:       2,
+		})
+		require.NoError(err)
+
+		txn.Commit()
+
+		require.Equal(2, cnt)
+		require.Equal(2, indexed)
+
+		txn = inmem.Txn(false)
+		defer txn.Abort()
+
+		val, err := txn.First("items", "id", "A")
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = txn.First("items", "id", "B")
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = txn.First("items", "id", "C")
+		require.NoError(err)
+		require.NotNil(val)
+
+		val, err = txn.First("items", "id", "D")
+		require.NoError(err)
+		require.NotNil(val)
+	})
+
+	t.Run("deletes all records", func(t *testing.T) {
+		require := require.New(t)
+
+		inmem, err := memdb.NewMemDB(schema)
+		require.NoError(err)
+
+		txn := inmem.Txn(true)
+		defer txn.Abort()
+
+		require.NoError(txn.Insert("items", &pti{"B"}))
+		require.NoError(txn.Insert("items", &pti{"C"}))
+		require.NoError(txn.Insert("items", &pti{"A"}))
+		require.NoError(txn.Insert("items", &pti{"D"}))
+
+		// Weird order on purpose to validate lexical ordering on pruning.
+
+		txn.Commit()
+
+		txn = inmem.Txn(true)
+		defer txn.Abort()
+
+		var (
+			mu      sync.Mutex
+			indexed int = 4
+		)
+
+		cnt, err := pruneOld(txn, pruneOp{
+			lock:      &mu,
+			table:     "items",
+			index:     "id",
+			indexArgs: []interface{}{""},
+			cur:       &indexed,
+			max:       0,
+		})
+		require.NoError(err)
+
+		txn.Commit()
+
+		require.Equal(4, cnt)
+		require.Equal(0, indexed)
+
+		txn = inmem.Txn(false)
+		defer txn.Abort()
+
+		val, err := txn.First("items", "id", "A")
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = txn.First("items", "id", "B")
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = txn.First("items", "id", "C")
+		require.NoError(err)
+		require.Nil(val)
+
+		val, err = txn.First("items", "id", "D")
+		require.NoError(err)
+		require.Nil(val)
+	})
+
+}

--- a/internal/server/singleprocess/state/state.go
+++ b/internal/server/singleprocess/state/state.go
@@ -29,7 +29,7 @@ var (
 
 	// pruneFns is the list of prune functions to call for appOperation types
 	// when performing state prune.
-	pruneFns []func(memTxn *memdb.Txn) (int, error)
+	pruneFns []func(memTxn *memdb.Txn) (string, int, error)
 )
 
 // State is the primary API for state mutation for the server.
@@ -146,11 +146,12 @@ func (s *State) Prune() error {
 	var records int
 
 	for _, f := range pruneFns {
-		cnt, err := f(memTxn)
+		tbl, cnt, err := f(memTxn)
 		if err != nil {
 			return err
 		}
 
+		s.log.Debug("Pruning table index data", "table", tbl, "removed-records", cnt)
 		records += cnt
 	}
 

--- a/internal/server/singleprocess/state/state.go
+++ b/internal/server/singleprocess/state/state.go
@@ -121,6 +121,22 @@ func (s *State) Close() error {
 	return s.db.Close()
 }
 
+// Prune should be called in a on a regular interval to allow State
+// to prune out old data.
+func (s *State) Prune() error {
+	memTxn := s.inmem.Txn(true)
+	defer memTxn.Abort()
+
+	err := s.jobsPruneOld(memTxn)
+	if err != nil {
+		return err
+	}
+
+	memTxn.Commit()
+
+	return nil
+}
+
 // schemaFn is an interface function used to create and return new memdb schema
 // structs for constructing an in-memory db.
 type schemaFn func() *memdb.TableSchema


### PR DESCRIPTION
This limits deployments and jobs to 10,000 records each. The code only prunes the data from the memory indexes, it leaves in the disk.

The pruning of data is done on a regular interval rather than inline during data inserts (ie, it's like a typical garbage collection process). The pruning logic is shared between app records and jobs as well.

Pruning the data from disk would come later.