### PR TITLE
update package.json and README for ui dev set up

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -12,7 +12,7 @@ You will need the following things properly installed on your computer.
   - You can use node version managers to manage all of your node versions, for example [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n), etc.
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Ember CLI](https://ember-cli.com/)
-
+- [Google Chrome](https://google.com/chrome/)
 
 ## Installation
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -7,16 +7,17 @@ A short introduction of this app could easily go here.
 
 You will need the following things properly installed on your computer.
 
-- [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) (with npm)
+- [Node.js v12](https://nodejs.org/)
+  - The current codebase has been tested to run well with `node` version 12 so it is _**strongly recommended**_ that you use this version
+  - You can use node version managers to manage all of your node versions, for example [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n), etc.
+- [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Ember CLI](https://ember-cli.com/)
-- [Google Chrome](https://google.com/chrome/)
+
 
 ## Installation
 
-- `git clone <repository-url>` this repository
-- `cd waypoint`
-- `npm install`
+- `cd waypoint/ui`
+- `yarn install`
 
 ## Running / Development
 
@@ -61,7 +62,6 @@ if you've made API changes in `/internal/server` and want to use those on the fr
 
 - MacOS only: `brew install gnu-sed` then follow the instructions to replace the default `sed`
 - Download [the 1.1.2 release of `mockery`](https://github.com/vektra/mockery/releases/tag/v1.1.2) and install in your `/go/bin` directory
-- use node 12.x: `nvm use 12`
 - install `ts-protoc-gen`: `yarn global add ts-protoc-gen` or `npm i -g ts-protoc-gen`
 
 #### Generate the API definitions

--- a/ui/package.json
+++ b/ui/package.json
@@ -107,7 +107,7 @@
     "webpack-bundle-analyzer": "^3.8.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This sets a fixed node.js version to 12, as well as updating the README for setting up a local dev environment.