### PR TITLE
Makefile: Use host network for pulling packages when building docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ docker/server:
 					--secret id=ssh.config,src="${HOME}/.ssh/config" \
 					--secret id=ssh.key,src="${HOME}/.ssh/config" \
 					-t waypoint:dev \
+					--network host \
 					.
 
 .PHONY: docker/evanphx


### PR DESCRIPTION
My docker engine seems to occasionally have issues pulling packages when building waypoint server.

```
#16 5.647 fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
#16 5.647 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.13/main: temporary error (try again later)
```

Using my host network resolves this, so adding a `--network` flag to the `docker/server` make target. If this isn't desired we can close this, but otherwise I'll have to keep this stashed locally since that seems to be the only reliable way I can fix this issue.