### PR TITLE
Add option for initial probe delay, timeout, and failure threshholds

### DIFF
--- a/.changelog/1246.txt
+++ b/.changelog/1246.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/k8s: Add new probe configuration options
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -562,7 +562,7 @@ type Config struct {
 	// made to the port.
 	ProbePath string `hcl:"probe_path,optional"`
 
-	// Probe details
+	// Probe details for describing a health check to be performed against a container.
 	Probe *Probe `hcl:"probe,block"`
 
 	// Optionally define various resources limits for kubernetes pod containers
@@ -589,6 +589,8 @@ type Config struct {
 	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 }
 
+// Probe describes a health check to be performed against a container to determine whether it is
+// alive or ready to receive traffic.
 type Probe struct {
 	// Time in seconds to wait before performing the initial liveness and readiness probes.
 	// Defaults to 5 seconds.
@@ -672,7 +674,8 @@ deploy "kubernetes" {
 	doc.SetField(
 		"probe",
 		"configuration to control liveness and readiness probes",
-		docs.Summary(),
+		docs.Summary("Probe describes a health check to be performed against a ",
+			"container to determine whether it is alive or ready to receive traffic."),
 		docs.SubFields(func(doc *docs.SubFieldDoc) {
 			doc.SetField(
 				"initial_delay",

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -248,6 +248,11 @@ func (p *Platform) Deploy(
 	// assume the first port defined is the 'main' port to use
 	defaultPort := int(containerPorts[0].ContainerPort)
 
+	initialDelaySeconds := int32(5)
+	if p.config.ProbeDelay != 0 {
+		initialDelaySeconds = int32(p.config.ProbeDelay)
+	}
+
 	// Update the deployment with our spec
 	deployment.Spec.Template.Spec = corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -262,7 +267,7 @@ func (p *Platform) Deploy(
 							Port: intstr.FromInt(defaultPort),
 						},
 					},
-					InitialDelaySeconds: 5,
+					InitialDelaySeconds: initialDelaySeconds,
 					TimeoutSeconds:      5,
 					FailureThreshold:    5,
 				},
@@ -272,7 +277,7 @@ func (p *Platform) Deploy(
 							Port: intstr.FromInt(defaultPort),
 						},
 					},
-					InitialDelaySeconds: 5,
+					InitialDelaySeconds: initialDelaySeconds,
 					TimeoutSeconds:      5,
 				},
 				Env:       env,
@@ -290,7 +295,7 @@ func (p *Platform) Deploy(
 					Port: intstr.FromInt(defaultPort),
 				},
 			},
-			InitialDelaySeconds: 5,
+			InitialDelaySeconds: initialDelaySeconds,
 			TimeoutSeconds:      5,
 			FailureThreshold:    5,
 		}
@@ -302,7 +307,7 @@ func (p *Platform) Deploy(
 					Port: intstr.FromInt(defaultPort),
 				},
 			},
-			InitialDelaySeconds: 5,
+			InitialDelaySeconds: initialDelaySeconds,
 			TimeoutSeconds:      5,
 		}
 	}
@@ -547,6 +552,10 @@ type Config struct {
 	// made to the port.
 	ProbePath string `hcl:"probe_path,optional"`
 
+	// Time in seconds to delay the initial liveness and readiness probes.
+	// Defaults to 5 seconds.
+	ProbeDelay uint `hcl:"probe_delay,optional"`
+
 	// Optionally define various resources limits for kubernetes pod containers
 	// such as memory and cpu.
 	Resources map[string]string `hcl:"resources,optional"`
@@ -634,6 +643,12 @@ deploy "kubernetes" {
 		docs.Summary(
 			"without this, the test will simply be that the application has bound to the port",
 		),
+	)
+
+	doc.SetField(
+		"probe_delay",
+		"time in seconds to delay the initial liveness and readiness probes",
+		docs.Default("5"),
 	)
 
 	doc.SetField(

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -672,27 +672,30 @@ deploy "kubernetes" {
 	doc.SetField(
 		"probe",
 		"configuration to control liveness and readiness probes",
-	)
+		docs.Summary(),
+		docs.SubFields(func(doc *docs.SubFieldDoc) {
+			doc.SetField(
+				"initial_delay",
+				"time in seconds to wait before performing the initial liveness and readiness probes",
+				docs.Default("5"),
+			)
 
-	doc.SetField(
-		"probe.initial_delay",
-		"time in seconds to wait before performing the initial liveness and readiness probes",
-		docs.Default("5"),
-	)
+			doc.SetField(
+				"timeout",
+				"time in seconds before the probe fails",
+				docs.Default("5"),
+			)
 
-	doc.SetField(
-		"probe.timeout",
-		"time in seconds before the probe fails",
-		docs.Default("5"),
-	)
+			doc.SetField(
+				"failure_threshold",
+				"number of times a liveness probe can fail before the container is killed",
+				docs.Summary(
+					"failureThreshold * TimeoutSeconds should be long enough to cover your worst case startup times",
+				),
+				docs.Default("5"),
+			)
 
-	doc.SetField(
-		"probe.failure_threshold",
-		"number of times a liveness probe can fail before the container is killed",
-		docs.Summary(
-			"failureThreshold * TimeoutSeconds should be long enough to cover your worst case startup times",
-		),
-		docs.Default("5"),
+		}),
 	)
 
 	doc.SetField(

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -675,6 +675,27 @@ deploy "kubernetes" {
 	)
 
 	doc.SetField(
+		"probe.initial_delay",
+		"time in seconds to wait before performing the initial liveness and readiness probes",
+		docs.Default("5"),
+	)
+
+	doc.SetField(
+		"probe.timeout",
+		"time in seconds before the probe fails",
+		docs.Default("5"),
+	)
+
+	doc.SetField(
+		"probe.failure_threshold",
+		"number of times a liveness probe can fail before the container is killed",
+		docs.Summary(
+			"failureThreshold * TimeoutSeconds should be long enough to cover your worst case startup times",
+		),
+		docs.Default("5"),
+	)
+
+	doc.SetField(
 		"scratch_path",
 		"a path for the service to store temporary data",
 		docs.Summary(
@@ -742,27 +763,6 @@ deploy "kubernetes" {
 			"namespace is the name of the Kubernetes namespace to apply the deployment in.",
 			"This is useful to create deployments in non-default namespaces without creating kubeconfig contexts for each",
 		),
-	)
-
-	doc.SetField(
-		"probe.initial_delay",
-		"time in seconds to wait before performing the initial liveness and readiness probes",
-		docs.Default("5"),
-	)
-
-	doc.SetField(
-		"probe.timeout",
-		"time in seconds before the probe fails",
-		docs.Default("5"),
-	)
-
-	doc.SetField(
-		"probe.failure_threshold",
-		"number of times a liveness probe can fail before the container is killed",
-		docs.Summary(
-			"failureThreshold * TimeoutSeconds should be long enough to cover your worst case startup times",
-		),
-		docs.Default("5"),
 	)
 
 	return doc, nil


### PR DESCRIPTION
If you have a project that takes more than 30 seconds to initialize, currently the only way to deploy it is by modifying the liveness initial delay seconds through kubectl. This adds the option to the kube hcl