### PR TITLE
Update runner stanza with 'enabled' instead of 'enable'

### DIFF
--- a/website/content/docs/waypoint-hcl/runner.mdx
+++ b/website/content/docs/waypoint-hcl/runner.mdx
@@ -22,7 +22,7 @@ command or via the UI by creating or modifying a project.
 
 ```hcl
 runner {
-  enable = true
+  enabled = true
 
   data_source "git" {
     url  = "https://github.com/hashicorp/waypoint-examples.git"


### PR DESCRIPTION
Update documentation to show correct values in the runner stanza.

```hcl
runner {
  enabled = true

  data_source "git" {
    url  = "https://github.com/hashicorp/waypoint-examples.git"
    path = "docker/node-js"
  }
}
