### PR TITLE
internal/core: fix dropped test error

### DIFF
--- a/internal/core/app_exec_test.go
+++ b/internal/core/app_exec_test.go
@@ -58,6 +58,7 @@ func TestAppExec_happy(t *testing.T) {
 	mockPluginArtifact := &pb.GetVersionInfoResponse{}
 
 	anyval, err := ptypes.MarshalAny(mockPluginArtifact)
+	require.NoError(err)
 
 	aresp, err := client.UpsertPushedArtifact(ctx, &pb.UpsertPushedArtifactRequest{
 		Artifact: serverptypes.TestValidArtifact(t, &pb.PushedArtifact{


### PR DESCRIPTION
This fixes a dropped test error in `internal/core`.