### PR TITLE
internal/ceb: fix dropped errors

### DIFF
--- a/internal/ceb/app_config_test.go
+++ b/internal/ceb/app_config_test.go
@@ -310,6 +310,7 @@ func TestConfig_dynamicConfigurable(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(err)
 
 	// Change our config
 	_, err = client.SetConfig(ctx, &pb.ConfigSetRequest{
@@ -351,6 +352,7 @@ func TestConfig_dynamicConfigurable(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(err)
 
 	// The child should change
 	require.Eventually(func() bool {
@@ -458,6 +460,7 @@ func TestConfig_dynamicConfigurableUnused(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(err)
 
 	// The child should start up
 	var pid string
@@ -487,6 +490,7 @@ func TestConfig_dynamicConfigurableUnused(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(err)
 
 	// Sleep for a bit and ensure we have the same value
 	{

--- a/internal/ceb/virtualceb/ceb.go
+++ b/internal/ceb/virtualceb/ceb.go
@@ -180,7 +180,9 @@ func (v *Virtual) RunExec(ctx context.Context, h ExecHandler, count int) error {
 				idx = exec.Index
 			}
 
-			err = v.startExec(ctx, h, exec, env)
+			if err := v.startExec(ctx, h, exec, env); err != nil {
+				return err
+			}
 			if count > 0 {
 				count--
 				if count == 0 {


### PR DESCRIPTION
This fixes dropped errors in `internal/ceb` and its subpackage `internal/ceb/virtualceb`.