### PR TITLE
Update backport.yml

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,7 @@
     pull_request_target:
       types:
         - closed
+        - labeled
   
   jobs:
     backport:


### PR DESCRIPTION
Apply backport PRs when labeled as well as closed. As far as who can label (emphasis mine):


> Anyone with read access to a repository can view and search the repository’s labels. **Anyone with triage access to a repository can apply/dismiss existing labels.** To create, edit, apply, or delete a label, you must have write access to the repository.


- https://docs.github.com/en/github/managing-your-work-on-github/managing-labels