### PR TITLE
cli: Fix incorrect command help output

### DIFF
--- a/.changelog/1628.txt
+++ b/.changelog/1628.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Fix incorrect description for `hostname list` command.
+```

--- a/internal/cli/hostname_list.go
+++ b/internal/cli/hostname_list.go
@@ -57,12 +57,12 @@ func (c *HostnameListCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *HostnameListCommand) Synopsis() string {
-	return "List all registered hostname."
+	return "List all registered hostnames."
 }
 
 func (c *HostnameListCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint hostname delete HOSTNAME
+Usage: waypoint hostname list
 
   List all registered hostnames.
 


### PR DESCRIPTION
Currently:

```
$ waypoint hostname list -h
Usage: waypoint hostname delete HOSTNAME
```

Fix:

```
$ waypoint hostname list -h
Usage: waypoint hostname list
```

Also

```
$ waypoint hostname -h
...
    list        List all registered hostname.
```

Change `registered hostname` => `registered hostnames`.