### PR TITLE
ui/tests: specify `include` in global a11y setup

### DIFF
--- a/ui/tests/helpers/a11y.ts
+++ b/ui/tests/helpers/a11y.ts
@@ -12,10 +12,11 @@ type OptionsWithContext = RunOptions & ContextObject;
 // Selectors of elements to exclude from a11y auditing. See the following docs
 // for more:
 // https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#include-exclude-object
+const include = [['#ember-testing-container']];
 const exclude = [['.pds-logomark'], ['.pds-tabNav'], ['.card-header'], ['iframe']];
 
 export function setup(): void {
   setupGlobalA11yHooks(() => true);
   setEnableA11yAudit(true);
-  setRunOptions({ exclude } as OptionsWithContext);
+  setRunOptions({ include, exclude } as OptionsWithContext);
 }


### PR DESCRIPTION
## Why the change?

This is a confusing aspect of ember-a11y-testing. Right now, if you specify `exclude` you *must* specify `include` too. The library does not automatically set `include`, rather it assumes that you are now totally in control of the aXe context settings. Whether this is desirable or not is a question for the maintainers of the repo.