### PR TITLE
UI: Use Mirage’s DB/ORM/Factory in tests and dev

### DIFF
--- a/ui/mirage/factories/application.ts
+++ b/ui/mirage/factories/application.ts
@@ -1,0 +1,12 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from '../faker';
+
+export default Factory.extend({
+  simple: trait({
+    name: 'simple-application',
+  }),
+
+  'with-random-name': trait({
+    name: () => `wp-${faker.hacker.noun()}`,
+  }),
+});

--- a/ui/mirage/factories/build.ts
+++ b/ui/mirage/factories/build.ts
@@ -1,0 +1,39 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+import { fakeId } from '../utils';
+
+export default Factory.extend({
+  afterCreate(build, server) {
+    if (!build.workspace) {
+      let workspace =
+        server.schema.workspaces.findBy({ name: 'default' }) || server.create('workspace', 'default');
+      build.update('workspace', workspace);
+    }
+  },
+
+  random: trait({
+    id: () => fakeId(),
+    sequence: (i) => i + 1,
+    labels: () => ({
+      'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
+      'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
+    }),
+    component: association('builder', 'with-random-name'),
+    status: association('random'),
+  }),
+
+  'seconds-old-success': trait({
+    status: association('random', 'success', 'seconds-old'),
+  }),
+
+  'minutes-old-success': trait({
+    status: association('random', 'success', 'minutes-old'),
+  }),
+
+  'hours-old-success': trait({
+    status: association('random', 'success', 'hours-old'),
+  }),
+
+  'days-old-success': trait({
+    status: association('random', 'success', 'days-old'),
+  }),
+});

--- a/ui/mirage/factories/component.ts
+++ b/ui/mirage/factories/component.ts
@@ -1,0 +1,37 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import { fakeComponentForKind } from '../utils';
+import { Component } from 'waypoint-pb';
+
+// eslint-disable-next-line ember/require-tagless-components
+export default Factory.extend({
+  unknown: trait({
+    type: 'UNKNOWN',
+  }),
+
+  builder: trait({
+    type: 'BUILDER',
+  }),
+
+  registry: trait({
+    type: 'REGISTRY',
+  }),
+
+  platform: trait({
+    type: 'PLATFORM',
+  }),
+
+  'release-manager': trait({
+    type: 'RELEASEMANAGER',
+  }),
+
+  'with-random-name': trait({
+    afterCreate(component) {
+      component.update('name', randomNameForType(component.type));
+    },
+  }),
+});
+
+function randomNameForType(type): string {
+  let kind = Component.Type[type as keyof typeof Component.Type];
+  return fakeComponentForKind(kind);
+}

--- a/ui/mirage/factories/deployment.ts
+++ b/ui/mirage/factories/deployment.ts
@@ -1,0 +1,45 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+import { fakeId } from '../utils';
+
+export default Factory.extend({
+  afterCreate(deployment, server) {
+    if (!deployment.workspace) {
+      let workspace =
+        server.schema.workspaces.findBy({ name: 'default' }) || server.create('workspace', 'default');
+      deployment.update('workspace', workspace);
+    }
+  },
+
+  random: trait({
+    id: () => fakeId(),
+    component: association('platform', 'with-random-name'),
+    sequence: (i) => i + 1,
+    status: association('random'),
+    state: 'CREATED',
+    labels: () => ({
+      'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
+      'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
+    }),
+
+    afterCreate(deployment) {
+      let url = `https://wildly-intent-honeybee--v${deployment.sequence}.waypoint.run`;
+      deployment.update('deployUrl', url);
+    },
+  }),
+
+  'seconds-old-success': trait({
+    status: association('random', 'success', 'seconds-old'),
+  }),
+
+  'minutes-old-success': trait({
+    status: association('random', 'success', 'minutes-old'),
+  }),
+
+  'hours-old-success': trait({
+    status: association('random', 'success', 'hours-old'),
+  }),
+
+  'days-old-success': trait({
+    status: association('random', 'success', 'days-old'),
+  }),
+});

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -1,0 +1,70 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from '../faker';
+
+export default Factory.extend({
+  simple: trait({
+    name: 'simple-project',
+  }),
+
+  'with-random-name': trait({
+    name: () => faker.hacker.noun(),
+  }),
+
+  // This is our primary demo trait for development mode
+  'marketing-public': trait({
+    name: 'marketing-public',
+    afterCreate(project, server) {
+      let application = server.create('application', 'with-random-name', { project });
+
+      let builds = [
+        server.create('build', 'random', 'seconds-old-success', { sequence: 4, application }),
+        server.create('build', 'random', 'minutes-old-success', { sequence: 3, application }),
+        server.create('build', 'random', 'hours-old-success', { sequence: 2, application }),
+        server.create('build', 'random', 'days-old-success', { sequence: 1, application }),
+      ];
+
+      let deployments = [
+        server.create('deployment', 'random', 'seconds-old-success', {
+          sequence: 4,
+          application,
+          build: builds[0],
+        }),
+        server.create('deployment', 'random', 'minutes-old-success', {
+          sequence: 3,
+          application,
+          build: builds[1],
+        }),
+        server.create('deployment', 'random', 'hours-old-success', {
+          sequence: 2,
+          application,
+          build: builds[2],
+        }),
+        server.create('deployment', 'random', 'days-old-success', {
+          sequence: 1,
+          application,
+          build: builds[3],
+        }),
+      ];
+
+      server.create('release', 'random', 'minutes-old-success', {
+        sequence: 3,
+        application,
+        deployment: deployments[2],
+      });
+      server.create('release', 'random', 'hours-old-success', {
+        sequence: 2,
+        application,
+        deployment: deployments[1],
+      });
+      server.create('release', 'random', 'days-old-success', {
+        sequence: 1,
+        application,
+        deployment: deployments[0],
+      });
+    },
+  }),
+
+  'with-remote-runners': trait({
+    remoteEnabled: true,
+  }),
+});

--- a/ui/mirage/factories/release.ts
+++ b/ui/mirage/factories/release.ts
@@ -1,0 +1,41 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+import { fakeId, sequenceRandom } from '../utils';
+
+export default Factory.extend({
+  afterCreate(release, server) {
+    if (!release.workspace) {
+      let workspace =
+        server.schema.workspaces.findBy({ name: 'default' }) || server.create('workspace', 'default');
+      release.update('workspace', workspace);
+    }
+  },
+
+  random: trait({
+    id: () => fakeId(),
+    component: association('release-manager', 'with-random-name'),
+    sequence: () => sequenceRandom(),
+    status: association('random'),
+    state: 'CREATED',
+    labels: () => ({
+      'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
+      'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
+    }),
+    url: 'https://wildly-intent-honeybee.waypoint.run',
+  }),
+
+  'seconds-old-success': trait({
+    status: association('random', 'success', 'seconds-old'),
+  }),
+
+  'minutes-old-success': trait({
+    status: association('random', 'success', 'minutes-old'),
+  }),
+
+  'hours-old-success': trait({
+    status: association('random', 'success', 'hours-old'),
+  }),
+
+  'days-old-success': trait({
+    status: association('random', 'success', 'days-old'),
+  }),
+});

--- a/ui/mirage/factories/status.ts
+++ b/ui/mirage/factories/status.ts
@@ -1,0 +1,49 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from '../faker';
+import { Status } from 'waypoint-pb';
+
+export default Factory.extend({
+  random: trait({
+    state: () => randomStateName(),
+
+    completeTime: () => faker.date.recent(),
+
+    afterCreate(status) {
+      let minutes = faker.random.number({ min: 1, max: 10 });
+      let startTime = new Date(status.completeTime.valueOf() - minutes * 60 * 1000);
+
+      status.update('startTime', startTime);
+    },
+  }),
+
+  success: trait({
+    state: 'SUCCESS',
+  }),
+
+  'seconds-old': trait({
+    completeTime: () => new Date(),
+  }),
+
+  'minutes-old': trait({
+    completeTime: () => new Date(new Date().valueOf() - faker.random.number({ min: 1, max: 15 }) * 60 * 1000),
+  }),
+
+  'hours-old': trait({
+    completeTime: () =>
+      new Date(new Date().valueOf() - faker.random.number({ min: 1, max: 5 }) * 60 * 60 * 1000),
+  }),
+
+  'days-old': trait({
+    completeTime: () =>
+      new Date(new Date().valueOf() - faker.random.number({ min: 1, max: 5 }) * 24 * 60 * 60 * 1000),
+  }),
+});
+
+type StateName = keyof typeof Status.State;
+function randomStateName(): StateName {
+  return sample(Object.keys(Status.State)) as StateName;
+}
+
+function sample<T>(array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}

--- a/ui/mirage/factories/workspace.ts
+++ b/ui/mirage/factories/workspace.ts
@@ -1,0 +1,7 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  default: trait({
+    name: 'default',
+  }),
+});

--- a/ui/mirage/helpers/protobufs.ts
+++ b/ui/mirage/helpers/protobufs.ts
@@ -1,0 +1,50 @@
+import * as protobuf from 'google-protobuf';
+import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
+
+/**
+ * Encodes the given protobuf message to base64-encoded wire format.
+ *
+ * @param msg the protobuf message you want to encode
+ * @returns msg in base64-encoded protobuf wire format
+ */
+export function encode(msg: protobuf.Message): string {
+  let resp = msg || new Empty();
+  let serialized = resp.serializeBinary();
+  let len = serialized.length;
+  let bytesArray = [0, 0, 0, 0];
+  let payload = new Uint8Array(5 + len);
+
+  for (let i = 3; i >= 0; i--) {
+    bytesArray[i] = len % 256;
+    len = len >>> 8;
+  }
+
+  payload.set(new Uint8Array(bytesArray), 1);
+  payload.set(serialized, 5);
+
+  let result = btoa(String.fromCharCode(...payload));
+
+  return result;
+}
+
+/**
+ * Decodes base64-encoded wire format to the given message type.
+ *
+ * @param type the type of protobuf message you’re expecting to decode
+ * @param data the base64-encoded protobuf wire format
+ * @returns reified protobuf message
+ */
+export function decode<T extends protobuf.Message>(
+  type: { deserializeBinary(msg: Uint8Array): T },
+  data: string
+): T {
+  let wireBase64 = data;
+  let wireAscii = atob(wireBase64);
+  let wireChars = [...wireAscii];
+  let msgChars = wireChars.slice(5);
+  let msgCharCodes = msgChars.map((s) => s.charCodeAt(0));
+  let msgBinary = Uint8Array.from(msgCharCodes);
+  let result = type.deserializeBinary(msgBinary);
+
+  return result;
+}

--- a/ui/mirage/models/application.ts
+++ b/ui/mirage/models/application.ts
@@ -1,0 +1,29 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import { Application, Ref } from 'waypoint-pb';
+
+export default Model.extend({
+  project: belongsTo(),
+  builds: hasMany(),
+  deployments: hasMany(),
+
+  toProtobuf(): Application {
+    let result = new Application();
+
+    // TODO: result.setExtension(...)
+    // TODO: result.setFileChangeSignal(...)
+    result.setName(this.name);
+    result.setProject(this.project.toProtobufRef());
+
+    return result;
+  },
+
+  toProtobufRef(): Ref.Application {
+    let result = new Ref.Application();
+
+    result.setApplication(this.name);
+    // TODO: result.setExtension(...)
+    result.setProject(this.project?.name);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/build.ts
+++ b/ui/mirage/models/build.ts
@@ -1,0 +1,31 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import { Build } from 'waypoint-pb';
+
+export default Model.extend({
+  application: belongsTo(),
+  workspace: belongsTo(),
+  component: belongsTo({ inverse: 'owner' }),
+  status: belongsTo({ inverse: 'owner' }),
+  deployments: hasMany(),
+
+  toProtobuf(): Build {
+    let result = new Build();
+
+    result.setApplication(this.application?.toProtobufRef());
+    // TODO: result.setArtifact(...)
+    result.setComponent(this.component?.toProtobuf());
+    // TODO: result.setExtension(...)
+    result.setId(this.id);
+    result.setJobId(this.JobId);
+    result.setSequence(this.sequence);
+    result.setStatus(this.status?.toProtobuf());
+    result.setTemplateData(this.templateData);
+    result.setWorkspace(this.workspace?.toProtobufRef());
+
+    for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
+      result.getLabelsMap().set(key, value);
+    }
+
+    return result;
+  },
+});

--- a/ui/mirage/models/component.ts
+++ b/ui/mirage/models/component.ts
@@ -1,0 +1,16 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Component } from 'waypoint-pb';
+
+// eslint-disable-next-line ember/require-tagless-components
+export default Model.extend({
+  owner: belongsTo({ polymorphic: true }),
+
+  toProtobuf(): Component {
+    let result = new Component();
+
+    result.setName(this.name);
+    result.setType(Component.Type[this.type as keyof typeof Component.Type]);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -1,0 +1,51 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Deployment, Operation } from 'waypoint-pb';
+
+const { PhysicalState } = Operation;
+type StateName = keyof typeof PhysicalState;
+
+export default Model.extend({
+  application: belongsTo(),
+  workspace: belongsTo(),
+  build: belongsTo(),
+  status: belongsTo({ inverse: 'owner' }),
+  component: belongsTo({ inverse: 'owner' }),
+
+  toProtobuf(): Deployment {
+    let result = new Deployment();
+
+    result.setApplication(this.application?.toProtobufRef());
+    result.setArtifactId(this.artifactId);
+    result.setComponent(this.component?.toProtobuf());
+    // TODO: result.setDeployment
+    // TODO: result.setExtension
+    // TODO: result.setGeneration
+    result.setHasEntrypointConfig(this.hasEntrypointConfig);
+    result.setHasExecPlugin(this.hasExecPlugin);
+    result.setHasLogsPlugin(this.hasLogsPlugin);
+    result.setId(this.id);
+    result.setJobId(this.jobId);
+    result.setPreload(this.preloadProtobuf());
+    result.setSequence(this.sequence);
+    result.setState(PhysicalState[this.state as StateName]);
+    result.setStatus(this.status?.toProtobuf());
+    result.setTemplateData(this.templateData);
+    result.setWorkspace(this.workspace.toProtobufRef());
+
+    for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
+      result.getLabelsMap().set(key, value);
+    }
+
+    return result;
+  },
+
+  preloadProtobuf(): Deployment.Preload {
+    let result = new Deployment.Preload();
+
+    // TODO: result.setArtifact
+    result.setBuild(this.build?.toProtobuf());
+    result.setDeployUrl(this.deployUrl);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/project.ts
+++ b/ui/mirage/models/project.ts
@@ -1,0 +1,31 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+import { Project, Ref } from 'waypoint-pb';
+
+export default Model.extend({
+  applications: hasMany(),
+
+  toProtobuf(): Project {
+    let result = new Project();
+
+    result.setApplicationsList(this.applications.models.map((a) => a.toProtobuf()));
+    // TODO: result.setDataSource(...)
+    // TODO: result.setDataSourcePoll(...)
+    // TODO: result.setExtension(...)
+    result.setFileChangeSignal(this.fileChangeSignal);
+    result.setName(this.name);
+    result.setRemoteEnabled(this.remoteEnabled);
+    result.setWaypointHcl(this.waypointHcl);
+    result.setWaypointHclFormat(Project.Format.HCL);
+
+    return result;
+  },
+
+  toProtobufRef(): Ref.Project {
+    let result = new Ref.Project();
+
+    // TODO: result.setExtension(...)
+    result.setProject(this.name);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -1,0 +1,48 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Release, Operation } from 'waypoint-pb';
+
+const { PhysicalState } = Operation;
+type StateName = keyof typeof PhysicalState;
+
+export default Model.extend({
+  application: belongsTo(),
+  workspace: belongsTo(),
+  deployment: belongsTo(),
+  status: belongsTo({ inverse: 'owner' }),
+  component: belongsTo({ inverse: 'owner' }),
+
+  toProtobuf(): Release {
+    let result = new Release();
+
+    result.setApplication(this.application?.toProtobufRef());
+    result.setComponent(this.component?.toProtobuf());
+    result.setDeploymentId(this.deployment?.id);
+    // TODO: result.setExtension
+    result.setId(this.id);
+    result.setJobId(this.jobId);
+    result.setPreload(this.preloadProtobuf());
+    // TODO: result.setRelease
+    result.setSequence(this.sequence);
+    result.setState(PhysicalState[this.state as StateName]);
+    result.setStatus(this.status?.toProtobuf());
+    result.setTemplateData(this.templateData);
+    result.setUrl(this.url);
+    result.setWorkspace(this.workspace?.toProtobufRef());
+
+    for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
+      result.getLabelsMap().set(key, value);
+    }
+
+    return result;
+  },
+
+  preloadProtobuf(): Release.Preload {
+    let result = new Release.Preload();
+
+    // TODO: result.setArtifact
+    result.setBuild(this.deployment?.build?.toProtobuf());
+    result.setDeployment(this.deployment?.toProtobuf());
+
+    return result;
+  },
+});

--- a/ui/mirage/models/status.ts
+++ b/ui/mirage/models/status.ts
@@ -1,0 +1,28 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Status } from 'waypoint-pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+
+export default Model.extend({
+  owner: belongsTo({ polymorphic: true }),
+
+  toProtobuf(): Status {
+    let result = new Status();
+
+    result.setCompleteTime(dateToTimestamp(this.completeTime));
+    result.setDetails(this.details);
+    // result.setError
+    // result.setExtension
+    result.setStartTime(dateToTimestamp(this.startTime));
+    result.setState(Status.State[this.state as keyof typeof Status.State]);
+
+    return result;
+  },
+});
+
+function dateToTimestamp(date: Date): Timestamp {
+  let result = new Timestamp();
+
+  result.setSeconds(Math.floor(date.valueOf() / 1000));
+
+  return result;
+}

--- a/ui/mirage/models/workspace.ts
+++ b/ui/mirage/models/workspace.ts
@@ -1,0 +1,25 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+import { Ref, Workspace } from 'waypoint-pb';
+
+export default Model.extend({
+  builds: hasMany(),
+
+  toProtobuf(): Workspace {
+    let result = new Workspace();
+
+    // TODO: result.setActiveTime
+    // TODO: result.setExtension
+    result.setName(this.name);
+    // TODO: result.setProjectsList
+
+    return result;
+  },
+
+  toProtobufRef(): Ref.Workspace {
+    let result = new Ref.Workspace();
+
+    result.setWorkspace(this.name);
+
+    return result;
+  },
+});

--- a/ui/mirage/scenarios/default.ts
+++ b/ui/mirage/scenarios/default.ts
@@ -1,0 +1,5 @@
+import { Server } from 'ember-cli-mirage';
+
+export default function (server: Server): void {
+  server.create('project', 'marketing-public');
+}

--- a/ui/mirage/serializers/application.ts
+++ b/ui/mirage/serializers/application.ts
@@ -1,21 +1,10 @@
-import { Serializer, Request } from 'ember-cli-mirage';
+import { Serializer } from 'ember-cli-mirage';
 import * as jspb from 'google-protobuf';
 import { Response } from 'miragejs';
+import { encode } from '../helpers/protobufs';
 
 export default class ApplicationSerializer extends Serializer {
-  serialize(model: jspb.Message, request: Request): Response {
-    let resp = model;
-    let serialized = resp.serializeBinary();
-    var len = serialized.length;
-    var bytesArray = [0, 0, 0, 0];
-    var payload = new Uint8Array(5 + len);
-    for (var i = 3; i >= 0; i--) {
-      bytesArray[i] = len % 256;
-      len = len >>> 8;
-    }
-    payload.set(new Uint8Array(bytesArray), 1);
-    payload.set(serialized, 5);
-
-    return new Response(200, {}, btoa(String.fromCharCode(...payload)));
+  serialize(msg: jspb.Message): Response {
+    return new Response(200, {}, encode(msg));
   }
 }

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -1,45 +1,29 @@
-import { Component, Ref, Deployment, ListDeploymentsResponse } from 'waypoint-pb';
-import { fakeId, fakeComponentForKind, statusRandom, sequenceRandom } from '../utils';
-import { createBuild } from './build';
+import { GetDeploymentRequest, ListDeploymentsRequest, ListDeploymentsResponse } from 'waypoint-pb';
+import { Request, Response } from 'ember-cli-mirage';
+import { decode } from '../helpers/protobufs';
 
-export function createDeployment(): Deployment {
-  let deploy = new Deployment();
-  deploy.setId(fakeId());
-
-  // todo(pearkes): create util
-  let workspace = new Ref.Workspace();
-  workspace.setWorkspace('default');
-
-  let component = new Component();
-  component.setType(Component.Type.PLATFORM);
-  component.setName(fakeComponentForKind(Component.Type.PLATFORM));
-
-  deploy.setSequence(sequenceRandom());
-  deploy.setStatus(statusRandom());
-  deploy.setComponent(component);
-  deploy.setWorkspace(workspace);
-
-  const preload = new Deployment.Preload();
-  preload.setBuild(createBuild());
-  preload.setDeployUrl(`https://wildly-intent-honeybee--${deploy.getSequence()}.alpha.waypoint.run`);
-
-  deploy.setPreload(preload);
-  deploy.setState(3);
-
-  deploy.getLabelsMap().set('common/vcs-ref', '0d56a9f8456b088dd0e4a7b689b842876fd47352');
-  deploy.getLabelsMap().set('common/vcs-ref-path', 'https://github.com/hashicorp/waypoint/commit/');
-
-  return deploy;
-}
-
-export function list(schema: any, { params, requestHeaders }) {
+export function list(schema: any, { requestBody }: Request): Response {
+  let requestMsg = decode(ListDeploymentsRequest, requestBody);
+  let projectName = requestMsg.getApplication().getProject();
+  let appName = requestMsg.getApplication().getApplication();
+  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let project = schema.projects.findBy({ name: projectName });
+  let application = schema.applications.findBy({ name: appName, projectId: project?.id });
+  let workspace = schema.workspaces.findBy({ name: workspaceName });
+  let deployments = schema.deployments.where({ applicationId: application?.id, workspaceId: workspace?.id });
+  let deploymentProtobufs = deployments.models.map((d) => d.toProtobuf());
   let resp = new ListDeploymentsResponse();
-  let deploys = new Array(createDeployment(), createDeployment(), createDeployment());
-  resp.setDeploymentsList(deploys);
+
+  resp.setDeploymentsList(deploymentProtobufs);
+
   return this.serialize(resp, 'application');
 }
 
-export function get(schema: any, { params, requestHeaders }) {
-  let deploy = createDeployment();
-  return this.serialize(deploy, 'application');
+export function get(schema: any, { requestBody }: Request): Response {
+  let requestMsg = decode(GetDeploymentRequest, requestBody);
+  let id = requestMsg.getRef().getId();
+  let model = schema.deployments.find(id);
+  let protobuf = model?.toProtobuf();
+
+  return this.serialize(protobuf, 'application');
 }

--- a/ui/mirage/services/project.ts
+++ b/ui/mirage/services/project.ts
@@ -1,50 +1,25 @@
-import { Build, Ref, ListProjectsResponse, GetProjectResponse, Project, Application } from 'waypoint-pb';
-import { fakeId } from '../utils';
-import faker from '../faker';
-import { dasherize } from '@ember/string';
-import { create } from 'domainx';
+import { ListProjectsResponse, GetProjectResponse } from 'waypoint-pb';
+import { decode } from '../helpers/protobufs';
+import { GetProjectRequest } from 'waypoint-pb';
+import { Request, Response } from 'miragejs';
 
-const projectName = 'marketing-public';
-
-function createProjectRef(): Ref.Project {
-  let build = new Build();
-  build.setId(fakeId());
-
-  // todo(pearkes): create util
-  let workspace = new Ref.Workspace();
-  workspace.setWorkspace('default');
-
-  let project = new Ref.Project();
-  project.setProject(projectName);
-
-  return project;
-}
-
-function createApp(): Application {
-  let app = new Application();
-  app.setName(`wp-${faker.hacker.noun()}`);
-
-  return app;
-}
-
-function createProject(): Project {
-  let proj = new Project();
-  proj.setName(projectName);
-  proj.setApplicationsList([createApp()]);
-
-  return proj;
-}
-
-export function list(schema: any, { params, requestHeaders }) {
+export function list(schema: any): Response {
   let resp = new ListProjectsResponse();
-  let projs = new Array(createProjectRef());
-  resp.setProjectsList(projs);
+  let projectRefs = schema.projects.all().models.map((p) => p.toProtobufRef());
+
+  resp.setProjectsList(projectRefs);
+
   return this.serialize(resp, 'application');
 }
 
-export function get(schema: any, { params, requestHeaders }) {
+export function get(schema: any, { requestBody }: Request): Response {
+  let requestMsg = decode(GetProjectRequest, requestBody);
+  let name = requestMsg.getProject().getProject();
+  let model = schema.projects.findBy({ name });
   let resp = new GetProjectResponse();
-  let proj = createProject();
-  resp.setProject(proj);
+  let project = model?.toProtobuf();
+
+  resp.setProject(project);
+
   return this.serialize(resp, 'application');
 }

--- a/ui/mirage/services/release.ts
+++ b/ui/mirage/services/release.ts
@@ -1,43 +1,29 @@
-import { Component, Ref, Release, ListReleasesResponse } from 'waypoint-pb';
-import { fakeId, fakeComponentForKind, statusRandom, sequenceRandom } from '../utils';
-import { createDeployment } from './deployment';
+import { ListReleasesRequest, ListReleasesResponse, GetReleaseRequest } from 'waypoint-pb';
+import { Request, Response } from 'ember-cli-mirage';
+import { decode } from '../helpers/protobufs';
 
-function createRelease(): Release {
-  let release = new Release();
-  release.setId(fakeId());
-
-  // todo(pearkes): create util
-  let workspace = new Ref.Workspace();
-  workspace.setWorkspace('default');
-
-  let component = new Component();
-  component.setType(Component.Type.RELEASEMANAGER);
-  component.setName(fakeComponentForKind(Component.Type.RELEASEMANAGER));
-
-  release.setSequence(sequenceRandom());
-  release.setStatus(statusRandom());
-  release.setComponent(component);
-  release.setWorkspace(workspace);
-  release.setDeploymentId(createDeployment().getId());
-
-  release.setUrl(`https://wildly-intent-honeybee--${release.getId().toLowerCase()}.alpha.waypoint.run`);
-
-  release.setState(3);
-
-  release.getLabelsMap().set('common/vcs-ref', '0d56a9f8456b088dd0e4a7b689b842876fd47352');
-  release.getLabelsMap().set('common/vcs-ref-path', 'https://github.com/hashicorp/waypoint/commit/');
-
-  return release;
-}
-
-export function list(schema: any, { params, requestHeaders }) {
+export function list(schema: any, { requestBody }: Request): Response {
+  let requestMsg = decode(ListReleasesRequest, requestBody);
+  let projectName = requestMsg.getApplication().getProject();
+  let appName = requestMsg.getApplication().getApplication();
+  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let project = schema.projects.findBy({ name: projectName });
+  let application = schema.applications.findBy({ name: appName, projectId: project?.id });
+  let workspace = schema.workspaces.findBy({ name: workspaceName });
+  let releases = schema.releases.where({ applicationId: application?.id, workspaceId: workspace?.id });
+  let releaseProtobufs = releases.models.map((d) => d.toProtobuf());
   let resp = new ListReleasesResponse();
-  let releases = new Array(createRelease(), createRelease(), createRelease());
-  resp.setReleasesList(releases);
+
+  resp.setReleasesList(releaseProtobufs);
+
   return this.serialize(resp, 'application');
 }
 
-export function get(schema: any, { params, requestHeaders }) {
-  let deploy = createRelease();
-  return this.serialize(deploy, 'application');
+export function get(schema: any, { requestBody }: Request) {
+  let requestMsg = decode(GetReleaseRequest, requestBody);
+  let id = requestMsg.getRef().getId();
+  let model = schema.releases.find(id);
+  let protobuf = model?.toProtobuf();
+
+  return this.serialize(protobuf, 'application');
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
     "ember-cli-flash": "^2.1.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
-    "ember-cli-mirage": "^1.1.7",
+    "ember-cli-mirage": "^2.2.0",
     "ember-cli-page-object": "^1.17.5",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/ui/tests/acceptance/builds-list-test.ts
+++ b/ui/tests/acceptance/builds-list-test.ts
@@ -8,7 +8,6 @@ import login from '../helpers/login';
 const buildsUrl = '/default/microchip/app/wp-bandwidth/builds';
 
 const page = create({
-  // todo(pearkes): seeds inline tests
   visit: visitable(buildsUrl),
   buildList: collection('[data-test-build-list] li'),
 });
@@ -19,9 +18,12 @@ module('Acceptance | builds list', function (hooks) {
   login();
 
   test('visiting builds page', async function (assert) {
+    let project = this.server.create('project', { name: 'microchip' });
+    let application = this.server.create('application', { name: 'wp-bandwidth', project });
+    this.server.createList('build', 4, 'random', { application });
+
     await page.visit();
 
-    // Currently no way to seed past the default in mirage/services/builds.ts
     assert.equal(page.buildList.length, 4);
     assert.equal(currentURL(), buildsUrl);
   });

--- a/ui/tests/acceptance/deployments-list-test.ts
+++ b/ui/tests/acceptance/deployments-list-test.ts
@@ -18,6 +18,10 @@ module('Acceptance | deployments list', function (hooks) {
   login();
 
   test('visiting deployments page', async function (assert) {
+    let project = this.server.create('project', { name: 'microchip' });
+    let application = this.server.create('application', { name: 'wp-bandwidth', project });
+    this.server.createList('deployment', 3, 'random', { application });
+
     await page.visit();
 
     assert.equal(page.list.length, 3);

--- a/ui/tests/acceptance/onboarding-test.ts
+++ b/ui/tests/acceptance/onboarding-test.ts
@@ -78,6 +78,8 @@ module('Acceptance | onboarding start', function (hooks) {
   login();
 
   test('sends users to default workspace after completion', async function (assert) {
+    this.server.create('project', 'marketing-public');
+
     await page.visit().nextStep();
 
     assert.equal(currentURL(), `/default`);

--- a/ui/tests/acceptance/releases-list-test.ts
+++ b/ui/tests/acceptance/releases-list-test.ts
@@ -18,6 +18,10 @@ module('Acceptance | releases list', function (hooks) {
   login();
 
   test('visiting releases page', async function (assert) {
+    let project = this.server.create('project', { name: 'microchip' });
+    let application = this.server.create('application', { name: 'wp-bandwidth', project });
+    this.server.createList('release', 3, { application });
+
     await page.visit();
 
     assert.equal(page.list.length, 3);

--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -2,6 +2,12 @@ declare module 'ember-cli-mirage/test-support' {
   export function setupMirage(hooks: NestedHooks): void;
 }
 
+declare module 'ember-test-helpers' {
+  interface TestContext {
+    server: any;
+  }
+}
+
 declare module 'ember-a11y-testing/test-support/audit' {
   export default function a11yAudit(target?: string | Element, axeOptions?: object): Promise<void>;
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2512,6 +2512,31 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
+"@embroider/macros@^0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.40.0.tgz#f58763b4cfb9b4089679b478a28627595341bc5a"
+  integrity sha512-ygChvFoebSi/N8b+A+XFncd454gLYBYHancrtY0AE/h6Y1HouoqQvji/IfaLisGoeuwUWuI9rCBv97COweu/rA==
+  dependencies:
+    "@embroider/shared-internals" "0.40.0"
+    assert-never "^1.1.0"
+    ember-cli-babel "^7.23.0"
+    lodash "^4.17.10"
+    resolve "^1.8.1"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.40.0.tgz#2f768c60f4f35ba5f9228f046f70324851e8bfe2"
+  integrity sha512-Ovr/i0Qgn6W6jdGXMvYJKlRoRpyBY9uhYozDSFKlBjeEmRJ0Plp7OST41+O5Td6Pqp+Rv2jVSnGzhA/MpC++NQ==
+  dependencies:
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^7.0.1"
+    lodash "^4.17.10"
+    pkg-up "^3.1.0"
+    resolve-package-path "^1.2.2"
+    semver "^7.3.2"
+    typescript-memoize "^1.0.0-alpha.3"
+
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
@@ -5499,7 +5524,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.2, broccoli-funnel@^3.0.3:
+broccoli-funnel@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz#26fd42632471f67a91f4770d1987118087219937"
   integrity sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==
@@ -7647,7 +7672,7 @@ ember-cli-babel@7.7.3:
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -8004,18 +8029,19 @@ ember-cli-lodash-subset@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
   integrity sha1-IMtop5D+D94kiN39jvu332/nZvI=
 
-ember-cli-mirage@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-1.1.7.tgz#846ec8e5199b15fa670da30dfa1708a8ee11e9dc"
-  integrity sha512-4kVLXXvgHYlv30ChM47U4xYnUtphIoEj+BQwXX0QT7pvD3KQxYnmfZSwlevSEVUy2UhbsBUPw6merENb+dIQ0A==
+ember-cli-mirage@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-2.2.0.tgz#38f4ec02536dd50ecdb265da2abbf7986d66b091"
+  integrity sha512-w+DrFEGuuLyHzJwOVkG0yOLvgwYezaMBNvvZJQzQkv1W3CsdhllkY1ZauYgL0dhrmYJwRFtp8DnaPQwBTDCSfA==
   dependencies:
+    "@embroider/macros" "^0.40.0"
     broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^3.0.2"
+    broccoli-funnel "^3.0.3"
     broccoli-merge-trees "^4.2.0"
     ember-auto-import "^1.2.19"
     ember-cli-babel "^7.5.0"
-    ember-get-config "^0.2.2"
-    ember-inflector "^2.0.0 || ^3.0.0"
+    ember-get-config "^0.2.4 || ^0.3.0"
+    ember-inflector "^2.0.0 || ^3.0.0 || ^4.0.0"
     lodash-es "^4.17.11"
     miragejs "^0.1.31"
 
@@ -8499,13 +8525,13 @@ ember-gesture-modifiers@^1.0.0:
     ember-cli-htmlbars "^5.2.0"
     ember-modifier "^2.1.0"
 
-ember-get-config@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
-  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
+"ember-get-config@^0.2.4 || ^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
+  integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==
   dependencies:
     broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^6.3.0"
+    ember-cli-babel "^7.0.0"
 
 ember-in-element-polyfill@^1.0.1:
   version "1.0.1"
@@ -8529,7 +8555,14 @@ ember-in-viewport@^3.8.0:
     intersection-observer-admin "~0.2.12"
     raf-pool "~0.1.4"
 
-"ember-inflector@^2.0.0 || ^3.0.0", ember-inflector@^3.0.1:
+"ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-4.0.1.tgz#e0aa9e39119156a278c80bb8cdec8462ecb8e6ab"
+  integrity sha512-D14nH2wVMp13ciOONcHMXwdL/IoMBSDXsGObF2rsQX7F8vGjwp+jnSNzZuGjjIvlBFQydOJ+R2n86J2e8HRTQA==
+  dependencies:
+    ember-cli-babel "^7.23.0"
+
+ember-inflector@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.1.tgz#04be6df4d7e4000f6d6bd70787cdc995f77be4ab"
   integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==


### PR DESCRIPTION
## What is this?

This change updates our UI development/testing stack to use [Mirage’s full DB/ORM/factory system](https://miragejs.com/docs/main-concepts/orm/) to manage fixture data.

Where previously we generated protobufs in `mirage/services/*.ts`, now we’ll manage fixtures using Mirage’s declarative API.

This gives us more control over fixture data, both in tests and in development mode.

## What does it look like?

Here’s what it looks like to create fixtures on-the-fly:

https://user-images.githubusercontent.com/34030/119402444-3a7d0c00-bcdd-11eb-8dec-268f8557e6f3.mp4

For an illustration of how this will aid our testing, see the diffs for our acceptance tests. Note particularly that we are no longer asserting on values that appear in global fixtures, and can instead declare *exactly* the data a particular tests needs:

**Before:**

```ts
await page.visit();

// Currently no way to seed past the default in mirage/services/builds.ts
assert.equal(page.buildList.length, 4);
```

**After:**

```ts
let project = this.server.create('project', { name: 'microchip' });
let application = this.server.create('application', { name: 'wp-bandwidth', project });
this.server.createList('build', 4, 'random', { application });

await page.visit();

assert.equal(page.buildList.length, 4);
```

## How does this work with grpc-web?

1. We add `toProtobuf` and in some cases `toProtobufRef` methods to our Mirage models.
2. In our mock gRPC handlers we retrieve the appropriate models from Mirage’s DB and then convert them to Waypoint Protobufs using aforementioned methods.
3. We introduce [`encode`](https://github.com/hashicorp/waypoint/blob/ui-use-full-mirage-orm/ui/mirage/helpers/protobufs.ts#L4-L28) and [`decode`](https://github.com/hashicorp/waypoint/blob/ui-use-full-mirage-orm/ui/mirage/helpers/protobufs.ts#L30-L50) functions for working with the protobuf wire format.

## Why are there so many TODOs? Why doesn’t `mirage/models` cover every type?

The exercise of mapping Mirage models to Waypoint Protobufs turns out to be a good way to familiarize oneself with the API and relationships between messages and entities in the system. Rather than presenting this work as “complete” I think it’s better to merge the groundwork presented here and then bring in the whole UI team to keep improving it together.

## How should I verify/review this change?

Something like this:

1. Check out the branch
2. `yarn ember serve`
3. Visit [http://localhost:4200/tests](http://localhost:4200/tests)
4. Verify everything’s green
5. Visit [http://localhost:4200](http://localhost:4200)
6. Verify everything is behaving more-or-less as it was before
7. Try playing around with the fixtures in dev and test
8. Report anything that breaks in a mysterious way