### PR TITLE
Inspecting boolean env var values.

### DIFF
--- a/.changelog/1699.txt
+++ b/.changelog/1699.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+core: Inspect values of enviromment variables meant to be booleans
+```
+

--- a/.changelog/1699.txt
+++ b/.changelog/1699.txt
@@ -1,4 +1,4 @@
 ```release-note:improvement
-core: Inspect values of enviromment variables meant to be booleans
+core: Correct parsing of boolean environment variables
 ```
 

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/plugin"
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/util"
 	"github.com/hashicorp/waypoint/internal/version"
 )
 
@@ -299,11 +300,11 @@ func WithEnvDefaults() Option {
 
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
-		cfg.ServerRequired = os.Getenv(envCEBServerRequired) != ""
-		cfg.ServerTls = os.Getenv(envServerTls) != ""
-		cfg.ServerTlsSkipVerify = os.Getenv(envServerTlsSkipVerify) != ""
+		cfg.ServerRequired = util.GetEnvBool(envCEBServerRequired, false)
+		cfg.ServerTls = util.GetEnvBool(envServerTls, false)
+		cfg.ServerTlsSkipVerify = util.GetEnvBool(envServerTlsSkipVerify, false)
 		cfg.InviteToken = os.Getenv(envCEBToken)
-		cfg.disable = os.Getenv(envCEBDisable) != ""
+		cfg.disable = util.GetEnvBool(envCEBDisable, false)
 
 		ceb.deploymentId = os.Getenv(envDeploymentId)
 

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -283,7 +283,7 @@ type Option func(*CEB, *config) error
 // environment variables. If this is NOT called, then the environment variable
 // based confiugration will be ignored.
 func WithEnvDefaults() Option {
-	return func(ceb *CEB, cfg *config) (err error) {
+	return func(ceb *CEB, cfg *config) error {
 		var port int
 		portStr := os.Getenv("PORT")
 		if portStr == "" {
@@ -301,6 +301,7 @@ func WithEnvDefaults() Option {
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
 
+		var err error
 		cfg.ServerRequired, err = env.GetBool(envCEBServerRequired, false)
 		if err != nil {
 			return err

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -16,11 +16,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/waypoint/internal/env"
 	"github.com/hashicorp/waypoint/internal/pkg/gatedwriter"
 	"github.com/hashicorp/waypoint/internal/plugin"
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint/internal/util"
 	"github.com/hashicorp/waypoint/internal/version"
 )
 
@@ -300,11 +300,11 @@ func WithEnvDefaults() Option {
 
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
-		cfg.ServerRequired = util.GetEnvBool(envCEBServerRequired, false)
-		cfg.ServerTls = util.GetEnvBool(envServerTls, false)
-		cfg.ServerTlsSkipVerify = util.GetEnvBool(envServerTlsSkipVerify, false)
+		cfg.ServerRequired = env.GetEnvBool(envCEBServerRequired, false)
+		cfg.ServerTls = env.GetEnvBool(envServerTls, false)
+		cfg.ServerTlsSkipVerify = env.GetEnvBool(envServerTlsSkipVerify, false)
 		cfg.InviteToken = os.Getenv(envCEBToken)
-		cfg.disable = util.GetEnvBool(envCEBDisable, false)
+		cfg.disable = env.GetEnvBool(envCEBDisable, false)
 
 		ceb.deploymentId = os.Getenv(envDeploymentId)
 

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -283,7 +283,7 @@ type Option func(*CEB, *config) error
 // environment variables. If this is NOT called, then the environment variable
 // based confiugration will be ignored.
 func WithEnvDefaults() Option {
-	return func(ceb *CEB, cfg *config) error {
+	return func(ceb *CEB, cfg *config) (err error) {
 		var port int
 		portStr := os.Getenv("PORT")
 		if portStr == "" {
@@ -301,31 +301,27 @@ func WithEnvDefaults() Option {
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
 
-		serverRequiredBool, err := env.GetEnvBool(envCEBServerRequired, false)
+		cfg.ServerRequired, err = env.GetEnvBool(envCEBServerRequired, false)
 		if err != nil {
 			return err
 		}
-		cfg.ServerRequired = serverRequiredBool
 
-		serverTlsBool, err := env.GetEnvBool(envServerTls, false)
+		cfg.ServerTls, err = env.GetEnvBool(envServerTls, false)
 		if err != nil {
 			return err
 		}
-		cfg.ServerTls = serverTlsBool
 
-		serverTlsSkipVerifyBool, err := env.GetEnvBool(envServerTlsSkipVerify, false)
+		cfg.ServerTlsSkipVerify, err = env.GetEnvBool(envServerTlsSkipVerify, false)
 		if err != nil {
 			return err
 		}
-		cfg.ServerTlsSkipVerify = serverTlsSkipVerifyBool
 
 		cfg.InviteToken = os.Getenv(envCEBToken)
 
-		disableCEBBool, err := env.GetEnvBool(envCEBDisable, false)
+		cfg.disable, err = env.GetEnvBool(envCEBDisable, false)
 		if err != nil {
 			return err
 		}
-		cfg.disable = disableCEBBool
 
 		ceb.deploymentId = os.Getenv(envDeploymentId)
 

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -300,11 +300,32 @@ func WithEnvDefaults() Option {
 
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
-		cfg.ServerRequired = env.GetEnvBool(envCEBServerRequired, false)
-		cfg.ServerTls = env.GetEnvBool(envServerTls, false)
-		cfg.ServerTlsSkipVerify = env.GetEnvBool(envServerTlsSkipVerify, false)
+
+		serverRequiredBool, err := env.GetEnvBool(envCEBServerRequired, false)
+		if err != nil {
+			return err
+		}
+		cfg.ServerRequired = serverRequiredBool
+
+		serverTlsBool, err := env.GetEnvBool(envServerTls, false)
+		if err != nil {
+			return err
+		}
+		cfg.ServerTls = serverTlsBool
+
+		serverTlsSkipVerifyBool, err := env.GetEnvBool(envServerTlsSkipVerify, false)
+		if err != nil {
+			return err
+		}
+		cfg.ServerTlsSkipVerify = serverTlsSkipVerifyBool
+
 		cfg.InviteToken = os.Getenv(envCEBToken)
-		cfg.disable = env.GetEnvBool(envCEBDisable, false)
+
+		disableCEBBool, err := env.GetEnvBool(envCEBDisable, false)
+		if err != nil {
+			return err
+		}
+		cfg.disable = disableCEBBool
 
 		ceb.deploymentId = os.Getenv(envDeploymentId)
 

--- a/internal/ceb/ceb.go
+++ b/internal/ceb/ceb.go
@@ -301,24 +301,24 @@ func WithEnvDefaults() Option {
 		cfg.URLServicePort = port
 		cfg.ServerAddr = os.Getenv(envServerAddr)
 
-		cfg.ServerRequired, err = env.GetEnvBool(envCEBServerRequired, false)
+		cfg.ServerRequired, err = env.GetBool(envCEBServerRequired, false)
 		if err != nil {
 			return err
 		}
 
-		cfg.ServerTls, err = env.GetEnvBool(envServerTls, false)
+		cfg.ServerTls, err = env.GetBool(envServerTls, false)
 		if err != nil {
 			return err
 		}
 
-		cfg.ServerTlsSkipVerify, err = env.GetEnvBool(envServerTlsSkipVerify, false)
+		cfg.ServerTlsSkipVerify, err = env.GetBool(envServerTlsSkipVerify, false)
 		if err != nil {
 			return err
 		}
 
 		cfg.InviteToken = os.Getenv(envCEBToken)
 
-		cfg.disable, err = env.GetEnvBool(envCEBDisable, false)
+		cfg.disable, err = env.GetBool(envCEBDisable, false)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/mitchellh/go-glint"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/env"
 	"github.com/hashicorp/waypoint/internal/pkg/signalcontext"
-	"github.com/hashicorp/waypoint/internal/util"
 	"github.com/hashicorp/waypoint/internal/version"
 )
 
@@ -140,7 +140,7 @@ func Commands(
 	}
 
 	// Set plain mode if set
-	if util.GetEnvBool(EnvPlain, false) {
+	if env.GetEnvBool(EnvPlain, false) {
 		baseCommand.globalOptions = append(baseCommand.globalOptions,
 			WithUI(terminal.NonInteractiveUI(ctx)))
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -140,7 +140,7 @@ func Commands(
 	}
 
 	// Set plain mode if set
-	outputModeBool, err := env.GetEnvBool(EnvPlain, false)
+	outputModeBool, err := env.GetBool(EnvPlain, false)
 	if err != nil {
 		log.Warn(err.Error())
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -140,7 +140,11 @@ func Commands(
 	}
 
 	// Set plain mode if set
-	if env.GetEnvBool(EnvPlain, false) {
+	outputModeBool, err := env.GetEnvBool(EnvPlain, false)
+	if err != nil {
+		log.Warn(err.Error())
+	}
+	if outputModeBool {
 		baseCommand.globalOptions = append(baseCommand.globalOptions,
 			WithUI(terminal.NonInteractiveUI(ctx)))
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/signalcontext"
+	"github.com/hashicorp/waypoint/internal/util"
 	"github.com/hashicorp/waypoint/internal/version"
 )
 
@@ -139,7 +140,7 @@ func Commands(
 	}
 
 	// Set plain mode if set
-	if os.Getenv(EnvPlain) != "" {
+	if util.GetEnvBool(EnvPlain, false) {
 		baseCommand.globalOptions = append(baseCommand.globalOptions,
 			WithUI(terminal.NonInteractiveUI(ctx)))
 	}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -16,7 +16,7 @@ func GetEnvBool(key string, defaultValue bool) (bool, error) {
 	}
 	value, err := strconv.ParseBool(strings.ToLower(envVal))
 	if err != nil {
-		return defaultValue, fmt.Errorf("failed to parse a boolean from environment variable %s=%s",key,envVal)
+		return defaultValue, fmt.Errorf("failed to parse a boolean from environment variable %s=%s", key, envVal)
 	}
 	return value, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,20 +1,22 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // GetEnvBool Extracts a boolean from an env var. Falls back to the default
 // if the key is unset or not a valid boolean.
-func GetEnvBool(key string, defaultValue bool) bool {
+func GetEnvBool(key string, defaultValue bool) (bool, error) {
 	envVal := os.Getenv(key)
 	if envVal == "" {
-		return defaultValue
+		return defaultValue, nil
 	}
-	value, err := strconv.ParseBool(envVal)
+	value, err := strconv.ParseBool(strings.ToLower(envVal)))
 	if err != nil {
-		return defaultValue
+		return defaultValue, fmt.Errorf("failed to parse a boolean from environment variable %s=%s",key,envVal)
 	}
-	return value
+	return value, nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,13 +1,13 @@
-package util
+package env
 
 import (
 	"os"
 	"strconv"
 )
 
-// Extracts a boolean from an env var. Falls back to the default if
-// The key is unset or not a valid boolean.
-func GetEnvBool(key string, defaultValue bool) (value bool) {
+// GetEnvBool Extracts a boolean from an env var. Falls back to the default
+// if the key is unset or not a valid boolean.
+func GetEnvBool(key string, defaultValue bool) bool {
 	envVal := os.Getenv(key)
 	if envVal == "" {
 		return defaultValue

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-// GetEnvBool Extracts a boolean from an env var. Falls back to the default
+// GetBool Extracts a boolean from an env var. Falls back to the default
 // if the key is unset or not a valid boolean.
-func GetEnvBool(key string, defaultValue bool) (bool, error) {
+func GetBool(key string, defaultValue bool) (bool, error) {
 	envVal := os.Getenv(key)
 	if envVal == "" {
 		return defaultValue, nil

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -14,7 +14,7 @@ func GetEnvBool(key string, defaultValue bool) (bool, error) {
 	if envVal == "" {
 		return defaultValue, nil
 	}
-	value, err := strconv.ParseBool(strings.ToLower(envVal)))
+	value, err := strconv.ParseBool(strings.ToLower(envVal))
 	if err != nil {
 		return defaultValue, fmt.Errorf("failed to parse a boolean from environment variable %s=%s",key,envVal)
 	}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,42 @@
+package env
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestGetEnvBool(t *testing.T) {
+	envVarTestKey := "WAYPOINT_GET_ENV_BOOL_TEST"
+	require := require.New(t)
+
+	t.Run("Unset env var returns default", func (t *testing.T) {
+		require.True(GetEnvBool(envVarTestKey, true))
+		require.False(GetEnvBool(envVarTestKey, false))
+	})
+
+	t.Run("Empty env var returns default", func (t *testing.T) {
+		os.Setenv(envVarTestKey, "")
+		require.True(GetEnvBool(envVarTestKey, true))
+		require.False(GetEnvBool(envVarTestKey, false))
+	})
+
+	t.Run("Non-truthy env var returns true", func (t *testing.T) {
+		os.Setenv(envVarTestKey, "unparseable")
+		require.True(GetEnvBool(envVarTestKey, true))
+		require.False(GetEnvBool(envVarTestKey, false))
+	})
+
+	t.Run("true/false env vars return non-default", func (t *testing.T) {
+		os.Setenv(envVarTestKey, "true")
+		require.True(GetEnvBool(envVarTestKey, false))
+
+		os.Setenv(envVarTestKey, "false")
+		require.False(GetEnvBool(envVarTestKey, true))
+	})
+
+	t.Run("1 evaluates as true", func (t *testing.T) {
+		os.Setenv(envVarTestKey, "1")
+		require.True(GetEnvBool(envVarTestKey, false))
+	})
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -11,33 +11,55 @@ func TestGetEnvBool(t *testing.T) {
 	require := require.New(t)
 
 	t.Run("Unset env var returns default", func(t *testing.T) {
-		require.True(GetEnvBool(envVarTestKey, true))
-		require.False(GetEnvBool(envVarTestKey, false))
+		b, err := GetEnvBool(envVarTestKey, true)
+		require.NoError(err)
+		require.True(b)
+
+		b, err = GetEnvBool(envVarTestKey, false)
+		require.NoError(err)
+		require.False(b)
 	})
 
 	t.Run("Empty env var returns default", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "")
-		require.True(GetEnvBool(envVarTestKey, true))
-		require.False(GetEnvBool(envVarTestKey, false))
+		b, err := GetEnvBool(envVarTestKey, true)
+		require.NoError(err)
+		require.True(b)
+
+		b, err = GetEnvBool(envVarTestKey, false)
+		require.NoError(err)
+		require.False(b)
 	})
 
-	t.Run("Non-truthy env var returns default", func(t *testing.T) {
+	t.Run("Non-truthy env var returns an error", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "unparseable")
-		require.True(GetEnvBool(envVarTestKey, true))
-		require.False(GetEnvBool(envVarTestKey, false))
+		_, err := GetEnvBool(envVarTestKey, true)
+		require.Error(err)
 	})
 
 	t.Run("true/false env vars return non-default", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "true")
-		require.True(GetEnvBool(envVarTestKey, false))
+		b, err := GetEnvBool(envVarTestKey, false)
+		require.NoError(err)
+		require.True(b)
 
 		os.Setenv(envVarTestKey, "false")
-		require.False(GetEnvBool(envVarTestKey, true))
+		b, err = GetEnvBool(envVarTestKey, true)
+		require.NoError(err)
+		require.False(b)
+	})
+
+	t.Run("boolean parsing is generous with capitalization", func(t *testing.T) {
+		os.Setenv(envVarTestKey, "tRuE")
+		b, err := GetEnvBool(envVarTestKey, false)
+		require.NoError(err)
+		require.True(b)
 	})
 
 	t.Run("1 evaluates as true", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "1")
-		require.True(GetEnvBool(envVarTestKey, false))
-		require.True(GetEnvBool(envVarTestKey, true))
+		b, err := GetEnvBool(envVarTestKey, false)
+		require.NoError(err)
+		require.True(b)
 	})
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -10,24 +10,24 @@ func TestGetEnvBool(t *testing.T) {
 	envVarTestKey := "WAYPOINT_GET_ENV_BOOL_TEST"
 	require := require.New(t)
 
-	t.Run("Unset env var returns default", func (t *testing.T) {
+	t.Run("Unset env var returns default", func(t *testing.T) {
 		require.True(GetEnvBool(envVarTestKey, true))
 		require.False(GetEnvBool(envVarTestKey, false))
 	})
 
-	t.Run("Empty env var returns default", func (t *testing.T) {
+	t.Run("Empty env var returns default", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "")
 		require.True(GetEnvBool(envVarTestKey, true))
 		require.False(GetEnvBool(envVarTestKey, false))
 	})
 
-	t.Run("Non-truthy env var returns default", func (t *testing.T) {
+	t.Run("Non-truthy env var returns default", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "unparseable")
 		require.True(GetEnvBool(envVarTestKey, true))
 		require.False(GetEnvBool(envVarTestKey, false))
 	})
 
-	t.Run("true/false env vars return non-default", func (t *testing.T) {
+	t.Run("true/false env vars return non-default", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "true")
 		require.True(GetEnvBool(envVarTestKey, false))
 
@@ -35,7 +35,7 @@ func TestGetEnvBool(t *testing.T) {
 		require.False(GetEnvBool(envVarTestKey, true))
 	})
 
-	t.Run("1 evaluates as true", func (t *testing.T) {
+	t.Run("1 evaluates as true", func(t *testing.T) {
 		os.Setenv(envVarTestKey, "1")
 		require.True(GetEnvBool(envVarTestKey, false))
 		require.True(GetEnvBool(envVarTestKey, true))

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -21,7 +21,7 @@ func TestGetEnvBool(t *testing.T) {
 		require.False(GetEnvBool(envVarTestKey, false))
 	})
 
-	t.Run("Non-truthy env var returns true", func (t *testing.T) {
+	t.Run("Non-truthy env var returns default", func (t *testing.T) {
 		os.Setenv(envVarTestKey, "unparseable")
 		require.True(GetEnvBool(envVarTestKey, true))
 		require.False(GetEnvBool(envVarTestKey, false))
@@ -38,5 +38,6 @@ func TestGetEnvBool(t *testing.T) {
 	t.Run("1 evaluates as true", func (t *testing.T) {
 		os.Setenv(envVarTestKey, "1")
 		require.True(GetEnvBool(envVarTestKey, false))
+		require.True(GetEnvBool(envVarTestKey, true))
 	})
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,65 +1,88 @@
 package env
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 )
 
-func TestGetEnvBool(t *testing.T) {
+func TestGetBool(t *testing.T) {
 	envVarTestKey := "WAYPOINT_GET_ENV_BOOL_TEST"
-	require := require.New(t)
 
-	t.Run("Unset env var returns default", func(t *testing.T) {
-		b, err := GetEnvBool(envVarTestKey, true)
-		require.NoError(err)
-		require.True(b)
-
-		b, err = GetEnvBool(envVarTestKey, false)
-		require.NoError(err)
-		require.False(b)
-	})
-
-	t.Run("Empty env var returns default", func(t *testing.T) {
-		os.Setenv(envVarTestKey, "")
-		b, err := GetEnvBool(envVarTestKey, true)
-		require.NoError(err)
-		require.True(b)
-
-		b, err = GetEnvBool(envVarTestKey, false)
-		require.NoError(err)
-		require.False(b)
-	})
-
-	t.Run("Non-truthy env var returns an error", func(t *testing.T) {
-		os.Setenv(envVarTestKey, "unparseable")
-		_, err := GetEnvBool(envVarTestKey, true)
-		require.Error(err)
-	})
-
-	t.Run("true/false env vars return non-default", func(t *testing.T) {
-		os.Setenv(envVarTestKey, "true")
-		b, err := GetEnvBool(envVarTestKey, false)
-		require.NoError(err)
-		require.True(b)
-
-		os.Setenv(envVarTestKey, "false")
-		b, err = GetEnvBool(envVarTestKey, true)
-		require.NoError(err)
-		require.False(b)
-	})
-
-	t.Run("boolean parsing is generous with capitalization", func(t *testing.T) {
-		os.Setenv(envVarTestKey, "tRuE")
-		b, err := GetEnvBool(envVarTestKey, false)
-		require.NoError(err)
-		require.True(b)
-	})
-
-	t.Run("1 evaluates as true", func(t *testing.T) {
-		os.Setenv(envVarTestKey, "1")
-		b, err := GetEnvBool(envVarTestKey, false)
-		require.NoError(err)
-		require.True(b)
-	})
+	tests := []struct {
+		name       string
+		defaultVal bool
+		envVal     string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "Empty env var returns default 1",
+			defaultVal: true,
+			envVal:     "",
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "Empty env var returns default 2",
+			defaultVal: false,
+			envVal:     "",
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "Non-truthy env var returns err",
+			defaultVal: false,
+			envVal:     "unparseable",
+			want:       false,
+			wantErr:    true,
+		},
+		{
+			name:       "'true' is true",
+			defaultVal: false,
+			envVal:     "true",
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "'false' is true",
+			defaultVal: true,
+			envVal:     "false",
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "1 is true",
+			defaultVal: false,
+			envVal:     "1",
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "0 is false",
+			defaultVal: true,
+			envVal:     "0",
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "Boolean parsing ignores capitalization",
+			defaultVal: false,
+			envVal:     "tRuE",
+			want:       true,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(envVarTestKey, tt.envVal)
+			got, err := GetBool(envVarTestKey, tt.defaultVal)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetBool() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetBool() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -127,8 +127,19 @@ func FromEnv() ConnectOption {
 	return func(c *connectConfig) error {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
-			c.Tls = env.GetEnvBool(EnvServerTls, false)
-			c.TlsSkipVerify = env.GetEnvBool(EnvServerTlsSkipVerify, false)
+
+			tlsBool, err := env.GetEnvBool(EnvServerTls, false)
+			if err != nil {
+				return err
+			}
+			c.Tls = tlsBool
+
+			tlsSkipVerifyBool, err := env.GetEnvBool(EnvServerTlsSkipVerify, false)
+			if err != nil {
+				return err
+			}
+			c.TlsSkipVerify = tlsSkipVerifyBool
+
 			c.Auth = os.Getenv(EnvServerToken) != ""
 		}
 

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -12,9 +12,9 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
+	"github.com/hashicorp/waypoint/internal/env"
 	"github.com/hashicorp/waypoint/internal/protocolversion"
 	"github.com/hashicorp/waypoint/internal/serverconfig"
-	"github.com/hashicorp/waypoint/internal/util"
 )
 
 // ErrNoServerConfig is the error when there is no server configuration
@@ -127,8 +127,8 @@ func FromEnv() ConnectOption {
 	return func(c *connectConfig) error {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
-			c.Tls = util.GetEnvBool(EnvServerTls, false)
-			c.TlsSkipVerify = util.GetEnvBool(EnvServerTlsSkipVerify, false)
+			c.Tls = env.GetEnvBool(EnvServerTls, false)
+			c.TlsSkipVerify = env.GetEnvBool(EnvServerTlsSkipVerify, false)
 			c.Auth = os.Getenv(EnvServerToken) != ""
 		}
 

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -124,21 +124,19 @@ type connectConfig struct {
 // FromEnv sources the connection information from the environment
 // using standard environment variables.
 func FromEnv() ConnectOption {
-	return func(c *connectConfig) error {
+	return func(c *connectConfig) (err error) {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
 
-			tlsBool, err := env.GetEnvBool(EnvServerTls, false)
+			c.Tls, err = env.GetEnvBool(EnvServerTls, false)
 			if err != nil {
 				return err
 			}
-			c.Tls = tlsBool
 
-			tlsSkipVerifyBool, err := env.GetEnvBool(EnvServerTlsSkipVerify, false)
+			c.TlsSkipVerify, err = env.GetEnvBool(EnvServerTlsSkipVerify, false)
 			if err != nil {
 				return err
 			}
-			c.TlsSkipVerify = tlsSkipVerifyBool
 
 			c.Auth = os.Getenv(EnvServerToken) != ""
 		}

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -128,12 +128,12 @@ func FromEnv() ConnectOption {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
 
-			c.Tls, err = env.GetEnvBool(EnvServerTls, false)
+			c.Tls, err = env.GetBool(EnvServerTls, false)
 			if err != nil {
 				return err
 			}
 
-			c.TlsSkipVerify, err = env.GetEnvBool(EnvServerTlsSkipVerify, false)
+			c.TlsSkipVerify, err = env.GetBool(EnvServerTlsSkipVerify, false)
 			if err != nil {
 				return err
 			}

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -124,10 +124,11 @@ type connectConfig struct {
 // FromEnv sources the connection information from the environment
 // using standard environment variables.
 func FromEnv() ConnectOption {
-	return func(c *connectConfig) (err error) {
+	return func(c *connectConfig) error {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
 
+			var err error
 			c.Tls, err = env.GetBool(EnvServerTls, false)
 			if err != nil {
 				return err

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/protocolversion"
 	"github.com/hashicorp/waypoint/internal/serverconfig"
+	"github.com/hashicorp/waypoint/internal/util"
 )
 
 // ErrNoServerConfig is the error when there is no server configuration
@@ -126,8 +127,8 @@ func FromEnv() ConnectOption {
 	return func(c *connectConfig) error {
 		if v := os.Getenv(EnvServerAddr); v != "" {
 			c.Addr = v
-			c.Tls = os.Getenv(EnvServerTls) != ""
-			c.TlsSkipVerify = os.Getenv(EnvServerTlsSkipVerify) != ""
+			c.Tls = util.GetEnvBool(EnvServerTls, false)
+			c.TlsSkipVerify = util.GetEnvBool(EnvServerTlsSkipVerify, false)
 			c.Auth = os.Getenv(EnvServerToken) != ""
 		}
 

--- a/internal/util/env.go
+++ b/internal/util/env.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"os"
+	"strconv"
+)
+
+// Extracts a boolean from an env var. Falls back to the default if
+// The key is unset or not a valid boolean.
+func GetEnvBool(key string, defaultValue bool) (value bool) {
+	envVal := os.Getenv(key)
+	if envVal == "" {
+		return defaultValue
+	}
+	value, err := strconv.ParseBool(envVal)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/website/content/docs/automating-execution/index.mdx
+++ b/website/content/docs/automating-execution/index.mdx
@@ -43,9 +43,9 @@ configure the Waypoint CLI for communication with the Waypoint server.
 - `WAYPOINT_SERVER_TOKEN`. Must be set to a Waypoint token, created with [`waypoint token new`](/commands/token-new)
 - `WAYPOINT_SERVER_ADDR`. The address to the Waypoint server gRPC address. This must
   be accessible from the network that the client is running on.
-- `WAYPOINT_SERVER_TLS`. Should be set to `1` to configure the client to use TLS when
+- `WAYPOINT_SERVER_TLS`. Should be set to a truthy value (e.g. "1") to configure the client to use TLS when
   connecting to the server.
-- `WAYPOINT_SERVER_TLS_SKIP_VERIFY`. Current must be set to `1` to disable TLS verification
+- `WAYPOINT_SERVER_TLS_SKIP_VERIFY`. Current must be set to truthy value (e.g. "1") to disable TLS verification
   when communicating with the server.
 
 ~> The Waypoint server token is sensitive and should be
@@ -71,7 +71,7 @@ If Waypoint detects that the terminal does not support interactivity it will out
 simpler "non-interactive" output mode. This output is easier to consume in
 a CI/CD systems logging views, or through log archiving systems. This is automatic
 and does not need to be explicitly configured, but can be forced by setting
-the environment variable `WAYPOINT_PLAIN` to `1`.
+the environment variable `WAYPOINT_PLAIN` to a truthy value (e.g. "1").
 
 ## Workspaces
 

--- a/website/content/docs/automating-execution/index.mdx
+++ b/website/content/docs/automating-execution/index.mdx
@@ -45,7 +45,7 @@ configure the Waypoint CLI for communication with the Waypoint server.
   be accessible from the network that the client is running on.
 - `WAYPOINT_SERVER_TLS`. Should be set to a truthy value (e.g. "1") to configure the client to use TLS when
   connecting to the server.
-- `WAYPOINT_SERVER_TLS_SKIP_VERIFY`. Current must be set to truthy value (e.g. "1") to disable TLS verification
+- `WAYPOINT_SERVER_TLS_SKIP_VERIFY`. Current must be set to a truthy value (e.g. "1") to disable TLS verification
   when communicating with the server.
 
 ~> The Waypoint server token is sensitive and should be

--- a/website/content/docs/entrypoint/disable.mdx
+++ b/website/content/docs/entrypoint/disable.mdx
@@ -22,10 +22,10 @@ deployments and apps.
 ## Disable at Runtime
 
 You can disable the entrypoint at runtime by setting the `WAYPOINT_CEB_DISABLE`
-environment variable to any non-empty value.
+environment variable to 1.
 
 This environment variable is checked immediately on entrypoint startup. If
-it is present and non-empty then the entrypoint will immediately execute the
+it is set to 1 then the entrypoint will immediately execute the
 child process. The entrypoint **will not** attempt to even connect to the
 server and will not use any network or disk resources.
 

--- a/website/content/docs/entrypoint/disable.mdx
+++ b/website/content/docs/entrypoint/disable.mdx
@@ -22,10 +22,10 @@ deployments and apps.
 ## Disable at Runtime
 
 You can disable the entrypoint at runtime by setting the `WAYPOINT_CEB_DISABLE`
-environment variable to 1.
+environment variable to a truthy value (e.g. "1").
 
 This environment variable is checked immediately on entrypoint startup. If
-it is set to 1 then the entrypoint will immediately execute the
+the value is true, then the entrypoint will immediately execute the
 child process. The entrypoint **will not** attempt to even connect to the
 server and will not use any network or disk resources.
 

--- a/website/content/docs/runner/run-manual.mdx
+++ b/website/content/docs/runner/run-manual.mdx
@@ -42,7 +42,7 @@ The environment variables specify how to connect to the server:
   that the runner can reach. The port should be for the gRPC API, and
   is typically 9701.
 
-- `WAYPOINT_SERVER_TLS` should be set to "true" if the server is listening
+- `WAYPOINT_SERVER_TLS` should be set to 1 if the server is listening
   on TLS. You may additionally set `WAYPOINT_SERVER_TLS_SKIP_VERIFY` to
   1 if the TLS cert is invalid and can be safely ignored
   such as in a development environment.

--- a/website/content/docs/runner/run-manual.mdx
+++ b/website/content/docs/runner/run-manual.mdx
@@ -42,9 +42,11 @@ The environment variables specify how to connect to the server:
   that the runner can reach. The port should be for the gRPC API, and
   is typically 9701.
 
-- `WAYPOINT_SERVER_TLS` should be set to 1 if the server is listening
-  on TLS. You may additionally set `WAYPOINT_SERVER_TLS_SKIP_VERIFY` to
-  1 if the TLS cert is invalid and can be safely ignored
+- `WAYPOINT_SERVER_TLS` should be set to a truthy value (e.g. "1") if
+  the server is listening on TLS.
+
+- `WAYPOINT_SERVER_TLS_SKIP_VERIFY` should be set to a truthy value
+  (e.g. "1") if the TLS cert is invalid and can be safely ignored,
   such as in a development environment.
 
 - `WAYPOINT_SERVER_TOKEN` should be an [auth token](/docs/server/auth)

--- a/website/content/docs/runner/run-manual.mdx
+++ b/website/content/docs/runner/run-manual.mdx
@@ -44,7 +44,7 @@ The environment variables specify how to connect to the server:
 
 - `WAYPOINT_SERVER_TLS` should be set to "true" if the server is listening
   on TLS. You may additionally set `WAYPOINT_SERVER_TLS_SKIP_VERIFY` to
-  a non-empty value if the TLS cert is invalid and can be safely ignored
+  1 if the TLS cert is invalid and can be safely ignored
   such as in a development environment.
 
 - `WAYPOINT_SERVER_TOKEN` should be an [auth token](/docs/server/auth)


### PR DESCRIPTION
Previously, we were taking any value for boolean env vars to mean "true". If someone specified `WAYPOINT_SERVER_TLS=false`, we would take that to mean true. This fixes that.

Note on the implementation - I hate to be the person to introduce a generic "util" package. If anyone has any better ideas for where to put this little function, or feels like we should just strconv in-line every time, I am open to those ideas.