### PR TITLE
internal/cli: server bootstrap should not spin up local runner

### DIFF
--- a/.changelog/1320.txt
+++ b/.changelog/1320.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: server bootstrap will not give auth token errors
+```

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -28,6 +28,7 @@ func (c *ServerBootstrapCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
+		WithNoAutoServer(),
 	); err != nil {
 		return 1
 	}


### PR DESCRIPTION
Fixes #1314

The local runner requires an auth token to spin up so if we're
bootstrapping we should not do this on the bootstrap commands.