### PR TITLE
builtin/k8s: Allow to configure Service annotations

### DIFF
--- a/.changelog/1393.txt
+++ b/.changelog/1393.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+builtin/k8s: Added Service annotations option to K8S release
+```

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -161,6 +161,9 @@ func (r *Releaser) Release(
 
 	service.Spec.Ports = servicePorts
 
+	// Apply Service annotations
+	service.Annotations = r.config.Annotations
+
 	// Create/update
 	if create {
 		step.Update("Creating service...")
@@ -267,6 +270,9 @@ func (r *Releaser) Destroy(
 
 // ReleaserConfig is the configuration structure for the Releaser.
 type ReleaserConfig struct {
+	// Annotations to be applied to the kube service.
+	Annotations map[string]string `hcl:"annotations,optional"`
+
 	// KubeconfigPath is the path to the kubeconfig file. If this is
 	// blank then we default to the home directory.
 	KubeconfigPath string `hcl:"kubeconfig,optional"`


### PR DESCRIPTION
I was looking to apply a AWS EKS load balancer configuration to the Service as described here, and implemented this change to support that: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/service/annotations/