### PR TITLE
Add ability to expose additinal ports for Docker

### DIFF
--- a/.changelog/1414.txt
+++ b/.changelog/1414.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugin/docker: Add support for exposing additional ports
+```

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -450,7 +450,7 @@ type PlatformConfig struct {
 	// config commands.
 	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 
-	// Additional ports to allow into the container
+	// Additional ports the application is listening on to expose on the container
 	ExtraPorts []uint `hcl:"extra_ports,optional"`
 
 	// Port that your service is running on within the actual container.
@@ -563,9 +563,10 @@ deploy {
 
 	doc.SetField(
 		"extra_ports",
-		"additional TCP ports to allow into the container",
+		"additional TCP ports the application is listening on to expose on the container",
 		docs.Summary(
-			"these additional ports are usually used to allow secondary services, such as debug ports",
+			"Used to define and expose multiple ports that the application is listening on for the container in use.",
+			"These ports will get merged with service_port when creating the container if defined.",
 		),
 	)
 


### PR DESCRIPTION
Addressing issue https://github.com/hashicorp/waypoint/issues/1390
- Added "extra_ports" following the same pattern used in `ec2`
  builtin

QA:
  - built waypoint binary
  - added `extra_ports` to deploy paramater of a docker waypoint project.
  - ran 'waypoint up' and confirm with `docker ps` that additional ports
    are exposed in "PORTS" and then check that the ports are accesible
    from the host.

    $ docker ps
      CONTAINER ID   IMAGE                                  COMMAND                  CREATED         STATUS         PORTS                                              NAMES
      0391224e473d   waypoint.local/example-python:latest   "/waypoint-entrypoin…"   5 seconds ago   Up 3 seconds   0.0.0.0:32780->8080/tcp, 0.0.0.0:32779->8081/tcp   example-python-01F4WE89J68A9RTQR4D2AKNX3X

    $ curl -I 0.0.0.0:32780
      HTTP/1.1 200 OK
      Server: gunicorn
      Date: Tue, 04 May 2021 20:04:25 GMT
      Connection: keep-alive
      Content-Type: text/html; charset=utf-8
      Content-Length: 1058

    $ curl -I 0.0.0.0:32779
      HTTP/1.1 200 OK
      Server: gunicorn
      Date: Tue, 04 May 2021 20:04:34 GMT
      Connection: keep-alive
      Content-Type: text/html; charset=utf-8
      Content-Length: 1058