### PR TITLE
ui/mirage: make request logging clearer

### DIFF
--- a/ui/mirage/utils.ts
+++ b/ui/mirage/utils.ts
@@ -74,10 +74,8 @@ export function fakeComponentForKind(kind: Component.Type): string {
  * dependent on the readability of the data being sent.
  */
 export function logRequestConsole(verb: string, path: string, request: FakeXMLHttpRequest) {
-  let url = request.responseURL.split('/');
-  if (url.length >= 5) {
-    console.groupCollapsed(`Mock: ${url[3]} ${url[4]}/${url[5]}`);
-  }
+  console.groupCollapsed(`Mock: ${verb} ${path}`);
+
   let { requestBody, responseText } = request;
   let loggedRequest: string, loggedResponse: string;
 
@@ -93,16 +91,16 @@ export function logRequestConsole(verb: string, path: string, request: FakeXMLHt
     loggedResponse = responseText;
   }
 
-  console.groupCollapsed('Response (base64 decoded)');
-  console.log(loggedResponse);
+  console.groupCollapsed('Request (raw)');
+  console.log(request);
   console.groupEnd();
 
-  console.groupCollapsed('Request (base64 decoded)');
+  console.groupCollapsed('Request (protobuf wire format)');
   console.log(loggedRequest);
   console.groupEnd();
 
-  console.groupCollapsed('Request (raw)');
-  console.log(request);
+  console.groupCollapsed('Response (protobuf wire format)');
+  console.log(loggedResponse);
   console.groupEnd();
 
   console.groupEnd();


### PR DESCRIPTION
## What is this?

A small tweak to the way we log mocked requests.

**Note:** Much of this was already in place, this is just a minor tweak to bring the grouping back.

## What does it look like?

### Before

<img width="202" alt="CleanShot 2021-05-26 at 17 06 57@2x" src="https://user-images.githubusercontent.com/34030/119687095-35d46700-be47-11eb-8074-0e20eb37ac30.png">

### After

<img width="428" alt="CleanShot 2021-05-26 at 17 24 05@2x" src="https://user-images.githubusercontent.com/34030/119687111-3b31b180-be47-11eb-832d-e72664a4fb41.png">
