### PR TITLE
Dockerfile: Remove SSH key injection from circle-ci and dockerfile build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,8 +218,6 @@ jobs:
           name: "Docker: Build image"
           command: |
             docker build \
-              --ssh default \
-              --secret id=ssh.config,src="${HOME}/project/.circleci/ssh_config" \
               --progress=plain \
               -t docker.pkg.github.com/hashicorp/waypoint/alpha:latest \
               -t docker.pkg.github.com/hashicorp/waypoint/alpha:$GIT_COMMIT \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,6 @@ jobs:
     environment:
       GOTAGS: ""
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - run:
           name: Install golangci-lint
@@ -60,9 +57,6 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - run:
           command: go mod tidy
@@ -99,9 +93,6 @@ jobs:
       # https://circleci.com/docs/2.0/configuration-reference/#docker-executor
       # but we can run a little over that limit.
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - attach_workspace:
           at: /go/bin
@@ -149,9 +140,6 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - attach_workspace: # this normally runs as the first job and has nothing to attach; only used in main branch after rebuilding UI
           at: .
@@ -175,9 +163,6 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - attach_workspace:
           at: .
@@ -217,9 +202,6 @@ jobs:
       <<: *ENVIRONMENT
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
@@ -235,12 +217,9 @@ jobs:
       - run:
           name: "Docker: Build image"
           command: |
-            # Note that the "id_rsa_FOO" key name is based on the fingerprint of the SSH key
-            # added in add_ssh_keys, but with colons removed.
             docker build \
               --ssh default \
               --secret id=ssh.config,src="${HOME}/project/.circleci/ssh_config" \
-              --secret id=ssh.key,src="${HOME}/.ssh/id_rsa_769415c8a041f08b9bf1f7364cd57f57" \
               --progress=plain \
               -t docker.pkg.github.com/hashicorp/waypoint/alpha:latest \
               -t docker.pkg.github.com/hashicorp/waypoint/alpha:$GIT_COMMIT \
@@ -323,9 +302,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - run: go get github.com/kevinburke/go-bindata/...
       - run: make static-assets
       - persist_to_workspace:
@@ -342,9 +318,6 @@ jobs:
       <<: *ENVIRONMENT
     steps:
       - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "76:94:15:c8:a0:41:f0:8b:9b:f1:f7:36:4c:d5:7f:57"
       - attach_workspace:
           at: .
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ WORKDIR /tmp/wp-prime
 RUN mkdir -p -m 0600 ~/.ssh \
     && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
-RUN --mount=type=ssh --mount=type=secret,id=ssh.config --mount=type=secret,id=ssh.key \
-    GIT_SSH_COMMAND="ssh -o \"ControlMaster auto\" -F \"/run/secrets/ssh.config\"" \
-    go mod download
+RUN go mod download
 RUN go get github.com/kevinburke/go-bindata/...
 
 COPY . /tmp/wp-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM docker.mirror.hashicorp.services/golang:1.16.5-alpine3.13 AS builder
 
-RUN apk add --no-cache git gcc libc-dev openssh make
+RUN apk add --no-cache git gcc libc-dev make
 
 RUN mkdir -p /tmp/wp-prime
 COPY go.sum /tmp/wp-prime
@@ -14,8 +14,6 @@ COPY go.mod /tmp/wp-prime
 
 WORKDIR /tmp/wp-prime
 
-RUN mkdir -p -m 0600 ~/.ssh \
-    && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
 RUN go mod download
 RUN go get github.com/kevinburke/go-bindata/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ COPY go.mod /tmp/wp-prime
 
 WORKDIR /tmp/wp-prime
 
-RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
 RUN go mod download
 RUN go get github.com/kevinburke/go-bindata/...
 

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ format: # format go code
 .PHONY: docker/server
 docker/server:
 	DOCKER_BUILDKIT=1 docker build \
-					--ssh default \
-					--secret id=ssh.config,src="${HOME}/.ssh/config" \
-					--secret id=ssh.key,src="${HOME}/.ssh/config" \
 					-t waypoint:dev \
 					.
 


### PR DESCRIPTION
This commit removes the injected ssh keys from the build process as well
as the various circle-ci jobs. It was originally added due to Waypoint
being a private repo and needing access to push the built container to
the alpha releases on github. Waypoint is no longer private, and now circle-ci
should still be able to push packages to github using the docker login step
instead.

We should probably backport this, but I'd like to wait until after this has merged and gone through the CI process. Just in case we have to revert. Our backport system can be applied most-merge now so waiting on applying the label isn't a huge deal.