### PR TITLE
Fixes job cancellation bug hidden behind race condition

### DIFF
--- a/.changelog/1538.txt
+++ b/.changelog/1538.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fix a bug that sometimes sends duplicate cancellation messages
+```

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -351,7 +351,7 @@ func (s *service) RunnerJobStream(
 			// the cancel time changes. The cancel time only changes if multiple
 			// cancel requests are made.
 			if job.CancelTime != nil &&
-				(lastJob == nil || lastJob.CancelTime.AsTime() != job.CancelTime.AsTime()) {
+				(lastJob == nil || !lastJob.CancelTime.AsTime().Equal(job.CancelTime.AsTime())) {
 				// The job is forced if we're in an error state. This must be true
 				// because we would've already exited the loop if we naturally
 				// got a terminal event.

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -3,7 +3,6 @@ package singleprocess
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -278,10 +277,7 @@ func (s *service) RunnerJobStream(
 	// so we can exit properly on client side close.
 	eventCh := make(chan *pb.RunnerJobStreamRequest, 1)
 	go func() {
-		defer func() {
-			time.Sleep(2 * time.Second)
-			cancel()
-		}()
+		defer cancel()
 
 		for {
 			log.Trace("waiting for job stream event")

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -3,6 +3,7 @@ package singleprocess
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -277,7 +278,10 @@ func (s *service) RunnerJobStream(
 	// so we can exit properly on client side close.
 	eventCh := make(chan *pb.RunnerJobStreamRequest, 1)
 	go func() {
-		defer cancel()
+		defer func() {
+			time.Sleep(2 * time.Second)
+			cancel()
+		}()
 
 		for {
 			log.Trace("waiting for job stream event")

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -355,7 +355,7 @@ func (s *service) RunnerJobStream(
 			// the cancel time changes. The cancel time only changes if multiple
 			// cancel requests are made.
 			if job.CancelTime != nil &&
-				(lastJob == nil || lastJob.CancelTime != job.CancelTime) {
+				(lastJob == nil || lastJob.CancelTime.AsTime() != job.CancelTime.AsTime()) {
 				// The job is forced if we're in an error state. This must be true
 				// because we would've already exited the loop if we naturally
 				// got a terminal event.


### PR DESCRIPTION
Fixed the issue that caused these failures in CI:

- https://app.circleci.com/pipelines/github/hashicorp/waypoint/5710/workflows/1a5d72db-0c69-4873-b52b-9ba984ef6d03/jobs/43406
- https://app.circleci.com/pipelines/github/hashicorp/waypoint/4393/workflows/3c705bad-3280-4e46-91ab-9c22c1636ee5/jobs/31799

This was a tricky one to track down. From the failed tests, we can see that the client was receiving duplicate cancellation events. I was able to replicate the failed test by adding a sleep [here](https://github.com/hashicorp/waypoint/blob/35a9d6f2577957aeaa2c847fa6b2a53d295864d0/internal/server/singleprocess/service_runner.go#L281-L284).


Here’s what I think is happening:

There are three goroutines at play here.  One watching for DB changes and adding them to a channel ([A](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L245-L274)), one listening for client events and adding them to a channel ([B](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L279-L318)), and a big one pulling off the channels and doing work ([C](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L322-L379)). 

In the [final phase of this test](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner_test.go#L260-L273), the client [sends a completion event onto the stream](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner_test.go#L261-L265). [B gets it](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L284), and [passes it to C synchronously](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L302) via an unbuffered channel. [C handles it](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L341), which eventually results in a DB update on the job (marking its state as Success), and then the race begins. 

On one side, B is going to return, which will trigger its[ deferred `cancel()`](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L280), which will cause C to return and the test to pass. On the other side, the update that C just made to the job is going to get picked up by [A’s watchset](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L266), which will result in one more [job update](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L260) for [C to process](https://github.com/hashicorp/waypoint/blob/2359bec96add1281a9f478cf93a612d6ee07a5ab/internal/server/singleprocess/service_runner.go#L345) before `cancel()` comes around, which  will exercise the bug. 

Generally, the memdb watchset path is slower than cancelling the context, so C never sees the final “Success” update to the job, and we don’t exercise the bug.

The bug is that we were treating the completion event as a cancellation event with an updated timestamp. It looks like `*timestamppb.Timestamp`’s aren’t nicely comparable with `==` - they return not equal even if they have the same underlying time values. Converting them to `time.Time` first does the trick.

Addresses one of the problems in #1521