### PR TITLE
state/status_report: Increase max records for status reports

### DIFF
--- a/internal/server/singleprocess/state/status_report.go
+++ b/internal/server/singleprocess/state/status_report.go
@@ -8,7 +8,9 @@ var statusReportOp = &appOperation{
 	Struct: (*pb.StatusReport)(nil),
 	Bucket: []byte("statusreport"),
 
-	MaximumIndexedRecords: 1, // Only store the "latest" status report
+	// This number is global, not per deployment. So we set this number to a high
+	// number instead of trying to store just "one" per deploy/release
+	MaximumIndexedRecords: 10000,
 }
 
 func init() {


### PR DESCRIPTION
The max record value was global, not per deployment or release. So
foreach deployment or release, status reports were getting pruned. This
commit increases the limit to match deployment state limits.