### PR TITLE
builtin/{docker/k8s/nomad}: Add advisory message on non-ready reports

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -220,10 +220,17 @@ func (p *Platform) Status(
 	st.Update("Determining overall container health...")
 	if result.Health == sdk.StatusReport_READY {
 		st.Step(terminal.StatusOK, fmt.Sprintf("Container %q is reporting ready!", containerInfo.Name))
-	} else if result.Health == sdk.StatusReport_PARTIAL {
-		st.Step(terminal.StatusWarn, fmt.Sprintf("Container %q is reporting partially available!", containerInfo.Name))
 	} else {
-		st.Step(terminal.StatusError, fmt.Sprintf("Container %q is reporting not ready!", containerInfo.Name))
+		if result.Health == sdk.StatusReport_PARTIAL {
+			st.Step(terminal.StatusWarn, fmt.Sprintf("Container %q is reporting partially available!", containerInfo.Name))
+		} else {
+			st.Step(terminal.StatusError, fmt.Sprintf("Container %q is reporting not ready!", containerInfo.Name))
+		}
+
+		// Extra advisory wording to let user know that the deployment could be still starting up
+		// if the report was generated immediately after it was deployed or released.
+		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
+			"is not ready, however your\napplication might be available or still starting up.")
 	}
 
 	return &result, nil

--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -229,8 +229,7 @@ func (p *Platform) Status(
 
 		// Extra advisory wording to let user know that the deployment could be still starting up
 		// if the report was generated immediately after it was deployed or released.
-		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
-			"is not ready, however your\napplication might be available or still starting up.")
+		st.Step(terminal.StatusWarn, mixedHealthWarn)
 	}
 
 	return &result, nil
@@ -845,6 +844,13 @@ deploy {
 
 	return doc, nil
 }
+
+var (
+	mixedHealthWarn = strings.TrimSpace(`
+Waypoint detected that the current deployment is not ready, however your application
+might be available or still starting up.
+`)
+)
 
 var (
 	_ component.Platform     = (*Platform)(nil)

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -700,10 +700,17 @@ func (p *Platform) Status(
 	st.Update("Determining overall container health...")
 	if result.Health == sdk.StatusReport_READY {
 		st.Step(terminal.StatusOK, fmt.Sprintf("Deployment %q is reporting ready!", deployment.Name))
-	} else if result.Health == sdk.StatusReport_PARTIAL {
-		st.Step(terminal.StatusWarn, fmt.Sprintf("Deployment %q is reporting partially available!", deployment.Name))
 	} else {
-		st.Step(terminal.StatusError, fmt.Sprintf("Deployment %q is reporting not ready!", deployment.Name))
+		if result.Health == sdk.StatusReport_PARTIAL {
+			st.Step(terminal.StatusWarn, fmt.Sprintf("Deployment %q is reporting partially available!", deployment.Name))
+		} else {
+			st.Step(terminal.StatusError, fmt.Sprintf("Deployment %q is reporting not ready!", deployment.Name))
+		}
+
+		// Extra advisory wording to let user know that the deployment could be still starting up
+		// if the report was generated immediately after it was deployed or released.
+		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
+			"is not ready, however your\napplication might be available or still starting up.")
 	}
 
 	// More UI detail for non-ready resources

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -709,8 +709,7 @@ func (p *Platform) Status(
 
 		// Extra advisory wording to let user know that the deployment could be still starting up
 		// if the report was generated immediately after it was deployed or released.
-		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
-			"is not ready, however your\napplication might be available or still starting up.")
+		st.Step(terminal.StatusWarn, mixedHealthWarn)
 	}
 
 	// More UI detail for non-ready resources
@@ -1036,6 +1035,13 @@ deploy "kubernetes" {
 
 	return doc, nil
 }
+
+var (
+	mixedHealthWarn = strings.TrimSpace(`
+Waypoint detected that the current deployment is not ready, however your application
+might be available or still starting up.
+`)
+)
 
 var (
 	_ component.Platform         = (*Platform)(nil)

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -343,8 +344,7 @@ func (r *Releaser) Status(
 
 		// Extra advisory wording to let user know that the deployment could be still starting up
 		// if the report was generated immediately after it was deployed or released.
-		st.Step(terminal.StatusWarn, "Waypoint detected that the current release "+
-			"is not ready, however your\napplication might be available or still starting up.")
+		st.Step(terminal.StatusWarn, mixedHealthReleaseWarn)
 	}
 
 	// More UI detail for non-ready resources
@@ -460,6 +460,13 @@ func (r *Releaser) Documentation() (*docs.Documentation, error) {
 
 	return doc, nil
 }
+
+var (
+	mixedHealthReleaseWarn = strings.TrimSpace(`
+Waypoint detected that the current release is not ready, however your application
+might be available or still starting up.
+`)
+)
 
 var (
 	_ component.ReleaseManager = (*Releaser)(nil)

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -334,10 +334,17 @@ func (r *Releaser) Status(
 	st.Update("Determining overall container health...")
 	if result.Health == sdk.StatusReport_READY {
 		st.Step(terminal.StatusOK, fmt.Sprintf("Release %q is reporting ready!", appName))
-	} else if result.Health == sdk.StatusReport_PARTIAL {
-		st.Step(terminal.StatusWarn, fmt.Sprintf("Release %q is reporting partially available!", appName))
 	} else {
-		st.Step(terminal.StatusError, fmt.Sprintf("Release %q is reporting not ready!", appName))
+		if result.Health == sdk.StatusReport_PARTIAL {
+			st.Step(terminal.StatusWarn, fmt.Sprintf("Release %q is reporting partially available!", appName))
+		} else {
+			st.Step(terminal.StatusError, fmt.Sprintf("Release %q is reporting not ready!", appName))
+		}
+
+		// Extra advisory wording to let user know that the deployment could be still starting up
+		// if the report was generated immediately after it was deployed or released.
+		st.Step(terminal.StatusWarn, "Waypoint detected that the current release "+
+			"is not ready, however your\napplication might be available or still starting up.")
 	}
 
 	// More UI detail for non-ready resources

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -296,8 +296,7 @@ func (p *Platform) Status(
 
 		// Extra advisory wording to let user know that the deployment could be still starting up
 		// if the report was generated immediately after it was deployed or released.
-		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
-			"is not ready, however your\napplication might be available or still starting up.")
+		st.Step(terminal.StatusWarn, mixedHealthWarn)
 	}
 
 	return &result, nil
@@ -436,6 +435,13 @@ deploy {
 
 	return doc, nil
 }
+
+var (
+	mixedHealthWarn = strings.TrimSpace(`
+Waypoint detected that the current deployment is not ready, however your application
+might be available or still starting up.
+`)
+)
 
 var (
 	_ component.Platform     = (*Platform)(nil)

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -287,10 +287,17 @@ func (p *Platform) Status(
 	st.Update("Determining overall container health...")
 	if result.Health == sdk.StatusReport_READY {
 		st.Step(terminal.StatusOK, fmt.Sprintf("Job %q is reporting ready!", deployment.Name))
-	} else if result.Health == sdk.StatusReport_PARTIAL {
-		st.Step(terminal.StatusWarn, fmt.Sprintf("Job %q is reporting partially available!", deployment.Name))
 	} else {
-		st.Step(terminal.StatusError, fmt.Sprintf("Job %q is reporting not ready!", deployment.Name))
+		if result.Health == sdk.StatusReport_PARTIAL {
+			st.Step(terminal.StatusWarn, fmt.Sprintf("Job %q is reporting partially available!", deployment.Name))
+		} else {
+			st.Step(terminal.StatusError, fmt.Sprintf("Job %q is reporting not ready!", deployment.Name))
+		}
+
+		// Extra advisory wording to let user know that the deployment could be still starting up
+		// if the report was generated immediately after it was deployed or released.
+		st.Step(terminal.StatusWarn, "Waypoint detected that the current deployment "+
+			"is not ready, however your\napplication might be available or still starting up.")
 	}
 
 	return &result, nil


### PR DESCRIPTION
This commit adds some additional wordage in the case where a deployment
or release report was generated and its health is anything other than
READY. In some cases, a report that was generated immediately after the
deployment or release will be unhealthy given slow startup times, so this
warning adds some extra context for what the report means.

As an aside, this is one of the reasons why https://github.com/hashicorp/waypoint/issues/1497 will be very useful! This status output based on a StatusFuncs returned report could live in a single spot rather than duplicated across all plugins.