### PR TITLE
Add ability to request an internal ALB for ECS

### DIFF
--- a/.changelog/1403.txt
+++ b/.changelog/1403.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+platform/ecs: Add ability to request an internal ALB for ECS
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -711,10 +711,10 @@ func createALB(
 		} else {
 			s.Update("Creating new ALB: %s", lbName)
 
-			scheme := "internet-facing"
+			scheme := elbv2.LoadBalancerSchemeEnumInternetFacing
 
 			if albConfig != nil && albConfig.InternalScheme != nil && *albConfig.InternalScheme {
-				scheme = "internal"
+				scheme = elbv2.LoadBalancerSchemeEnumInternal
 			}
 
 			clb, err := elbsrv.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{

--- a/builtin/aws/ecs/platform_test.go
+++ b/builtin/aws/ecs/platform_test.go
@@ -104,4 +104,31 @@ func TestPlatformConfig(t *testing.T) {
 
 		require.NoError(t, p.ConfigSet(cfg))
 	})
+
+	t.Run("errors if internal and listener are set", func(t *testing.T) {
+		var p Platform
+
+		i := true
+		cfg := &Config{
+			ALB: &ALBConfig{
+				InternalScheme: &i,
+				ListenerARN:    "abc",
+			},
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("fine with just internal", func(t *testing.T) {
+		var p Platform
+
+		i := true
+		cfg := &Config{
+			ALB: &ALBConfig{
+				InternalScheme: &i,
+			},
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
 }


### PR DESCRIPTION
This PR adds the ability to request that a created ALB for ECS is internal scheme.

Closes #652.