### PR TITLE
Removed references to id in favor of seq #

### DIFF
--- a/.changelog/1713.txt
+++ b/.changelog/1713.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Removed references to IDs in favor of sequence # to align with CLI
+```

--- a/ui/app/components/actions/deploy.hbs
+++ b/ui/app/components/actions/deploy.hbs
@@ -7,7 +7,7 @@
   <div class="cli-hint">
     <p>To deploy this build you can run the following command in the CLI</p>
     <CopyableCode @ref="deploy-cli-hint">
-      <pre><code id="deploy-cli-hint">waypoint deploy {{@id}}</code></pre>
+      <pre><code id="deploy-cli-hint">waypoint deploy {{@sequence}}</code></pre>
     </CopyableCode>
     <small><ExternalLink href="https://waypointproject.io/commands/deploy">Read more in our documentation</ExternalLink></small>
   </div>

--- a/ui/app/components/actions/release.hbs
+++ b/ui/app/components/actions/release.hbs
@@ -7,7 +7,7 @@
   <div class="cli-hint">
     <p>To release this deployment you can run the following command in the CLI</p>
     <CopyableCode @ref="release-cli-hint">
-      <pre><code id="release-cli-hint">waypoint release {{@id}}</code></pre>
+      <pre><code id="release-cli-hint">waypoint release {{@sequence}}</code></pre>
     </CopyableCode>
     <small><ExternalLink href="https://waypointproject.io/commands/release">Read more in our documentation</ExternalLink></small>
   </div>

--- a/ui/app/components/app-card/build.hbs
+++ b/ui/app/components/app-card/build.hbs
@@ -2,8 +2,7 @@
   <div class="app-card-item app-card-item--latest">
     <LinkTo @route="workspace.projects.project.app.build" @models={{array @model.id}}>
       <p>
-        <b class="badge badge--version">#{{@model.sequence}}</b>
-        <code>{{truncate @model.id 8 false}}</code>
+        <b class="badge badge--version">v{{@model.sequence}}</b>
         {{#if (eq @model.status.state 1)}}
         <b class="badge">
           <Pds::Icon @type="clock-outline" class="icon" />
@@ -35,8 +34,7 @@
   <li class="app-card-item">
     <LinkTo @route="workspace.projects.project.app.build" @models={{array @model.id}}>
       <p>
-        <b class="badge badge--version">#{{@model.sequence}}</b>
-        <code>{{truncate @model.id 8 false}}</code>
+        <b class="badge badge--version">v{{@model.sequence}}</b>
         {{#if (eq @model.status.state 1)}}
           <b class="badge">
             <Pds::Icon @type="clock-outline" class="icon" />

--- a/ui/app/components/app-card/deployment.hbs
+++ b/ui/app/components/app-card/deployment.hbs
@@ -3,7 +3,6 @@
   <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @model.id }}>
     <p>
       <b class="badge badge--version">v{{@model.sequence}}</b>
-      <code>{{truncate @model.id 8 false}}</code>
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
@@ -41,7 +40,6 @@
   <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @model.id}}>
     <p>
       <b class="badge badge--version">v{{@model.sequence}}</b>
-      <code>{{truncate @model.id 8 false}}</code>
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />

--- a/ui/app/components/app-card/release.hbs
+++ b/ui/app/components/app-card/release.hbs
@@ -3,7 +3,6 @@
     <LinkTo @route="workspace.projects.project.app.release" @models={{array @model.id }}>
       <p>
         <b class="badge badge--version">v{{@model.sequence}}</b>
-        <code>{{truncate @model.id 8 false}}</code>
       </p>
       <small>
         <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
@@ -39,7 +38,6 @@
     <LinkTo @route="workspace.projects.project.app.release" @models={{array @model.id}}>
       <p>
         <b class="badge badge--version">v{{@model.sequence}}</b>
-        <code>{{truncate @model.id 8 false}}</code>
       </p>
       <small>
         <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -1,8 +1,7 @@
 <li class="app-item">
   <LinkTo @route="workspace.projects.project.app.build" @models={{array @build.id}}>
     <p>
-      <b class="badge badge--version">#{{@build.sequence}}</b>
-      <code>{{@build.id}}</code>
+      <b class="badge badge--version">v{{@build.sequence}}</b>
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @build.component.name}} class="icon" />

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -6,7 +6,6 @@
   <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @deployment.id}}>
     <p>
       <b class="badge badge--version">v{{@deployment.sequence}}</b>
-      <code>{{@deployment.id}}</code>
       {{#if (eq @deployment.state 4)}}
         <b data-test-destroyed-badge class="badge badge--destroyed">
           <Pds::Icon @type="trash" class="icon" />&nbsp; {{t "page.deployments.destroyed_label"}}

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -2,7 +2,6 @@
   <LinkTo @route="workspace.projects.project.app.release" @models={{array @release.id}}>
     <p>
       <b class="badge badge--version">v{{@release.sequence}}</b>
-      <code>{{@release.id}}</code>
     </p>
     <small>
       <Pds::Icon @type={{icon-for-component @release.component.name}} class="icon" />

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -1,7 +1,7 @@
 <PageHeader @iconName="build">
   <div class="title">
     <h2>
-      <b class="badge badge--version">#{{@model.sequence}}</b> <code>{{@model.id}}</code>
+      <b class="badge badge--version">v{{@model.sequence}}</b>
     </h2>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
@@ -16,7 +16,7 @@
     </small>
   </div>
   <div class="actions">
-    <Actions::Deploy @id={{@model.id}} />
+    <Actions::Deploy @sequence={{@model.sequence}} />
   </div>
 </PageHeader>
 

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -1,7 +1,7 @@
 <PageHeader @iconName="upload">
   <div class="title">
     {{! TODO(jgwhite): Make this a real <h1> }}
-    <h2 aria-level="1"><b class="badge badge--version">#{{@model.sequence}}</b> <code>{{@model.id}}</code></h2>
+    <h1 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b></h1>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
       <span>Deployed by <b>{{component-name @model.component.name}}</b>
@@ -14,7 +14,7 @@
         <span>{{lowercase @model.preload.deployUrl}}</span>
         <Pds::Icon @type="exit" class="icon" />
       </ExternalLink>
-      <Actions::Release @id={{@model.id}} />
+      <Actions::Release @sequence={{@model.sequence}} />
     </div>
   </div>
 </PageHeader>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -1,7 +1,7 @@
 <PageHeader @iconName="public-default">
   <div class="title">
     {{! TODO(jgwhite): Make this a real <h1> }}
-    <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b> <code>{{ @model.id }}</code></h2>
+    <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b></h2>
     <small>
       <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
       <span>Released on <b>{{component-name @model.component.name}}</b>


### PR DESCRIPTION
Addresses #1513 
## What's Included
- Removed the instances of the build/deployment/release ID hash in the UI
- Updated the CLI hints to utilize sequence numbers instead of ID (see last screenshot)

## What's Not Included
- Updating the URL of individual build/deployment/release to use sequence number
- Creating a tooltip/UI for displaying the ID and allowing users to copy to clipboard

## Screenshots
### **_List of builds without ID_**
![builds list without id](https://user-images.githubusercontent.com/60155296/123693747-70eeff00-d826-11eb-96e4-2d5ecfea5224.png)
### **_List of deployments without ID_**
![deployments list without id](https://user-images.githubusercontent.com/60155296/123693756-74828600-d826-11eb-9336-11fdec7c432f.png)
### **_List of releases without ID_**
![releases list without id](https://user-images.githubusercontent.com/60155296/123693760-76e4e000-d826-11eb-8af4-92420e4458b2.png)
### **_Individual build's page, note the cli hint `waypoint deploy 4` using the sequence # not ID_**
![localhost_4200_default_marketing-public_app_wp-matrix_builds](https://user-images.githubusercontent.com/60155296/123693860-9845cc00-d826-11eb-86e6-6c7dd84b2a8a.png)