### PR TITLE
Backport/docs/remove old doc with wrong info/release 04x

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -125,9 +125,12 @@ build {
 	)
 
 	doc.SetField(
-		"buildargs",
-		"An array of strings of build-time variables passed as build-arg to docker"+
-			"or img for the build step.",
+		"build_args",
+		"build args to pass to docker or img for the build step",
+		docs.Summary(
+			"An array of strings of build-time variables passed as build-arg to docker",
+			" or img for the build step.",
+		),
 	)
 
 	doc.SetField(

--- a/website/content/commands/hostname-list.mdx
+++ b/website/content/commands/hostname-list.mdx
@@ -2,14 +2,14 @@
 layout: commands
 page_title: 'Commands: Hostname list'
 sidebar_title: 'hostname list'
-description: 'List all registered hostname.'
+description: 'List all registered hostnames.'
 ---
 
 # Waypoint Hostname list
 
 Command: `waypoint hostname list`
 
-List all registered hostname.
+List all registered hostnames.
 
 @include "commands/hostname-list_desc.mdx"
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -31,6 +31,10 @@ Usage: `waypoint server upgrade [options]`
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
 
+#### docker Options
+
+- `-docker-server-image=<string>` - Docker image for the Waypoint server.
+
 #### ecs Options
 
 - `-ecs-cluster=<string>` - Configures the Cluster to upgrade.
@@ -60,9 +64,5 @@ Usage: `waypoint server upgrade [options]`
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-
-#### docker Options
-
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
 
 @include "commands/server-upgrade_more.mdx"

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -37,11 +37,19 @@ build {
 }
 ```
 
+### Required Parameters
+
+This plugin has no required parameters.
+
 ### Optional Parameters
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
 #### build_args
+
+Build args to pass to docker or img for the build step.
+
+An array of strings of build-time variables passed as build-arg to docker or img for the build step.
 
 - Type: **map of string to string**
 - **Optional**

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -37,14 +37,6 @@ build {
 }
 ```
 
-### Required Parameters
-
-These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
-
-#### buildargs
-
-An array of strings of build-time variables passed as build-arg to dockeror img for the build step.
-
 ### Optional Parameters
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.


### PR DESCRIPTION
The backporter [failed to cherry-pick](https://github.com/hashicorp/waypoint/pull/1703) these commits from [this PR](https://github.com/hashicorp/waypoint/pull/1703) so I am doing it now manually.