### PR TITLE
plugin/nomad: Ensure Namespace is set if not set by user

### DIFF
--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -111,6 +111,10 @@ func (p *Platform) Deploy(
 				},
 			},
 		}
+
+		if p.config.Namespace == "" {
+			p.config.Namespace = "default"
+		}
 		job.Namespace = &p.config.Namespace
 		job.AddTaskGroup(tg)
 		tg.AddTask(&api.Task{


### PR DESCRIPTION
Since we have to pass through namespace as a ptr, if namespace is unset
then it gets dereferenced as empty string rather than nil, which means
the Nomad job api `Canonicalize()` doesn't end up setting a default
namespace. This commit fixes that by ensuring the namespace Waypoint
provides is set to a default.