### PR TITLE
show usage example on 'waypoint context use' command

### DIFF
--- a/internal/cli/context_use.go
+++ b/internal/cli/context_use.go
@@ -30,7 +30,7 @@ func (c *ContextUseCommand) Run(args []string) int {
 
 	// Require one argument
 	if len(args) != 1 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 


### PR DESCRIPTION
This change shows the usage example when you run `waypoint context use` command. See below for the before and after.

Before:
<img width="584" alt="Screen Shot 2021-04-12 at 5 17 12 PM" src="https://user-images.githubusercontent.com/107074/114469512-ed245f80-9bb2-11eb-9343-080ec2905484.png">

After:
<img width="573" alt="Screen Shot 2021-04-12 at 5 17 28 PM" src="https://user-images.githubusercontent.com/107074/114469530-f6adc780-9bb2-11eb-967b-8d63f8d5be37.png">
