### PR TITLE
Update internal GCP Auth to use new SignJWT endpoint

### DIFF
--- a/.changelog/1389.txt
+++ b/.changelog/1389.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/vault: Use Service Account Credentials API for GCP SignJWT endpoint
+```


### PR DESCRIPTION
Updates Waypoints' internal GCP auth to use GCP's IAM Service Account Credential endpoint for signing JWTs, as the IAM endpoint versions are deprecated and being turned off (not totally sure when but speculation/inference is around July 1, 2021). See https://cloud.google.com/iam/docs/migrating-to-credentials-api for more information on the deprecation and migration. 

I'm honestly not sure where this is used and there isn't a directly related test file associated with this, so I have not tested other than to ensure the project still compiles.

See also for more backstory:

- https://github.com/hashicorp/vault-plugin-auth-gcp/issues/100
- https://github.com/hashicorp/go-gcp-common/pull/4
- https://github.com/hashicorp/vault-plugin-auth-gcp/pull/108
- https://github.com/hashicorp/vault/pull/11473

Note: I added the `pr/no-changelog` label because I didn't feel this change warranted it, but let me know if you'd prefer one added