### PR TITLE
Use accessible values for toggle theme

### DIFF
--- a/ui/app/components/app-form/project-settings.hbs
+++ b/ui/app/components/app-form/project-settings.hbs
@@ -142,8 +142,13 @@
             @showLabels={{true}}
             @name="git-sync-enabled"
             @value={{this.project.dataSourcePoll.enabled}}
+            @size="small"
             @onToggle={{fn (mut this.project.dataSourcePoll.enabled)}} as |toggle|>
-            <toggle.switch/>
+            <toggle.switch
+              @onLabel='git sync on'
+              @offLabel='git sync off'
+              @name="Git Sync"
+              />
 
             <toggle.label for="git-sync-enabled">
               <span class="pds-toggleLabel">

--- a/ui/app/styles/_x-toggle.scss
+++ b/ui/app/styles/_x-toggle.scss
@@ -1,0 +1,14 @@
+:root {
+  --toggle-color-off: #{dehex(color.$ui-cool-gray-300)};
+  --toggle-color-on: #{dehex(color.$blue-500)};
+}
+
+.x-toggle-light.x-toggle-btn {
+  background: rgb(var(--toggle-color-off));
+}
+
+.x-toggle:checked + label > .x-toggle-light.x-toggle-btn {
+  background: rgb(var(--toggle-color-on));
+}
+
+

--- a/ui/app/styles/_x-toggle.scss
+++ b/ui/app/styles/_x-toggle.scss
@@ -4,11 +4,11 @@
 }
 
 .x-toggle-light.x-toggle-btn {
-  background: rgb(var(--toggle-color-off));
+  background-color: rgb(var(--toggle-color-off));
 }
 
 .x-toggle:checked + label > .x-toggle-light.x-toggle-btn {
-  background: rgb(var(--toggle-color-on));
+  background-color: rgb(var(--toggle-color-on));
 }
 
 

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -128,3 +128,4 @@ svg.icon {
 @import './_header';
 @import './_page';
 @import './pds-form';
+@import './x-toggle';


### PR DESCRIPTION
The default theme used for the toggle component wasn't passing accessibility standards. This updates the theme to have a higher contrast in the default state, and use the styleguide blue for the checked state. 

A next step would possibly be to re-export the addon with a fully customized style for consumption by the `pds-addon`, or more simply have a custom theme class, but this shoudl do for now.

![toggle-colors](https://user-images.githubusercontent.com/1416421/111200925-88c9ac80-85c2-11eb-92d6-a4bfbeba1d87.gif)
