### PR TITLE
cli: ignore error if server doesn't have health checks

### DIFF
--- a/.changelog/1596.txt
+++ b/.changelog/1596.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Ignore error on Unimplemented for health checks
+```

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -116,7 +116,7 @@ func (c *DeploymentListCommand) Run(args []string) int {
 			Application: app.Ref(),
 			Workspace:   wsRef,
 		})
-		if status.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound || status.Code(err) == codes.Unimplemented {
 			err = nil
 			statusReportResp = nil
 		}


### PR DESCRIPTION
Fixes #1595

CLI: built off branch
Server: 0.3.2

Before fix:
```
$ waypoint deployment list
! unknown method GetLatestStatusReport for service hashicorp.waypoint.Waypoint
```

After fix:
```
$ waypoint deployment list
     | ID | PLATFORM |  DETAILS   |    STARTED     |   COMPLETED    |     HEALTH      
-----+----+----------+------------+----------------+----------------+-----------------
  🚀 |  2 | docker   | artifact:2 | 48 seconds ago | 47 seconds ago | Unknown status  
  ✔  |  1 | docker   | artifact:1 | 54 seconds ago | 52 seconds ago | Unknown status  
```