### PR TITLE
cmd/waypoint-entrypoint: default log level to DEBUG, env var to change

### DIFF
--- a/.changelog/1330.txt
+++ b/.changelog/1330.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+entrypoint: default log level changed to DEBUG
+```
+
+```release-note:improvement
+entrypoint: can change log level using the `WAYPOINT_LOG_LEVEL` env var, which can also be set with `waypoint config`
+```

--- a/cmd/waypoint-entrypoint/main.go
+++ b/cmd/waypoint-entrypoint/main.go
@@ -25,9 +25,11 @@ func realMain() int {
 	flag.Usage = usage
 	flag.Parse()
 
-	// TODO(mitchellh): proper log setup
+	// This logger always uses debug logging. These logs don't go to
+	// the log stream. The entrypoint will create a new logger that respects
+	// the WAYPOINT_LOG_LEVEL env var.
 	log := hclog.L()
-	hclog.L().SetLevel(hclog.Trace)
+	log.SetLevel(hclog.Debug)
 
 	// Create a context that is cancelled on interrupt
 	ctx, closer := signalcontext.WithInterrupt(context.Background(), log)

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -31,6 +31,11 @@ const (
 	envCEBDisable          = "WAYPOINT_CEB_DISABLE"
 	envCEBServerRequired   = "WAYPOINT_CEB_SERVER_REQUIRED"
 	envCEBToken            = "WAYPOINT_CEB_INVITE_TOKEN"
+
+	// envLogLevel is the env var to set with the log level. This
+	// env var matches the Waypoint CLI on purpose. This can be set on
+	// the entrypoint process OR via app config (`waypoint config`).
+	envLogLevel = "WAYPOINT_LOG_LEVEL"
 )
 
 const (

--- a/internal/ceb/config.go
+++ b/internal/ceb/config.go
@@ -170,6 +170,10 @@ func (ceb *CEB) watchConfig(
 			// to put a `:=` there and break things. This makes it more explicit.
 			env = newEnv
 
+			// Process it for any keys that we handle differently (such as
+			// WAYPOINT_LOG_LEVEL)
+			ceb.processAppEnv(env)
+
 			// Set our new env vars
 			newCmd := ceb.copyCmd(ceb.childCmdBase)
 			newCmd.Env = append(newCmd.Env, env...)

--- a/internal/ceb/config_test.go
+++ b/internal/ceb/config_test.go
@@ -1,0 +1,34 @@
+package ceb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessAppEnv_logs(t *testing.T) {
+	data := TestCEB(t)
+	ceb := data.CEB
+
+	ceb.processAppEnv([]string{
+		envLogLevel + "=TRACE",
+	})
+	require.True(t, ceb.logger.IsTrace())
+
+	ceb.processAppEnv([]string{
+		envLogLevel + "=DEBUG",
+	})
+	require.True(t, ceb.logger.IsDebug())
+
+	// Unset everything should stay the same.
+	ceb.processAppEnv([]string{})
+	require.True(t, ceb.logger.IsDebug())
+
+	// Send bogus stuff to test that we don't crash
+	ceb.processAppEnv([]string{envLogLevel})
+	ceb.processAppEnv([]string{envLogLevel + "="})
+	ceb.processAppEnv([]string{envLogLevel + "=="})
+	ceb.processAppEnv([]string{"=="})
+	ceb.processAppEnv([]string{})
+	require.True(t, ceb.logger.IsDebug())
+}

--- a/internal/ceb/log.go
+++ b/internal/ceb/log.go
@@ -25,10 +25,20 @@ func (ceb *CEB) initSystemLogger() {
 	// and let us register additional sinks for streaming and so on.
 	opts := *hclog.DefaultOptions
 	opts.Name = "entrypoint"
-	opts.Level = hclog.Trace
+	opts.Level = hclog.Debug
 	intercept := hclog.NewInterceptLogger(&opts)
 	nonintercept := hclog.New(&opts)
 	ceb.logger = intercept
+
+	// Set our initial log level
+	if v := os.Getenv(envLogLevel); v != "" {
+		level := hclog.LevelFromString(v)
+		if level == hclog.NoLevel {
+			ceb.logger.Warn("log level provided in env var is invalid", v)
+		} else {
+			ceb.logger.SetLevel(level)
+		}
+	}
 
 	// Create our reader/writer that will send to the server log stream.
 	r, w := io.Pipe()

--- a/internal/ceb/testing.go
+++ b/internal/ceb/testing.go
@@ -44,12 +44,16 @@ func TestCEB(t testing.T, opts ...Option) *TestCEBData {
 }
 
 type TestCEBData struct {
+	CEB     *CEB
 	Horizon hzntest.DevSetup
 }
 
 func withTestDefaults(t testing.T, data *TestCEBData, doneCh chan<- struct{}) Option {
 	return func(ceb *CEB, cfg *config) error {
 		defer close(doneCh)
+
+		// Store a reference to the CEB
+		data.CEB = ceb
 
 		// If we have no server configured, create that.
 		if ceb.client == nil && cfg.ServerAddr == "" {

--- a/website/content/docs/entrypoint/index.mdx
+++ b/website/content/docs/entrypoint/index.mdx
@@ -72,6 +72,29 @@ will only "wake up" from blocking on network traffic when it receives new
 application configuration, a request for `exec`, an inbound request from the
 URL service, etc.
 
+## Logging
+
+The entrypoint itself emits logs about its own behavior. These logs are
+in addition to the logs emitted by the deployed application. We differentiate
+between the two by calling one "entrypoint logs" and the other "application
+logs".
+
+Entrypoint logs are also streamed and can be viewed via `waypoint logs`. If
+`waypoint logs` is not working, the entrypoint logs are also emitted to stderr.
+This is primarily for debugging purposes in case the entrypoint is not
+functioning properly.
+
+The default log level for entrypoint logs is `DEBUG`. You may change the
+log level by setting the `WAYPOINT_LOG_LEVEL` environment variable to
+one of: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` (values further to the
+left are more verbose than those to the right). This environment variable
+may be set at build time, using deployment plugin configuration, or
+via the [waypoint config CLI](/docs/app-config#setting-configuration-via-the-cli).
+
+-> **Note:** The `WAYPOINT_LOG_LEVEL` environment variable must be set
+within the runtime environment of your deployment, not on your local machine.
+This is a common error when attempting to change entrypoint log levels.
+
 ## Failure Behavior
 
 The Waypoint entrypoint is designed to be resilient to failure scenarios

--- a/website/content/docs/troubleshooting.mdx
+++ b/website/content/docs/troubleshooting.mdx
@@ -79,12 +79,12 @@ $ docker volume list
 
 Locate the volumes named starting with `pack-cache-` and remove them with `docker volume rm`.
 
-# Investigating deployed applications
+# Investigating Deployed Applications
 
 Waypoint includes several commands to support debugging and monitoring while
 developing your application.
 
-## Exec into the application container
+## Exec Into the Application Container
 
 After deploying your application, you can use `waypoint exec` to run
 commands in the context of the most recent deployment. Typically, `waypoint exec` will be used for running database migrations and debugging. However, you
@@ -121,10 +121,11 @@ Type `exit` to leave the interactive Docker session.
 $ exit
 ```
 
-## View Waypoint application logs
+## View Waypoint Application and Entrypoint Logs
 
 In the application's directory, run the `logs` command to observe the running
-logs for your deployment.
+logs for your deployment. This will include logs from the
+[entrypoint](/docs/entrypoint) if it is in use.
 
 ```shell-session
 $ waypoint logs
@@ -142,6 +143,10 @@ existing deployment.
 ```
 
 Press `Ctrl-C` to exit the `logs` command.
+
+You may increase the verbosity of entrypoint logs by setting the
+`WAYPOINT_LOG_LEVEL` environment variable. See the documentation on
+[entrypoint logs](/docs/entrypoint#logging) for more information.
 
 ## Access the Waypoint web UI
 


### PR DESCRIPTION
Fixes #1164

This changes the default log level to DEBUG, which is considerably more
quiet than TRACE but still provides ample debugging help for now while
the project is early.

The WAYPOINT_LOG_LEVEL environment variable can be set (even with
`waypoint config set`) to change this behavior at anytime.