### PR TITLE
plugin/ecs: Allow memory_reservation to be set on the main container

### DIFF
--- a/.changelog/1415.txt
+++ b/.changelog/1415.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugin/ecs: Allow memory_reservation to be set on primary container
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1006,8 +1006,8 @@ func (p *Platform) Launch(
 			},
 		},
 		Environment:       env,
-		Memory:            aws.Int64(int64(p.config.Memory)),
-		MemoryReservation: aws.Int64(int64(p.config.MemoryReservation)),
+		Memory:            utils.OptionalInt64(int64(p.config.Memory)),
+		MemoryReservation: utils.OptionalInt64(int64(p.config.MemoryReservation)),
 		Secrets:           secrets,
 		LogConfiguration: &ecs.LogConfiguration{
 			LogDriver: aws.String("awslogs"),
@@ -1053,8 +1053,8 @@ func (p *Platform) Launch(
 			},
 			Secrets:           secrets,
 			Environment:       env,
-			Memory:            aws.Int64(int64(container.Memory)),
-			MemoryReservation: aws.Int64(int64(container.MemoryReservation)),
+			Memory:            utils.OptionalInt64(int64(container.Memory)),
+			MemoryReservation: utils.OptionalInt64(int64(container.MemoryReservation)),
 		}
 
 		additionalContainers = append(additionalContainers, c)

--- a/builtin/aws/ecs/platform_test.go
+++ b/builtin/aws/ecs/platform_test.go
@@ -11,7 +11,8 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
-			ALB: &ALBConfig{},
+			Memory: 512,
+			ALB:    &ALBConfig{},
 		}
 
 		require.NoError(t, p.ConfigSet(cfg))
@@ -21,6 +22,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				CertificateId: "xyz",
 			},
@@ -33,6 +35,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				ListenerARN: "xyz",
 			},
@@ -45,6 +48,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				CertificateId: "xyz",
 				ListenerARN:   "abc",
@@ -58,6 +62,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				ZoneId:      "xyz",
 				FQDN:        "a.b",
@@ -72,6 +77,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				ZoneId: "xyz",
 			},
@@ -84,6 +90,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				FQDN: "xyz",
 			},
@@ -96,6 +103,7 @@ func TestPlatformConfig(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				ZoneId: "xyz",
 				FQDN:   "a.b",
@@ -110,6 +118,7 @@ func TestPlatformConfig(t *testing.T) {
 
 		i := true
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				InternalScheme: &i,
 				ListenerARN:    "abc",
@@ -124,11 +133,76 @@ func TestPlatformConfig(t *testing.T) {
 
 		i := true
 		cfg := &Config{
+			Memory: 512,
 			ALB: &ALBConfig{
 				InternalScheme: &i,
 			},
 		}
 
 		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("allows no memory_reservation", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory: 512,
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("allows memory_reservation same as memory", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory:            512,
+			MemoryReservation: 512,
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("allows memory_reservation less than memory", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory:            512,
+			MemoryReservation: 256,
+		}
+
+		require.NoError(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("disallows too small values of memory", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory: 3,
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("disallows too small values of memory_reservation", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory:            512,
+			MemoryReservation: 3,
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
+
+	t.Run("disallows memory_reservation greater than memory", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory:            512,
+			MemoryReservation: 513,
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
 	})
 }

--- a/builtin/aws/utils/values.go
+++ b/builtin/aws/utils/values.go
@@ -1,0 +1,9 @@
+package utils
+
+func OptionalInt64(v int64) *int64 {
+	if v == 0 {
+		return nil
+	}
+
+	return &v
+}


### PR DESCRIPTION
Closes #1163

This also enforces the memory and memory_reservation settings on the additional containers.