### PR TITLE
Nomad Jobspec Plugin

### DIFF
--- a/.changelog/1299.txt
+++ b/.changelog/1299.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugin/nomad: A new plugin "nomad-jobspec" for deploying a Nomad job specification directly.
+```

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -1,0 +1,226 @@
+package jobspec
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	"github.com/hashicorp/waypoint-plugin-sdk/docs"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/waypoint/builtin/docker"
+	"github.com/hashicorp/waypoint/builtin/nomad"
+)
+
+const (
+	metaId = "waypoint.hashicorp.com/id"
+)
+
+// Platform is the Platform implementation for Nomad.
+type Platform struct {
+	config Config
+}
+
+// Config implements Configurable
+func (p *Platform) Config() (interface{}, error) {
+	return &p.config, nil
+}
+
+// DeployFunc implements component.Platform
+func (p *Platform) DeployFunc() interface{} {
+	return p.Deploy
+}
+
+// DestroyFunc implements component.Destroyer
+func (p *Platform) DestroyFunc() interface{} {
+	return p.Destroy
+}
+
+// GenerationFunc implements component.Generation
+func (p *Platform) GenerationFunc() interface{} {
+	return p.Generation
+}
+
+// Deploy deploys an image to Nomad.
+func (p *Platform) Deploy(
+	ctx context.Context,
+	log hclog.Logger,
+	src *component.Source,
+	img *docker.Image,
+	deployConfig *component.DeploymentConfig,
+	ui terminal.UI,
+) (*nomad.Deployment, error) {
+	// We'll update the user in real time
+	sg := ui.StepGroup()
+	defer sg.Wait()
+	s := sg.Add("Initializing the Nomad client...")
+	defer func() { s.Abort() }()
+
+	// Get our client
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+	jobclient := client.Jobs()
+
+	// Parse the HCL
+	s.Update("Parsing the job specification...")
+	job, err := p.jobspec(client, p.config.Jobspec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create our deployment and set an initial ID
+	var result nomad.Deployment
+	result.Id = deployConfig.Id
+	result.Name = *job.ID
+
+	// Set our deployment ID on the meta.
+	job.SetMeta(metaId, result.Id)
+
+	// Register job
+	s.Update("Registering job %q...", *job.Name)
+	regResult, _, err := jobclient.Register(job, nil)
+	if err != nil {
+		return nil, err
+	}
+	s.Done()
+
+	// Wait on the allocation
+	st := ui.Status()
+	defer st.Close()
+	evalID := regResult.EvalID
+	st.Update(fmt.Sprintf("Monitoring evaluation %q", evalID))
+	if err := nomad.NewMonitor(st, client).Monitor(evalID); err != nil {
+		return nil, err
+	}
+	st.Step(terminal.StatusOK, "Deployment successfully rolled out!")
+
+	return &result, nil
+}
+
+// Destroy deletes the Nomad job.
+func (p *Platform) Destroy(
+	ctx context.Context,
+	log hclog.Logger,
+	deployment *nomad.Deployment,
+	ui terminal.UI,
+) error {
+	// We'll update the user in real time
+	st := ui.Status()
+	defer st.Close()
+
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return err
+	}
+
+	st.Update("Deleting job...")
+	_, _, err = client.Jobs().Deregister(deployment.Name, true, nil)
+	return err
+}
+
+// Generation returns the generation ID. The ID we use is the name of the
+// job since this is the unique ID that determines insert vs. update behavior
+// for Nomad.
+func (p *Platform) Generation(
+	ctx context.Context,
+	log hclog.Logger,
+	src *component.Source,
+	img *docker.Image,
+	deployConfig *component.DeploymentConfig,
+	ui terminal.UI,
+) ([]byte, error) {
+	// Get our client
+	client, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the HCL
+	job, err := p.jobspec(client, p.config.Jobspec)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(*job.ID), nil
+}
+
+func (p *Platform) jobspec(client *api.Client, path string) (*api.Job, error) {
+	jobspec, err := ioutil.ReadFile(p.config.Jobspec)
+	if err != nil {
+		return nil, err
+	}
+	job, err := client.Jobs().ParseHCL(string(jobspec), true)
+	if err != nil {
+		return nil, err
+	}
+	if job.ID == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "job ID must not be empty")
+	}
+	if job.Name == nil {
+		job.Name = job.ID
+	}
+
+	return job, nil
+}
+
+// Config is the configuration structure for the Platform.
+type Config struct {
+	// The path to the job specification to load.
+	Jobspec string `hcl:"jobspec,attr"`
+}
+
+func (p *Platform) Documentation() (*docs.Documentation, error) {
+	doc, err := docs.New(docs.FromConfig(&Config{}), docs.FromFunc(p.DeployFunc()))
+	if err != nil {
+		return nil, err
+	}
+
+	doc.Description(`
+Deploy to a Nomad cluster from a pre-existing Nomad job specification file.
+
+This plugin lets you use any pre-existing Nomad job specification file to
+deploy to Nomad. This deployment is able to support all the features of Waypoint.
+You may use Waypoint's [templating features](https://www.waypointproject.io/docs/waypoint-hcl/functions/template)
+to template the Nomad jobspec with information such as the artifact from
+a previous build step, entrypoint environment variables, etc.
+`)
+
+	doc.Example(`
+deploy {
+  use "nomad-jobspec" {
+    jobspec = "${path.app}/app.nomad"
+  }
+}
+`)
+
+	doc.Example(`
+deploy {
+  use "nomad-jobspec" {
+    // Templated to perhaps bring in the artifact from a previous
+	// build/registry, entrypoint env vars, etc.
+    jobspec = templatefile("${path.app}/app.nomad.tpl")
+  }
+}
+`)
+
+	doc.SetField(
+		"jobspec",
+		"Path to a Nomad job specification file.",
+	)
+
+	return doc, nil
+}
+
+var (
+	_ component.Generation   = (*Platform)(nil)
+	_ component.Platform     = (*Platform)(nil)
+	_ component.Configurable = (*Platform)(nil)
+	_ component.Destroyer    = (*Platform)(nil)
+)

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -187,9 +187,35 @@ Deploy to a Nomad cluster from a pre-existing Nomad job specification file.
 
 This plugin lets you use any pre-existing Nomad job specification file to
 deploy to Nomad. This deployment is able to support all the features of Waypoint.
-You may use Waypoint's [templating features](https://www.waypointproject.io/docs/waypoint-hcl/functions/template)
+You may use Waypoint's [templating features](/docs/waypoint-hcl/functions/template)
 to template the Nomad jobspec with information such as the artifact from
 a previous build step, entrypoint environment variables, etc.
+
+### Artifact Access
+
+You may use Waypoint's [templating features](/docs/waypoint-hcl/functions/template)
+to access information such as the artifact from the build or push stages.
+An example below shows this by using ` + "`templatefile`" + ` mixed with
+variables such as ` + "`artifact.image`" + ` to dynamically configure the
+Docker image within the Nomad job specification.
+
+### Entrypoint Functionality
+
+Waypoint [entrypoint functionality](/docs/entrypoint#functionality) such
+as logs, exec, app configuration, and more require two properties to be true:
+
+1. The running image must already have the Waypoint entrypoint installed
+  and configured as the entrypoint. This should happen in the build stage.
+
+2. Proper environment variables must be set so the entrypoint knows how
+  to communicate to the Waypoint server. **This step happens in this
+  deployment stage.**
+
+**Step 2 does not happen automatically.** You must manually set the entrypoint
+environment variables using the [templating feature](/docs/waypoint-hcl/functions/template).
+One of the examples below shows the entrypoint environment variables being
+injected.
+
 `)
 
 	doc.Example(`
@@ -201,11 +227,33 @@ deploy {
 `)
 
 	doc.Example(`
+// The waypoint.hcl file
 deploy {
   use "nomad-jobspec" {
     // Templated to perhaps bring in the artifact from a previous
 	// build/registry, entrypoint env vars, etc.
     jobspec = templatefile("${path.app}/app.nomad.tpl")
+  }
+}
+
+// The app.nomad.tpl file
+job "web" {
+  datacenters = ["dc1"]
+
+  group "app" {
+    task "app" {
+      driver = "docker"
+
+      config {
+        image = "${artifact.image}:${artifact.tag}"
+      }
+
+      env {
+        %{ for k,v in entrypoint.env ~}
+        ${k} = "${v}"
+        %{ endfor ~}
+      }
+    }
   }
 }
 `)

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -242,7 +242,7 @@ deploy {
 deploy {
   use "nomad-jobspec" {
     // Templated to perhaps bring in the artifact from a previous
-	// build/registry, entrypoint env vars, etc.
+    // build/registry, entrypoint env vars, etc.
     jobspec = templatefile("${path.app}/app.nomad.tpl")
   }
 }
@@ -264,9 +264,9 @@ job "web" {
         ${k} = "${v}"
         %{ endfor ~}
 
-		// Ensure we set PORT for the URL service. This is only necessary
-		// if we want the URL service to function.
-		PORT = 3000
+        // Ensure we set PORT for the URL service. This is only necessary
+        // if we want the URL service to function.
+        PORT = 3000
       }
     }
   }

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -216,6 +216,17 @@ environment variables using the [templating feature](/docs/waypoint-hcl/function
 One of the examples below shows the entrypoint environment variables being
 injected.
 
+### URL Service
+
+If you want your workload to be accessible by the
+[Waypoint URL service](/docs/url), you must set the PORT environment variable
+within your job and be using the Waypoint entrypoint (documented in the
+previous section).
+
+The PORT environment variable should be the port that your web service
+is listening on that the URL service will connect to. See one of the examples
+below for more details.
+
 `)
 
 	doc.Example(`
@@ -252,6 +263,10 @@ job "web" {
         %{ for k,v in entrypoint.env ~}
         ${k} = "${v}"
         %{ endfor ~}
+
+		// Ensure we set PORT for the URL service. This is only necessary
+		// if we want the URL service to function.
+		PORT = 3000
       }
     }
   }

--- a/builtin/nomad/jobspec/plugin.go
+++ b/builtin/nomad/jobspec/plugin.go
@@ -1,0 +1,11 @@
+package jobspec
+
+import (
+	"github.com/hashicorp/waypoint-plugin-sdk"
+)
+
+// Options are the SDK options to use for instantiation for
+// the Nomad plugin.
+var Options = []sdk.Option{
+	sdk.WithComponents(&Platform{}),
+}

--- a/builtin/nomad/monitor.go
+++ b/builtin/nomad/monitor.go
@@ -62,7 +62,7 @@ type monitor struct {
 
 // newMonitor returns a new monitor. The returned monitor will
 // write output information to the provided ui.
-func newMonitor(ui terminal.Status, client *api.Client) *monitor {
+func NewMonitor(ui terminal.Status, client *api.Client) *monitor {
 	mon := &monitor{
 		ui:     ui,
 		client: client,
@@ -126,9 +126,9 @@ func (m *monitor) update(update *evalState) {
 	}
 }
 
-// monitor is used to start monitoring the given evaluation ID. It
+// Monitor is used to start monitoring the given evaluation ID. It
 // writes output directly to the terminal ui, and returns an error.
-func (m *monitor) monitor(evalID string) error {
+func (m *monitor) Monitor(evalID string) error {
 	// Track if we encounter a scheduling failure. This can only be
 	// detected while querying allocations, so we use this bool to
 	// carry that status into the return code.

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -175,7 +175,7 @@ func (p *Platform) Deploy(
 	// Wait on the allocation
 	st.Update(fmt.Sprintf("Monitoring evaluation %q", evalID))
 
-	if err := newMonitor(st, client).monitor(evalID); err != nil {
+	if err := NewMonitor(st, client).Monitor(evalID); err != nil {
 		return nil, err
 	}
 	st.Step(terminal.StatusOK, "Deployment successfully rolled out!")

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -23,6 +23,7 @@ import (
 	pluginK8s "github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/builtin/netlify"
 	"github.com/hashicorp/waypoint/builtin/nomad"
+	"github.com/hashicorp/waypoint/builtin/nomad/jobspec"
 	"github.com/hashicorp/waypoint/builtin/pack"
 	"github.com/hashicorp/waypoint/builtin/tfc"
 	"github.com/hashicorp/waypoint/builtin/vault"
@@ -45,6 +46,7 @@ var (
 		"aws-ecs":                  ecs.Options,
 		"aws-ecr":                  ecr.Options,
 		"nomad":                    nomad.Options,
+		"nomad-jobspec":            jobspec.Options,
 		"aws-ami":                  ami.Options,
 		"aws-ec2":                  ec2.Options,
 		"aws-alb":                  alb.Options,


### PR DESCRIPTION
Builds on #1298. 

This introduces a plugin that can deploy to Nomad directly from a job specification file. This uses the mutable deployments functionality introduced in #1298. Example below:

```hcl
// The waypoint.hcl file
deploy {
  use "nomad-jobspec" {
    // Templated to perhaps bring in the artifact from a previous
	// build/registry, entrypoint env vars, etc.
    jobspec = templatefile("${path.app}/app.nomad.tpl")
  }
}
// The app.nomad.tpl file
job "web" {
  datacenters = ["dc1"]
  group "app" {
    task "app" {
      driver = "docker"
      config {
        image = "${artifact.image}:${artifact.tag}"

        // For local Nomad, you prob don't need this on a real deploy
        network_mode = "host"
      }
      env {
        %{ for k,v in entrypoint.env ~}
        ${k} = "${v}"
        %{ endfor ~}

        // For URL service
        PORT = "3000"
      }
    }
  }
}
```