### PR TITLE
ui: Added coverage of cli-generated project editing on dashboard

### DIFF
--- a/ui/app/components/app-form/project-settings.ts
+++ b/ui/app/components/app-form/project-settings.ts
@@ -144,19 +144,22 @@ export default class AppFormProjectSettings extends Component<ProjectSettingsArg
     return true;
   }
 
-  populateExistingFields(newProject, savedModel) {
-    for (const [key, value] of Object.entries(newProject)) {
+  populateExistingFields(projectFromArgs, currentModel) {
+    for (const [key, value] of Object.entries(projectFromArgs)) {
       if (isEmpty(value)) {
         continue;
       }
 
       // if the value is a nested object, recursively call this function
       if (typeof value === 'object') {
-        return this.populateExistingFields(newProject[key], savedModel[key]);
+        this.populateExistingFields(
+          projectFromArgs[key],
+          !isEmpty(currentModel[key]) ? currentModel[key] : {}
+        );
       }
 
-      if (value !== savedModel[key]) {
-        savedModel[key] = value;
+      if (value !== currentModel[key]) {
+        currentModel[key] = value;
       }
     }
   }

--- a/ui/tests/integration/components/app-form/project-settings-test.ts
+++ b/ui/tests/integration/components/app-form/project-settings-test.ts
@@ -22,6 +22,49 @@ module('Integration | Component | app-form/project-settings', function (hooks) {
     assert.dom('#git-source-password').hasValue('');
   });
 
+  test('populated applications list does not break render', async function (assert) {
+    this.set('project', {
+      applicationsList: [
+        {
+          name: 'app-1',
+          project: {
+            project: 'project',
+          },
+        },
+      ],
+      dataSource: {
+        git: {
+          url: 'https://github.com',
+        },
+      },
+    });
+    await render(hbs`<AppForm::ProjectSettings @project={{this.project}} />`);
+
+    assert.dom('#git-source-url').hasValue('https://github.com');
+    assert.dom('#git-auth-not-set').isChecked();
+  });
+
+  test('cli generated project does not break render', async function (assert) {
+    this.set('project', {
+      applicationsList: [
+        {
+          name: 'app-1',
+          project: {
+            project: 'project',
+          },
+        },
+      ],
+      dataSource: undefined,
+      dataSourcePoll: undefined,
+    });
+    await render(hbs`<AppForm::ProjectSettings @project={{this.project}} />`);
+
+    assert.dom('#git-source-url').hasValue('');
+    assert.dom('#git-auth-basic').isChecked();
+    assert.dom('#git-source-username').hasValue('');
+    assert.dom('#git-source-password').hasValue('');
+  });
+
   test('basic auth project loads properly', async function (assert) {
     this.set('project', {
       dataSource: {


### PR DESCRIPTION
Fixes bug introduced with PR #1623 

### Nature of Bug
- When a project is created with the CLI (`waypoint init`), you could not edit the project settings on the UI (received an error)