### PR TITLE
Not embedding hclConfig as a pointer.

### DIFF
--- a/.changelog/1710.txt
+++ b/.changelog/1710.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: fix crash that could occur when running commands outside the context of a project with an hcl config file.
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Config struct {
-	*hclConfig
+	hclConfig
 
 	ctx      *hcl.EvalContext
 	path     string
@@ -132,7 +132,7 @@ func Load(path string, opts *LoadOptions) (*Config, error) {
 	}
 
 	return &Config{
-		hclConfig: &cfg,
+		hclConfig: cfg,
 		ctx:       ctx,
 		path:      filepath.Dir(path),
 		pathData:  pathData,


### PR DESCRIPTION
## What problem is this solving?

This addresses the panic within https://github.com/hashicorp/waypoint/issues/1704.

The problem here is that, if we embed a pointer to a private struct, and the private struct is nil, the caller has no way to determine if the embedded struct's values are safe to access.

This manifests here: https://github.com/hashicorp/waypoint/blob/124f4555ae306fb528adfaa65d39dfc72d41c075/internal/cli/base.go#L253

There is no way to determine of `c.cfg.Runner` is safe to access. `c.cfg` can be non-nil on its own, but it will _become_ nil when inspecting `c.cfg.Runner` if the embedded `*hclConfig` is nil.

A simplified example of the problem:

https://play.golang.org/p/sbAPT2HGJqW

If hclConfig is not a pointer, we won't get a nil pointer deference when looking at its fields.

## Is this change safe?

I believe so - we don't have any methods on hclConfig that require it to be a pointer. We also never statefully maniuplate it outside of the context of `cfg`, as far as I can see. I've tested this locally and it doesn't seem to break anything.