### PR TITLE
cli/upgrade: Check for required upgrade flags and print better message 

### DIFF
--- a/.changelog/1372.txt
+++ b/.changelog/1372.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Print warning and help docs if required flags for upgrade are not included
+```

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -452,7 +452,7 @@ Rerun the command with '-auto-approve' to continue with the upgrade.
 `)
 	platformReqMsg = strings.TrimSpace(`
 A platform is required and must match the server context.
-Rerun the command with '-platform=' and include the patform of the context to
+Rerun the command with '-platform=' and include the platform of the context to
 upgrade.
 `)
 	upgradeFailHelp = strings.TrimSpace(`

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -49,14 +49,21 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 
 	// Error handling from input
 
-	if !c.confirm {
+	// NOTE(briancain): This check will look different once https://github.com/hashicorp/waypoint/issues/1233
+	// is implemeneted. This func should initially look for the platform
+	// saved in the context and if none was included, fall back to look for an
+	// included platform flag like we do below
+	if !c.confirm && c.platform == "" {
+		c.ui.Output(confirmReqMsg, terminal.WithErrorStyle())
+		c.ui.Output(platformReqMsg, terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
+		return 1
+	} else if !c.confirm {
 		c.ui.Output(confirmReqMsg, terminal.WithErrorStyle())
 		return 1
-	}
-
-	if c.platform == "" {
+	} else if c.platform == "" {
 		c.ui.Output(
-			"A platform is required and must match the server context",
+			platformReqMsg,
 			terminal.WithErrorStyle(),
 		)
 		return 1
@@ -442,6 +449,11 @@ var (
 	confirmReqMsg       = strings.TrimSpace(`
 Upgrading Waypoint server requires confirmation.
 Rerun the command with '-auto-approve' to continue with the upgrade.
+`)
+	platformReqMsg = strings.TrimSpace(`
+A platform is required and must match the server context.
+Rerun the command with '-platform=' and include the patform of the context to
+upgrade.
 `)
 	upgradeFailHelp = strings.TrimSpace(`
 Upgrading Waypoint server has failed. To restore from a snapshot, use the command:


### PR DESCRIPTION
Because `-auto-approve` and `-platform` are currently required flags for
using the server upgrade command, this commit modifies how we let the
user know about missing flags to prevent them from including one,
running the command, and seeing another is required. Doing both up front
should reduce the back and forth for when someone wants to run the
upgrade command. If neither are included, we also print the help text
for the upgrade command.

Fixes #1371