### PR TITLE
cmd/waypoint-entrypoint: dump heap profile on SIGUSR1

### DIFF
--- a/cmd/waypoint-entrypoint/debug.go
+++ b/cmd/waypoint-entrypoint/debug.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/pprof"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"golang.org/x/sys/unix"
+)
+
+// debugSignalHandler writes a heap profile to the system temporary
+// directory when SIGUSR1 is received. The output path for each dump
+// is logged.
+//
+// NOTE(mitchellh): In the future, I expect that we'll dump a lot more
+// data and perhaps store a tar file or some other format. Given the
+// debug nature of this file, I'm not going to worry too much about tagging
+// the file type and so on.
+func debugSignalHandler(ctx context.Context, log hclog.Logger) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, unix.SIGUSR1)
+	defer signal.Stop(ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ch:
+		}
+
+		// Dump the profile to a timestamped file
+		path := filepath.Join(os.TempDir(), fmt.Sprintf(
+			"waypoint_heap_%d", time.Now().Unix()))
+		log.Warn("SIGUSR1 received, dumping heap profile", "path", path)
+
+		// Get the profile, this is predefined by Go and should always exist.
+		profile := pprof.Lookup("heap")
+		if profile == nil {
+			log.Error("heap profile not found, this should not be possible")
+			continue
+		}
+
+		// Write it
+		f, err := os.Create(path)
+		if err != nil {
+			log.Error("error opening file to dump profile", "err", err)
+			continue
+		}
+		err = profile.WriteTo(f, 0)
+		f.Close()
+		if err != nil {
+			log.Error("error writing heap profile", "err", err)
+		}
+	}
+}

--- a/cmd/waypoint-entrypoint/main.go
+++ b/cmd/waypoint-entrypoint/main.go
@@ -74,6 +74,9 @@ func realMain() int {
 		return 1
 	}
 
+	// Start our debug signal handler
+	go debugSignalHandler(ctx, log.Named("debug"))
+
 	// Run our core logic
 	err := ceb.Run(ctx,
 		ceb.WithEnvDefaults(),


### PR DESCRIPTION
This adds functionality to dump a heap profile (in pprof format) when the entrypoint receives a SIGUSR1. The profile is written to the system temporary directory with a timestamp. The exact path that was dumped is logged. 

I hope to use this to debug #1192 and any future issues.

In the future, the team mentioned it'd be really cool if the server can request this information from an entrypoint and we can potentially use that to debug weird deployments. I think that's a good idea, but this is a simple thing we can do now and backport safely so I'm opening this PR first. 