### PR TITLE
ci: backporting fixes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
-          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name | sort -rV | head -n1)
+          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
           echo "Latest backport label: $latest_backport_label"
 
           # set BACKPORT_TARGET_TEMPLATE for backport-assistant

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.2.2
+    container: hashicorpdev/backport-assistant:0.2.3
     steps:
       - name: Run Backport Assistant for stable-website
         run: |


### PR DESCRIPTION
We updated the `backport-assistant` image to include `curl` and `jq`. I also added a missing quote to close out the jq command I missed. 