### PR TITLE
Add context inspect (and better context help)

### DIFF
--- a/.changelog/1458.txt
+++ b/.changelog/1458.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add `context inspect` command to aid in user enjoyment of waypoint contexts.
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -99,6 +99,9 @@ type baseCommand struct {
 	// autoServer will be set to true if an automatic in-memory server
 	// is allowd.
 	autoServer bool
+
+	// The home directory that we loaded the waypoint config from
+	homeConfigPath string
 }
 
 // Close cleans up any resources that the command created. This should be
@@ -166,6 +169,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 		return err
 	}
 	homeConfigPath = filepath.Dir(homeConfigPath)
+	c.homeConfigPath = homeConfigPath
 	c.Log.Debug("home configuration directory", "path", homeConfigPath)
 
 	// Setup our base directory for context management

--- a/internal/cli/context_help.go
+++ b/internal/cli/context_help.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-homedir"
+	"github.com/posener/complete"
+)
+
+type ContextHelpCommand struct {
+	*baseCommand
+
+	SynopsisText string
+	HelpText     string
+}
+
+func (c *ContextHelpCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	flagSet := c.Flags()
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(flagSet),
+		WithNoConfig(),
+		WithClient(false),
+	); err != nil {
+		return 1
+	}
+
+	return cli.RunResultHelp
+}
+
+func (c *ContextHelpCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
+}
+
+func (c *ContextHelpCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ContextHelpCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *ContextHelpCommand) Synopsis() string {
+	return strings.TrimSpace(c.SynopsisText)
+}
+
+func (c *ContextHelpCommand) Help() string {
+	homePath := c.homeConfigPath
+
+	dir, err := homedir.Dir()
+	if err == nil {
+		if strings.HasPrefix(homePath, dir) {
+			homePath = "~" + homePath[len(dir):]
+		}
+	}
+	str := fmt.Sprintf("%s\nContext Info:\n  Config Path: %s\n", c.HelpText, homePath)
+	return formatHelp(str)
+}

--- a/internal/cli/context_inspect.go
+++ b/internal/cli/context_inspect.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/posener/complete"
+)
+
+type ContextInspectCommand struct {
+	*baseCommand
+
+	flagJson bool
+}
+
+func (c *ContextInspectCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	flagSet := c.Flags()
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(flagSet),
+		WithNoConfig(),
+		WithClient(false),
+	); err != nil {
+		return 1
+	}
+
+	def, err := c.contextStorage.Default()
+	if err != nil {
+		def = "<unknown>"
+	}
+
+	if c.flagJson {
+		data, err := json.MarshalIndent(map[string]interface{}{
+			"config_path":     c.homeConfigPath,
+			"default_context": def,
+		}, "", "  ")
+		if err != nil {
+			c.ui.Output("Error rendering json: %s", err)
+			return 1
+		}
+
+		c.ui.Output(string(data))
+		return 0
+	}
+
+	c.ui.Output("Context Info:", terminal.WithHeaderStyle())
+
+	if def == "" {
+		def = "<unset>"
+	}
+
+	c.ui.NamedValues([]terminal.NamedValue{
+		{
+			Name: "config path", Value: c.homeConfigPath,
+		},
+		{
+			Name: "default context", Value: def,
+		},
+	}, terminal.WithInfoStyle())
+
+	return 0
+}
+
+func (c *ContextInspectCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "json",
+			Target:  &c.flagJson,
+			Usage:   "Output information in JSON format",
+			Default: false,
+		})
+	})
+}
+
+func (c *ContextInspectCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ContextInspectCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *ContextInspectCommand) Synopsis() string {
+	return "Output current context info."
+}
+
+func (c *ContextInspectCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint context inspect <name>=<value>
+
+  Output information the current waypoint context.
+
+` + c.Flags().Help())
+}

--- a/internal/cli/context_inspect.go
+++ b/internal/cli/context_inspect.go
@@ -26,6 +26,50 @@ func (c *ContextInspectCommand) Run(args []string) int {
 		return 1
 	}
 
+	if len(c.args) >= 1 {
+		cc, err := c.contextStorage.Load(c.args[0])
+		if err != nil {
+			c.ui.Output("Error loading context '%s': %s", c.args[0], err)
+			return 1
+		}
+
+		if c.flagJson {
+			data, err := json.MarshalIndent(cc.Server, "", "  ")
+			if err != nil {
+				c.ui.Output("Error rendering json: %s", err)
+				return 1
+			}
+
+			c.ui.Output(string(data))
+			return 0
+		}
+
+		c.ui.Output("Context Info:", terminal.WithHeaderStyle())
+
+		c.ui.NamedValues([]terminal.NamedValue{
+			{
+				Name: "address", Value: cc.Server.Address,
+			},
+			{
+				Name: "address internal", Value: cc.Server.AddressInternal,
+			},
+			{
+				Name: "tls", Value: cc.Server.Tls,
+			},
+			{
+				Name: "tls skip verify", Value: cc.Server.TlsSkipVerify,
+			},
+			{
+				Name: "require auth", Value: cc.Server.RequireAuth,
+			},
+			{
+				Name: "platform", Value: cc.Server.Platform,
+			},
+		}, terminal.WithInfoStyle())
+
+		return 0
+	}
+
 	def, err := c.contextStorage.Default()
 	if err != nil {
 		def = "<unknown>"
@@ -45,7 +89,7 @@ func (c *ContextInspectCommand) Run(args []string) int {
 		return 0
 	}
 
-	c.ui.Output("Context Info:", terminal.WithHeaderStyle())
+	c.ui.Output("Context Settings:", terminal.WithHeaderStyle())
 
 	if def == "" {
 		def = "<unset>"
@@ -85,14 +129,14 @@ func (c *ContextInspectCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ContextInspectCommand) Synopsis() string {
-	return "Output current context info."
+	return "Output context info."
 }
 
 func (c *ContextInspectCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint context inspect <name>=<value>
+Usage: waypoint context inspect [<name>]
 
-  Output information the current waypoint context.
+  Output information about a waypoint context or general context info.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -390,9 +390,15 @@ func Commands(
 		},
 
 		"context": func() (cli.Command, error) {
-			return &helpCommand{
+			return &ContextHelpCommand{
+				baseCommand:  baseCommand,
 				SynopsisText: helpText["context"][0],
 				HelpText:     helpText["context"][1],
+			}, nil
+		},
+		"context inspect": func() (cli.Command, error) {
+			return &ContextInspectCommand{
+				baseCommand: baseCommand,
 			}, nil
 		},
 		"context create": func() (cli.Command, error) {

--- a/internal/serverconfig/config.go
+++ b/internal/serverconfig/config.go
@@ -6,30 +6,30 @@ import (
 
 // Client configures a client to connect to a server.
 type Client struct {
-	Address string `hcl:"address,attr"`
+	Address string `hcl:"address,attr" json:"address"`
 
 	// Tls, if true, will connect to the server with TLS. If TlsSkipVerify
 	// is true, the certificate presented by the server will not be validated.
-	Tls           bool `hcl:"tls,optional"`
-	TlsSkipVerify bool `hcl:"tls_skip_verify,optional"`
+	Tls           bool `hcl:"tls,optional" json:"tls,omitempty"`
+	TlsSkipVerify bool `hcl:"tls_skip_verify,optional" json:"tls_skip_verify,omitempty"`
 
 	// AddressInternal is a temporary config to work with local deployments
 	// on platforms such as Docker for Mac. We need to discuss a more
 	// long term approach to this.
-	AddressInternal string `hcl:"address_internal,optional"`
+	AddressInternal string `hcl:"address_internal,optional" json:"address_internal,omitempty"`
 
 	// Indicates that we need to present a token to connect to this server.
-	RequireAuth bool `hcl:"require_auth,optional"`
+	RequireAuth bool `hcl:"require_auth,optional" json:"require_path,omitempty"`
 
 	// AuthToken is the token to use to authenticate to the server.
 	// Note this will be stored plaintext on disk. You can also use the
 	// WAYPOINT_SERVER_TOKEN env var.
-	AuthToken string `hcl:"auth_token,optional"`
+	AuthToken string `hcl:"auth_token,optional" json:"auth_token,omitempty"`
 
 	// The platform for where the server is running. Although this option should
 	// be required, it's optional to support previously set contexts that did
 	// not have a platform.
-	Platform string `hcl:"platform,optional"`
+	Platform string `hcl:"platform,optional" json:"platform,omitempty"`
 }
 
 // Env returns a slice of environment variables in key=value settings


### PR DESCRIPTION
This adds a new `context inspect` command that helps users discover what the context actually is.

Additionally, it enhances the help text for `waypoint context` to include the main config path, since it's common that a user is going to be interested in that value if they're looking at the context help.

Fixes #1107 