### PR TITLE
docker: support build args

### DIFF
--- a/.changelog/1346.txt
+++ b/.changelog/1346.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-plugins/docker: Add support for build args
+plugins/docker: Add support for build args for both docker and img builders
 ```

--- a/.changelog/1346.txt
+++ b/.changelog/1346.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugins/docker: Add support for build args
+```

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -121,6 +121,12 @@ build {
 		),
 	)
 
+	doc.SetField(
+		"buildargs",
+		"An array of strings of build-time variables passed as build-arg to docker"+
+			"or img for the build step.",
+	)
+
 	return doc, nil
 }
 

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -276,9 +276,6 @@ func (b *Builder) Build(
 
 // Translates BuildArgs from a map of key vals into a string of '--build-arg key=vals'
 func createBuildArgsString(m map[string]*string) string {
-	if m == nil {
-		return ""
-	}
 	b := []string{}
 	for key, value := range m {
 		b = append(b, fmt.Sprintf("--build-arg \"%s=%s\"", key, *value))

--- a/builtin/docker/img.go
+++ b/builtin/docker/img.go
@@ -23,6 +23,7 @@ func (b *Builder) buildWithImg(
 	dockerfilePath string,
 	contextDir string,
 	tag string,
+	buildArgs string,
 ) error {
 	step := sg.Add("Building Docker image with img...")
 	defer func() {
@@ -37,6 +38,7 @@ func (b *Builder) buildWithImg(
 		"build",
 		"-f", dockerfilePath,
 		"-t", tag,
+		buildArgs,
 		".",
 	)
 


### PR DESCRIPTION
This commit adds the support build args:

``` build {
        use "docker" {
                dockerfile="./simple_project/Dockerfile"
                build_args=["TEST_PATH=.", "BIN_PATH_2=./.bin/app"]
	}
    }
```