### PR TITLE
Bug: adding release or deployment ID to the status report

### DIFF
--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -334,7 +334,9 @@ func (op *statusReportOperation) Do(
 	}
 	realMsg.ResourcesHealth = resourcesHealth
 
-	// Add the deployment/release ID to the report. TODO: wire the resource ID through explicitly
+	// Add the deployment/release ID to the report.
+	// TODO: this is a stopgap solution - we should wire resource ID information into here in a more generic way
+	// rather than continue to append to this switch case.
 	switch op.Target.(type) {
 	case *pb.Deployment:
 		realMsg.TargetId = &pb.StatusReport_DeploymentId{DeploymentId: op.Target.(*pb.Deployment).Id}

--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -332,6 +333,15 @@ func (op *statusReportOperation) Do(
 		}
 	}
 	realMsg.ResourcesHealth = resourcesHealth
+
+	switch op.Target.(type) {
+	case *pb.Deployment:
+		realMsg.TargetId = &pb.StatusReport_DeploymentId{DeploymentId: op.Target.(*pb.Deployment).Id}
+	case *pb.Release:
+		realMsg.TargetId = &pb.StatusReport_ReleaseId{ReleaseId: op.Target.(*pb.Release).Id}
+	default:
+		return nil, fmt.Errorf("unsupported status operation type")
+	}
 
 	op.result = result.(*sdk.StatusReport)
 

--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -334,6 +334,7 @@ func (op *statusReportOperation) Do(
 	}
 	realMsg.ResourcesHealth = resourcesHealth
 
+	// Add the deployment/release ID to the report. TODO: wire the resource ID through explicitly
 	switch op.Target.(type) {
 	case *pb.Deployment:
 		realMsg.TargetId = &pb.StatusReport_DeploymentId{DeploymentId: op.Target.(*pb.Deployment).Id}

--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/zclconf/go-cty/cty"
@@ -337,13 +335,14 @@ func (op *statusReportOperation) Do(
 	// Add the deployment/release ID to the report.
 	// TODO: this is a stopgap solution - we should wire resource ID information into here in a more generic way
 	// rather than continue to append to this switch case.
-	switch op.Target.(type) {
+
+	switch target := op.Target.(type) {
 	case *pb.Deployment:
-		realMsg.TargetId = &pb.StatusReport_DeploymentId{DeploymentId: op.Target.(*pb.Deployment).Id}
+		realMsg.TargetId = &pb.StatusReport_DeploymentId{DeploymentId: target.Id}
 	case *pb.Release:
-		realMsg.TargetId = &pb.StatusReport_ReleaseId{ReleaseId: op.Target.(*pb.Release).Id}
+		realMsg.TargetId = &pb.StatusReport_ReleaseId{ReleaseId: target.Id}
 	default:
-		return nil, fmt.Errorf("unsupported status operation type")
+		return nil, status.Errorf(codes.FailedPrecondition, "unsupported status operation type")
 	}
 
 	op.result = result.(*sdk.StatusReport)

--- a/internal/core/app_status_report_test.go
+++ b/internal/core/app_status_report_test.go
@@ -118,12 +118,16 @@ func TestAppDeploymentStatusReport(t *testing.T) {
 		})
 
 		// Status Report
+
 		srResp, err := app.DeploymentStatusReport(context.Background(), deploy)
 		statusReport := &sdk.StatusReport{}
 		anypb.UnmarshalTo(srResp.StatusReport, statusReport, proto.UnmarshalOptions{})
 		require.NoError(err)
 		require.NotNil(srResp.StatusReport)
 		require.NotNil(statusReport.Health)
+
+		require.IsType(srResp.TargetId, &pb.StatusReport_DeploymentId{})
+		require.Equal(srResp.TargetId.(*pb.StatusReport_DeploymentId).DeploymentId, deploy.Id)
 
 	})
 }
@@ -251,6 +255,9 @@ func TestAppReleaseStatusReport(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(srResp.StatusReport)
 		require.NotNil(statusReport.Health)
+
+		require.IsType(srResp.TargetId, &pb.StatusReport_ReleaseId{})
+		require.Equal(srResp.TargetId.(*pb.StatusReport_ReleaseId).ReleaseId, release.Id)
 
 	})
 }


### PR DESCRIPTION
I don't think this is the *right* way to wire this information through, but it seems to work for now.