### PR TITLE
Upgrade bolt to bbolt

### DIFF
--- a/.changelog/1631.txt
+++ b/.changelog/1631.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-core: Upgrade from unmaintained `boltdb/bolt` to `etcd-io/bbolt`
-```

--- a/.changelog/1631.txt
+++ b/.changelog/1631.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Upgrade from unmaintained `boltdb/bolt` to `etcd-io/bbolt`
+```

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/aws/aws-sdk-go v1.36.31
 	github.com/bmatcuk/doublestar v1.1.5
-	github.com/boltdb/bolt v1.3.1
 	github.com/buildpacks/pack v0.18.1
 	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
@@ -98,6 +97,7 @@ require (
 	github.com/vektra/mockery v1.1.2
 	github.com/zclconf/go-cty v1.8.2
 	github.com/zclconf/go-cty-yaml v1.0.2
+	go.etcd.io/bbolt v1.3.3
 	go.uber.org/goleak v1.1.10
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,6 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
-github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=
 github.com/briandowns/spinner v1.11.1/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/buildpacks/imgutil v0.0.0-20201211223552-8581300fe2b2/go.mod h1:NC93OGDehA2ksqgTzugeQcPqmTpilMPYRO+XaFsDyts=
@@ -1202,6 +1200,7 @@ github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgK
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	hznhub "github.com/hashicorp/horizon/pkg/hub"
 	hzntest "github.com/hashicorp/horizon/pkg/testutils/central"
@@ -25,6 +24,7 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/posener/complete"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	hznhub "github.com/hashicorp/horizon/pkg/hub"
 	hzntest "github.com/hashicorp/horizon/pkg/testutils/central"

--- a/internal/client/server.go
+++ b/internal/client/server.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/golang/protobuf/ptypes/empty"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/waypoint/internal/protocolversion"

--- a/internal/client/server.go
+++ b/internal/client/server.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
 

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"sync"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	wphznpb "github.com/hashicorp/waypoint-hzn/pkg/pb"
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	wphznpb "github.com/hashicorp/waypoint-hzn/pkg/pb"
 

--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -8,12 +8,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/application.go
+++ b/internal/server/singleprocess/state/application.go
@@ -1,8 +1,8 @@
 package state
 
 import (
-	"github.com/boltdb/bolt"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/config.go
+++ b/internal/server/singleprocess/state/config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/config_source.go
+++ b/internal/server/singleprocess/state/config_source.go
@@ -3,10 +3,10 @@ package state
 import (
 	"strings"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure/v2"
+	bolt "go.etcd.io/bbolt"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )

--- a/internal/server/singleprocess/state/db.go
+++ b/internal/server/singleprocess/state/db.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/internal/server/singleprocess/state/hmac.go
+++ b/internal/server/singleprocess/state/hmac.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )

--- a/internal/server/singleprocess/state/job.go
+++ b/internal/server/singleprocess/state/job.go
@@ -7,11 +7,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/project.go
+++ b/internal/server/singleprocess/state/project.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/server_config.go
+++ b/internal/server/singleprocess/state/server_config.go
@@ -1,9 +1,9 @@
 package state
 
 import (
-	"github.com/boltdb/bolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )

--- a/internal/server/singleprocess/state/server_id.go
+++ b/internal/server/singleprocess/state/server_id.go
@@ -1,7 +1,7 @@
 package state
 
 import (
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 var (

--- a/internal/server/singleprocess/state/server_urltoken.go
+++ b/internal/server/singleprocess/state/server_urltoken.go
@@ -1,7 +1,7 @@
 package state
 
 import (
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 var (

--- a/internal/server/singleprocess/state/snapshot.go
+++ b/internal/server/singleprocess/state/snapshot.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/gofrs/flock"
 	"github.com/hashicorp/go-hclog"
 	"github.com/natefinch/atomic"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/state/state.go
+++ b/internal/server/singleprocess/state/state.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 )

--- a/internal/server/singleprocess/state/state.go
+++ b/internal/server/singleprocess/state/state.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"sync"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 )
 
 // The global variables below can be set by init() functions of other

--- a/internal/server/singleprocess/state/testing.go
+++ b/internal/server/singleprocess/state/testing.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"

--- a/internal/server/singleprocess/state/testing.go
+++ b/internal/server/singleprocess/state/testing.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 )
 
 // TestState returns an initialized State for testing.

--- a/internal/server/singleprocess/state/workspace.go
+++ b/internal/server/singleprocess/state/workspace.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/go-memdb"

--- a/internal/server/singleprocess/state/workspace.go
+++ b/internal/server/singleprocess/state/workspace.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"time"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hashicorp/go-memdb"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/testing.go
+++ b/internal/server/singleprocess/testing.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	hznhub "github.com/hashicorp/horizon/pkg/hub"
 	hznpb "github.com/hashicorp/horizon/pkg/pb"
@@ -19,6 +18,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"

--- a/internal/server/singleprocess/testing.go
+++ b/internal/server/singleprocess/testing.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"github.com/hashicorp/go-hclog"
 	hznhub "github.com/hashicorp/horizon/pkg/hub"
 	hznpb "github.com/hashicorp/horizon/pkg/pb"


### PR DESCRIPTION
[Boltdb](https://github.com/boltdb/bolt) is no longer maintained, and causes intermittent test failures. Bolt also causes a runtime crash when attempting to run `go test` with the `-race` flag.

Etcd's bbolt is api-compatible with boltdb, and it's database file appears to be structurally compatible too. I've tested reading builds, config, deployments, jobs, projects, status reports, and releases created by `bolt`, and writing and reading new values with `bbolt`, and it all works as expected. 

There are no documented structural incompatibilities or related issues that I've found, and there are examples of [other](https://github.com/influxdata/kapacitor/commit/91b7bd7d29db8ece58bc557a2a8c49ad16338ae0) [projects](https://github.com/wakatime/wakatime-cli/commit/175ec848d36d3d29fd4aa1c144edddd5fdca82ce) doing this successfully.

Note that [raft-boltdb](https://github.com/hashicorp/raft-boltdb/pull/23) chose to perform this upgrade by migrating the database file, but moreso out of an abundance of caution than to work around any specific issues.

Closes https://github.com/hashicorp/waypoint/issues/1537