### PR TITLE
add docs and fmt to commands nav data

### DIFF
--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -123,6 +123,14 @@
     "path": "deployment-list"
   },
   {
+    "title": "docs",
+    "path": "docs"
+  },
+  {
+    "title": "fmt",
+    "path": "fmt"
+  },
+  {
     "title": "hostname delete",
     "path": "hostname-delete"
   },


### PR DESCRIPTION
This is done so `fmt` and `docs` documentation pages show up on the website