### PR TITLE
website: bring nested-node in scope for sub-pages

### DIFF
--- a/website/pages/commands/[[...page]].jsx
+++ b/website/pages/commands/[[...page]].jsx
@@ -8,6 +8,9 @@ import {
 const NAV_DATA_FILE = 'data/commands-nav-data.json'
 const CONTENT_DIR = 'content/commands'
 const basePath = 'commands'
+import NestedNode from 'components/nested-node'
+
+const additionalComponents = { NestedNode }
 
 export default function DocsLayout(props) {
   return (
@@ -15,6 +18,7 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
+      additionalComponents={additionalComponents}
     />
   )
 }

--- a/website/pages/plugins/[[...page]].jsx
+++ b/website/pages/plugins/[[...page]].jsx
@@ -8,6 +8,9 @@ import {
 const NAV_DATA_FILE = 'data/plugins-nav-data.json'
 const CONTENT_DIR = 'content/plugins'
 const basePath = 'plugins'
+import NestedNode from 'components/nested-node'
+
+const additionalComponents = { NestedNode }
 
 export default function DocsLayout(props) {
   return (
@@ -15,6 +18,7 @@ export default function DocsLayout(props) {
       product={{ name: productName, slug: productSlug }}
       baseRoute={basePath}
       staticProps={props}
+      additionalComponents={additionalComponents}
     />
   )
 }


### PR DESCRIPTION
closes #1462  (hopefully)

@evanphx - my initial test in `/content/docs/index.mdx` showed things were working but then I realized I hadn't put the `<NestedNode>` component in scope for `/commands` or `/plugins`. This fixes that issue but let me know if thats not exactly the issue you were observing. 
