### PR TITLE
builtin/vault/internal/auth: deprecate errwrap.Wrapf()

### DIFF
--- a/builtin/vault/internal/auth/kubernetes/kubernetes.go
+++ b/builtin/vault/internal/auth/kubernetes/kubernetes.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 
@@ -79,7 +78,7 @@ func (k *kubernetesMethod) Authenticate(ctx context.Context, client *api.Client)
 
 	jwtString, err := k.readJWT()
 	if err != nil {
-		return "", nil, nil, errwrap.Wrapf("error reading JWT with Kubernetes Auth: {{err}}", err)
+		return "", nil, nil, fmt.Errorf("error reading JWT with Kubernetes Auth: %w", err)
 	}
 
 	return fmt.Sprintf("%s/login", k.mountPath), nil, map[string]interface{}{


### PR DESCRIPTION
`errwrap.Wrapf()` is deprecated, and recommends using `fmt.Errorf()`.

This PR replaces `errwrap.Wrapf()` throughout the subpackages of `builtin/vault/internal/auth`.