### PR TITLE
ui: Use kubernetes icon for kubernetes-apply

### DIFF
--- a/ui/app/helpers/icon-for-component.ts
+++ b/ui/app/helpers/icon-for-component.ts
@@ -14,6 +14,7 @@ export function iconForComponent([component]: [string]): string {
     case 'google-cloud-run':
       return 'logo-gcp-color';
     case 'kubernetes':
+    case 'kubernetes-apply':
       return 'logo-kubernetes-color-alt';
     case 'nomad':
     case 'nomad-jobspec':

--- a/ui/mirage/factories/component.ts
+++ b/ui/mirage/factories/component.ts
@@ -44,6 +44,10 @@ export default Factory.extend({
     name: 'kubernetes',
   }),
 
+  'kubernetes-apply': trait({
+    name: 'kubernetes-apply',
+  }),
+
   'with-random-name': trait({
     afterCreate(component) {
       component.update('name', randomNameForType(component.type));

--- a/ui/mirage/factories/deployment.ts
+++ b/ui/mirage/factories/deployment.ts
@@ -44,6 +44,10 @@ export default Factory.extend({
     component: association('platform', 'kubernetes'),
   }),
 
+  'kubernetes-apply': trait({
+    component: association('platform', 'kubernetes-apply'),
+  }),
+
   'seconds-old-success': trait({
     status: association('random', 'success', 'seconds-old'),
   }),


### PR DESCRIPTION
## What is this?

Does what it says on the tin. Closes #1575

## What does it look like?

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/34030/120711623-e41f8280-c4bf-11eb-971d-c682a1c5345d.png) | ![after](https://user-images.githubusercontent.com/34030/120711627-e550af80-c4bf-11eb-94fd-a0c7ec7ddced.png) |

## How do I test it?

1. Check out the branch
2. Run the ui dev server
   ```sh
   cd ui && yarn start
   ```
3. Make the following change on `ui/mirage/factories/project.ts:156`:
   ```diff
   - server.create('deployment', 'random', 'nomad-jobspec', 'seconds-old-success', {
   + server.create('deployment', 'random', 'kubernetes-apply', 'seconds-old-success', {
   ```
4. [Visit the app view](http://localhost:4200/default/marketing-public/app/wp-matrix/deployments)
5. Verify that the latest deployment has the Kubernetes icon