### PR TITLE
feat(internal/config): add workspace variable

### DIFF
--- a/.changelog/1419.txt
+++ b/.changelog/1419.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+internal/config: add `${workspace}` variable
+```

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -58,7 +58,7 @@ func (c *Config) Apps() []string {
 
 // App returns the configured app named n. If the app doesn't exist, this
 // will return (nil, nil).
-func (c *Config) App(n string, workspace string, ctx *hcl.EvalContext) (*App, error) {
+func (c *Config) App(n string, ctx *hcl.EvalContext) (*App, error) {
 	ctx = appendContext(c.ctx, ctx)
 
 	// Find the app by progressively decoding
@@ -86,7 +86,7 @@ func (c *Config) App(n string, workspace string, ctx *hcl.EvalContext) (*App, er
 	// Build a new context with our app-scoped values
 	ctx = ctx.NewChild()
 	addPathValue(ctx, pathData)
-	addWorkspaceValue(ctx, workspace)
+	addWorkspaceValue(ctx, c.workspace)
 
 	// Full decode
 	var app App

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -58,7 +58,7 @@ func (c *Config) Apps() []string {
 
 // App returns the configured app named n. If the app doesn't exist, this
 // will return (nil, nil).
-func (c *Config) App(n string, ctx *hcl.EvalContext) (*App, error) {
+func (c *Config) App(n string, workspace string, ctx *hcl.EvalContext) (*App, error) {
 	ctx = appendContext(c.ctx, ctx)
 
 	// Find the app by progressively decoding
@@ -86,6 +86,7 @@ func (c *Config) App(n string, ctx *hcl.EvalContext) (*App, error) {
 	// Build a new context with our app-scoped values
 	ctx = ctx.NewChild()
 	addPathValue(ctx, pathData)
+	addWorkspaceValue(ctx, workspace)
 
 	// Full decode
 	var app App

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -266,7 +266,9 @@ func TestConfigApp_compare(t *testing.T) {
 			cfg, err := Load(filepath.Join("testdata", "compare", tt.File), "")
 			require.NoError(err)
 
-			app, err := cfg.App(tt.App, "default", nil)
+			cfg.workspace = "default"
+
+			app, err := cfg.App(tt.App, nil)
 			require.NoError(err)
 
 			tt.Func(t, app)
@@ -305,8 +307,9 @@ func TestAppValidate(t *testing.T) {
 
 			cfg, err := Load(filepath.Join("testdata", "validate", tt.File), "")
 			require.NoError(err)
+			cfg.workspace = "default"
 
-			app, err := cfg.App(tt.App, "default", nil)
+			app, err := cfg.App(tt.App, nil)
 			require.NoError(err)
 			require.NotNil(app)
 

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -266,7 +266,7 @@ func TestConfigApp_compare(t *testing.T) {
 			cfg, err := Load(filepath.Join("testdata", "compare", tt.File), "")
 			require.NoError(err)
 
-			app, err := cfg.App(tt.App, nil)
+			app, err := cfg.App(tt.App, "default", nil)
 			require.NoError(err)
 
 			tt.Func(t, app)
@@ -306,7 +306,7 @@ func TestAppValidate(t *testing.T) {
 			cfg, err := Load(filepath.Join("testdata", "validate", tt.File), "")
 			require.NoError(err)
 
-			app, err := cfg.App(tt.App, nil)
+			app, err := cfg.App(tt.App, "default", nil)
 			require.NoError(err)
 			require.NotNil(app)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,9 +15,14 @@ import (
 type Config struct {
 	*hclConfig
 
-	ctx      *hcl.EvalContext
-	path     string
-	pathData map[string]string
+	ctx       *hcl.EvalContext
+	path      string
+	pathData  map[string]string
+	workspace string
+}
+
+func (c *Config) SetWorkspace(workspace string) {
+	c.workspace = workspace
 }
 
 type hclConfig struct {

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -124,7 +124,7 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 
 	// Initialize all the applications and load all their components.
 	for _, name := range opts.Config.Apps() {
-		appConfig, err := opts.Config.App(name, nil)
+		appConfig, err := opts.Config.App(name, p.workspace, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error loading app %q: %w", name, err)
 		}

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -124,7 +124,8 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 
 	// Initialize all the applications and load all their components.
 	for _, name := range opts.Config.Apps() {
-		appConfig, err := opts.Config.App(name, p.workspace, nil)
+		opts.Config.SetWorkspace(p.workspace)
+		appConfig, err := opts.Config.App(name, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error loading app %q: %w", name, err)
 		}


### PR DESCRIPTION
This commit adds the `${workspace}` variable, so that one can have
a single `.hcl` file deployed across multiple workspaces
(e.g: multi-branch gitops repo) and merge easily the `.hcl` files
without having to worry about a branch-dependant variable.

```hcl
project = "waypoint-workspace-demo"

app "kibana-xyz" {
    build {
        use "docker-pull" {
            image = "kibana"
            tag   = "latest"
        }
    }

    deploy {
        use "cloudfoundry" {
            organisation = "some-org"
            space = "space-${workspace}"
	}
    }
}
```

This change is probably also useful for Kubernetes and Nomad,
as you could have a 1:1 mapping between Waypoint workspaces and
Kubernetes / Nomad namespaces. Since it's provided as a variable,
the possibilities are endless.


## Example

```
waypoint up -workspace=default
```

Results, in this case in:

```
» Deploying...
 + Validating parameters
 + Connecting to Cloud Foundry at https://swisscom.ch
 + Selecting organisation: some-org
 + Selecting space: space-develop
 + Searching app: kibana-xyz-e6fa4bcd [not found]
```

---

```
waypoint up -workspace=staging
```

Results, in this case in:

```
» Deploying...
 + Validating parameters
 + Connecting to Cloud Foundry at https://swisscom.ch
 + Selecting organisation: some-org
 + Selecting space: space-staging
 + Searching app: kibana-xyz-6092d4c4 [not found]
```
