### PR TITLE
plugin/aws/alb bug: adding generated time to ALB releaser status report

### DIFF
--- a/builtin/aws/alb/releaser.go
+++ b/builtin/aws/alb/releaser.go
@@ -16,6 +16,7 @@ import (
 	sdk "github.com/hashicorp/waypoint-plugin-sdk/proto/gen"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Releaser struct {
@@ -463,6 +464,8 @@ func (r *Releaser) Status(
 		report.HealthMessage = fmt.Sprintf("All targets are unhealthy, however your application might be available or still starting up.")
 		st.Step(terminal.StatusWarn, report.HealthMessage)
 	}
+
+	report.GeneratedTime = timestamppb.Now()
 
 	return &report, nil
 }


### PR DESCRIPTION
This was missing in the initial implementation of aws ALB status reports.

Also note: it looks like `ptypes.TimestampNow` has been [deprecated](https://github.com/golang/protobuf/blob/v1.5.2/ptypes/timestamp.go#L52) in favor of `timestamppb.Now`, so I'm using that here instead.