### PR TITLE
Bug: remove Operation flags from runner-agent command.

### DIFF
--- a/.changelog/1708.txt
+++ b/.changelog/1708.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-core/runner: prevent use of operation flags on `runner agent` command
+cli: prevent use of operation flags on `runner agent` command
 ```
 

--- a/.changelog/1708.txt
+++ b/.changelog/1708.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core/runner: prevent use of operation flags on `runner agent` command
+```
+

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -191,7 +191,7 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 }
 
 func (c *RunnerAgentCommand) Flags() *flag.Sets {
-	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
+	return c.flagSet(0, func(set *flag.Sets) {
 		f := set.NewSet("Command Options")
 		f.BoolVar(&flag.BoolVar{
 			Name:   "enable-dynamic-config",

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -23,13 +23,6 @@ Usage: `waypoint runner agent [options]`
 - `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-workspace=<string>` - Workspace to operate in.
 
-#### Operation Options
-
-- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
-- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
-
 #### Command Options
 
 - `-enable-dynamic-config` - Allow dynamic config to be created when an exec plugin is used.


### PR DESCRIPTION
From my reading, the Operation flags are not applicable to runner-agent.

Closes #1704