### PR TITLE
Fixes #1295: Use namespace config option when deploying nomad job

### DIFF
--- a/.changelog/1300.txt
+++ b/.changelog/1300.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/nomad: use namespace config option for deploy
+```

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -111,6 +111,7 @@ func (p *Platform) Deploy(
 				},
 			},
 		}
+		job.Namespace = &p.config.Namespace
 		job.AddTaskGroup(tg)
 		tg.AddTask(&api.Task{
 			Name:   result.Name,


### PR DESCRIPTION
Prior to this commit, the namespace config option was not used when
configuring a job for deploy. This commit fixes that by honoring the
namespace config value and using it for the job alloc.