### PR TITLE
Fix issue with parsing string slices from command line input

### DIFF
--- a/.changelog/1669.txt
+++ b/.changelog/1669.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix issue parsing string slice inputs
+```

--- a/internal/pkg/flag/flag_string_slice.go
+++ b/internal/pkg/flag/flag_string_slice.go
@@ -65,7 +65,7 @@ func (s *stringSliceValue) Set(val string) error {
 		*s.target = nil
 	}
 
-	*s.target = append(*s.target, strings.TrimSpace(val))
+	*s.target = append(*s.target, strings.Split(strings.TrimSpace(val), ",")...)
 	return nil
 }
 

--- a/internal/pkg/flag/flag_string_slice_test.go
+++ b/internal/pkg/flag/flag_string_slice_test.go
@@ -1,0 +1,38 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringSlice(t *testing.T) {
+	require := require.New(t)
+
+	var valA, valB []string
+	sets := NewSets()
+	{
+		set := sets.NewSet("A")
+		set.StringSliceVar(&StringSliceVar{
+			Name:   "a",
+			Target: &valA,
+		})
+	}
+
+	{
+		set := sets.NewSet("B")
+		set.StringSliceVar(&StringSliceVar{
+			Name:   "b",
+			Target: &valB,
+		})
+	}
+
+	err := sets.Parse([]string{
+		"-b", "somevalueB",
+		"-a", "somevalueA,somevalueB",
+	})
+	require.NoError(err)
+
+	require.Equal([]string{"somevalueB"}, valB)
+	require.Equal([]string{"somevalueA", "somevalueB"}, valA)
+}


### PR DESCRIPTION
The flagset type of `StringSliceVar` does not correctly parse a comma separated string from input in the CLI.

Example:

```
$ waypoint server install -accept-tos -platform=ecs -ecs-subnets=subnet-f123,subnet-b456
```

Produced a value of: `[]string{"subnet-f123,subnet-b456"}` instead of the expected `[]string{"subnet-f123","subnet-b456"}`

Fixes https://github.com/hashicorp/waypoint/issues/1651