### PR TITLE
{serverinstall/builtin}/nomad: Provide config values for memory and CPU

### DIFF
--- a/.changelog/1318.txt
+++ b/.changelog/1318.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugin/nomad: Add CPU and Memory resource options for server and runner installs
+```

--- a/.changelog/1318.txt
+++ b/.changelog/1318.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-plugin/nomad: Add CPU and Memory resource options for server and runner installs
+plugin/nomad: Add CPU and Memory resource options for server and runner installs, and app deploys
 ```

--- a/.changelog/1318.txt
+++ b/.changelog/1318.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 plugin/nomad: Add CPU and Memory resource options for server and runner installs
 ```

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	// default resources used for the deployed app. Can be overridden
-	// through config flags at install. Note that these are the same defaults
+	// through the resources stanza in a deploy. Note that these are the same defaults
 	// used currently in Nomad if left unconfigured.
 	defaultResourcesCPU      = 100
 	defaultResourcesMemoryMB = 300

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,14 @@ import (
 const (
 	metaId    = "waypoint.hashicorp.com/id"
 	metaNonce = "waypoint.hashicorp.com/nonce"
+)
+
+var (
+	// default resources used for the deployed app. Can be overridden
+	// through config flags at install. Note that these are the same defaults
+	// used currently in Nomad if left unconfigured.
+	defaultResourcesCPU      = 100
+	defaultResourcesMemoryMB = 300
 )
 
 // Platform is the Platform implementation for Nomad.
@@ -113,10 +122,19 @@ func (p *Platform) Deploy(
 		}
 		job.Namespace = &p.config.Namespace
 		job.AddTaskGroup(tg)
-		tg.AddTask(&api.Task{
+		task := &api.Task{
 			Name:   result.Name,
 			Driver: "docker",
-		})
+		}
+
+		if p.config.Resources != nil {
+			task.Resources = &api.Resources{
+				CPU:      p.config.Resources.CPU,
+				MemoryMB: p.config.Resources.MemoryMB,
+			}
+		}
+
+		tg.AddTask(task)
 		err = nil
 	}
 	if err != nil {
@@ -222,6 +240,10 @@ type Config struct {
 	// The Nomad region to deploy to, defaults to "global"
 	Region string `hcl:"region,optional"`
 
+	// The amount of resources to allocate to the Nomad task for the deployed
+	// application
+	Resources *Resources `hcl:"resources,block"`
+
 	// Port that your service is running on within the actual container.
 	// Defaults to port 3000.
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
@@ -233,6 +255,11 @@ type Config struct {
 	// selected via environment variable. Most configuration should use the waypoint
 	// config commands.
 	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
+}
+
+type Resources struct {
+	CPU      *int `hcl:"cpu,optional"`
+	MemoryMB *int `hcl:"memorymb,optional"`
 }
 
 // AuthConfig maps the the Nomad Docker driver 'auth' config block
@@ -291,6 +318,24 @@ deploy {
 		"replicas",
 		"The replica count for the job.",
 		docs.Default("1"),
+	)
+
+	doc.SetField(
+		"resources",
+		"The amount of resources to allocate to the deployed allocation.",
+		docs.SubFields(func(doc *docs.SubFieldDoc) {
+			doc.SetField(
+				"cpu",
+				"Amount of CPU in MHz to allocate to this task",
+				docs.Default(strconv.Itoa(defaultResourcesCPU)),
+			)
+
+			doc.SetField(
+				"memorymb",
+				"Amount of memory in MB to allocate to this task.",
+				docs.Default(strconv.Itoa(defaultResourcesMemoryMB)),
+			)
+		}),
 	)
 
 	doc.SetField(

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -663,11 +663,11 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	cpu := defaultResourcesCPU
 	mem := defaultResourcesMemory
 
-	if c.runnerResourcesCPU != "" {
+	if c.serverResourcesCPU != "" {
 		cpu, _ = strconv.Atoi(c.serverResourcesCPU)
 	}
 
-	if c.runnerResourcesMemory != "" {
+	if c.serverResourcesMemory != "" {
 		mem, _ = strconv.Atoi(c.serverResourcesMemory)
 	}
 	task.Resources = &api.Resources{
@@ -839,7 +839,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-runner-memory",
 		Target:  &i.config.runnerResourcesCPU,
-		Usage:   "MB of Memory to allocate to the Server job task.",
+		Usage:   "MB of Memory to allocate to the runner job task.",
 		Default: strconv.Itoa(defaultResourcesMemory),
 	})
 
@@ -904,7 +904,7 @@ func (i *NomadInstaller) UpgradeFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-server-memory",
 		Target:  &i.config.serverResourcesMemory,
-		Usage:   "MB of Memory to allocate to the Server job task.",
+		Usage:   "MB of Memory to allocate to the server job task.",
 		Default: strconv.Itoa(defaultResourcesMemory),
 	})
 
@@ -918,7 +918,7 @@ func (i *NomadInstaller) UpgradeFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-runner-memory",
 		Target:  &i.config.runnerResourcesMemory,
-		Usage:   "MB of Memory to allocate to the Server job task.",
+		Usage:   "MB of Memory to allocate to the runner job task.",
 		Default: strconv.Itoa(defaultResourcesMemory),
 	})
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -29,7 +29,19 @@ type nomadConfig struct {
 	region         string   `hcl:"namespace,optional"`
 	datacenters    []string `hcl:"datacenters,optional"`
 	policyOverride bool     `hcl:"policy_override,optional"`
+
+	serverResourcesCPU    string `hcl:"server_resources_cpu,optional"`
+	serverResourcesMemory string `hcl:"server_resources_memory,optional"`
+	runnerResourcesCPU    string `hcl:"runner_resources_cpu,optional"`
+	runnerResourcesMemory string `hcl:"runner_resources_memory,optional"`
 }
+
+var (
+	// default resources used for both the Server and its runners. Can be overridden
+	// through config flags at install
+	defaultResourcesCPU    = 200
+	defaultResourcesMemory = 600
+)
 
 // Install is a method of NomadInstaller and implements the Installer interface to
 // register a waypoint-server job with a Nomad cluster
@@ -647,6 +659,21 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	task.Env = map[string]string{
 		"PORT": defaultGrpcPort,
 	}
+
+	cpu := defaultResourcesCPU
+	mem := defaultResourcesMemory
+
+	if c.runnerResourcesCPU != "" {
+		cpu, _ = strconv.Atoi(c.serverResourcesCPU)
+	}
+
+	if c.runnerResourcesMemory != "" {
+		mem, _ = strconv.Atoi(c.serverResourcesMemory)
+	}
+	task.Resources = &api.Resources{
+		CPU:      &cpu,
+		MemoryMB: &mem,
+	}
 	tg.AddTask(task)
 
 	return job
@@ -677,6 +704,21 @@ func waypointRunnerNomadJob(c nomadConfig, opts *InstallRunnerOpts) *api.Job {
 			"-vvv",
 		},
 		"auth_soft_fail": c.authSoftFail,
+	}
+
+	cpu := defaultResourcesCPU
+	mem := defaultResourcesMemory
+
+	if c.runnerResourcesCPU != "" {
+		cpu, _ = strconv.Atoi(c.runnerResourcesCPU)
+	}
+
+	if c.runnerResourcesMemory != "" {
+		mem, _ = strconv.Atoi(c.runnerResourcesMemory)
+	}
+	task.Resources = &api.Resources{
+		CPU:      &cpu,
+		MemoryMB: &mem,
 	}
 
 	task.Env = map[string]string{}
@@ -774,6 +816,34 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
+		Name:    "nomad-server-cpu",
+		Target:  &i.config.serverResourcesCPU,
+		Usage:   "Number of CPUs to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesCPU),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-server-memory",
+		Target:  &i.config.serverResourcesCPU,
+		Usage:   "MB of Memory to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesMemory),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-runner-cpu",
+		Target:  &i.config.runnerResourcesCPU,
+		Usage:   "Number of CPUs to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesCPU),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-runner-memory",
+		Target:  &i.config.runnerResourcesCPU,
+		Usage:   "MB of Memory to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesMemory),
+	})
+
+	set.StringVar(&flag.StringVar{
 		Name:    "nomad-server-image",
 		Target:  &i.config.serverImage,
 		Usage:   "Docker image for the Waypoint server.",
@@ -822,6 +892,34 @@ func (i *NomadInstaller) UpgradeFlags(set *flag.Set) {
 		Target:  &i.config.region,
 		Default: "global",
 		Usage:   "Region to install to for Nomad.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-server-cpu",
+		Target:  &i.config.serverResourcesCPU,
+		Usage:   "CPU required to run this task in MHz.",
+		Default: strconv.Itoa(defaultResourcesCPU),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-server-memory",
+		Target:  &i.config.serverResourcesMemory,
+		Usage:   "MB of Memory to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesMemory),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-runner-cpu",
+		Target:  &i.config.runnerResourcesCPU,
+		Usage:   "CPU required to run this task in MHz.",
+		Default: strconv.Itoa(defaultResourcesCPU),
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "nomad-runner-memory",
+		Target:  &i.config.runnerResourcesMemory,
+		Usage:   "MB of Memory to allocate to the Server job task.",
+		Default: strconv.Itoa(defaultResourcesMemory),
 	})
 
 	set.StringVar(&flag.StringVar{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -818,7 +818,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-server-cpu",
 		Target:  &i.config.serverResourcesCPU,
-		Usage:   "Number of CPUs to allocate to the Server job task.",
+		Usage:   "CPU required to run this task in MHz.",
 		Default: strconv.Itoa(defaultResourcesCPU),
 	})
 
@@ -832,7 +832,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-runner-cpu",
 		Target:  &i.config.runnerResourcesCPU,
-		Usage:   "Number of CPUs to allocate to the Server job task.",
+		Usage:   "CPU required to run this task in MHz.",
 		Default: strconv.Itoa(defaultResourcesCPU),
 	})
 


### PR DESCRIPTION
This commit introduces config options to use when defining a Server and
Runner nomad job config. If no option is specified, it will use the
configured defaults for Waypoint. This commit also increases the default
CPU in MHz to 200 and Memory in MB to 600 (double the default for Nomad
tasks)

It also introduces resources stanza for nomads deploy. Unlike the install for a server and runner, it sticks to the default resource size.

Fixes #1302