### PR TITLE
github: only run changelog checker for PRs against main

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -7,7 +7,6 @@ on:
     # Runs on PRs to main and all release branches
     branches:
       - main
-      - release/*
 
 jobs:
   # checks that a .changelog entry is present for a PR


### PR DESCRIPTION
We really only care about including changelog entries when PRs are
opened against `main`. PRs against `release/*` are typically only
backport PRs, so it doesn't make sense to fail the PR for a missing
changelog entry.