### PR TITLE
internal/cli: version shows Waypoint server version

### DIFF
--- a/.changelog/1364.txt
+++ b/.changelog/1364.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: version command now shoes the server version
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -237,7 +237,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 	// Create our client
 	if baseCfg.Client {
-		c.project, err = c.initClient()
+		c.project, err = c.initClient(nil)
 		if err != nil {
 			c.logError(c.Log, "failed to create client", err)
 			return err

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -64,7 +65,10 @@ func (c *baseCommand) initConfigLoad(path string) (*configpkg.Config, error) {
 }
 
 // initClient initializes the client.
-func (c *baseCommand) initClient() (*clientpkg.Project, error) {
+//
+// If ctx is nil, c.Ctx will be used. If ctx is non-nil, that context will be
+// used and c.Ctx will be ignored.
+func (c *baseCommand) initClient(ctx context.Context) (*clientpkg.Project, error) {
 	// We use our flag-based connection info if the user set an addr.
 	var flagConnection *clicontext.Config
 	if v := c.flagConnection; v.Server.Address != "" {
@@ -102,6 +106,10 @@ func (c *baseCommand) initClient() (*clientpkg.Project, error) {
 		opts = append(opts, clientpkg.WithUI(c.ui))
 	}
 
+	if ctx == nil {
+		ctx = c.Ctx
+	}
+
 	// Create our client
-	return clientpkg.New(c.Ctx, opts...)
+	return clientpkg.New(ctx, opts...)
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -234,7 +234,7 @@ func (c *InitCommand) validateServer() bool {
 	defer sg.Wait()
 
 	s := sg.Add("Validating server credentials...")
-	client, err := c.initClient()
+	client, err := c.initClient(nil)
 	if err != nil {
 		c.stepError(s, initStepConnect, err)
 		return false

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"context"
+	"errors"
+	"time"
+
 	"github.com/posener/complete"
 
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/serverclient"
 	"github.com/hashicorp/waypoint/internal/version"
 )
 
@@ -22,12 +27,26 @@ func (c *VersionCommand) Run(args []string) int {
 		WithFlags(flagSet),
 		WithNoConfig(),
 		WithClient(false),
+		WithNoAutoServer(),
 	); err != nil {
 		return 1
 	}
 
 	out := c.VersionInfo.FullVersionNumber(true)
-	c.ui.Output(out)
+	c.ui.Output("CLI: %s", out)
+
+	// Get our server version. We use a short context here.
+	ctx, cancel := context.WithTimeout(c.Ctx, 2*time.Second)
+	defer cancel()
+	client, err := c.initClient(ctx)
+	if err != nil && !errors.Is(err, serverclient.ErrNoServerConfig) {
+		c.ui.Output("Error connecting to server to read server version: %s", err.Error())
+	}
+
+	if err == nil {
+		server := client.ServerVersion()
+		c.ui.Output("Server: %s", server.Version)
+	}
 
 	return 0
 }
@@ -52,9 +71,11 @@ func (c *VersionCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint version
 
-  Prints the version of this Waypoint CLI.
+  Prints the version information for Waypoint.
 
-  There are no arguments or flags to this command. Any additional arguments or
-  flags are ignored.
+  This command will show the version of the current Waypoint CLI. If
+  the CLI is configured to communicate to a Waypoint server, the server
+  version will also be shown.
+
 `)
 }

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -27,6 +27,7 @@ type Project struct {
 	labels              map[string]string
 	dataSourceOverrides map[string]string
 	cleanupFunc         func()
+	serverVersion       *pb.VersionInfo
 
 	local bool
 
@@ -139,6 +140,11 @@ func (c *Project) WorkspaceRef() *pb.Ref_Workspace {
 // Local is true if the server is an in-process just-in-time server.
 func (c *Project) Local() bool {
 	return c.localServer
+}
+
+// ServerVersion returns the server version that this client is connected to.
+func (c *Project) ServerVersion() *pb.VersionInfo {
+	return c.serverVersion
 }
 
 // Close should be called to clean up any resources that the client created.

--- a/internal/client/server.go
+++ b/internal/client/server.go
@@ -187,6 +187,9 @@ func (c *Project) negotiateApiVersion(ctx context.Context) error {
 		"entrypoint_current", resp.Info.Entrypoint.Current,
 	)
 
+	// Store the server version info
+	c.serverVersion = resp.Info
+
 	vsn, err := protocolversion.Negotiate(protocolversion.Current().Api, resp.Info.Api)
 	if err != nil {
 		return err

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -3,6 +3,7 @@ package serverclient
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -14,6 +15,10 @@ import (
 	"github.com/hashicorp/waypoint/internal/protocolversion"
 	"github.com/hashicorp/waypoint/internal/serverconfig"
 )
+
+// ErrNoServerConfig is the error when there is no server configuration
+// found for connection.
+var ErrNoServerConfig = errors.New("no server connection configuration found")
 
 // ConnectOption is used to configure how Waypoint server connection
 // configuration is sourced.
@@ -40,7 +45,7 @@ func Connect(ctx context.Context, opts ...ConnectOption) (*grpc.ClientConn, erro
 			return nil, nil
 		}
 
-		return nil, fmt.Errorf("no server credentials found")
+		return nil, ErrNoServerConfig
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -72,7 +72,7 @@ func (c *VersionInfo) FullVersionNumber(rev bool) string {
 		return "Waypoint (version unknown)"
 	}
 
-	fmt.Fprintf(&versionString, "Waypoint %s", c.Version)
+	fmt.Fprintf(&versionString, "%s", c.Version)
 	if c.VersionPrerelease != "" && c.GitDescribe == "" {
 		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
 	}


### PR DESCRIPTION
Fixes #1323 

This augments `waypoint version` to show the server version when available. This fails gracefully if the connection fails or there is no Waypoint server available. This command uses an arbitrary 2 second timeout so it doesn't block for a very long time if the connection is not working or taking a long time (unlike the CLI for other operations which will wait much longer).

![image](https://user-images.githubusercontent.com/1299/115440933-24070080-a1c5-11eb-89b0-f24c03b54624.png)
