### PR TITLE
add app name variable

### DIFF
--- a/.changelog/1709.txt
+++ b/.changelog/1709.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+internal/config: add `${app.name}` variable
+```

--- a/.changelog/1709.txt
+++ b/.changelog/1709.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-internal/config: add `${app.name}` variable
+config: add `${app.name}` variable
 ```

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -86,7 +86,9 @@ func (c *Config) App(n string, ctx *hcl.EvalContext) (*App, error) {
 	// Build a new context with our app-scoped values
 	ctx = ctx.NewChild()
 	addPathValue(ctx, pathData)
-	addAppValue(ctx, rawApp.Name)
+	addMapVariable(ctx, "app", map[string]string{
+		"name": rawApp.Name,
+	})
 
 	// Full decode
 	var app App

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -86,6 +86,7 @@ func (c *Config) App(n string, ctx *hcl.EvalContext) (*App, error) {
 	// Build a new context with our app-scoped values
 	ctx = ctx.NewChild()
 	addPathValue(ctx, pathData)
+	addAppValue(ctx, rawApp.Name)
 
 	// Full decode
 	var app App

--- a/internal/config/eval_context.go
+++ b/internal/config/eval_context.go
@@ -65,15 +65,6 @@ func addWorkspaceValue(ctx *hcl.EvalContext, v string) {
 	})
 }
 
-// addAppValue adds the app values to the context. This
-// adds the `app` map and currently only supports the `app.name`
-// value.
-func addAppValue(ctx *hcl.EvalContext, v string) {
-	addMapVariable(ctx, "app", map[string]string{
-		"name": v,
-	})
-}
-
 // addPathValue adds the "path" variable to the context.
 func addPathValue(ctx *hcl.EvalContext, v map[string]string) {
 	addMapVariable(ctx, "path", v)

--- a/internal/config/eval_context.go
+++ b/internal/config/eval_context.go
@@ -65,6 +65,15 @@ func addWorkspaceValue(ctx *hcl.EvalContext, v string) {
 	})
 }
 
+// addAppValue adds the app values to the context. This
+// adds the `app` map and currently only supports the `app.name`
+// value.
+func addAppValue(ctx *hcl.EvalContext, v string) {
+	addMapVariable(ctx, "app", map[string]string{
+		"name": v,
+	})
+}
+
 // addPathValue adds the "path" variable to the context.
 func addPathValue(ctx *hcl.EvalContext, v map[string]string) {
 	addMapVariable(ctx, "path", v)


### PR DESCRIPTION
This commit adds the ${app.name} variable, so that can have
use for generation strings for anything, for example

```
project = "nutcorp"

app "hamster" {
  config {
    env = {
      APP_NAME = "${app.name}"
      ENV = "dev"
    }
  }

  build {
    use "docker" {
      dockerfile = "../../../projects/${app.name}/Dockerfile"
      build_args = {
        PROJECT_PATH="./projects/${app.name}"
      }
      context    = "../../../"
    }

    registry {
      use "aws-ecr" {
        region     = "us-east-2"
        repository = "nutcorp-${app.name}"
        tag        = "latest"
      }
    }
  }
}

app "vole" {
  config {
    env = {
      APP_NAME = "${app.name}"
      ENV = "dev"
    }
  }

  build {
    use "docker" {
      dockerfile = "../../../projects/${app.name}/Dockerfile"
      build_args = {
        PROJECT_PATH="./projects/${app.name}"
      }
      context    = "../../../"
    }

    registry {
      use "aws-ecr" {
        region     = "us-east-2"
        repository = "nutcorp-${app.name}"
        tag        = "latest"
      }
    }
  }
}

```

### Test
[![asciicast](https://asciinema.org/a/h5yIdbKEfjSafpZs1RwRJADIh.svg)](https://asciinema.org/a/h5yIdbKEfjSafpZs1RwRJADIh)