### PR TITLE
ui: mutable deployments

### DIFF
--- a/.changelog/1549.txt
+++ b/.changelog/1549.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Mutable deployments support on web dashboard.
+```

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -1,17 +1,21 @@
-<li class={{if (eq @deployment.state 4) "app-item app-item--destroyed" "app-item"}}>
+<li
+  class="app-item
+  {{if (not-eq @deployment.sequence @latest.sequence) "app-item--previous"}}
+  {{if (eq @deployment.state 4) "app-item--destroyed"}}"
+>
   <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @deployment.id}}>
     <p>
       <b class="badge badge--version">v{{@deployment.sequence}}</b>
       <code>{{@deployment.id}}</code>
       {{#if (eq @deployment.state 4)}}
-        <b class="badge badge--destroyed">
-          <Pds::Icon @type="trash" class="icon" />&nbsp;Destroyed
+        <b data-test-destroyed-badge class="badge badge--destroyed">
+          <Pds::Icon @type="trash" class="icon" />&nbsp; {{t "page.deployments.destroyed_label"}}
         </b>
       {{/if}}
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @deployment.component.name}} class="icon" />
-      <span>{{if (eq @deployment.status.state 1) 'Deploying' 'Deployed'}} by
+      <span>{{t (concat "page.deployments.status_prefix." @deployment.status.state)}}
         <b>{{component-name @deployment.component.name}}</b>
         {{#if (eq @deployment.status.state 1)}}
         (Started {{date-format-distance-to-now @deployment.status.startTime.seconds }})
@@ -21,9 +25,13 @@
       </span>
     </small>
   </LinkTo>
-  {{#if (and @deployment.preload.deployUrl (not-eq @deployment.state 4))}}
-    <ExternalLink href="https://{{@deployment.preload.deployUrl}}" class="button button--secondary button--external-link">
-      <span>{{lowercase @deployment.preload.deployUrl}}</span>
+  {{#if (not-eq @latest.id @deployment.id)}}
+  <small class="replacement-info">
+    {{t "page.deployments.replaced_label"}}<b class="badge badge--version">v{{@latest.sequence}}</b>
+  </small>
+  {{else if (and @deployment.preload.deployUrl (not-eq @deployment.state 4))}}
+    <ExternalLink data-test-external-deployment-button href="https://{{@deployment.preload.deployUrl}}" class="button button--secondary button--external-link">
+      <span>{{t "page.deployments.external_url_label"}}</span>
       <Pds::Icon @type="exit" class="icon" />
     </ExternalLink>
   {{/if}}

--- a/ui/app/controllers/workspace/projects/project/app/deployments.ts
+++ b/ui/app/controllers/workspace/projects/project/app/deployments.ts
@@ -3,21 +3,22 @@ import { tracked } from '@glimmer/tracking';
 import { Deployment } from 'waypoint-pb';
 import { action } from '@ember/object';
 export default class WorkspaceProjectsProjectAppDeployments extends Controller {
-  queryParams = ['destroyed'];
+  queryParams = [
+    {
+      isShowingDestroyed: {
+        as: 'destroyed',
+      },
+    },
+  ];
 
-  @tracked destroyed = false;
+  @tracked isShowingDestroyed = false;
 
   get hasMoreDeployments(): boolean {
     return this.model.filter((deployment: Deployment.AsObject) => deployment.state == 4).length > 0;
   }
 
   get deployments(): Deployment.AsObject[] {
-    if (this.destroyed) {
-      return this.model;
-    } else {
-      let deploys = this.model.filter((deployment: Deployment.AsObject) => deployment.state != 4);
-      return deploys;
-    }
+    return this.model;
   }
 
   get deploymentsByGeneration(): GenerationGroup[] {
@@ -40,7 +41,7 @@ export default class WorkspaceProjectsProjectAppDeployments extends Controller {
 
   @action
   showDestroyed(): void {
-    this.destroyed = true;
+    this.isShowingDestroyed = true;
   }
 }
 

--- a/ui/app/controllers/workspace/projects/project/app/deployments.ts
+++ b/ui/app/controllers/workspace/projects/project/app/deployments.ts
@@ -3,25 +3,49 @@ import { tracked } from '@glimmer/tracking';
 import { Deployment } from 'waypoint-pb';
 import { action } from '@ember/object';
 export default class WorkspaceProjectsProjectAppDeployments extends Controller {
-  queryParams = ['destroyed']
+  queryParams = ['destroyed'];
 
   @tracked destroyed = false;
 
-  get hasMoreDeployments() {
-    return this.model.filter((deployment: Deployment.AsObject) => deployment.state == 4).length > 0
+  get hasMoreDeployments(): boolean {
+    return this.model.filter((deployment: Deployment.AsObject) => deployment.state == 4).length > 0;
   }
 
-  get deployments() {
+  get deployments(): Deployment.AsObject[] {
     if (this.destroyed) {
-      return this.model
+      return this.model;
     } else {
-      const deploys = this.model.filter((deployment: Deployment.AsObject) => deployment.state != 4)
+      let deploys = this.model.filter((deployment: Deployment.AsObject) => deployment.state != 4);
       return deploys;
     }
   }
 
+  get deploymentsByGeneration(): GenerationGroup[] {
+    let result: GenerationGroup[] = [];
+
+    for (let deployment of this.deployments) {
+      let id = deployment.generation?.id ?? deployment.id;
+      let group = result.find((group) => group.generationID === id);
+
+      if (!group) {
+        group = new GenerationGroup(id);
+        result.push(group);
+      }
+
+      group.deployments.push(deployment);
+    }
+
+    return result;
+  }
+
   @action
-  showDestroyed() {
+  showDestroyed(): void {
     this.destroyed = true;
   }
+}
+
+class GenerationGroup {
+  deployments: Deployment.AsObject[] = [];
+
+  constructor(public generationID: string) {}
 }

--- a/ui/app/helpers/icon-for-component.ts
+++ b/ui/app/helpers/icon-for-component.ts
@@ -16,6 +16,7 @@ export function iconForComponent([component]: [string]): string {
     case 'kubernetes':
       return 'logo-kubernetes-color-alt';
     case 'nomad':
+    case 'nomad-jobspec':
       return 'logo-nomad-color';
     case 'pack':
       return 'logo-pack-color';

--- a/ui/app/styles/_app-item.scss
+++ b/ui/app/styles/_app-item.scss
@@ -4,6 +4,7 @@
   justify-content: space-between;
   flex-wrap: wrap;
   width: 100%;
+  padding-left: scale.$sm-2;
 
   a:not(.button) {
     display: flex;
@@ -26,7 +27,7 @@
     font-size: 1rem;
   }
 
-  &.app-item--destroyed code{
+  &.app-item--destroyed code {
     color: rgb(var(--text-muted));
   }
 
@@ -63,5 +64,19 @@
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+  }
+
+  .replacement-info {
+    b {
+      text-transform: inherit;
+      margin-left: scale.$sm-2;
+    }
+  }
+
+  &--previous {
+    background: color.$ui-cool-gray-050;
+    background-clip: border-box;
+    margin-bottom: 0px;
+    border-top: 1rem solid color.$ui-cool-gray-050;
   }
 }

--- a/ui/app/styles/_page.scss
+++ b/ui/app/styles/_page.scss
@@ -186,13 +186,12 @@
   ul.list {
     li {
       padding-bottom: scale.$base;
-      margin-bottom: scale.$base;
+      border-top: 1rem solid transparent;
+      margin-bottom: 0;
       border-bottom: 1px solid rgb(var(--border));
 
       &:last-child {
-        padding-bottom: 0;
-        margin-bottom: 0;
-        border: none;
+        border-bottom: none;
       }
     }
   }

--- a/ui/app/templates/workspace/projects/project/app/deployments.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployments.hbs
@@ -3,8 +3,10 @@
 </h3>
 
 <ul data-test-deployment-list=true class="list">
-  {{#each this.deployments as |deployment|}}
-    <AppItem::Deployment @deployment={{deployment}} />
+  {{#each this.deploymentsByGeneration key="generationID" as |group|}}
+    {{#each group.deployments key="id" as |deployment|}}
+      <AppItem::Deployment @deployment={{deployment}} />
+    {{/each}}
   {{else}}
     <EmptyState>
       <p>There are no deployments to display for this app yet</p>

--- a/ui/app/templates/workspace/projects/project/app/deployments.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployments.hbs
@@ -2,10 +2,12 @@
   {{t "page.deployments.title"}}
 </h3>
 
-<ul data-test-deployment-list=true class="list">
+<ul data-test-deployment-list class="list">
   {{#each this.deploymentsByGeneration key="generationID" as |group|}}
     {{#each group.deployments key="id" as |deployment|}}
-      <AppItem::Deployment @deployment={{deployment}} />
+      {{#if (or this.isShowingDestroyed (not-eq deployment.state 4))}}
+        <AppItem::Deployment @deployment={{deployment}} @latest={{group.deployments.[0]}} />
+      {{/if}}
     {{/each}}
   {{else}}
     <EmptyState>
@@ -17,20 +19,20 @@
         from the CLI</p>
     </EmptyState>
   {{/each}}
-  {{#if (and this.hasMoreDeployments (not this.destroyed))}}
-    <div class="destroyed-deployments-filter">
-      <Pds::HelpText>
-        Some deployments have been destroyed and are hidden.
-        <Pds::Button
-          @compact={{true}}
-          @variant="ghost"
-          {{on "click" this.showDestroyed}}>
-          Display destroyed deployments
-        </Pds::Button>
-      </Pds::HelpText>
-    </div>
-  {{/if}}
-
 </ul>
+{{#if (and this.hasMoreDeployments (not this.isShowingDestroyed))}}
+  <div class="destroyed-deployments-filter">
+    <Pds::HelpText>
+      {{t "page.deployments.destroyed_and_hidden_state"}}
+      <Pds::Button
+        data-test-display-destroyed-button
+        @compact={{true}}
+        @variant="ghost"
+        {{on "click" this.showDestroyed}}>
+        {{t "page.deployments.display_destroyed"}}
+      </Pds::Button>
+    </Pds::HelpText>
+  </div>
+{{/if}}
 
 {{outlet}}

--- a/ui/mirage/factories/build.ts
+++ b/ui/mirage/factories/build.ts
@@ -2,6 +2,9 @@ import { Factory, trait, association } from 'ember-cli-mirage';
 import { fakeId } from '../utils';
 
 export default Factory.extend({
+  id: () => fakeId(),
+  sequence: (i) => i + 1,
+
   afterCreate(build, server) {
     if (!build.workspace) {
       let workspace =
@@ -11,14 +14,20 @@ export default Factory.extend({
   },
 
   random: trait({
-    id: () => fakeId(),
-    sequence: (i) => i + 1,
     labels: () => ({
       'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
       'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
     }),
     component: association('builder', 'with-random-name'),
     status: association('random'),
+  }),
+
+  docker: trait({
+    component: association('builder', 'docker'),
+  }),
+
+  pack: trait({
+    component: association('builder', 'pack'),
   }),
 
   'seconds-old-success': trait({

--- a/ui/mirage/factories/component.ts
+++ b/ui/mirage/factories/component.ts
@@ -24,6 +24,26 @@ export default Factory.extend({
     type: 'RELEASEMANAGER',
   }),
 
+  docker: trait({
+    name: 'docker',
+  }),
+
+  pack: trait({
+    name: 'pack',
+  }),
+
+  nomad: trait({
+    name: 'nomad',
+  }),
+
+  'nomad-jobspec': trait({
+    name: 'nomad-jobspec',
+  }),
+
+  kubernetes: trait({
+    name: 'kubernetes',
+  }),
+
   'with-random-name': trait({
     afterCreate(component) {
       component.update('name', randomNameForType(component.type));

--- a/ui/mirage/factories/deployment.ts
+++ b/ui/mirage/factories/deployment.ts
@@ -2,6 +2,9 @@ import { Factory, trait, association } from 'ember-cli-mirage';
 import { fakeId } from '../utils';
 
 export default Factory.extend({
+  id: () => fakeId(),
+  sequence: (i) => i + 1,
+
   afterCreate(deployment, server) {
     if (!deployment.workspace) {
       let workspace =
@@ -11,9 +14,7 @@ export default Factory.extend({
   },
 
   random: trait({
-    id: () => fakeId(),
     component: association('platform', 'with-random-name'),
-    sequence: (i) => i + 1,
     status: association('random'),
     state: 'CREATED',
     labels: () => ({
@@ -25,6 +26,22 @@ export default Factory.extend({
       let url = `https://wildly-intent-honeybee--v${deployment.sequence}.waypoint.run`;
       deployment.update('deployUrl', url);
     },
+  }),
+
+  docker: trait({
+    component: association('platform', 'docker'),
+  }),
+
+  nomad: trait({
+    component: association('platform', 'nomad'),
+  }),
+
+  'nomad-jobspec': trait({
+    component: association('platform', 'nomad-jobspec'),
+  }),
+
+  kubernetes: trait({
+    component: association('platform', 'kubernetes'),
   }),
 
   'seconds-old-success': trait({

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -10,6 +10,10 @@ export default Factory.extend({
     name: () => faker.hacker.noun(),
   }),
 
+  'with-remote-runners': trait({
+    remoteEnabled: true,
+  }),
+
   // This is our primary demo trait for development mode
   'marketing-public': trait({
     name: 'marketing-public',
@@ -64,7 +68,105 @@ export default Factory.extend({
     },
   }),
 
-  'with-remote-runners': trait({
-    remoteEnabled: true,
+  // For demoing and working against mutable deployments
+  'mutable-deployments': trait({
+    name: 'mutable-project',
+
+    afterCreate(project, server) {
+      let application = server.create('application', { name: 'mutable-application', project });
+
+      let builds = [
+        server.create('build', 'docker', 'days-old-success', {
+          application,
+          sequence: 1,
+        }),
+        server.create('build', 'docker', 'days-old-success', {
+          application,
+          sequence: 2,
+        }),
+        server.create('build', 'docker', 'hours-old-success', {
+          application,
+          sequence: 3,
+        }),
+        server.create('build', 'docker', 'hours-old-success', {
+          application,
+          sequence: 4,
+        }),
+        server.create('build', 'docker', 'minutes-old-success', {
+          application,
+          sequence: 5,
+        }),
+        server.create('build', 'docker', 'minutes-old-success', {
+          application,
+          sequence: 6,
+        }),
+        server.create('build', 'docker', 'seconds-old-success', {
+          application,
+          sequence: 7,
+        }),
+      ];
+
+      let generations = [
+        server.create('generation', {
+          id: 'job-v1',
+          initialSequence: 1,
+        }),
+        server.create('generation', {
+          id: 'job-v2',
+          initialSequence: 4,
+        }),
+      ];
+
+      let deployments = [
+        server.create('deployment', 'random', 'nomad-jobspec', 'days-old-success', {
+          application,
+          generation: generations[0],
+          build: builds[0],
+          sequence: 1,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'days-old-success', {
+          application,
+          generation: generations[0],
+          build: builds[1],
+          sequence: 2,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'hours-old-success', {
+          application,
+          generation: generations[0],
+          build: builds[2],
+          sequence: 3,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'hours-old-success', {
+          application,
+          generation: generations[1],
+          build: builds[2],
+          sequence: 4,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'minutes-old-success', {
+          application,
+          generation: generations[1],
+          build: builds[2],
+          sequence: 5,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'minutes-old-success', {
+          application,
+          generation: generations[1],
+          build: builds[2],
+          sequence: 6,
+        }),
+        server.create('deployment', 'random', 'nomad-jobspec', 'seconds-old-success', {
+          application,
+          generation: generations[1],
+          build: builds[2],
+          sequence: 7,
+        }),
+      ];
+
+      server.create('release', 'random', 'nomad-jobspec', 'seconds-old-success', {
+        sequence: 1,
+        deployment: deployments[0],
+        application,
+      });
+    },
   }),
 });

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -129,6 +129,7 @@ export default Factory.extend({
           generation: generations[0],
           build: builds[1],
           sequence: 2,
+          state: 'DESTROYED',
         }),
         server.create('deployment', 'random', 'nomad-jobspec', 'hours-old-success', {
           application,
@@ -139,25 +140,25 @@ export default Factory.extend({
         server.create('deployment', 'random', 'nomad-jobspec', 'hours-old-success', {
           application,
           generation: generations[1],
-          build: builds[2],
+          build: builds[3],
           sequence: 4,
         }),
         server.create('deployment', 'random', 'nomad-jobspec', 'minutes-old-success', {
           application,
           generation: generations[1],
-          build: builds[2],
+          build: builds[4],
           sequence: 5,
         }),
         server.create('deployment', 'random', 'nomad-jobspec', 'minutes-old-success', {
           application,
           generation: generations[1],
-          build: builds[2],
+          build: builds[5],
           sequence: 6,
         }),
         server.create('deployment', 'random', 'nomad-jobspec', 'seconds-old-success', {
           application,
           generation: generations[1],
-          build: builds[2],
+          build: builds[6],
           sequence: 7,
         }),
       ];

--- a/ui/mirage/factories/release.ts
+++ b/ui/mirage/factories/release.ts
@@ -1,7 +1,10 @@
 import { Factory, trait, association } from 'ember-cli-mirage';
-import { fakeId, sequenceRandom } from '../utils';
+import { fakeId } from '../utils';
 
 export default Factory.extend({
+  id: () => fakeId(),
+  sequence: (i) => i + 1,
+
   afterCreate(release, server) {
     if (!release.workspace) {
       let workspace =
@@ -11,9 +14,7 @@ export default Factory.extend({
   },
 
   random: trait({
-    id: () => fakeId(),
     component: association('release-manager', 'with-random-name'),
-    sequence: () => sequenceRandom(),
     status: association('random'),
     state: 'CREATED',
     labels: () => ({
@@ -21,6 +22,18 @@ export default Factory.extend({
       'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
     }),
     url: 'https://wildly-intent-honeybee.waypoint.run',
+  }),
+
+  nomad: trait({
+    component: association('release-manager', { name: 'nomad' }),
+  }),
+
+  'nomad-jobspec': trait({
+    component: association('release-manager', { name: 'nomad-jobspec' }),
+  }),
+
+  kubernetes: trait({
+    component: association('release-manager', { name: 'kubernetes' }),
   }),
 
   'seconds-old-success': trait({

--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -10,6 +10,7 @@ export default Model.extend({
   build: belongsTo(),
   status: belongsTo({ inverse: 'owner' }),
   component: belongsTo({ inverse: 'owner' }),
+  generation: belongsTo(),
 
   toProtobuf(): Deployment {
     let result = new Deployment();
@@ -18,8 +19,7 @@ export default Model.extend({
     result.setArtifactId(this.artifactId);
     result.setComponent(this.component?.toProtobuf());
     // TODO: result.setDeployment
-    // TODO: result.setExtension
-    // TODO: result.setGeneration
+    result.setGeneration(this.generation?.toProtobuf());
     result.setHasEntrypointConfig(this.hasEntrypointConfig);
     result.setHasExecPlugin(this.hasExecPlugin);
     result.setHasLogsPlugin(this.hasLogsPlugin);
@@ -30,7 +30,7 @@ export default Model.extend({
     result.setState(PhysicalState[this.state as StateName]);
     result.setStatus(this.status?.toProtobuf());
     result.setTemplateData(this.templateData);
-    result.setWorkspace(this.workspace.toProtobufRef());
+    result.setWorkspace(this.workspace?.toProtobufRef());
 
     for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
       result.getLabelsMap().set(key, value);

--- a/ui/mirage/models/generation.ts
+++ b/ui/mirage/models/generation.ts
@@ -1,0 +1,15 @@
+import { Model, hasMany } from 'miragejs';
+import { Generation } from 'waypoint-pb';
+
+export default Model.extend({
+  deployment: hasMany(),
+
+  toProtobuf(): Generation {
+    let result = new Generation();
+
+    result.setId(this.id);
+    result.setInitialSequence(this.initialSequence);
+
+    return result;
+  },
+});

--- a/ui/mirage/scenarios/default.ts
+++ b/ui/mirage/scenarios/default.ts
@@ -2,4 +2,5 @@ import { Server } from 'ember-cli-mirage';
 
 export default function (server: Server): void {
   server.create('project', 'marketing-public');
+  server.create('project', 'mutable-deployments');
 }

--- a/ui/mirage/services/build.ts
+++ b/ui/mirage/services/build.ts
@@ -14,6 +14,8 @@ export function list(schema: any, { requestBody }: Request): Response {
   let buildProtobufs = builds.models.map((b) => b.toProtobuf());
   let resp = new ListBuildsResponse();
 
+  buildProtobufs.sort((a, b) => b.getSequence() - a.getSequence());
+
   resp.setBuildsList(buildProtobufs);
 
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -14,6 +14,8 @@ export function list(schema: any, { requestBody }: Request): Response {
   let deploymentProtobufs = deployments.models.map((d) => d.toProtobuf());
   let resp = new ListDeploymentsResponse();
 
+  deploymentProtobufs.sort((a, b) => b.getSequence() - a.getSequence());
+
   resp.setDeploymentsList(deploymentProtobufs);
 
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/release.ts
+++ b/ui/mirage/services/release.ts
@@ -14,6 +14,8 @@ export function list(schema: any, { requestBody }: Request): Response {
   let releaseProtobufs = releases.models.map((d) => d.toProtobuf());
   let resp = new ListReleasesResponse();
 
+  releaseProtobufs.sort((a, b) => b.getSequence() - a.getSequence());
+
   resp.setReleasesList(releaseProtobufs);
 
   return this.serialize(resp, 'application');

--- a/ui/tests/acceptance/deployments-list-test.ts
+++ b/ui/tests/acceptance/deployments-list-test.ts
@@ -2,14 +2,18 @@ import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { visitable, create, collection } from 'ember-cli-page-object';
+import { visitable, create, collection, clickable } from 'ember-cli-page-object';
 import login from 'waypoint/tests/helpers/login';
+import { isEqual } from 'date-fns';
 
 const url = '/default/microchip/app/wp-bandwidth/deployments';
 
 const page = create({
   visit: visitable(url),
   list: collection('[data-test-deployment-list] li'),
+  deploymentLinks: collection('[data-test-external-deployment-button]'),
+  destroyedBadges: collection('[data-test-destroyed-badge]'),
+  showDestroyed: clickable('[data-test-display-destroyed-button]'),
 });
 
 module('Acceptance | deployments list', function (hooks) {
@@ -26,5 +30,59 @@ module('Acceptance | deployments list', function (hooks) {
 
     assert.equal(page.list.length, 3);
     assert.equal(currentURL(), url);
+  });
+
+  test('visiting deployments page with mutable deployments', async function (assert) {
+    let project = this.server.create('project', { name: 'microchip' });
+    let application = this.server.create('application', { name: 'wp-bandwidth', project });
+
+    let generations = [
+      this.server.create('generation', {
+        id: 'job-v1',
+        initialSequence: 1,
+      }),
+      this.server.create('generation', {
+        id: 'job-v2',
+        initialSequence: 4,
+      }),
+    ];
+
+    this.server.create('deployment', 'random', 'nomad-jobspec', 'days-old-success', {
+      application,
+      generation: generations[0],
+      sequence: 1,
+    });
+    this.server.create('deployment', 'random', 'nomad-jobspec', 'days-old-success', {
+      application,
+      generation: generations[0],
+      sequence: 2,
+      state: 'DESTROYED',
+    });
+    this.server.create('deployment', 'random', 'nomad-jobspec', 'hours-old-success', {
+      application,
+      generation: generations[1],
+      sequence: 3,
+    });
+    this.server.create('deployment', 'random', 'nomad-jobspec', 'minutes-old-success', {
+      application,
+      generation: generations[1],
+      sequence: 4,
+    });
+    this.server.create('deployment', 'random', 'nomad-jobspec', 'seconds-old-success', {
+      application,
+      generation: generations[1],
+      sequence: 5,
+    });
+
+    await page.visit();
+
+    assert.equal(page.list.length, 4);
+    assert.equal(page.deploymentLinks.length, 1);
+
+    await page.showDestroyed();
+
+    assert.equal(page.list.length, 5);
+    assert.equal(page.deploymentLinks.length, 1);
+    assert.equal(page.destroyedBadges.length, 1);
   });
 });

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -21,6 +21,16 @@ page:
     title: 'Builds'
   deployments:
     title: 'Deployments'
+    destroyed_label: 'Destroyed'
+    external_url_label: 'Visit Deployment'
+    replaced_label: 'Replaced by '
+    destroyed_and_hidden_state: 'Some deployments have been destroyed and are hidden'
+    display_destroyed: 'Display destroyed deployments'
+    status_prefix:
+      0: 'Deploying by ' # UNKNOWN
+      1: 'Deploying by ' # RUNNING
+      2: 'Deployed by ' # SUCCESS
+      3: 'Failed to deploy by ' # ERROR
   releases:
     title: 'Releases'
 


### PR DESCRIPTION
## What is this?

Addresses #1239

Adds the UI to display _mutable deployments_.  

_Mutable deployments_ are groups of deployment versions that utilize the same resources, where newer deployments in the same _generation_ overwrite previous deployments (ie only latest version is deployed at the same deployment URL). This functionality was added to accommodate users' existing workflows.

## What’s the plan?

- [x] Create good fixture data in Mirage
- [x] Implement the designs
- [x] Ensure immutable deployments still render well
- [x] Ensure destroyed deployments still render well
- [x] Use the `{{t ...}}` helper for all text
- [x] Write some light tests (we can probably borrow the dev Mirage config)
- [x] Changelog entry

## What does it look like?

<img width="1411" alt="Screen Shot 2021-06-02 at 1 17 39 PM" src="https://user-images.githubusercontent.com/60155296/120524369-fe187280-c3a4-11eb-8482-05e436e8788c.png">  

> Deployments list without destroyed deployments, note the grayed background of overwritten deployments + link to deployment only on latest



<img width="1405" alt="Screen Shot 2021-06-02 at 1 17 47 PM" src="https://user-images.githubusercontent.com/60155296/120524493-1be5d780-c3a5-11eb-8588-e26d0f2307ce.png">  

> Deployments list with destroyed deployment


## How do I verify it?

1. Check out this branch
2. `yarn ember serve`
3. Visit `http://localhost:4200/tests`
4. Verify all tests pass
5. Visit `http://localhost:4200`
6. Check the deployments under `mutable-application` in `mutable-project`
7. Verify there's no buggy behavior and everything else is untouched (check the builds section)