### PR TITLE
refetch model on route reentry

### DIFF
--- a/ui/app/routes/workspace/projects/project/settings.ts
+++ b/ui/app/routes/workspace/projects/project/settings.ts
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
-import { Project} from 'waypoint-pb';
+import { Ref, GetProjectRequest } from 'waypoint-pb';
+interface ProjectModelParams {
+  project_id: string;
+}
 
 export default class WorkspaceProjectsProjectSettings extends Route {
   @service api!: ApiService;
@@ -23,7 +26,16 @@ export default class WorkspaceProjectsProjectSettings extends Route {
   }
 
   async model() {
-    let proj = this.modelFor('workspace.projects.project') as Project.AsObject;
-    return proj;
+    // Setup the project request
+    let ref = new Ref.Project();
+    let params = this.paramsFor('workspace.projects.project') as ProjectModelParams;
+    ref.setProject(params.project_id);
+    let req = new GetProjectRequest();
+    req.setProject(ref);
+
+    let resp = await this.api.client.getProject(req, this.api.WithMeta());
+    let project = resp.getProject();
+
+    return project?.toObject();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/1268

Previously, the model would cache on the route, and not update properly, this fixes it by refetching when entering the route.