### PR TITLE
internal/server: increase test delta tolerance to 1 second from 0.1

### DIFF
--- a/internal/server/singleprocess/service_exec_test.go
+++ b/internal/server/singleprocess/service_exec_test.go
@@ -493,7 +493,7 @@ func TestService_waitOnJobStarted(t *testing.T) {
 	require.NoError(err)
 	dur := time.Since(ts)
 
-	require.InDelta(1.0, dur.Seconds(), 0.1)
+	require.InDelta(1.0, dur.Seconds(), 1.0)
 
 	require.Equal(pb.Job_ERROR, js)
 }


### PR DESCRIPTION
Fixes #1562

A 0.1 second delta is too tight for multi-tenant CI systems. For the
test logic itself, even a 1 second tolerance is absolutely semantically
fine. We just want to ensure the job is started expediently.