### PR TITLE
ui/mirage: improve reporting of unhandled requests

### DIFF
--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -1,4 +1,6 @@
+import Ember from 'ember';
 import { logRequestConsole } from './utils';
+import failUnhandledRequest from './helpers/fail-unhandled-request';
 import { Server } from 'miragejs';
 
 import * as build from './services/build';
@@ -22,6 +24,10 @@ export default function (this: Server) {
 
   this.pretender.handledRequest = logRequestConsole;
 
+  if (Ember.testing) {
+    this.pretender.unhandledRequest = failUnhandledRequest;
+  }
+
   this.post('/ListBuilds', build.list);
   this.post('/GetBuild', build.get);
   this.post('/ListDeployments', deployment.list);
@@ -35,6 +41,8 @@ export default function (this: Server) {
   this.post('/GetRelease', release.get);
   this.post('/GetVersionInfo', versionInfo.get);
 
-  // Pass through all other requests
-  this.passthrough();
+  if (!Ember.testing) {
+    // Pass through all other requests
+    this.passthrough();
+  }
 }

--- a/ui/mirage/helpers/fail-unhandled-request.ts
+++ b/ui/mirage/helpers/fail-unhandled-request.ts
@@ -1,0 +1,17 @@
+import * as QUnit from 'qunit';
+
+/**
+ * Reports an unhandled request to QUnit, to surface missing handlers more
+ * clearly.
+ */
+export default function failUnhandledRequest(verb: string, path: string): void {
+  let result = false;
+  let message = `There is no Mirage handler for ${verb} ${path}. Please define one in ui/mirage/config.ts.`;
+  // Technically it is possible to get the real stack using `new
+  // Error().stack` but honestly it’s pretty opaque and not terribly useful
+  // for debugging. Easier to bring folks here so they can add a breakpoint
+  // and dig around.
+  let source = 'ui/mirage/helpers/fail-unhandled-request.ts:16';
+
+  QUnit.config.current.assert.pushResult({ result, message, source });
+}


### PR DESCRIPTION
## What is this?

Previously unhandled gRPC calls would silently fail in tests, leading to confusing and hard-to-debug behavior. With this change, unhandled gRPC calls will produce a clear output in the test UI.

## What does it look like?

<img width="762" alt="CleanShot 2021-05-26 at 17 07 47@2x" src="https://user-images.githubusercontent.com/34030/119684754-09b7e680-be45-11eb-918a-49b19038d5b1.png">

(Previously you’d see no error at all, not even in the console. I don’t currently understand why not 😅)

## How do I verify this?

1. Check out the branch
2. `cd ui && yarn ember serve`
3. Visit [http://localhost:4200/tests](http://localhost:4200/tests)
4. Try commenting out [`ui/mirage/config.ts:42`](https://github.com/hashicorp/waypoint/blob/ui-mirage-unhandled/ui/mirage/config.ts#L42)
5. Verify the test output says something sensible