### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2586,9 +2586,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-2.0.0.tgz",
-      "integrity": "sha512-3xmaf7cU1lCUS/hgnpqokUw731xAPR51q5rCLuazMtSVasjnGqqoFSQfkQRycllUiCGG/GiMYSaBCY+WlwQXTQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-image": {
       "version": "4.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/react-content": "7.0.0",
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
-    "@hashicorp/react-head": "2.0.0",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-image": "4.0.0",
     "@hashicorp/react-product-downloader": "8.0.0",
     "@hashicorp/react-section-header": "5.0.2",

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -5,7 +5,6 @@ import useAnchorLinkAnalytics from '@hashicorp/nextjs-scripts/lib/anchor-link-an
 import Router from 'next/router'
 import HashiHead from '@hashicorp/react-head'
 import HashiStackMenu from '@hashicorp/react-hashi-stack-menu'
-import Head from 'next/head'
 import AlertBanner from '@hashicorp/react-alert-banner'
 import createConsentManager from '@hashicorp/nextjs-scripts/lib/consent-manager'
 import { ErrorBoundary } from '@hashicorp/nextjs-scripts/lib/bugsnag'
@@ -29,7 +28,6 @@ export default function App({ Component, pageProps }) {
   return (
     <ErrorBoundary FallbackComponent={Error}>
       <HashiHead
-        is={Head}
         title={title}
         siteName={title}
         description={description}

--- a/website/pages/_document.js
+++ b/website/pages/_document.js
@@ -10,7 +10,9 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <HashiHead is={Head} />
+        <Head>
+          <HashiHead />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -1,5 +1,4 @@
 import VERSION, { packageManagers } from 'data/version.js'
-import Head from 'next/head'
 import HashiHead from '@hashicorp/react-head'
 import { productName, productSlug } from 'data/metadata'
 import ProductDownloader from '@hashicorp/react-product-downloader'
@@ -8,8 +7,7 @@ import styles from './style.module.css'
 export default function DownloadsPage({ releases }) {
   return (
     <span className={styles.downloads}>
-      <HashiHead is={Head} title={`Downloads | ${productName} by HashiCorp`} />
-
+      <HashiHead title={`Downloads | ${productName} by HashiCorp`} />
       <ProductDownloader
         releases={releases}
         packageManagers={packageManagers}


### PR DESCRIPTION
[Preview](https://waypoint-mhpjhd5uu-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**Before**
<img width="1256" alt="Screen Shot 2021-06-25 at 9 12 48 AM" src="https://user-images.githubusercontent.com/36613477/123454563-8e596a00-d595-11eb-863b-470f4707d3be.png">

**After**
<img width="1241" alt="Screen Shot 2021-06-25 at 9 12 30 AM" src="https://user-images.githubusercontent.com/36613477/123454584-95807800-d595-11eb-9544-5d848580b416.png">
