### PR TITLE
internal/cli: don't use conn if error during accept

### DIFF
--- a/.changelog/1426.txt
+++ b/.changelog/1426.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: runner will not crash if liveness check has error
+```

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -133,7 +133,8 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 			for {
 				conn, err := ln.Accept()
 				if err != nil {
-					log.Warn("error accepting liveness connection: %s", err)
+					log.Warn("error accepting liveness connection", "err", err)
+					continue
 				}
 
 				// Immediately close. The liveness check only ensures a


### PR DESCRIPTION
This prevents a crash that could happen since during the error case conn
is nil.