### PR TITLE
wrap log output to container width (for breakable content)

### DIFF
--- a/ui/app/styles/_page.scss
+++ b/ui/app/styles/_page.scss
@@ -509,6 +509,7 @@
         font-size: 12px;
         padding: scale.$sm-4 0;
         line-height: var(--pds-lineHeight--dense);
+        white-space: pre-wrap;
 
         &:empty {
           display: none;

--- a/ui/app/styles/_page.scss
+++ b/ui/app/styles/_page.scss
@@ -462,6 +462,7 @@
         width: 100%;
         flex-shrink: 0;
         overflow-x: auto;
+        max-width: 73rem;
 
         &::-webkit-scrollbar {
           width: scale.$sm-3;


### PR DESCRIPTION
<img width="362" alt="Screen Shot 2021-04-07 at 19 46 24" src="https://user-images.githubusercontent.com/1416421/113911330-2ab37200-97da-11eb-9976-1acc86a8e45b.png">

Fixes https://github.com/hashicorp/waypoint/issues/1277