### PR TITLE
ui: Fix dark mode elements

### DIFF
--- a/ui/app/styles/_app-item.scss
+++ b/ui/app/styles/_app-item.scss
@@ -84,4 +84,10 @@
     margin-bottom: 0px;
     border-top: 1rem solid color.$ui-cool-gray-050;
   }
+
+  @media (prefers-color-scheme: dark) {
+    &--previous {
+      background: color.$ui-cool-gray-800;
+    }
+  }
 }

--- a/ui/app/styles/_page.scss
+++ b/ui/app/styles/_page.scss
@@ -181,6 +181,12 @@
         color: rgb(var(--text));
       }
     }
+
+    @media (prefers-color-scheme: dark) {
+      a:hover {
+        background: color.$ui-cool-gray-800;
+      }
+    }
   }
 
   ul.list {


### PR DESCRIPTION
Addresses a couple of minor issues where the dark mode version of the UI was unreadable.

Fixes:
https://github.com/hashicorp/waypoint/issues/1582

Before:

![Safari 2021-06-04 at 14 15 39@2x](https://user-images.githubusercontent.com/51724/120806962-5d11ef00-c53f-11eb-961b-cfc25acb7997.png)

After:

![Safari 2021-06-04 at 14 15 24@2x](https://user-images.githubusercontent.com/51724/120806985-626f3980-c53f-11eb-9add-14431ed98178.png)
