### PR TITLE
Remove datadir caching of netlify tokens. Fixes #1468

### DIFF
--- a/.changelog/1474.txt
+++ b/.changelog/1474.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/netlify: Restore operations by no longer caching automatically retrieved access tokens
+```


### PR DESCRIPTION
We don't support datadir's anymore and missed updating netlify. This also means likely no one is using the netlify plugin, perhaps we should just remove it.