### PR TITLE
Project name is optional for remote operations (and does not need to match, either)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 type hclConfig struct {
-	Project string            `hcl:"project,attr"`
+	Project string            `hcl:"project,optional"`
 	Runner  *Runner           `hcl:"runner,block" default:"{}"`
 	Labels  map[string]string `hcl:"labels,optional"`
 	Plugin  []*Plugin         `hcl:"plugin,block"`

--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -90,6 +90,19 @@ func (r *Runner) executeJob(
 		return nil, err
 	}
 
+	// If we have a project specified on the job, override the configuration
+	// project with that. This allows the same Waypoint configuration to
+	// be shared by multiple projects, which is very possible in the UI,
+	// and less useful when stored as a file in the repo.
+	if v := job.Application.Project; v != "" {
+		cfg.Project = v
+	}
+
+	// Validate our configuration
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	// Setup our project data directory.
 	projDir, err := datadir.NewProject(filepath.Join(wd, ".waypoint"))
 	if err != nil {

--- a/ui/app/templates/workspace/projects/new.hbs
+++ b/ui/app/templates/workspace/projects/new.hbs
@@ -12,9 +12,6 @@
         <label for="project-name" class="pds-fieldName">
           {{t 'form.project_new.project_name_label'}}
         </label>
-        <Pds::HelpText>
-          <p>{{t 'form.project_new.project_name_helptext'}}</p>
-        </Pds::HelpText>
         <Pds::Input
           @type="text"
           id="project-name"

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -28,7 +28,6 @@ form:
   project_new:
     title: 'New Project'
     project_name_label: 'Project Name'
-    project_name_helptext: 'The Project Name needs to match your waypoint.hcl configuration.'
     create_git_label: 'Git Configuration'
     create_git_helptext: 'Connect a git repository. If you skip this, you can always configure it later in project settings.'
     create_git_checkbox_label: 'Connect a Git repository to this Project'

--- a/website/content/docs/waypoint-hcl/index.mdx
+++ b/website/content/docs/waypoint-hcl/index.mdx
@@ -131,7 +131,9 @@ variables in the dedicated [variables section](/docs/waypoint-hcl/variables).
 
 - `project` `(string)` - The name of the project. This should be unique
   for the Waypoint server and must not be changed later. This is used to
-  organize information on the server.
+  organize information on the server. **This field is optional if you're
+  using [remote operations](/docs/projects/remote), including those
+  triggered via [Git polling](/docs/projects/git).**
 
 ~> **Warning: the project name can not be changed.** Changing the project
 name is not currently supported. If you change the name, the history,


### PR DESCRIPTION
I noticed the UI had this little note:

![image](https://user-images.githubusercontent.com/1299/113795675-4a776700-9702-11eb-8b8e-1805c1862fea.png)

And I didn't like it! The behavior when the projects didn't match was weird (it'd just _create_ a new project of that name on run) and this requirement to have the UI field exactly match something in the waypoint.hcl just was a poor UX.

This PR makes it so that the project field is optional for remote operations. If it is specified, the project name that invoked the operation _always takes precedence_. So even if the waypoint.hcl says `project = "foo"`, if you create a project in the UI named `my-website`, the operations and such will be associated with `my-website` and "foo" will be totally ignored.

You must still specify a `project` attribute for local operations, local `waypoint init`, etc. 