### PR TITLE
cli: set default to 30s for runner polling

### DIFF
--- a/.changelog/1690.txt
+++ b/.changelog/1690.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: set runner poll interval default for runner defined in waypoint.hcl
+```

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -309,9 +309,6 @@ func (c *InitCommand) validateProject() bool {
 				Enabled:  v.Enabled,
 				Interval: v.Interval,
 			}
-			if poll.Interval == "" {
-				poll.Interval = "30s"
-			}
 		}
 
 		resp, err := client.UpsertProject(c.Ctx, &pb.UpsertProjectRequest{

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -309,6 +309,9 @@ func (c *InitCommand) validateProject() bool {
 				Enabled:  v.Enabled,
 				Interval: v.Interval,
 			}
+			if poll.Interval == "" {
+				poll.Interval = "30s"
+			}
 		}
 
 		resp, err := client.UpsertProject(c.Ctx, &pb.UpsertProjectRequest{

--- a/internal/server/singleprocess/state/project.go
+++ b/internal/server/singleprocess/state/project.go
@@ -361,7 +361,7 @@ func (s *State) projectIndexSet(txn *memdb.Txn, id []byte, value *pb.Project) er
 	if p := value.DataSourcePoll; p != nil && p.Enabled {
 		// If it's empty at this point, we'll set the default here.
 		if p.Interval == "" {
-			p.Interval = "30s"
+			p.Interval = defaultPollInterval
 		}
 		interval, err := time.ParseDuration(p.Interval)
 		if err != nil {
@@ -468,6 +468,8 @@ const (
 	projectIndexNextPollIndexName = "next-poll"
 
 	projectWaypointHclMaxSize = 5 * 1024 // 5 MB
+
+	defaultPollInterval = "30s"
 )
 
 type projectIndexRecord struct {

--- a/internal/server/singleprocess/state/project.go
+++ b/internal/server/singleprocess/state/project.go
@@ -359,7 +359,10 @@ func (s *State) projectIndexSet(txn *memdb.Txn, id []byte, value *pb.Project) er
 	// up to downstream users to call ProjectNextPoll repeatedly to iterate
 	// over the next projects to poll and do something.
 	if p := value.DataSourcePoll; p != nil && p.Enabled {
-		// This should be validated downstream so this should never fail.
+		// If it's empty at this point, we'll set the default here.
+		if p.Interval == "" {
+			p.Interval = "30s"
+		}
 		interval, err := time.ParseDuration(p.Interval)
 		if err != nil {
 			return err


### PR DESCRIPTION
The poll interval is not required and should default to 30s if not specified. This is handled on the `project apply` side by setting a default for the flag value. But if a user sets their runner config directly in the waypoint.hcl, then currently no default is set. This results in an error from `time`: `! time: invalid duration ""`.
This fix adds the default time duration in lieu of an empty string if the interval is not specified.