### PR TITLE
Dockerfile: Remove `img` from `apk add` in `imgbase` stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN make BUILDTAGS="seccomp noembed dfrunmount dfsecrets dfssh" && mv img /usr/b
 # https://github.com/genuinetools/img/blob/d858ac71f93cc5084edd2ba2d425b90234cf2ead/Dockerfile
 FROM docker.mirror.hashicorp.services/alpine AS imgbase
 RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev \
-    gcc git libcap-dev libtool libxslt img runc
+    gcc git libcap-dev libtool libxslt runc
 RUN git clone https://github.com/shadow-maint/shadow.git /shadow
 WORKDIR /shadow
 RUN git checkout 59c2dabb264ef7b3137f5edb52c0b31d5af0cf76


### PR DESCRIPTION
Currently `make docker/server` fails on arm64 (specifically an M1 Mac) because there isn’t an arm64 version of `img` available on the Alpine registry yet.

```
❯ make docker/server
DOCKER_BUILDKIT=1 docker build \
  --ssh default \
  --secret id=ssh.config,src="/Users/jamie/.ssh/config" \
  --secret id=ssh.key,src="/Users/jamie/.ssh/config" \
  -t waypoint:dev \
  .
[+] Building 6.8s (10/41)                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                            0.0s
 => => transferring dockerfile: 4.36kB                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                               0.0s
 => => transferring context: 71B                                                                                                                                0.0s
 => resolve image config for docker.mirror.hashicorp.services/docker/dockerfile:experimental                                                                    1.9s
 => CACHED docker-image://docker.mirror.hashicorp.services/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496  0.0s
 => [internal] load metadata for docker.mirror.hashicorp.services/alpine:latest                                                                                 2.9s
 => [internal] load metadata for docker.mirror.hashicorp.services/golang:alpine                                                                                 3.1s
 => CANCELED [internal] load build context                                                                                                                      1.5s
 => => transferring context: 56.93MB                                                                                                                            1.5s
 => [builder  1/14] FROM docker.mirror.hashicorp.services/golang:alpine@sha256:4dd403b2e7a689adc5b7110ba9cd5da43d216cfcfccfbe2b35680effcf336c7e                 0.0s
 => CACHED [stage-3  1/10] FROM docker.mirror.hashicorp.services/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f                 0.0s
 => ERROR [imgbase 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev     gcc git libcap-dev libtool libxslt img runc           1.5s
------                                                                                                                                                               
 > [imgbase 2/6] RUN apk add --no-cache autoconf automake build-base byacc gettext gettext-dev     gcc git libcap-dev libtool libxslt img runc:                      
#15 0.426 fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/aarch64/APKINDEX.tar.gz                                                                             
#15 0.852 fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/aarch64/APKINDEX.tar.gz                                                                        
#15 1.430 ERROR: unable to select packages:                                                                                                                          
#15 1.446   img (no such package):
#15 1.446     required by: world[img]
------
executor failed running [/bin/sh -c apk add --no-cache autoconf automake build-base byacc gettext gettext-dev     gcc git libcap-dev libtool libxslt img runc]: exit code: 1
make: *** [docker/server] Error 1
```

We build our own fork of `img` in the `imgbuilder` stage, which is used in the final image so it seems like the APK package is surplus to requirements. This patch removes `img` from the `apk add` instruction, which allows the `make docker/server` to complete successfully on the M1 Mac. I tested the new image against the Docker and Kubernetes tutorials and it appears to work correctly.