### PR TITLE
config/funcs: template functions to return valid ArgError values

### DIFF
--- a/.changelog/1679.txt
+++ b/.changelog/1679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fix crash that could occur when using `templatefile` with certain HCL files
+```

--- a/internal/config/funcs/template_test.go
+++ b/internal/config/funcs/template_test.go
@@ -50,9 +50,19 @@ func TestTemplateString(t *testing.T) {
 		{
 			"missing variable",
 			cty.StringVal("Hello, ${name}!"),
-			nil,
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"not_name": cty.StringVal("Jodie"),
+				})},
 			cty.NilVal,
 			`vars map does not contain key "name"`,
+		},
+		{
+			"no variables at all",
+			cty.StringVal("Hello, ${name}!"),
+			nil, // must blame the template for the missing variable in this case
+			cty.NilVal,
+			`but this call has no vars map`,
 		},
 		{
 			"parent value",
@@ -150,9 +160,19 @@ func TestTemplateFile(t *testing.T) {
 		},
 		{
 			cty.StringVal("testdata/filesystem/hello.tmpl"),
-			nil,
+			[]cty.Value{
+				cty.MapVal(map[string]cty.Value{
+					"not_name": cty.StringVal("Jodie"),
+				}),
+			},
 			cty.NilVal,
 			`vars map does not contain key "name"`,
+		},
+		{
+			cty.StringVal("testdata/filesystem/hello.tmpl"),
+			nil, // must blame the template for the missing variable in this case
+			cty.NilVal,
+			`but this call has no vars map`,
 		},
 		{
 			cty.StringVal("testdata/filesystem/func.tmpl"),


### PR DESCRIPTION
The template functions are all defined with a variadic parameter to collect zero or more `vars` maps, but that means we need to be careful to handle the case where there are no `vars` maps at all.

This code seems to have originally been derived from Terraform's `templatefile` which has a non-variadic `vars, and so Terraform was correct to assume that argument 1 would always be present. Since Waypoint's version allows omitting it, we'll handle that situation by putting the "blame" on the template argument instead, to suggest that it's invalid to refer to any variables inside a template call that doesn't have any variables.

The previous incorrect result was originally a panic due to violating the contract HCL expects for `function.ArgError`, although hashicorp/hcl#472 addressed that by just returning a less-specific error message in that case. This fix therefore boils down to just highlighting a more specific part of the input in the error message HCL will ultimately return.

---

This originally arose in #1675. With this change, the input from that issue should return the new error message I added here and the error message should identify the `"${path.app}/job.hcl.tpl"` argument specifically as the expression that caused the error.
