### PR TITLE
ui: display status reports on deployments

### DIFF
--- a/.changelog/1559.txt
+++ b/.changelog/1559.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Add reporting on status of a deployment
+```

--- a/ui/app/components/app-card/deployment.hbs
+++ b/ui/app/components/app-card/deployment.hbs
@@ -4,19 +4,6 @@
     <p>
       <b class="badge badge--version">v{{@model.sequence}}</b>
       <code>{{truncate @model.id 8 false}}</code>
-      {{#if (eq @model.status.state 1)}}
-        <b class="badge">
-          <Pds::Icon @type="clock-outline" class="icon" />
-        </b>
-        {{else if (eq @model.status.state 2)}}
-        <b class="badge badge--success">
-          <Pds::Icon @type="check-plain" class="icon" />
-        </b>
-        {{else if (eq @model.status.state 3)}}
-        <b class="badge badge--error">
-          <Pds::Icon @type="alert-triangle" class="icon" />
-        </b>
-      {{/if}}
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
@@ -30,6 +17,15 @@
       </span>
     </small>
   </LinkTo>
+  {{#if @model.statusReport}}
+    {{#let @model.statusReport.health as |health|}}
+      <StatusBadge
+        @state={{health.healthStatus}}
+        @message={{health.healthMessage}}
+        @iconOnly={{true}}
+      />
+    {{/let}}
+  {{/if}}
   {{#if @model.preload.deployUrl}}
   <ExternalLink
     href="https://{{@model.preload.deployUrl}}"
@@ -51,21 +47,30 @@
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
       <span>
         {{#if (eq @model.status.state 1)}}
-        Started {{date-format-distance-to-now @model.status.startTime.seconds }}
+          Started {{date-format-distance-to-now @model.status.startTime.seconds }}
         {{else}}
-        {{date-format-distance-to-now @model.status.completeTime.seconds }}
+          {{date-format-distance-to-now @model.status.completeTime.seconds }}
         {{/if}}
       </span>
     </small>
+    {{#if @model.statusReport}}
+      {{#let @model.statusReport.health as |health|}}
+        <StatusBadge
+          @state={{health.healthStatus}}
+          @message={{health.healthMessage}}
+          @iconOnly={{true}}
+        />
+      {{/let}}
+    {{/if}}
   </LinkTo>
   {{#if @model.preload.deployUrl}}
-  <ExternalLink
-    href="https://{{@model.preload.deployUrl}}"
-    title="https://{{@model.preload.deployUrl}}"
-    class="button button--secondary button--compact"
-  >
-    <Pds::Icon @type="exit" class="icon" />
-  </ExternalLink>
+    <ExternalLink
+      href="https://{{@model.preload.deployUrl}}"
+      title="https://{{@model.preload.deployUrl}}"
+      class="button button--secondary button--compact"
+    >
+      <Pds::Icon @type="exit" class="icon" />
+    </ExternalLink>
   {{/if}}
 </li>
 {{/if}}

--- a/ui/app/components/app-card/deployments.hbs
+++ b/ui/app/components/app-card/deployments.hbs
@@ -1,4 +1,7 @@
-<Card @classNames={{unless @deployments.length 'empty-state'}}>
+<Card
+  data-test-latest-deployments
+  class={{unless @deployments.length 'empty-state'}}
+>
   {{#if @deployments.length}}
     <Card::Header>
       <h4>

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -25,6 +25,14 @@
       </span>
     </small>
   </LinkTo>
+  {{#if @deployment.statusReport}}
+    {{#let @deployment.statusReport.health as |health|}}
+      <StatusBadge
+        @state={{health.healthStatus}}
+        @message={{health.healthMessage}}
+      />
+    {{/let}}
+  {{/if}}
   {{#if (not-eq @latest.id @deployment.id)}}
   <small class="replacement-info">
     {{t "page.deployments.replaced_label"}}<b class="badge badge--version">v{{@latest.sequence}}</b>

--- a/ui/app/components/card.hbs
+++ b/ui/app/components/card.hbs
@@ -1,3 +1,3 @@
-<div class="card {{@classNames}}">
+<div class="card {{@classNames}}" ...attributes>
   {{yield}}
 </div>

--- a/ui/app/components/status-badge/index.hbs
+++ b/ui/app/components/status-badge/index.hbs
@@ -1,10 +1,23 @@
-<b class="badge badge-status badge-status--{{this.statusClass}} {{if this.iconOnly 'badge-status--icon-only'}}">
+<b
+  class="
+    badge
+    badge-status
+    badge-status--{{this.statusClass}}
+    {{if @iconOnly 'badge-status--icon-only'}}
+  "
+  data-test-status-badge={{this.statusClass}}
+  tabindex="0"
+>
   <Pds::Icon @type={{this.iconType}}/>
-  {{#unless this.iconOnly}}
+  {{#unless @iconOnly}}
     {{t (concat 'status_badge.' this.statusClass '.text')}}
     {{yield}}
   {{/unless}}
-  <EmberTooltip @side="top">
-    {{t (concat 'status_badge.' this.statusClass '.tooltip')}}
+  <EmberTooltip @side={{or @tooltipSide "top"}}>
+    {{#if @message}}
+      {{@message}}
+    {{else}}
+      {{t (concat 'status_badge.' this.statusClass '.tooltip')}}
+    {{/if}}
   </EmberTooltip>
 </b>

--- a/ui/app/components/status-badge/index.ts
+++ b/ui/app/components/status-badge/index.ts
@@ -1,61 +1,41 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+
 interface StatusBadgeArgs {
-  state: number;
-  iconOnly: boolean;
+  state?: State;
+  iconOnly?: boolean;
+  message?: string;
 }
 
+type State = 'UNKNOWN' | 'ALIVE' | 'READY' | 'DOWN' | 'PARTIAL';
+
 export default class StatusBadge extends Component<StatusBadgeArgs> {
-  @tracked iconOnly = false;
-  @tracked state: number;
-
-  constructor(owner: any, args: StatusBadgeArgs) {
-    super(owner, args);
-    this.state = args.state;
-    this.iconOnly = args.iconOnly;
-  }
-
-  get statusClass() {
-    let { state } = this.args;
-    switch (state) {
-      case 4:
-        return 'partial';
-        break;
-      case 3:
-        return 'down';
-        break;
-      case 2:
-        return 'ready';
-        break;
-      case 1:
+  get statusClass(): string {
+    switch (this.args.state) {
+      case 'ALIVE':
         return 'alive';
-        break;
-      case 0:
-        return 'unknown';
-        break;
+      case 'READY':
+        return 'ready';
+      case 'DOWN':
+        return 'down';
+      case 'PARTIAL':
+        return 'partial';
+      case 'UNKNOWN':
       default:
         return 'unknown';
     }
   }
 
-  get iconType() {
-    let { state } = this.args;
-    switch (state) {
-      case 4:
-        return 'alert-triangle';
-        break;
-      case 3:
-        return 'cancel-circle-fill';
-        break;
-      case 2:
-        return 'check-plain';
-        break;
-      case 1:
+  get iconType(): string {
+    switch (this.args.state) {
+      case 'ALIVE':
         return 'run';
-        break;
-      case 0:
-        return 'help-circle-outline';
-        break;
+      case 'READY':
+        return 'check-plain';
+      case 'DOWN':
+        return 'cancel-circle-fill';
+      case 'PARTIAL':
+        return 'alert-triangle';
+      case 'UNKNOWN':
       default:
         return 'help-circle-outline';
     }

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -23,7 +23,7 @@ interface WithStatusReport {
   statusReport: StatusReport.AsObject;
 }
 
-interface ResolvedModel {
+export interface ResolvedModel {
   application: Ref.Application.AsObject;
   deployments: (Deployment.AsObject & WithStatusReport)[];
   releases: (Release.AsObject & WithStatusReport)[];

--- a/ui/app/routes/workspace/projects/project/app/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment.ts
@@ -1,8 +1,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
-import { GetDeploymentRequest, Deployment, Ref } from 'waypoint-pb';
-import { AppRouteModel } from '../app';
+import { GetDeploymentRequest, Deployment, Ref, StatusReport } from 'waypoint-pb';
+import { AppRouteModel, ResolvedModel as ResolvedAppRouteModel } from '../app';
 
 interface DeploymentModelParams {
   deployment_id: string;
@@ -12,6 +12,10 @@ interface Breadcrumb {
   label: string;
   icon: string;
   args: string[];
+}
+
+interface WithStatusReport {
+  statusReport?: StatusReport.AsObject;
 }
 
 export default class DeploymentDetail extends Route {
@@ -42,5 +46,12 @@ export default class DeploymentDetail extends Route {
     let resp = await this.api.client.getDeployment(req, this.api.WithMeta());
     let deploy: Deployment = resp;
     return deploy.toObject();
+  }
+
+  afterModel(model: Deployment.AsObject & WithStatusReport): void {
+    let { statusReports } = this.modelFor('workspace.projects.project.app') as ResolvedAppRouteModel;
+    let statusReport = statusReports.find((sr) => sr.deploymentId === model.id);
+
+    model.statusReport = statusReport;
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment.ts
@@ -8,10 +8,16 @@ interface DeploymentModelParams {
   deployment_id: string;
 }
 
+interface Breadcrumb {
+  label: string;
+  icon: string;
+  args: string[];
+}
+
 export default class DeploymentDetail extends Route {
   @service api!: ApiService;
 
-  breadcrumbs(model: AppRouteModel) {
+  breadcrumbs(model: AppRouteModel): Breadcrumb[] {
     if (!model) return [];
     return [
       {
@@ -27,13 +33,13 @@ export default class DeploymentDetail extends Route {
     ];
   }
 
-  async model(params: DeploymentModelParams) {
-    var ref = new Ref.Operation();
+  async model(params: DeploymentModelParams): Promise<Deployment.AsObject> {
+    let ref = new Ref.Operation();
     ref.setId(params.deployment_id);
-    var req = new GetDeploymentRequest();
+    let req = new GetDeploymentRequest();
     req.setRef(ref);
 
-    var resp = await this.api.client.getDeployment(req, this.api.WithMeta());
+    let resp = await this.api.client.getDeployment(req, this.api.WithMeta());
     let deploy: Deployment = resp;
     return deploy.toObject();
   }

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -15,6 +15,10 @@ import {
   Release,
   ListReleasesRequest,
   ListReleasesResponse,
+  StatusReport,
+  ListStatusReportsRequest,
+  ListStatusReportsResponse,
+  GetLatestStatusReportRequest,
 } from 'waypoint-pb';
 import config from 'waypoint/config/environment';
 
@@ -93,6 +97,32 @@ export default class ApiService extends Service {
     let resp: ListReleasesResponse = await this.client.listReleases(req, this.WithMeta());
 
     return resp.getReleasesList().map((d) => d.toObject());
+  }
+
+  async listStatusReports(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<StatusReport.AsObject[]> {
+    let req = new ListStatusReportsRequest();
+    req.setWorkspace(wsRef);
+    req.setApplication(appRef);
+
+    let order = new OperationOrder();
+    order.setDesc(true);
+    req.setOrder(order);
+
+    let resp: ListStatusReportsResponse = await this.client.listStatusReports(req, this.WithMeta());
+
+    return resp.getStatusReportsList().map((d) => d.toObject());
+  }
+
+  async getLatestStatusReport(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<StatusReport|undefined>{
+    let req = new GetLatestStatusReportRequest();
+    req.setApplication(appRef);
+    // We have to try/catch to avoid failing the hash request because the api errors if no statusReport is available
+    try {
+      let resp: StatusReport = await this.client.getLatestStatusReport(req, this.WithMeta());
+      return resp.toObject();
+    } catch {
+      return;
+    }
   }
 }
 

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -51,11 +51,11 @@ export default class ApiService extends Service {
   }
 
   async listDeployments(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<Deployment.AsObject[]> {
-    var req = new ListDeploymentsRequest();
+    let req = new ListDeploymentsRequest();
     req.setWorkspace(wsRef);
     req.setApplication(appRef);
 
-    var order = new OperationOrder();
+    let order = new OperationOrder();
     order.setDesc(true);
     req.setOrder(order);
 
@@ -65,11 +65,11 @@ export default class ApiService extends Service {
   }
 
   async listBuilds(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<Build.AsObject[]> {
-    var req = new ListBuildsRequest();
+    let req = new ListBuildsRequest();
     req.setWorkspace(wsRef);
     req.setApplication(appRef);
 
-    var order = new OperationOrder();
+    let order = new OperationOrder();
     order.setLimit(3);
     order.setDesc(true);
     // todo(pearkes): set order
@@ -81,11 +81,11 @@ export default class ApiService extends Service {
   }
 
   async listReleases(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<Release.AsObject[]> {
-    var req = new ListReleasesRequest();
+    let req = new ListReleasesRequest();
     req.setWorkspace(wsRef);
     req.setApplication(appRef);
 
-    var order = new OperationOrder();
+    let order = new OperationOrder();
     order.setLimit(3);
     order.setDesc(true);
     req.setOrder(order);

--- a/ui/app/styles/_app-card.scss
+++ b/ui/app/styles/_app-card.scss
@@ -105,7 +105,7 @@ li.app-card-item {
 
   .button {
     flex-grow: 0;
-    margin-left: scale.$sm-2;
+    margin-left: scale.$sm--1;
   }
 }
 
@@ -124,9 +124,14 @@ div.app-card-item {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    flex-grow: 1;
   }
 
   .button {
+    margin-left: scale.$sm--1;
+  }
+
+  .badge-status {
     margin-left: auto;
   }
 }

--- a/ui/app/styles/_app-item.scss
+++ b/ui/app/styles/_app-item.scss
@@ -56,6 +56,11 @@
     }
   }
 
+  .badge-status {
+    margin-left: auto;
+    margin-right: scale.$lg--2;
+  }
+
   .button {
     max-width: 100%;
 

--- a/ui/app/styles/_page.scss
+++ b/ui/app/styles/_page.scss
@@ -622,7 +622,7 @@
     padding: scale.$lg-4;
 
     p {
-      color: rgb(var(--text-subtle));
+      color: rgb(var(--text-muted));
       @include Typography.Interface(M);
       margin: scale.$sm-2;
 

--- a/ui/app/styles/_status-badge.scss
+++ b/ui/app/styles/_status-badge.scss
@@ -43,6 +43,7 @@
   }
 
   &.badge-status--icon-only {
+    padding: scale.$sm-4 scale.$sm-4;
     .pds-icon {
       margin-right: 0;
       margin-left: 0;

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -133,6 +133,12 @@ svg.icon {
   flex-shrink: 0;
 }
 
+.pds-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 @import './_footer';
 @import './_header';
 @import './_notifications';

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -1,6 +1,7 @@
 <PageHeader @iconName="upload">
   <div class="title">
-    <h2><b class="badge badge--version">#{{@model.sequence}}</b> <code>{{@model.id}}</code></h2>
+    {{! TODO(jgwhite): Make this a real <h1> }}
+    <h2 aria-level="1"><b class="badge badge--version">#{{@model.sequence}}</b> <code>{{@model.id}}</code></h2>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
       <span>Deployed by <b>{{component-name @model.component.name}}</b>

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -21,17 +21,14 @@
 
 <div class="item-row">
   <div class="item">
-    {{#if (eq @model.status.state 1)}}
-    <b class="badge">{{t 'state.deployment.pending'}}</b>
-    {{else if (eq @model.status.state 2)}}
-    <b class="badge badge--success">{{t 'state.deployment.success'}}</b>
-    {{else if (eq @model.status.state 3)}}
-    <b class="badge badge--error">
-      {{t 'state.deployment.error'}}
-      {{#if @model.status.error.message}}
-        : {{@model.status.error.message}}
-      {{/if}}
-    </b>
+    {{#if @model.statusReport}}
+      {{#let @model.statusReport.health as |health|}}
+        <StatusBadge
+          @state={{health.healthStatus}}
+          @message={{health.healthMessage}}
+          @tooltipSide="right"
+        />
+      {{/let}}
     {{/if}}
   </div>
 

--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -10,6 +10,7 @@ import * as token from './services/token';
 import * as inviteToken from './services/invite-token';
 import * as release from './services/release';
 import * as versionInfo from './services/version-info';
+import * as statusReport from './services/status-report';
 
 export default function (this: Server) {
   this.namespace = 'hashicorp.waypoint.Waypoint';
@@ -40,6 +41,8 @@ export default function (this: Server) {
   this.post('/ListReleases', release.list);
   this.post('/GetRelease', release.get);
   this.post('/GetVersionInfo', versionInfo.get);
+  this.post('/ListStatusReports', statusReport.list);
+  this.post('/GetLatestStatusReport', statusReport.getLatest);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -11,6 +11,7 @@ import * as inviteToken from './services/invite-token';
 import * as release from './services/release';
 import * as versionInfo from './services/version-info';
 import * as statusReport from './services/status-report';
+import * as job from './services/job';
 
 export default function (this: Server) {
   this.namespace = 'hashicorp.waypoint.Waypoint';
@@ -43,6 +44,7 @@ export default function (this: Server) {
   this.post('/GetVersionInfo', versionInfo.get);
   this.post('/ListStatusReports', statusReport.list);
   this.post('/GetLatestStatusReport', statusReport.getLatest);
+  this.post('/GetJobStream', job.stream);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/factories/health.ts
+++ b/ui/mirage/factories/health.ts
@@ -1,0 +1,33 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  unknown: trait({
+    status: 'UNKNOWN',
+    message: 'Check is not responding',
+    name: 'http',
+  }),
+
+  alive: trait({
+    status: 'ALIVE',
+    message: 'Some resources are alive, application isn’t responding yet',
+    name: 'http',
+  }),
+
+  ready: trait({
+    status: 'READY',
+    message: 'All resources are alive, application is responding',
+    name: 'http',
+  }),
+
+  down: trait({
+    status: 'DOWN',
+    message: 'No resources are alive, application is not responding',
+    name: 'http',
+  }),
+
+  partial: trait({
+    status: 'PARTIAL',
+    message: 'Some resources are down, application is responding',
+    name: 'http',
+  }),
+});

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -32,21 +32,25 @@ export default Factory.extend({
           sequence: 4,
           application,
           build: builds[0],
+          statusReport: server.create('status-report', 'alive', { application }),
         }),
         server.create('deployment', 'random', 'minutes-old-success', {
           sequence: 3,
           application,
           build: builds[1],
+          statusReport: server.create('status-report', 'ready', { application }),
         }),
         server.create('deployment', 'random', 'hours-old-success', {
           sequence: 2,
           application,
           build: builds[2],
+          statusReport: server.create('status-report', 'partial', { application }),
         }),
         server.create('deployment', 'random', 'days-old-success', {
           sequence: 1,
           application,
           build: builds[3],
+          statusReport: server.create('status-report', 'down', { application }),
         }),
       ];
 

--- a/ui/mirage/factories/status-report.ts
+++ b/ui/mirage/factories/status-report.ts
@@ -1,0 +1,43 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  afterCreate(statusReport, server) {
+    if (!statusReport.workspace) {
+      let workspace =
+        server.schema.workspaces.findBy({ name: 'default' }) || server.create('workspace', 'default');
+      statusReport.update('workspace', workspace);
+    }
+  },
+
+  status: association('minutes-old', 'success'),
+
+  unknown: trait({
+    afterCreate(statusReport, server) {
+      server.create('health', 'unknown', { statusReport });
+    },
+  }),
+
+  alive: trait({
+    afterCreate(statusReport, server) {
+      server.create('health', 'alive', { statusReport });
+    },
+  }),
+
+  ready: trait({
+    afterCreate(statusReport, server) {
+      server.create('health', 'ready', { statusReport });
+    },
+  }),
+
+  down: trait({
+    afterCreate(statusReport, server) {
+      server.create('health', 'down', { statusReport });
+    },
+  }),
+
+  partial: trait({
+    afterCreate(statusReport, server) {
+      server.create('health', 'partial', { statusReport });
+    },
+  }),
+});

--- a/ui/mirage/factories/status.ts
+++ b/ui/mirage/factories/status.ts
@@ -3,17 +3,17 @@ import faker from '../faker';
 import { Status } from 'waypoint-pb';
 
 export default Factory.extend({
+  afterCreate(status) {
+    let minutes = faker.random.number({ min: 1, max: 10 });
+    let startTime = new Date(status.completeTime.valueOf() - minutes * 60 * 1000);
+
+    status.update('startTime', startTime);
+  },
+
   random: trait({
     state: () => randomStateName(),
 
     completeTime: () => faker.date.recent(),
-
-    afterCreate(status) {
-      let minutes = faker.random.number({ min: 1, max: 10 });
-      let startTime = new Date(status.completeTime.valueOf() - minutes * 60 * 1000);
-
-      status.update('startTime', startTime);
-    },
   }),
 
   success: trait({

--- a/ui/mirage/models/application.ts
+++ b/ui/mirage/models/application.ts
@@ -5,6 +5,7 @@ export default Model.extend({
   project: belongsTo(),
   builds: hasMany(),
   deployments: hasMany(),
+  statusReports: hasMany(),
 
   toProtobuf(): Application {
     let result = new Application();

--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -11,6 +11,7 @@ export default Model.extend({
   status: belongsTo({ inverse: 'owner' }),
   component: belongsTo({ inverse: 'owner' }),
   generation: belongsTo(),
+  statusReport: belongsTo({ inverse: 'target' }),
 
   toProtobuf(): Deployment {
     let result = new Deployment();

--- a/ui/mirage/models/health.ts
+++ b/ui/mirage/models/health.ts
@@ -1,0 +1,18 @@
+import { Model, belongsTo } from 'miragejs';
+import { StatusReport } from 'waypoint-pb';
+
+export default Model.extend({
+  statusReport: belongsTo({ inverse: 'health' }),
+  statusReportList: belongsTo('status-report', { inverse: 'resourcesHealthList' }),
+
+  toProtobuf(): StatusReport.Health {
+    let result = new StatusReport.Health();
+
+    result.setHealthStatus(this.status);
+    result.setHealthMessage(this.message);
+    result.setName(this.name);
+    result.setId(this.id);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -10,6 +10,7 @@ export default Model.extend({
   deployment: belongsTo(),
   status: belongsTo({ inverse: 'owner' }),
   component: belongsTo({ inverse: 'owner' }),
+  statusReport: belongsTo({ inverse: 'target ' }),
 
   toProtobuf(): Release {
     let result = new Release();

--- a/ui/mirage/models/status-report.ts
+++ b/ui/mirage/models/status-report.ts
@@ -1,0 +1,32 @@
+import { Model, belongsTo, hasMany } from 'miragejs';
+import { StatusReport } from 'waypoint-pb';
+import MirageDeployment from './deployment';
+import MirageRelease from './release';
+
+export default Model.extend({
+  application: belongsTo(),
+  workspace: belongsTo(),
+  target: belongsTo({ polymorphic: true }),
+  status: belongsTo({ inverse: 'owner' }),
+  health: belongsTo({ inverse: 'statusReport' }),
+  resourcesHealthList: hasMany('health', { inverse: 'statusReportList' }),
+
+  toProtobuf(): StatusReport {
+    let result = new StatusReport();
+
+    result.setApplication(this.application?.toProtobufRef());
+    result.setWorkspace(this.workspace?.toProtobufRef());
+    if (this.target instanceof MirageDeployment) {
+      result.setDeploymentId(this.target.id);
+    } else if (this.target instanceof MirageRelease) {
+      result.setReleaseId(this.release.id);
+    }
+    result.setStatus(this.status?.toProtobuf());
+    result.setId(this.id);
+    // TODO: result.setStatusReport(value?: google_protobuf_any_pb.Any)
+    result.setHealth(this.health?.toProtobuf());
+    result.setResourcesHealthList(this.resourcesHealthList.models.map((h) => h.toProtobuf()));
+
+    return result;
+  },
+});

--- a/ui/mirage/models/workspace.ts
+++ b/ui/mirage/models/workspace.ts
@@ -3,6 +3,7 @@ import { Ref, Workspace } from 'waypoint-pb';
 
 export default Model.extend({
   builds: hasMany(),
+  statusReports: hasMany(),
 
   toProtobuf(): Workspace {
     let result = new Workspace();

--- a/ui/mirage/services/job.ts
+++ b/ui/mirage/services/job.ts
@@ -1,0 +1,10 @@
+import { Response } from 'miragejs';
+import { GetJobStreamResponse } from 'waypoint-pb';
+
+export function stream(): Response {
+  let result = new GetJobStreamResponse();
+
+  // TODO(jgwhite): Implement GetJobStream handler
+
+  return this.serialize(result, 'application');
+}

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'miragejs';
+import { ListStatusReportsRequest, ListStatusReportsResponse } from 'waypoint-pb';
+import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
+import { decode } from '../helpers/protobufs';
+
+export function list(schema: any, { requestBody }: Request): Response {
+  let requestMsg = decode(ListStatusReportsRequest, requestBody);
+  let projectName = requestMsg.getApplication().getProject();
+  let appName = requestMsg.getApplication().getApplication();
+  let project = schema.projects.findBy({ name: projectName });
+  let app = schema.applications.findBy({ projectId: project.id, name: appName });
+  // TODO: account for filters
+  // TODO: account for workspace
+  let statusReports = app.statusReports.models;
+  let statusReportProtobufs = statusReports.map((s) => s.toProtobuf());
+  let result = new ListStatusReportsResponse();
+
+  result.setStatusReportsList(statusReportProtobufs);
+
+  return this.serialize(result, 'application');
+}
+
+export function getLatest(): Response {
+  return this.serialize(new Empty(), 'application');
+}

--- a/ui/tests/acceptance/deployment-detail-test.ts
+++ b/ui/tests/acceptance/deployment-detail-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import login from 'waypoint/tests/helpers/login';
+
+module('Acceptance | deployment detail', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  login();
+
+  test('displays a status report badge if available', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    let deployment = this.server.create('deployment', 'random', { application });
+    this.server.create('status-report', 'ready', { application, target: deployment });
+
+    await visit(`/default/acme-project/app/acme-app/deployment/${deployment.id}`);
+
+    assert.dom('[data-test-status-badge="ready"]').exists();
+  });
+
+  test('displays no status report badge if none is available', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    let deployment = this.server.create('deployment', 'random', { application });
+
+    await visit(`/default/acme-project/app/acme-app/deployment/${deployment.id}`);
+
+    assert.dom('[data-test-status-badge]').doesNotExist();
+  });
+});

--- a/ui/tests/integration/components/status-badge-test.ts
+++ b/ui/tests/integration/components/status-badge-test.ts
@@ -1,71 +1,108 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, focus } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | status-badge', function(hooks) {
+module('Integration | Component | status-badge', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders different states', async function(assert) {
+  test('renders the correct class for @state', async function (assert) {
+    await render(hbs`
+      <StatusBadge @state={{this.state}} />
+    `);
 
-    let partialBuild = {
-      status: {
-        state: 4,
-      },
-    };
+    assert.dom('.badge-status--unknown').exists();
 
-    let downBuild = {
-      status: {
-        state: 3,
-      },
-    };
+    this.set('state', 'UNKNOWN');
+    assert.dom('.badge-status--unknown').exists();
 
-    let readyBuild = {
-      status: {
-        state: 2,
-      },
-    };
+    this.set('state', 'ALIVE');
+    assert.dom('.badge-status--alive').exists();
 
-    let aliveBuild = {
-      status: {
-        state: 1,
-      },
-    };
+    this.set('state', 'READY');
+    assert.dom('.badge-status--ready').exists();
 
-    let unknownBuild = {
-      status: {
-        state: 0,
-      },
-    };
+    this.set('state', 'DOWN');
+    assert.dom('.badge-status--down').exists();
 
-    this.build = partialBuild;
+    this.set('state', 'PARTIAL');
+    assert.dom('.badge-status--partial').exists();
+  });
 
-    await render(hbs`<StatusBadge @state={{this.build.status.state}}/>`);
+  test('renders the correct icon for @state', async function (assert) {
+    await render(hbs`
+      <StatusBadge @state={{this.state}} />
+    `);
 
-    assert.equal(this.element.getElementsByClassName('badge-status--partial').length, 1);
+    assert.dom('[data-test-icon-type="help-circle-outline"]').exists();
 
-    this.build = downBuild;
+    this.set('state', 'UNKNOWN');
+    assert.dom('[data-test-icon-type="help-circle-outline"]').exists();
 
-    await render(hbs`<StatusBadge @state={{this.build.status.state}}/>`);
+    this.set('state', 'ALIVE');
+    assert.dom('[data-test-icon-type="run"]').exists();
 
-    assert.equal(this.element.getElementsByClassName('badge-status--down').length, 1);
+    this.set('state', 'READY');
+    assert.dom('[data-test-icon-type="check-plain"]').exists();
 
-    this.build = readyBuild;
+    this.set('state', 'DOWN');
+    assert.dom('[data-test-icon-type="cancel-circle-fill"]').exists();
 
-    await render(hbs`<StatusBadge @state={{this.build.status.state}}/>`);
+    this.set('state', 'PARTIAL');
+    assert.dom('[data-test-icon-type="alert-triangle"]').exists();
+  });
 
-    assert.equal(this.element.getElementsByClassName('badge-status--ready').length, 1);
+  test('renders the correct text for @state', async function (assert) {
+    await render(hbs`
+      <StatusBadge @state={{this.state}} />
+    `);
 
-    this.build = aliveBuild;
+    assert.dom('[data-test-status-badge]').includesText('Unknown');
 
-    await render(hbs`<StatusBadge @state={{this.build.status.state}}/>`);
+    this.set('state', 'UNKNOWN');
+    assert.dom('[data-test-status-badge]').includesText('Unknown');
 
-    assert.equal(this.element.getElementsByClassName('badge-status--alive').length, 1);
+    this.set('state', 'ALIVE');
+    assert.dom('[data-test-status-badge]').includesText('Starting…');
 
-    this.build = unknownBuild;
+    this.set('state', 'READY');
+    assert.dom('[data-test-status-badge]').includesText('Up');
 
-    await render(hbs`<StatusBadge @state={{this.build.status.state}}/>`);
+    this.set('state', 'DOWN');
+    assert.dom('[data-test-status-badge]').includesText('Down');
 
-    assert.equal(this.element.getElementsByClassName('badge-status--unknown').length, 1);
+    this.set('state', 'PARTIAL');
+    assert.dom('[data-test-status-badge]').includesText('Partial');
+  });
+
+  test('does not render text if @iconOnly={{true}}', async function (assert) {
+    await render(hbs`
+      <StatusBadge @state="READY" @iconOnly={{true}} />
+    `);
+
+    assert.dom('[data-test-status-badge]').doesNotIncludeText('Up');
+  });
+
+  test('renders a default tooltip for @state', async function (assert) {
+    await render(hbs`
+      <StatusBadge @state="READY" />
+    `);
+
+    await focus('[data-test-status-badge]');
+
+    assert.dom('.ember-tooltip').includesText('Application is ready');
+  });
+
+  test('renders @message as a tooltip', async function (assert) {
+    await render(hbs`
+      <StatusBadge
+        @state={{this.state}}
+        @message="Test message"
+      />
+    `);
+
+    await focus('[data-test-status-badge]');
+
+    assert.dom('.ember-tooltip').includesText('Test message');
   });
 });

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -115,7 +115,7 @@ status_badge:
     text: 'Up'
     tooltip: 'Application is ready'
   alive:
-    text: 'Starting...'
+    text: 'Starting…'
     tooltip: 'Application is starting'
   unknown:
     text: 'Unknown'


### PR DESCRIPTION
## What is this?

Fixes #1237 

This PR adds badges to deployments indicating the result of Waypoint’s latest status report (aka health check).

## What’s the plan?

- [x] Create `<StatusBadge>`
- [x] Add Mirage layer
- [x] Load status reports
- [x] Display status report badge on deployment list view (where available)
- [x] Display status report badge on deployment detail view (where available)
- [x] Add test coverage
- [x] Add changelog entry

## What are we saving for a future PR/release?

- Fix icon alignment in Safari (#1586)
- Make the “starting…” icon pulse (steal tailwind pulse CSS) (#1587)
- Fix awkward wrapping of tooltips, maybe align center (#1588)
- Display status report on releases
- Use `<StatusBadge>` everywhere in place of the existing success/failure badges (#1581)

## What does it look like?

<img width="1612" alt="image" src="https://user-images.githubusercontent.com/34030/120653745-473df480-c481-11eb-824c-dbaeed900f5c.png">

<img width="1612" alt="image" src="https://user-images.githubusercontent.com/34030/120653785-51f88980-c481-11eb-98ef-647b0e58640d.png">


## How do I verify it?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui-health-checks-integration
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the demo deployment list view](http://localhost:4200/default/marketing-public/app/wp-matrix/deployments)
4. Verify you see status badges
5. [Visit the demo deployment detail view](http://localhost:4200/default/marketing-public/app/wp-matrix/deployment/R7X1PI460E031I83UAJ8JYUA)
6. Verify you see a status badge

### For realsies

1. Check out the branch:
   ```sh
   git checkout ui-health-checks-integration
   ```
2. Build the ember app
   ```sh
   (cd ui && make)
   ```
3. Bundle the static assets
   ```sh
   make static-assets
   ```
4. Build the dev server
   ```sh
   make docker/server
   ```
5. Build the CLI
   ```sh
   make bin
   ```
6. Install waypoint on your platform of choice, i.e.
   ```sh
   ./waypoint install -platform=kubernetes -accept-tos -k8s-server-image=waypoint:dev
   ```
7. Open the UI
   ```
   ./waypoint ui -authenticate
   ```
8. Try out an example app of your choice (i.e. [kubernetes/nodejs](https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs))
9. Verify you see status badges