### PR TITLE
builtin/nomad: update docs for auth block

### DIFF
--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -357,7 +357,7 @@ deploy {
         use "nomad" {
           region = "global"
           datacenter = "dc1"
-          auth = {
+          auth {
             username = "username"
             password = "password"
           }


### PR DESCRIPTION
This PR updates the docs to match the auth block that was initially added as a map in #646 and later changed to a block in #656  