### PR TITLE
ui: display status report indicators on releases

### DIFF
--- a/.changelog/1657.txt
+++ b/.changelog/1657.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add reporting on status of a release
+```

--- a/ui/app/components/app-card/release.hbs
+++ b/ui/app/components/app-card/release.hbs
@@ -4,19 +4,6 @@
       <p>
         <b class="badge badge--version">v{{@model.sequence}}</b>
         <code>{{truncate @model.id 8 false}}</code>
-        {{#if (eq @model.status.state 1)}}
-          <b class="badge">
-            <Pds::Icon @type="clock-outline" class="icon" />
-          </b>
-          {{else if (eq @model.status.state 2)}}
-          <b class="badge badge--success">
-            <Pds::Icon @type="check-plain" class="icon" />
-          </b>
-          {{else if (eq @model.status.state 3)}}
-          <b class="badge badge--error">
-            <Pds::Icon @type="alert-triangle" class="icon" />
-          </b>
-        {{/if}}
       </p>
       <small>
         <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
@@ -30,6 +17,17 @@
         </span>
       </small>
     </LinkTo>
+
+		{{#if @model.statusReport}}
+			{{#let @model.statusReport.health as |health|}}
+				<StatusBadge
+					@state={{health.healthStatus}}
+					@message={{health.healthMessage}}
+					@iconOnly={{true}}
+				/>
+			{{/let}}
+		{{/if}}
+
     {{#if @model.url}}
     <ExternalLink href={{@model.url}} title={{@model.url}} class="button button--primary">
       <Pds::Icon @type="exit" class="icon" />

--- a/ui/app/components/app-card/releases.hbs
+++ b/ui/app/components/app-card/releases.hbs
@@ -1,4 +1,7 @@
-<Card @classNames={{unless @releases.length 'empty-state'}}>
+<Card
+	data-test-latest-releases
+	@classNames={{unless @releases.length 'empty-state'}}
+>
   {{#if @releases.length}}
     <Card::Header>
       <h4>

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -17,6 +17,15 @@
     </small>
   </LinkTo>
 
+  {{#if @release.statusReport}}
+    {{#let @release.statusReport.health as |health|}}
+      <StatusBadge
+        @state={{health.healthStatus}}
+        @message={{health.healthMessage}}
+      />
+    {{/let}}
+  {{/if}}
+
   {{#if (and @isLatest @release.url)}}
     <ExternalLink href={{@release.url}} class="button button--primary button--external-link">
       <span>{{@release.url}}</span>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -1,6 +1,7 @@
 <PageHeader @iconName="public-default">
   <div class="title">
-    <h2><b class="badge badge--version">v{{@model.sequence}}</b> <code>{{ @model.id }}</code></h2>
+    {{! TODO(jgwhite): Make this a real <h1> }}
+    <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b> <code>{{ @model.id }}</code></h2>
     <small>
       <Pds::Icon @type=(icon-for-component @model.component.name) class="icon" />
       <span>Released on <b>{{component-name @model.component.name}}</b>
@@ -19,17 +20,14 @@
 
 <div class="item-row">
   <div class="item">
-    {{#if (eq @model.state 1)}}
-    <b class="badge">{{t 'state.release.pending'}}</b>
-    {{else if (eq @model.status.state 2)}}
-    <b class="badge badge--success">{{t 'state.release.success'}}</b>
-    {{else if (eq @model.status.state 3)}}
-    <b class="badge badge--error">
-      {{t 'state.release.error'}}
-      {{#if @model.status.error.message}}
-        : {{@model.status.error.message}}
-      {{/if}}
-    </b>
+    {{#if @model.statusReport}}
+      {{#let @model.statusReport.health as |health|}}
+        <StatusBadge
+          @state={{health.healthStatus}}
+          @message={{health.healthMessage}}
+          @tooltipSide="right"
+        />
+      {{/let}}
     {{/if}}
   </div>
 

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -58,6 +58,7 @@ export default Factory.extend({
         sequence: 3,
         application,
         deployment: deployments[2],
+        statusReport: server.create('status-report', 'ready', { application }),
       });
       server.create('release', 'random', 'hours-old-success', {
         sequence: 2,

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -10,7 +10,7 @@ export default Model.extend({
   deployment: belongsTo(),
   status: belongsTo({ inverse: 'owner' }),
   component: belongsTo({ inverse: 'owner' }),
-  statusReport: belongsTo({ inverse: 'target ' }),
+  statusReport: belongsTo({ inverse: 'target' }),
 
   toProtobuf(): Release {
     let result = new Release();

--- a/ui/mirage/models/status-report.ts
+++ b/ui/mirage/models/status-report.ts
@@ -16,10 +16,11 @@ export default Model.extend({
 
     result.setApplication(this.application?.toProtobufRef());
     result.setWorkspace(this.workspace?.toProtobufRef());
+
     if (this.target instanceof MirageDeployment) {
       result.setDeploymentId(this.target.id);
     } else if (this.target instanceof MirageRelease) {
-      result.setReleaseId(this.release.id);
+      result.setReleaseId(this.target.id);
     }
     result.setStatus(this.status?.toProtobuf());
     result.setId(this.id);

--- a/ui/tests/acceptance/release-detail-test-test.ts
+++ b/ui/tests/acceptance/release-detail-test-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import login from 'waypoint/tests/helpers/login';
+
+module('Acceptance | release detail', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  login();
+
+  test('displays a status report badge if available', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    let release = this.server.create('release', 'random', { application });
+    this.server.create('status-report', 'ready', { application, target: release });
+
+    await visit(`/default/acme-project/app/acme-app/release/${release.id}`);
+
+    assert.dom('[data-test-status-badge="ready"]').exists();
+  });
+
+  test('displays no status report badge if none is available', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    let release = this.server.create('release', 'random', { application });
+
+    await visit(`/default/acme-project/app/acme-app/release/${release.id}`);
+
+    assert.dom('[data-test-status-badge]').doesNotExist();
+  });
+});

--- a/ui/tests/acceptance/releases-list-test.ts
+++ b/ui/tests/acceptance/releases-list-test.ts
@@ -27,4 +27,19 @@ module('Acceptance | releases list', function (hooks) {
     assert.equal(page.list.length, 3);
     assert.equal(currentURL(), url);
   });
+
+  test('status reports appear where available', async function (assert) {
+    let project = this.server.create('project', { name: 'microchip' });
+    let application = this.server.create('application', { name: 'wp-bandwidth', project });
+    this.server.create('release', 'random', {
+      application,
+      sequence: 1,
+      statusReport: this.server.create('status-report', 'ready', { application }),
+    });
+
+    await page.visit();
+
+    assert.dom('[data-test-latest-releases] [data-test-status-badge="ready"]').exists();
+    assert.dom('[data-test-release-list] [data-test-status-badge="ready"]').exists();
+  });
 });


### PR DESCRIPTION
## Why the change?

Closes #1590

## What’s the plan?

- [x] Add `<StatusBadge>` to `<AppCard::Release>`
- [x] Add `<StatusBadge>` to `<AppItem::Release>`
- [x] Add `<StatusBadge>` to release detail page

## What does it look like?

![image](https://user-images.githubusercontent.com/34030/122075710-93caed80-cdfa-11eb-9173-7a6682e2629a.png)

![image](https://user-images.githubusercontent.com/34030/122077609-2b7d0b80-cdfc-11eb-89b1-5695502e5b39.png)

![image](https://user-images.githubusercontent.com/34030/122075820-a47b6380-cdfa-11eb-8018-b26f6c11844f.png)

## How do I verify it?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/status-report-indicators-on-releases
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the demo release list view](http://localhost:4200/default/marketing-public/app/wp-matrix/releases)
4. Verify you see status badges
5. [Visit the demo release detail view](http://localhost:4200/default/marketing-public/app/wp-matrix/release/CAXCKWV8U0WYGFJCSKA4HYLB)
6. Verify you see a status badge

### For realsies

1. Check out the branch:
   ```sh
   git checkout ui/status-report-indicators-on-releases
   ```
2. Build the ember app
   ```sh
   (cd ui && make)
   ```
3. Bundle the static assets
   ```sh
   make static-assets
   ```
4. Build the dev server
   ```sh
   make docker/server
   ```
5. Build the CLI
   ```sh
   make bin
   ```
6. Install waypoint on your platform of choice, i.e.
   ```sh
   ./waypoint install -platform=kubernetes -accept-tos -k8s-server-image=waypoint:dev
   ```
7. Open the UI
   ```
   ./waypoint ui -authenticate
   ```
8. Try out an example app of your choice (i.e. [kubernetes/nodejs](https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs))
9. Verify you see status badges