### PR TITLE
fix: adapt doc build, add to shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp/
 /waypoint
 /waypoint-entrypoint
 /pkg
+/doc
 
 # System-specific
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ static-assets:
 
 .PHONY: gen/doc
 gen/doc:
+	mkdir -p ./doc/ 
 	@rm -rf ./doc/* 2> /dev/null
 	protoc -I=. \
 		-I=./vendor/proto/api-common-protos/ \

--- a/shell.nix
+++ b/shell.nix
@@ -107,6 +107,7 @@ in pkgs.mkShell rec {
     pkgs.nodejs-12_x
     pkgs.protobufPin
     pkgs.postgresql_12
+    pkgs.protoc-gen-doc
     go-protobuf
     go-protobuf-json
     go-tools


### PR DESCRIPTION
This fix corrects the way `make gen/doc` works on newly cloned repositories (that are missing the `doc/` folder) and adds an entry for `protoc-gen-doc` in the `shell.nix` file.