### PR TITLE
cli: give helpful error msg on context commands

### DIFF
--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -31,7 +31,7 @@ func (c *ContextCreateCommand) Run(args []string) int {
 
 	// Require one argument
 	if len(args) != 1 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_delete.go
+++ b/internal/cli/context_delete.go
@@ -32,7 +32,7 @@ func (c *ContextDeleteCommand) Run(args []string) int {
 	}
 
 	if len(args) != 1 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_rename.go
+++ b/internal/cli/context_rename.go
@@ -26,7 +26,7 @@ func (c *ContextRenameCommand) Run(args []string) int {
 	args = flagSet.Args()
 
 	if len(args) != 2 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/context_verify.go
+++ b/internal/cli/context_verify.go
@@ -32,7 +32,7 @@ func (c *ContextVerifyCommand) Run(args []string) int {
 	}
 
 	if len(args) > 1 {
-		c.ui.Output(c.Flags().Help(), terminal.WithErrorStyle())
+		c.ui.Output(c.Help(), terminal.WithErrorStyle())
 		return 1
 	}
 


### PR DESCRIPTION
Previous output left the user confused as to what the actual problem was:
```
$ waypoint context create -server-addr=xxxxxx
! Global Options:
  
    -app=<string>
...
```

Updated:
```
$ waypoint context create
! Usage: waypoint context create [options] NAME
  
    Creates a new context.
  
  Global Options:
...
```