### PR TITLE
cli/{deploy,release}: Account for inplace deploys for release

### DIFF
--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -89,7 +89,8 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 
 		// inplace is true if this was an in-place deploy. We detect this
 		// if we have a generation that uses a non-matching sequence number
-		inplace := result.Deployment.Generation.Id != "" &&
+		inplace := result.Deployment.Generation != nil &&
+			result.Deployment.Generation.Id != "" &&
 			result.Deployment.Generation.InitialSequence != result.Deployment.Sequence
 
 		// Output

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -89,7 +89,7 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 
 		// inplace is true if this was an in-place deploy. We detect this
 		// if we have a generation that uses a non-matching sequence number
-		inplace := result.Deployment.Generation != nil &&
+		inplace := result.Deployment.Generation.Id != "" &&
 			result.Deployment.Generation.InitialSequence != result.Deployment.Sequence
 
 		// Output

--- a/internal/cli/releases_create.go
+++ b/internal/cli/releases_create.go
@@ -144,7 +144,10 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 
 		// If the released deploy doesn't match what we requested, it is
 		// because they share a generation, meaning the release was a noop.
-		if result.Release.DeploymentId != deploy.Id {
+		inplace := deploy.Generation.Id != "" &&
+			deploy.Generation.InitialSequence != deploy.Sequence
+
+		if result.Release.DeploymentId != deploy.Id && inplace {
 			app.UI.Output(strings.TrimSpace(releaseMatchingGen)+"\n",
 				deploy.Sequence,
 				deploy.Component.Name,

--- a/internal/cli/releases_create.go
+++ b/internal/cli/releases_create.go
@@ -144,7 +144,7 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 
 		// If the released deploy doesn't match what we requested, it is
 		// because they share a generation, meaning the release was a noop.
-		inplace := deploy.Generation.Id != "" &&
+		inplace := deploy.Generation != nil && deploy.Generation.Id != "" &&
 			deploy.Generation.InitialSequence != deploy.Sequence
 
 		if result.Release.DeploymentId != deploy.Id && inplace {


### PR DESCRIPTION
This commit fixes a bug where the release subcommand would print a
message about in place releases and generations. This is only true if
the deployment is mutable. It also looks to see if the geration id is
empty rather than if the whole struct is nil, since the value ends up
initialized but empty even with immutable deploys