### PR TITLE
Fix GRPC TLS connect

### DIFF
--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -97,7 +97,7 @@ func New(ctx context.Context, opts ...Option) (*Project, error) {
 		client.activeRunner = r
 
 		// We spin up the job processing here. Anything that spawns jobs (either locally spawned
-		// or server spawned) will be processed by this runner ONLY if the runner is directly targetted.
+		// or server spawned) will be processed by this runner ONLY if the runner is directly targeted.
 		// Because this runner's lifetime is bound to a CLI context and therefore transient, we don't
 		// want to accept jobs that aren't related to local activities (job's queued or RPCs made)
 		// because they'll hang the CLI randomly as those jobs run (it's also a security issue).
@@ -112,7 +112,7 @@ func New(ctx context.Context, opts ...Option) (*Project, error) {
 }
 
 // LocalRunnerId returns the id of the runner that this project started
-// This is used to target jobs specificly at this runner.
+// This is used to target jobs specifically at this runner.
 func (c *Project) LocalRunnerId() (string, bool) {
 	if c.activeRunner == nil {
 		return "", false

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -59,6 +59,10 @@ func Connect(ctx context.Context, opts ...ConnectOption) (*grpc.ClientConn, erro
 		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(
 			credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}),
 		))
+	} else {
+		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(
+			credentials.NewTLS(&tls.Config{}),
+		))
 	}
 
 	if cfg.Auth {


### PR DESCRIPTION
When a new context is created and `-server-tls` is set to true, but `-server-tls-skip-verify` is false (default configuration!), the TLS options are not added to the GRPC dial options, causing (in my case) the following error:

```
$ waypoint context verify
 ! Connecting with context "dev"...
! Error connecting with context "dev": grpc: no transport security set (use grpc.WithInsecure() explicitly or set
  credentials)
```

With this PR, the behavior is fixed and we're now able to connect to a TLS backend without a problem:

```
___waypoint_context_verify context verify
 + Context "dev" connected successfully.
```