### PR TITLE
Change the AWS log level to match the waypoint log level. Fixes #1319

### DIFF
--- a/.changelog/1404.txt
+++ b/.changelog/1404.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+platform/aws: Set the AWS log level along with the waypoint log level
+```

--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -40,6 +40,7 @@ func (r *Releaser) Release(
 ) (*Release, error) {
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: target.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err
@@ -51,7 +52,7 @@ func (r *Releaser) Release(
 		lbName = "waypoint-" + src.App
 	}
 
-	// We have to clamp at a length of 32 because the Name field to 
+	// We have to clamp at a length of 32 because the Name field to
 	// CreateLoadBalancer requires that the name is 32 characters or less.
 	if len(lbName) > 32 {
 		lbName = lbName[:32]

--- a/builtin/aws/ami/builder.go
+++ b/builtin/aws/ami/builder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
@@ -81,11 +82,13 @@ func (b *Builder) Config() (interface{}, error) {
 // Build
 func (b *Builder) Build(
 	ctx context.Context,
+	log hclog.Logger,
 	ui terminal.UI,
 	src *component.Source,
 ) (*Image, error) {
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: b.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err

--- a/builtin/aws/ec2/platform.go
+++ b/builtin/aws/ec2/platform.go
@@ -91,6 +91,7 @@ func (p *Platform) Deploy(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err
@@ -305,6 +306,7 @@ func (p *Platform) Destroy(
 ) error {
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return err

--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -67,6 +67,7 @@ func (r *Registry) Push(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: r.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -228,6 +228,7 @@ func (p *Platform) Deploy(
 		Init: func(s LifecycleStatus) error {
 			sess, err = utils.GetSession(&utils.SessionConfig{
 				Region: p.config.Region,
+				Logger: log,
 			})
 			if err != nil {
 				return err
@@ -1322,6 +1323,7 @@ func (p *Platform) Destroy(
 ) error {
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return err

--- a/builtin/aws/ecs/releaser.go
+++ b/builtin/aws/ecs/releaser.go
@@ -44,6 +44,7 @@ func (r *Releaser) Release(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: r.p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err

--- a/builtin/aws/lambda/ecs.go
+++ b/builtin/aws/lambda/ecs.go
@@ -197,6 +197,7 @@ func (e *ecsLauncher) Launch(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: e.Region,
+		Logger: L,
 	})
 	if err != nil {
 		return nil, err

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -206,6 +206,7 @@ func (p *Platform) Deploy(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return nil, err
@@ -622,6 +623,7 @@ func (p *Platform) Destroy(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return err
@@ -673,6 +675,7 @@ func (p *Platform) DestroyWorkspace(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return err

--- a/builtin/aws/lambda/platform_logs.go
+++ b/builtin/aws/lambda/platform_logs.go
@@ -28,6 +28,7 @@ func (p *Platform) Logs(
 
 	sess, err := utils.GetSession(&utils.SessionConfig{
 		Region: p.config.Region,
+		Logger: log,
 	})
 	if err != nil {
 		return err

--- a/builtin/aws/utils/session.go
+++ b/builtin/aws/utils/session.go
@@ -3,10 +3,22 @@ package utils
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/hashicorp/go-hclog"
 )
 
 func GetSession(c *SessionConfig) (*session.Session, error) {
 	config := aws.NewConfig().WithRegion(c.Region)
+
+	if c.Logger != nil {
+		l := c.Logger
+
+		switch {
+		case l.IsDebug():
+			config = config.WithLogLevel(aws.LogDebug)
+		case l.IsTrace():
+			config = config.WithLogLevel(aws.LogDebugWithRequestRetries)
+		}
+	}
 
 	return session.NewSessionWithOptions(session.Options{
 		Config:            *config,
@@ -16,4 +28,5 @@ func GetSession(c *SessionConfig) (*session.Session, error) {
 
 type SessionConfig struct {
 	Region string
+	Logger hclog.Logger
 }


### PR DESCRIPTION
I also considered setting aws's log function to be a proxy for hclog.Logger, but didn't because there are no levels on it, so it's best it shows up as just opaque output for the human to parse visually. 