### PR TITLE
feat(builtin/k8s): Kubernetes improvements

### DIFF
--- a/.changelog/1317.txt
+++ b/.changelog/1317.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugins/k8s: Add more configuration options to Kubernetes plugin
+```

--- a/.changelog/1317.txt
+++ b/.changelog/1317.txt
@@ -1,3 +1,8 @@
-```release-note:feature
+```release-note:improvement
 plugins/k8s: Add more configuration options to Kubernetes plugin
+```
+
+```release-note:breaking-change
+plugins/k8s: `scratch_path` now uses an array of strings instead of a string, allowing you to specify
+multiple directories to be mounted as [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
 ```

--- a/.changelog/1317.txt
+++ b/.changelog/1317.txt
@@ -1,5 +1,5 @@
 ```release-note:improvement
-plugins/k8s: Add more configuration options to Kubernetes plugin
+plugins/k8s: Add configuration options for pods and its security contexts
 ```
 
 ```release-note:breaking-change

--- a/builtin/k8s/deployment.go
+++ b/builtin/k8s/deployment.go
@@ -22,7 +22,7 @@ func (d *Deployment) newDeployment(name string) *appsv1.Deployment {
 		},
 
 		// Note both name and app are included here. 'app' is expected for certain
-		// k8s integrations, where as waypoint expepcts 'name' else where for release
+		// k8s integrations, where as waypoint expects 'name' else where for release
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -599,8 +599,8 @@ type Config struct {
 	// such as memory and cpu.
 	Resources map[string]string `hcl:"resources,optional"`
 
-	// A path to a directory that will be created for the service to store
-	// temporary data.
+	// An array of paths to directories that will be mounted as EmptyDirVolumes in the pod
+	// to store temporary data.
 	ScratchSpace []string `hcl:"scratch_path,optional"`
 
 	// ServiceAccount is the name of the Kubernetes service account to apply to the

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -618,6 +618,7 @@ type Config struct {
 	// config commands.
 	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 
+	// Pod describes the configuration for the pod
 	Pod *Pod `hcl:"pod,block"`
 }
 

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -153,7 +153,7 @@ func (p *Platform) Deploy(
 	// Build our env vars
 	env := []corev1.EnvVar{
 		{
-			Name:  "WAYPOINT_EXPOSED_PORT",
+			Name:  "PORT",
 			Value: fmt.Sprint(p.config.Ports[0]["port"]),
 		},
 	}

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -291,7 +291,7 @@ func (p *Platform) Deploy(
 		Resources: resourceRequirements,
 	}
 
-	if p.config.Pod.Container != nil {
+	if p.config.Pod != nil && p.config.Pod.Container != nil {
 		containerCfg := p.config.Pod.Container
 		if containerCfg.Command != nil {
 			container.Command = *containerCfg.Command


### PR DESCRIPTION
This PR adds multiple new configuration options to the Kubernetes plugin, namely:

#### dbc0c0bfb86c6bf3dc0edd6df1195ae184e63a4d k8s: support multiple scratch_path, add Pod Security Context config

This commit adds the support for multiple scratch_paths:

```hcl
deploy {
  use "kubernetes" {
    image_secret = "regcred"
    scratch_path = [
      "/tmp",
      "/var/cache"
    ]
  }
}
```

and additionally adds support for pod configurations (for now
only limited to `security_context`):

```hcl

deploy {
  use "kubernetes" {
    pod {
      security_context {
        run_as_user = 1000
        run_as_non_root = true
      }
    }
  }
}
```

---

#### 970c025e86c631d7881aa67e5789f810a1405b39 k8s: add more options, rename PORT env to WAYPOINT_EXPOSED_PORT

This commit adds the possibility to specify new config elements in the HCL file. With these additions is now possible to define a `container` block that can be used to specify:

- `command`
- `args`

In addition to this change, PodSecurityContext now supports the `fs_group` option.

This commit additionally adds a (maybe controversial?) change. The `PORT` environment variable is renamed to `WAYPOINT_EXPOSED_PORT` to avoid clashing with other environment variables that might have been specified in `static_environment`