### PR TITLE
builtin/k8s: Fix ‘ports’ configurability

### DIFF
--- a/.changelog/1650.txt
+++ b/.changelog/1650.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+builtin/k8s: fix `ports` configurability
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -600,10 +600,6 @@ func (p *Platform) Deploy(
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
-	if p.config.ServicePort == 0 {
-		p.config.ServicePort = 3000
-	}
-
 	// Create our resource manager and create
 	rm := p.resourceManager(log)
 	if err := rm.CreateAll(


### PR DESCRIPTION
Looks like **0.4.0** release broke multi-port K8S configuration by setting `ServicePort = 3000` if it is not specified in the config. By forcing `ServicePort` to always defined, a multi-port configuration using `Ports` always fails the mutual-exclusivity check with the following error:

```
* Cannot define both 'service_port' and 'ports'. Use 'ports' for configuring multiple container ports.
```

This PR ensures the default port is used only if neither `service_port` nor `ports` is configured.
