### PR TITLE
Makefile: Add target for generating server proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ gen/changelog:
 		-note-template .changelog/note.tmpl \
 		-this-release $(THIS_RELEASE)
 
+.PHONY: gen/server
+gen/server:
+	go generate ./internal/server 
+
 .PHONY: gen/ts
 gen/ts:
 	@rm -rf ./ui/lib/api-common-protos/google 2> /dev/null


### PR DESCRIPTION
This also makes the command for generating the server proto more
discoverable.