### PR TITLE
Makefile: Add target for generating plugin protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,11 @@ gen/changelog:
 		-note-template .changelog/note.tmpl \
 		-this-release $(THIS_RELEASE)
 
+# generates protos for the plugins inside builtin
+.PHONY: gen/plugins
+gen/plugins:
+	go generate ./builtin/...
+
 .PHONY: gen/server
 gen/server:
 	go generate ./internal/server 


### PR DESCRIPTION
Since https://github.com/hashicorp/waypoint/pull/1385 might be contentious or the wrong change entirely, I am opening a new PR for now to include the makefile target for generating plugin protos.