### PR TITLE
ci: add backporting of docs to latest release branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,29 +1,49 @@
 ---
   name: Backport Assistant Runner
-  
+
   on:
     pull_request_target:
       types:
         - closed
         - labeled
-  
-  jobs:
-    backport:
-      if: github.event.pull_request.merged
-      runs-on: ubuntu-latest
-      container: hashicorpdev/backport-assistant:0.2.2
-      steps:
-        - name: Run Backport Assistant for stable-website
-          run: |
-            backport-assistant backport -automerge
-          env:
-            BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-            BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
-            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-        - name: Run Backport Assistant for release branches
-          run: |
-            backport-assistant backport -automerge
-          env:
-            BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
-            BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
-            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.2
+    steps:
+      - name: Run Backport Assistant for stable-website
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Run Backport Assistant backport website changes to latest release branch
+        run: |
+          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels")
+          ret="$?"
+          if [[ "$ret" -ne 0 ]]; then
+              echo "The GitHub API returned $ret"
+              exit $ret
+          fi
+
+          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
+          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name | sort -rV | head -n1)
+          echo "Latest backport label: $latest_backport_label"
+
+          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
+          # trims backport/ from the beginning with parameter substitution
+          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Run Backport Assistant for release branches
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,11 +1,11 @@
 ---
-  name: Backport Assistant Runner
+name: Backport Assistant Runner
 
-  on:
-    pull_request_target:
-      types:
-        - closed
-        - labeled
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
 
 jobs:
   backport:


### PR DESCRIPTION
This PR adds a small backport-assistant configuration to backport any `backport/website` changes to the latest release branch. Previously, website changes were backported to `stable-website` if the `backport/website` label was applied but if it was not backported to the latest release branch, when the release was cut, it wouldn't contain those changes and would essentially 'revert' them. This will make sure that any docs changes that are picked with `backport/website` will also make it into the next release force-push from the release branch -> `stable-website`. 