### PR TITLE
waypoint/internal/server/singleprocess: fix dropped test error

### DIFF
--- a/internal/server/singleprocess/service_logs_test.go
+++ b/internal/server/singleprocess/service_logs_test.go
@@ -99,6 +99,7 @@ func TestServiceGetLogStream_depPlugin(t *testing.T) {
 			HasLogsPlugin: true,
 		}),
 	})
+	require.NoError(t, err)
 
 	fakeRunner, err := server.Id()
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a dropped error in `waypoint/internal/server/singleprocess`.