### PR TITLE
Quickfix for input contrast in dark mode

### DIFF
--- a/ui/app/styles/_input.scss
+++ b/ui/app/styles/_input.scss
@@ -25,6 +25,14 @@ $input-focus: inset 0 1px 1px 1px rgba(var(--shadow), 0.1), 0 0 0 3px rgba(var(-
   }
 }
 
+.pds-input.pds--textLike, .pds-textarea {
+  color: rgb(var(--input-text));
+  background: rgb(var(--input));
+  &::placeholder {
+    color: rgb(var(--input-text-placeholder));
+  }
+}
+
 input {
   color: rgb(var(--input-text));
   font-size: scale.$base;

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -75,6 +75,8 @@ $button-shadow: 0 3px 2px rgba(var(--shadow), 0.2);
     --info: #{dehex(color.$blue-800)};
     --info-text: #{dehex(color.$blue-200)};
     --pds-color: #{dehex(color.$white)};
+    --pds-input-backgroundColor: #{dehex(color.$ui-cool-gray-900)};
+    --pds-input-color: #{dehex(color.$white)};
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/1262 

We'll do a better fix with `pds-addon` later

<img width="1070" alt="Screen Shot 2021-04-07 at 22 17 09" src="https://user-images.githubusercontent.com/1416421/113928799-8b997500-97ef-11eb-994a-274ae59ea63b.png">
<img width="1170" alt="Screen Shot 2021-04-07 at 22 17 00" src="https://user-images.githubusercontent.com/1416421/113928816-8fc59280-97ef-11eb-96d9-b387a7463013.png">
