### PR TITLE
internal/server: Refactor how server queues poll jobs

### DIFF
--- a/internal/server/singleprocess/poll_project.go
+++ b/internal/server/singleprocess/poll_project.go
@@ -48,7 +48,7 @@ func (pp *projectPoll) PollJob(
 	project interface{},
 ) (*pb.QueueJobRequest, error) {
 	p, ok := project.(*pb.Project)
-	if !ok {
+	if !ok || p == nil {
 		log.Error("could not generate poll job for project, incorrect type passed in")
 		return nil, status.Error(codes.FailedPrecondition, "incorrect type passed into Project PollJob")
 	}
@@ -92,7 +92,7 @@ func (pp *projectPoll) Complete(
 	project interface{},
 ) error {
 	p, ok := project.(*pb.Project)
-	if !ok {
+	if !ok || p == nil {
 		log.Error("could not mark project poll as complete, incorrect type passed in")
 		return status.Error(codes.FailedPrecondition, "incorrect type passed into Project Complete")
 	}

--- a/internal/server/singleprocess/poll_project.go
+++ b/internal/server/singleprocess/poll_project.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
-type ProjectPoll struct {
+type projectPoll struct {
 	// state is the state management interface that provides functions for
 	// safely mutating server state.
 	state *state.State
@@ -22,7 +22,7 @@ type ProjectPoll struct {
 // Peek returns the latest project to poll on
 // If there is an error in the ProjectPollPeek, it will return nil
 // to allow the outer caller loop to continue and try again
-func (pp *ProjectPoll) Peek(
+func (pp *projectPoll) Peek(
 	ws memdb.WatchSet,
 	log hclog.Logger,
 ) (interface{}, time.Time, error) {
@@ -39,7 +39,7 @@ func (pp *ProjectPoll) Peek(
 }
 
 // PollJob will generate a job to queue a project on
-func (pp *ProjectPoll) PollJob(
+func (pp *projectPoll) PollJob(
 	project interface{},
 	log hclog.Logger,
 ) (*pb.QueueJobRequest, error) {
@@ -83,7 +83,7 @@ func (pp *ProjectPoll) PollJob(
 
 // Complete will mark the job that was queued as complete, if it
 // fails to do so, it will return false with the err to continue the loop
-func (pp *ProjectPoll) Complete(
+func (pp *projectPoll) Complete(
 	project interface{},
 	log hclog.Logger,
 ) error {

--- a/internal/server/singleprocess/poll_project.go
+++ b/internal/server/singleprocess/poll_project.go
@@ -1,0 +1,101 @@
+package singleprocess
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
+)
+
+type ProjectPoll struct {
+	// state is the state management interface that provides functions for
+	// safely mutating server state.
+	state *state.State
+}
+
+// Peek returns the latest project to poll on
+// If there is an error in the ProjectPollPeek, it will return nil
+// to allow the outer caller loop to continue and try again
+func (pp *ProjectPoll) Peek(
+	ws memdb.WatchSet,
+	log hclog.Logger,
+) (interface{}, time.Time, error) {
+	p, pollTime, err := pp.state.ProjectPollPeek(ws)
+	if err != nil {
+		return nil, time.Time{}, err // continue loop
+	}
+
+	if p != nil {
+		log = log.With("project", p.Name)
+	}
+
+	return p, pollTime, nil
+}
+
+// PollJob will generate a job to queue a project on
+func (pp *ProjectPoll) PollJob(
+	project interface{},
+	log hclog.Logger,
+) (*pb.QueueJobRequest, error) {
+	p, ok := project.(*pb.Project)
+	if !ok {
+		log.Error("could not generate poll job for project, incorrect type passed in")
+		return nil, status.Error(codes.FailedPrecondition, "incorrect type passed into Project PollJob")
+	}
+
+	jobRequest := &pb.QueueJobRequest{
+		Job: &pb.Job{
+			// SingletonId so that we only have one poll operation at
+			// any time queued per project.
+			SingletonId: fmt.Sprintf("poll/%s", p.Name),
+
+			Application: &pb.Ref_Application{
+				Project: p.Name,
+				// No Application set since PollOp is project-oriented
+			},
+
+			// Polling always happens on the default workspace even
+			// though the PollOp is across every workspace.
+			Workspace: &pb.Ref_Workspace{Workspace: "default"},
+
+			// Poll!
+			Operation: &pb.Job_Poll{
+				Poll: &pb.Job_PollOp{},
+			},
+
+			// Any runner is fine for polling.
+			TargetRunner: &pb.Ref_Runner{
+				Target: &pb.Ref_Runner_Any{
+					Any: &pb.Ref_RunnerAny{},
+				},
+			},
+		},
+	}
+
+	return jobRequest, nil
+}
+
+// Complete will mark the job that was queued as complete, if it
+// fails to do so, it will return false with the err to continue the loop
+func (pp *ProjectPoll) Complete(
+	project interface{},
+	log hclog.Logger,
+) error {
+	p, ok := project.(*pb.Project)
+	if !ok {
+		log.Error("could not mark project poll as complete, incorrect type passed in")
+		return status.Error(codes.FailedPrecondition, "incorrect type passed into Project Complete")
+	}
+
+	// Mark this as complete so the next poll gets rescheduled.
+	if err := pp.state.ProjectPollComplete(p, time.Now()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/server/singleprocess/poll_project.go
+++ b/internal/server/singleprocess/poll_project.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
+// projectPoll accepts a state management interface which provides access
+// to a projects current state implementation. Functions like Peek and Complete
+// need access to this state interface for peeking at the next available project
+// as well as marking a projects poll as complete.
 type projectPoll struct {
 	// state is the state management interface that provides functions for
 	// safely mutating server state.

--- a/internal/server/singleprocess/poll_project.go
+++ b/internal/server/singleprocess/poll_project.go
@@ -23,8 +23,8 @@ type projectPoll struct {
 // If there is an error in the ProjectPollPeek, it will return nil
 // to allow the outer caller loop to continue and try again
 func (pp *projectPoll) Peek(
-	ws memdb.WatchSet,
 	log hclog.Logger,
+	ws memdb.WatchSet,
 ) (interface{}, time.Time, error) {
 	p, pollTime, err := pp.state.ProjectPollPeek(ws)
 	if err != nil {
@@ -40,8 +40,8 @@ func (pp *projectPoll) Peek(
 
 // PollJob will generate a job to queue a project on
 func (pp *projectPoll) PollJob(
-	project interface{},
 	log hclog.Logger,
+	project interface{},
 ) (*pb.QueueJobRequest, error) {
 	p, ok := project.(*pb.Project)
 	if !ok {
@@ -84,8 +84,8 @@ func (pp *projectPoll) PollJob(
 // Complete will mark the job that was queued as complete, if it
 // fails to do so, it will return false with the err to continue the loop
 func (pp *projectPoll) Complete(
-	project interface{},
 	log hclog.Logger,
+	project interface{},
 ) error {
 	p, ok := project.(*pb.Project)
 	if !ok {

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -2,7 +2,6 @@ package singleprocess
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/boltdb/bolt"
@@ -142,7 +141,7 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 	// TODO: When more items are added, move this else where
 	// pollableItems is a map of potential items Waypoint can queue a poll for.
 	// Each item should implement the pollHandler interface
-	var pollableItems = map[string]pollHandler{
+	pollableItems := map[string]pollHandler{
 		"project": &projectPoll{state: s.state},
 	}
 
@@ -153,7 +152,7 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 	// See the func docs for more info.
 	for pollName, pollItem := range pollableItems {
 		s.bgWg.Add(1)
-		go s.runPollQueuer(s.bgCtx, &s.bgWg, pollItem, log.Named(fmt.Sprintf("%s_poll_queuer", pollName)))
+		go s.runPollQueuer(s.bgCtx, &s.bgWg, pollItem, log.Named("poll_queuer").Named(pollName))
 	}
 
 	// Start out state pruning background goroutine. This calls

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -143,7 +143,7 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 	// pollableItems is a map of potential items Waypoint can queue a poll for.
 	// Each item should implement the pollHandler interface
 	var pollableItems = map[string]pollHandler{
-		"project": &ProjectPoll{state: s.state},
+		"project": &projectPoll{state: s.state},
 	}
 
 	// Start our polling background goroutines.


### PR DESCRIPTION
This commit refactors how the server queues poll operations. Initially,
we would only poll on projects. This commit refactors that behavior to
include an interface named pollHandler, which allows for more kinds of
items to queue poll jobs on.

One of the motivating factors for this work is to make the poller support different kinds of operations so that status reports (and other things) can be generated on an interval.