### PR TITLE
Properly validate the ECS ALB options. Fixes #1070

### DIFF
--- a/.changelog/1401.txt
+++ b/.changelog/1401.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+platform/ecs: Fix bug where certificate and other fields had to be set to empty string to use listener.
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -17,12 +17,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/builtin/docker"
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 )
 
 type Platform struct {
@@ -32,6 +34,42 @@ type Platform struct {
 // Config implements Configurable
 func (p *Platform) Config() (interface{}, error) {
 	return &p.config, nil
+}
+
+// ConfigSet is called after a configuration has been decoded
+// we can use this to validate the config
+func (p *Platform) ConfigSet(config interface{}) error {
+	c, ok := config.(*Config)
+	if !ok {
+		// this should never happen
+		return fmt.Errorf("Invalid configuration, expected *cloudrun.Config, got %T", config)
+	}
+
+	if c.ALB != nil {
+		alb := c.ALB
+		err := validationext.Error(validation.ValidateStruct(alb,
+			validation.Field(&alb.CertificateId,
+				validation.Empty.When(alb.ListenerARN != "").Error("certificate can not be used with listener"),
+			),
+			validation.Field(&alb.ZoneId,
+				validation.Empty.When(alb.ListenerARN != ""),
+				validation.Required.When(alb.FQDN != ""),
+			),
+			validation.Field(&alb.FQDN,
+				validation.Empty.When(alb.ListenerARN != ""),
+				validation.Required.When(alb.ZoneId != "").Error("fqdn only valid with zone_id"),
+			),
+			validation.Field(&alb.ListenerARN,
+				validation.Empty.When(alb.CertificateId != "" || alb.ZoneId != "" || alb.FQDN != "").Error("listener_arn can not be used with other options"),
+			),
+		))
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // DeployFunc implements component.Platform
@@ -1350,13 +1388,13 @@ func (p *Platform) Destroy(
 
 type ALBConfig struct {
 	// Certificate ARN to attach to the load balancer
-	CertificateId string `hcl:"certificate"`
+	CertificateId string `hcl:"certificate,optional"`
 
 	// Route53 Zone to setup record in
-	ZoneId string `hcl:"zone_id"`
+	ZoneId string `hcl:"zone_id,optional"`
 
 	// Fully qualified domain name of the record to create in the target zone id
-	FQDN string `hcl:"domain_name"`
+	FQDN string `hcl:"domain_name,optional"`
 
 	// When set, waypoint will configure the target group into the specified
 	// ALB Listener ARN. This allows for usage of existing ALBs.

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/builtin/docker"
-	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 )
 
 type Platform struct {
@@ -47,7 +46,7 @@ func (p *Platform) ConfigSet(config interface{}) error {
 
 	if c.ALB != nil {
 		alb := c.ALB
-		err := validationext.Error(validation.ValidateStruct(alb,
+		err := utils.Error(validation.ValidateStruct(alb,
 			validation.Field(&alb.CertificateId,
 				validation.Empty.When(alb.ListenerARN != "").Error("certificate can not be used with listener"),
 			),

--- a/builtin/aws/ecs/platform_test.go
+++ b/builtin/aws/ecs/platform_test.go
@@ -1,0 +1,107 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformConfig(t *testing.T) {
+	t.Run("empty is fine", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{},
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("fine if only cert", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				CertificateId: "xyz",
+			},
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("fine if only listener", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				ListenerARN: "xyz",
+			},
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("errors if cert and listener are set", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				CertificateId: "xyz",
+				ListenerARN:   "abc",
+			},
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("errors if zone_id and fqdn and listener are set", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				ZoneId:      "xyz",
+				FQDN:        "a.b",
+				ListenerARN: "abc",
+			},
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("errors if zone_id but not fqdn are set", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				ZoneId: "xyz",
+			},
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("errors if fqdn but not zone_id are set", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				FQDN: "xyz",
+			},
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("fine with just zone and fqdn", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			ALB: &ALBConfig{
+				ZoneId: "xyz",
+				FQDN:   "a.b",
+			},
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+}

--- a/builtin/aws/utils/validations.go
+++ b/builtin/aws/utils/validations.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error takes an error and turns an ozzo-validation.Errors into a
+// gRPC status error with field violations populated. If the error is
+// nil or not an ozzo-validation error, it is returned as-is.
+//
+// Note that validate.Validate doesn't return a validate.Errors. Only validation
+// on structs and other containers will return the proper structure that will
+// be wrapped by this call. This should be used against request structures.
+func Error(err error) error {
+	// Nil error returns nil directly
+	if err == nil {
+		return nil
+	}
+
+	// If it isn't a validation error, then return it as-is
+	verr, ok := err.(validation.Errors)
+	if !ok {
+		return err
+	}
+
+	// Build up the status and accumulate the errors.
+	st := status.New(codes.InvalidArgument, verr.Error())
+
+	// This should NEVER fail, we verified with the code that this should
+	// never fail. If it does, we panic because it should be impossible.
+	st, err = st.WithDetails(&errdetails.BadRequest{
+		FieldViolations: errorAppend(nil, "", verr),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return st.Err()
+}
+
+// errorAppend accumulates field violations by recursively nesting into the
+// validation errors. We have to recurse to get nested structs/maps/etc.
+// With each recursion, we prefix the errors with the field path to that
+// error.
+func errorAppend(
+	v []*errdetails.BadRequest_FieldViolation,
+	prefix string,
+	verr validation.Errors) []*errdetails.BadRequest_FieldViolation {
+	for k, err := range verr {
+		field := k
+		if prefix != "" {
+			field = prefix + "." + field
+		}
+
+		// If we have another validation error, then recurse
+		if verr, ok := err.(validation.Errors); ok {
+			v = errorAppend(v, field, verr)
+			continue
+		}
+
+		v = append(v, &errdetails.BadRequest_FieldViolation{
+			Field:       field,
+			Description: err.Error(),
+		})
+	}
+
+	return v
+}


### PR DESCRIPTION
Since we've got a more complex relationship between the values that can be modeled in HCL tags, this introduces using ozzo to validate parts of the config struct.