### PR TITLE
Default git ref to HEAD

### DIFF
--- a/ui/app/components/app-form/project-settings.ts
+++ b/ui/app/components/app-form/project-settings.ts
@@ -48,7 +48,7 @@ const DEFAULT_PROJECT_MODEL = {
     git: {
       url: '',
       path: '',
-      ref: '',
+      ref: 'HEAD',
       basic: {
         username: '',
         password: ''
@@ -201,7 +201,11 @@ export default class AppFormProjectSettings extends Component<ProjectSettingsArg
     let git = new Job.Git();
     git.setUrl(project.dataSource.git.url);
     git.setPath(project.dataSource.git.path);
-    git.setRef(project.dataSource.git.ref);
+    if (!project.dataSource.git.ref) {
+      git.setRef('HEAD');
+    } else {
+      git.setRef(project.dataSource.git.ref);
+    }
 
     // Git Authentication settings
     if (this.authBasic) {


### PR DESCRIPTION
Addresses #1264

- defaults field value to `HEAD`
- if ref is deleted and left empty, API query sets it to `HEAD` anyway