### PR TITLE
Install the correct version of mockery.

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,5 +19,5 @@ import _ "github.com/golang/protobuf/protoc-gen-go"
 //go:generate go install github.com/mitchellh/protoc-gen-go-json
 import _ "github.com/mitchellh/protoc-gen-go-json"
 
-//go:generate go install github.com/vektra/mockery
+//go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=1.1.2" github.com/vektra/mockery/cmd/mockery
 import _ "github.com/vektra/mockery"


### PR DESCRIPTION
Without specifying a mockery package, nothing gets installed.

Without injecting the version via ldflags, mockery prepends the wrong version number (v1.0.0) to all of the mocks that it generates. I do not love hard-coding 1.1.2 in here, but this seems unlikely to change frequently and I don't see another path. Bash trickery inside `go:generate` seems to not work and would be a bit hacky anyway.