### PR TITLE
Enhancement: moving api-common-protos from vendor to 3rdparty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "3rdparty/proto/api-common-protos"]
-	path = 3rdparty/proto/api-common-protos
+[submodule "thirdparty/proto/api-common-protos"]
+	path = thirdparty/proto/api-common-protos
 	url = https://github.com/googleapis/api-common-protos

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "vendor/proto/api-common-protos"]
-	path = vendor/proto/api-common-protos
+[submodule "3rdparty/proto/api-common-protos"]
+	path = 3rdparty/proto/api-common-protos
 	url = https://github.com/googleapis/api-common-protos

--- a/Makefile
+++ b/Makefile
@@ -77,17 +77,19 @@ gen/changelog:
 # generates protos for the plugins inside builtin
 .PHONY: gen/plugins
 gen/plugins:
+	@test -s "3rdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 	go generate ./builtin/...
 
 .PHONY: gen/server
 gen/server:
+	@test -s "3rdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 	go generate ./internal/server 
 
 .PHONY: gen/ts
 gen/ts:
 	@rm -rf ./ui/lib/api-common-protos/google 2> /dev/null
 	protoc -I=. \
-		-I=./vendor/proto/api-common-protos/ \
+		-I=./3rdparty/proto/api-common-protos/ \
 		./internal/server/proto/server.proto \
 		--js_out=import_style=commonjs:ui/lib/waypoint-pb/ \
 		--grpc-web_out=import_style=typescript,mode=grpcwebtext:ui/lib/waypoint-client/
@@ -104,8 +106,8 @@ gen/ts:
 	find . -type f -wholename './ui/lib/waypoint-client/*' | xargs sed -i 's/..\/..\/..\/internal\/server\/protwaypoint-pb/waypoint-pb/g'
 
 	protoc \
-		-I=./vendor/proto/api-common-protos/ \
-		./vendor/proto/api-common-protos/google/**/*.proto \
+		-I=./3rdparty/proto/api-common-protos/ \
+		./3rdparty/proto/api-common-protos/google/**/*.proto \
 		--js_out=import_style=commonjs,binary:ui/lib/api-common-protos/ \
 		--ts_out=ui/lib/api-common-protos/
 	@rm -rf ./ui/lib/waypoint-pb/internal
@@ -123,7 +125,7 @@ gen/doc:
 	mkdir -p ./doc/ 
 	@rm -rf ./doc/* 2> /dev/null
 	protoc -I=. \
-		-I=./vendor/proto/api-common-protos/ \
+		-I=./3rdparty/proto/api-common-protos/ \
 		--doc_out=./doc --doc_opt=html,index.html \
 		./internal/server/proto/server.proto
 

--- a/Makefile
+++ b/Makefile
@@ -77,19 +77,19 @@ gen/changelog:
 # generates protos for the plugins inside builtin
 .PHONY: gen/plugins
 gen/plugins:
-	@test -s "3rdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
+	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 	go generate ./builtin/...
 
 .PHONY: gen/server
 gen/server:
-	@test -s "3rdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
+	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 	go generate ./internal/server 
 
 .PHONY: gen/ts
 gen/ts:
 	@rm -rf ./ui/lib/api-common-protos/google 2> /dev/null
 	protoc -I=. \
-		-I=./3rdparty/proto/api-common-protos/ \
+		-I=./thirdparty/proto/api-common-protos/ \
 		./internal/server/proto/server.proto \
 		--js_out=import_style=commonjs:ui/lib/waypoint-pb/ \
 		--grpc-web_out=import_style=typescript,mode=grpcwebtext:ui/lib/waypoint-client/
@@ -106,8 +106,8 @@ gen/ts:
 	find . -type f -wholename './ui/lib/waypoint-client/*' | xargs sed -i 's/..\/..\/..\/internal\/server\/protwaypoint-pb/waypoint-pb/g'
 
 	protoc \
-		-I=./3rdparty/proto/api-common-protos/ \
-		./3rdparty/proto/api-common-protos/google/**/*.proto \
+		-I=./thirdparty/proto/api-common-protos/ \
+		./thirdparty/proto/api-common-protos/google/**/*.proto \
 		--js_out=import_style=commonjs,binary:ui/lib/api-common-protos/ \
 		--ts_out=ui/lib/api-common-protos/
 	@rm -rf ./ui/lib/waypoint-pb/internal
@@ -125,7 +125,7 @@ gen/doc:
 	mkdir -p ./doc/ 
 	@rm -rf ./doc/* 2> /dev/null
 	protoc -I=. \
-		-I=./3rdparty/proto/api-common-protos/ \
+		-I=./thirdparty/proto/api-common-protos/ \
 		--doc_out=./doc --doc_opt=html,index.html \
 		./internal/server/proto/server.proto
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-//go:generate sh -c "protoc -I../../vendor/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
+//go:generate sh -c "protoc -I../../3rdparty/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
 //go:generate mv ./proto/server.pb.json.go ./gen
 //go:generate mockery -all -case underscore -dir ./gen -output ./gen/mocks
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-//go:generate sh -c "protoc -I../../3rdparty/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
+//go:generate sh -c "protoc -I../../thirdparty/proto/api-common-protos -I ../.. ../../internal/server/proto/server.proto --go_out=plugins=grpc:../.. --go-json_out=../.."
 //go:generate mv ./proto/server.pb.json.go ./gen
 //go:generate mockery -all -case underscore -dir ./gen -output ./gen/mocks
 


### PR DESCRIPTION
If there is a `vendor` folder at the project root, the Goland IDE ignores go modules and downloads all dependencies into that vendor folder. Until now, I've been working around this by deleting the vendor folder until I need to regenerate protobufs. Renaming `vendor` to `3rdparty` also makes us more consistent with waypoint-plugin-sdk.

I also added tests to the `make gen` commands to verify that the submodule has been initialized, and instructs you to do so if not.