### PR TITLE
internal/cli: add project help text

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -449,6 +449,12 @@ func Commands(
 			}, nil
 		},
 
+		"project": func() (cli.Command, error) {
+			return &helpCommand{
+				SynopsisText: helpText["project"][0],
+				HelpText:     helpText["project"][1],
+			}, nil
+		},
 		"project list": func() (cli.Command, error) {
 			return &ProjectListCommand{
 				baseCommand: baseCommand,
@@ -718,6 +724,16 @@ deployments. These can be used to share previews with teammates, see
 unreleased deployments, and more.
 
 For more information see: https://waypointproject.io/docs/url
+`,
+	},
+
+	"project": {
+		"Project management",
+		`
+Project management.
+
+Projects are comprised of one or more applications. A project maps 
+to a VCS repository (if one exists).
 `,
 	},
 


### PR DESCRIPTION
Before
```
$ waypoint help
Welcome to Waypoint
...
Other commands
...
  logs            Show log output from the current application deployment
  project         
  runner          Runner management
...
```
```
$ waypoint project -h
This command is accessed by using one of the subcommands below.

Subcommands:
    apply    Create or update a project.
    list     List all registered projects.
```

After
```
$ waypoint help
Welcome to Waypoint
...
Other commands
...
  logs            Show log output from the current application deployment
  project         Project management
  runner          Runner management
...
```
```
$ waypoint project -h
Usage: waypoint project SUBCOMMAND

  Project management.
  
  Projects are comprised of one or more applications. A project maps 
  to a VCS repository (if one exists).

Subcommands:
    apply    Create or update a project.
    list     List all registered projects.
```
