### PR TITLE
Added "timestamp" HCL function

### DIFF
--- a/.changelog/1255.txt
+++ b/.changelog/1255.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+config: `timestamp` function allows you to avail the current date and time in your Waypoint configuration.
+```

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -593,6 +593,7 @@ func (c *AppDocsCommand) funcsMDX() int {
 	addFuncs(funcs.VCSGitFuncs("."))
 	addFuncs(funcs.Filesystem())
 	addFuncs(funcs.Encoding())
+	addFuncs(funcs.Datetime())
 
 	docs := funcs.Docs()
 

--- a/internal/config/eval_context.go
+++ b/internal/config/eval_context.go
@@ -33,6 +33,7 @@ func EvalContext(parent *hcl.EvalContext, pwd string) *hcl.EvalContext {
 	addFuncs(funcs.VCSGitFuncs(pwd))
 	addFuncs(funcs.Filesystem())
 	addFuncs(funcs.Encoding())
+	addFuncs(funcs.Datetime())
 
 	return result
 }

--- a/internal/config/funcs/datetime.go
+++ b/internal/config/funcs/datetime.go
@@ -1,0 +1,24 @@
+package funcs
+
+import (
+	"time"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// Stdlib are the functions provided by the HCL stdlib.
+func Datetime() map[string]function.Function {
+	return map[string]function.Function{
+		"timestamp": TimestampFunc,
+	}
+}
+
+// TimestampFunc constructs a function that returns a string representation of the current date and time.
+var TimestampFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	Type:   function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.StringVal(time.Now().UTC().Format(time.RFC3339)), nil
+	},
+})

--- a/internal/config/funcs/datetime_test.go
+++ b/internal/config/funcs/datetime_test.go
@@ -1,0 +1,26 @@
+package funcs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestTimestamp(t *testing.T) {
+	currentTime := time.Now().UTC()
+
+	result, err := TimestampFunc.Call([]cty.Value{})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	resultTime, err := time.Parse(time.RFC3339, result.AsString())
+	if err != nil {
+		t.Fatalf("Error parsing timestamp: %s", err)
+	}
+
+	if resultTime.Sub(currentTime).Seconds() > 10.0 {
+		t.Fatalf("Timestamp Diff too large. Expected: %s\nReceived: %s", currentTime.Format(time.RFC3339), result.AsString())
+	}
+}


### PR DESCRIPTION
I'm trying to put a date into my docker registry tags with `formatdate`, but I couldn't find a way to get the current timestamp. This code was copied from Terraform. 