### PR TITLE
website: stub in <NestedNode> authoring component

### DIFF
--- a/website/components/nested-node/index.jsx
+++ b/website/components/nested-node/index.jsx
@@ -1,0 +1,12 @@
+import s from './style.module.css'
+
+export default function NestedNode(props) {
+  const childrenArray = props.children.split('.')
+  const removed = childrenArray.splice(0, 1)
+  return (
+    <>
+      <span className={s.root}>{removed}.</span>
+      {childrenArray.join('.')}
+    </>
+  )
+}

--- a/website/components/nested-node/style.module.css
+++ b/website/components/nested-node/style.module.css
@@ -1,0 +1,3 @@
+.root {
+  color: #ccc;
+}

--- a/website/components/nested-node/style.module.css
+++ b/website/components/nested-node/style.module.css
@@ -1,3 +1,3 @@
 .root {
-  color: #ccc;
+  color: #949494;
 }

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -6,6 +6,8 @@ import {
   generateStaticProps,
 } from '@hashicorp/react-docs-page/server'
 import Placement from 'components/placement-table'
+import NestedNode from 'components/nested-node'
+const additionalComponents = { Placement, NestedNode }
 
 const subpath = 'docs'
 
@@ -16,7 +18,7 @@ function DocsLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
-      additionalComponents={{ Placement }}
+      additionalComponents={additionalComponents}
     />
   )
 }
@@ -26,7 +28,12 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  return generateStaticProps({ subpath, productName, params })
+  return generateStaticProps({
+    subpath,
+    productName,
+    params,
+    additionalComponents,
+  })
 }
 
 export default DocsLayout


### PR DESCRIPTION
this adds the ability to wrap text in `<NestedNode>` which will color the first item in object syntax as gray. this should be a marginal improvement for documenting nested API parameters

![image](https://user-images.githubusercontent.com/49507/111682911-48a13e80-87fb-11eb-9590-02198587e22b.png)
