### PR TITLE
Make all deploy variables available in the DefaultReleaser setup

### DIFF
--- a/.changelog/1254.txt
+++ b/.changelog/1254.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: default releasers initialize properly when they use HCL variables
+```

--- a/internal/config/eval_context.go
+++ b/internal/config/eval_context.go
@@ -45,7 +45,7 @@ func appendContext(parent, child *hcl.EvalContext) *hcl.EvalContext {
 	}
 
 	// We need to get the full tree of contexts since we need to go
-	// paernt => child traversal but HCL only supports child => parent.
+	// parent => child traversal but HCL only supports child => parent.
 	var tree []*hcl.EvalContext
 	for current := child; current != nil; current = current.Parent() {
 		tree = append(tree, current)

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -103,7 +103,13 @@ func (a *App) createReleaser(ctx context.Context, hclCtx *hcl.EvalContext) (*Com
 	}
 
 	// No releaser. Let's try a default releaser if we can. We first
-	// initialize the platform.
+	// initialize the platform. We need to configure the eval context to
+	// match a deployment.
+	hclCtx = hclCtx.NewChild()
+	if _, err := a.deployEvalContext(ctx, hclCtx); err != nil {
+		return nil, err
+	}
+
 	log.Debug("no release manager plugin, initializing platform to check for default releaser")
 	platformC, err := componentCreatorMap[component.PlatformType].Create(ctx, a, hclCtx)
 	if err != nil {


### PR DESCRIPTION
This fixes two major bugs in core that have likely existed since 0.2.0:

First, when creating a _default releaser_, we need to ensure all the same HCL variables are available as during a `deploy {}` block render, since the deploy plugin is what gives us our default releaser.

Next, when setting up HCL variables, we wouldn't respect parent scopes and lose anything that wasn't in the innermost scope. This fixes our config parsing to properly respect all those scopes.