### PR TITLE
cli/up: Only print inplace deploy message if generation id exists

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -58,6 +58,7 @@ func (c *UpCommand) Run(args []string) int {
 		// inplace is true if this was an in-place deploy. We detect this
 		// if we have a generation that uses a non-matching sequence number
 		inplace := result.Deploy.Deployment.Generation != nil &&
+			result.Deploy.Deployment.Generation.Id != "" &&
 			result.Deploy.Deployment.Generation.InitialSequence != result.Deploy.Deployment.Sequence
 
 		// Output


### PR DESCRIPTION
This commit fixes a UI output bug where Waypoint would declare the
deployment was mutable and deployed in place for immutable deploys due
to the inplace check not looking for generation id existing.

I apparently missed the up cli fix. For reference this was already fixed in deploy/release https://github.com/hashicorp/waypoint/pull/1366