### PR TITLE
k8s: support multiple scratch_path, add Pod Security Context config

### DIFF
--- a/builtin/k8s/deployment.go
+++ b/builtin/k8s/deployment.go
@@ -22,7 +22,7 @@ func (d *Deployment) newDeployment(name string) *appsv1.Deployment {
 		},
 
 		// Note both name and app are included here. 'app' is expected for certain
-		// k8s integrations, where as waypoint expepcts 'name' else where for release
+		// k8s integrations, where as waypoint expects 'name' else where for release
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{


### PR DESCRIPTION
This commit adds the support for multiple scratch_paths:

```hcl
deploy {
  use "kubernetes" {
    image_secret = "regcred"
    scratch_path = [
      "/tmp",
      "/var/cache"
    ]
  }
}
```

and additionally adds support for pod configurations (for now only limited to `security_context`):

```hcl

deploy {
  use "kubernetes" {
    pod {
      security_context {
        run_as_user = 1000
        run_as_non_root = true
      }
    }
  }
}
```