### PR TITLE
ui: Fix template lint violations

### DIFF
--- a/ui/app/components/actions/context.hbs
+++ b/ui/app/components/actions/context.hbs
@@ -1,4 +1,4 @@
-<span class="hint-link connect-link" {{on "click" this.toggleHint}}>
+<span class="hint-link connect-link" role="button" {{on "click" this.toggleHint}}>
   <Pds::Icon @type="bolt" class="nav-icon" />
   CLI
 </span>
@@ -9,5 +9,5 @@
     <ContextCreate></ContextCreate>
     <small><ExternalLink href="https://waypointproject.io/commands/context-create">Read more in our documentation</ExternalLink></small>
   </div>
-  <div class="cli-hint-overlay" {{on "click" this.toggleHint}}></div>
+  <div class="cli-hint-overlay" role="button" {{on "click" this.toggleHint}}></div>
 {{/if}}

--- a/ui/app/components/actions/deploy.hbs
+++ b/ui/app/components/actions/deploy.hbs
@@ -11,5 +11,5 @@
     </CopyableCode>
     <small><ExternalLink href="https://waypointproject.io/commands/deploy">Read more in our documentation</ExternalLink></small>
   </div>
-  <div class="cli-hint-overlay" {{on "click" this.toggleHint}}></div>
+  <div class="cli-hint-overlay" role="button" {{on "click" this.toggleHint}}></div>
 {{/if}}

--- a/ui/app/components/actions/invite.hbs
+++ b/ui/app/components/actions/invite.hbs
@@ -1,4 +1,4 @@
-<span class="hint-link" {{on "click" this.toggleHint}}>
+<span class="hint-link" role="button" {{on "click" this.toggleHint}}>
   <Pds::Icon @type="plus-circle-outline" class="nav-icon" />
   Invite
 </span>
@@ -22,5 +22,5 @@
     <ExternalLink href="https://waypointproject.io/docs">Read more in our documentation</ExternalLink>
   </small>
 </div>
-<div class="cli-hint-overlay" {{on "click" this.toggleHint}}></div>
+<div class="cli-hint-overlay" role="button" {{on "click" this.toggleHint}}></div>
 {{/if}}

--- a/ui/app/components/actions/release.hbs
+++ b/ui/app/components/actions/release.hbs
@@ -11,5 +11,5 @@
     </CopyableCode>
     <small><ExternalLink href="https://waypointproject.io/commands/release">Read more in our documentation</ExternalLink></small>
   </div>
-  <div class="cli-hint-overlay" {{on "click" this.toggleHint}}></div>
+  <div class="cli-hint-overlay" role="button" {{on "click" this.toggleHint}}></div>
 {{/if}}

--- a/ui/app/components/context-create/index.hbs
+++ b/ui/app/components/context-create/index.hbs
@@ -1,7 +1,7 @@
 <CopyableCode @ref="context-create">
   <pre tabindex="0"><code id="context-create">waypoint context create \
     -server-addr={{this.hostname}} \
-    -server-auth-token=<span data-test-token=true>{{this.token}}</span> \
+    -server-auth-token=<span data-test-token>{{this.token}}</span> \
     -server-require-auth=true \
     -set-default {{this.contextName}}</code></pre>
 </CopyableCode>

--- a/ui/app/components/log-stream/index.hbs
+++ b/ui/app/components/log-stream/index.hbs
@@ -15,9 +15,13 @@
             <code>{{line}}</code>
           </div>
         {{/each}}
-        <div class="output-end" {{in-viewport
-          onEnter=(action (mut this.isFollowingLogs) true)
-          onExit=(action (mut this.isFollowingLogs) false)}} {{did-update this.updateScroll this.logLines.length}}></div>
+        <div class="output-end"
+          {{in-viewport
+            onEnter=(fn (mut this.isFollowingLogs) true)
+            onExit=(fn (mut this.isFollowingLogs) false)
+          }}
+          {{did-update this.updateScroll this.logLines.length}}
+        ></div>
       </div>
     </div>
   {{else}}

--- a/ui/app/components/log-stream/index.hbs
+++ b/ui/app/components/log-stream/index.hbs
@@ -2,7 +2,7 @@
   {{#if this.lines}}
     <div class="output-scroll-y">
       {{#unless this.isFollowingLogs}}
-        <button class="follow-logs" {{on "click" this.followLogs}}>
+        <button class="follow-logs" type="button" {{on "click" this.followLogs}}>
           <Pds::Icon @type="arrow-down" class="icon" />
           {{#if (gt this.badgeCount 0)}}
             <div class="badge">{{this.badgeCount}}</div>

--- a/ui/app/components/login-invite/index.hbs
+++ b/ui/app/components/login-invite/index.hbs
@@ -3,7 +3,7 @@
     <label for="invite-token-field">{{if @cli (t 'invite_login.input.cli_label') (t 'invite_login.input.label')}}</label>
     <Input
       autofocus
-      data-test-invite-login=true
+      data-test-invite-login
       @value={{this.inviteToken}}
       id="invite-token-field"
       placeholder={{if @cli (t 'invite_login.input.cli_placeholder') (t 'invite_login.input.placeholder')}} />

--- a/ui/app/components/login-invite/index.hbs
+++ b/ui/app/components/login-invite/index.hbs
@@ -1,4 +1,4 @@
-<form {{action 'login' on='submit'}} class="login">
+<form {{on "submit" this.login}} class="login">
   <fieldset>
     <label for="invite-token-field">{{if @cli (t 'invite_login.input.cli_label') (t 'invite_login.input.label')}}</label>
     <Input
@@ -10,8 +10,8 @@
     </fieldset>
 
     <button
-      data-test-invite-login-submit {{action "login"}}
-      type="button"
+      data-test-invite-login-submit
+      type="submit"
       class="button button--primary">
       {{if @cli (t 'invite_login.cli_button') (t 'invite_login.button')}}
     </button>

--- a/ui/app/components/login-invite/index.ts
+++ b/ui/app/components/login-invite/index.ts
@@ -34,7 +34,9 @@ export default class InviteLoginForm extends Component<InviteLoginFormArgs> {
   }
 
   @action
-  async login() {
+  async login(event?: Event) {
+    event?.preventDefault();
+
     var req = new ConvertInviteTokenRequest();
     req.setToken(this.inviteToken);
     var resp = await this.api.client.convertInviteToken(req, this.api.WithMeta());

--- a/ui/app/components/login-token/index.hbs
+++ b/ui/app/components/login-token/index.hbs
@@ -1,4 +1,4 @@
-<form {{action 'login' on='submit'}} class="login">
+<form {{on "submit" this.login}} class="login">
   <fieldset>
     <label>{{t 'login.instruction'}}</label>
     <CopyableCode @ref="waypoint-token-new">
@@ -19,7 +19,6 @@
 
   <button
     data-test-login-submit
-    {{action "login"}}
     type="button"
     class="button button--primary">
     {{t 'login.button'}}

--- a/ui/app/components/login-token/index.hbs
+++ b/ui/app/components/login-token/index.hbs
@@ -11,7 +11,7 @@
     <label for="token-field">{{t 'login.input.label'}}</label>
     <Input
       autofocus
-      data-test-login=true
+      data-test-login
       @value={{this.token}}
       id="token-field"
       placeholder={{t 'login.input.placeholder'}} />

--- a/ui/app/components/login-token/index.ts
+++ b/ui/app/components/login-token/index.ts
@@ -11,7 +11,9 @@ export default class LoginForm extends Component {
   token = '';
 
   @action
-  async login() {
+  async login(event?: Event) {
+    event?.preventDefault();
+
     await this.session.setToken(this.token);
     return this.router.transitionTo('workspaces');
   }

--- a/ui/app/components/operation-logs/index.hbs
+++ b/ui/app/components/operation-logs/index.hbs
@@ -54,9 +54,14 @@
             {{/if}}
           </div>
         {{/each}}
-        <div class="output-end" {{in-viewport
-          onEnter=(action (mut this.isFollowingLogs) true)
-          onExit=(action (mut this.isFollowingLogs) false)}} {{did-update this.updateScroll this.logLines.length}}></div>
+        <div
+          class="output-end"
+          {{in-viewport
+            onEnter=(fn (mut this.isFollowingLogs) true)
+            onExit=(fn (mut this.isFollowingLogs) false)
+          }}
+          {{did-update this.updateScroll this.logLines.length}}
+        ></div>
       </div>
     </div>
   {{else}}

--- a/ui/app/components/operation-logs/index.hbs
+++ b/ui/app/components/operation-logs/index.hbs
@@ -45,7 +45,7 @@
 
             {{!-- Step object --}}
             {{#if (eq line.type this.typeStep)}}
-              <code>{{{ansi-to-html line.logLine.output}}}</code>
+              <code>{{ansi-to-html line.logLine.output}}</code>
             {{/if}}
 
             {{!-- Status --}}

--- a/ui/app/components/operation-logs/index.hbs
+++ b/ui/app/components/operation-logs/index.hbs
@@ -2,7 +2,7 @@
   {{#if this.logLines}}
     <div class="output-scroll-y">
       {{#unless this.isFollowingLogs}}
-        <button class="follow-logs" {{on "click" this.followLogs}}>
+        <button type="button" class="follow-logs" {{on "click" this.followLogs}}>
           <Pds::Icon @type="arrow-down" class="icon" />
           {{#if (gt this.badgeCount 0)}}
             <div class="badge">{{this.badgeCount}}</div>

--- a/ui/app/helpers/ansi-to-html.ts
+++ b/ui/app/helpers/ansi-to-html.ts
@@ -1,14 +1,15 @@
 import { helper } from '@ember/component/helper';
 import * as Anser from 'anser';
+import { htmlSafe } from '@ember/template';
 
 // ansiToHtml
-export function ansiToHtml([text]: [string]): string {
+export function ansiToHtml([text]: [string]): string | ReturnType<typeof htmlSafe> {
   if (!text) return '';
 
   // Simple escaping
   text = text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-  return Anser.default.ansiToHtml(text);
+  return htmlSafe(Anser.default.ansiToHtml(text));
 }
 
 export default helper(ansiToHtml);

--- a/ui/app/templates/onboarding/connect.hbs
+++ b/ui/app/templates/onboarding/connect.hbs
@@ -14,6 +14,6 @@
 <hr />
 
 <div class="onboarding-footer">
-  <LinkTo @route="onboarding.start" data-test-next-step=true class="button button--secondary">Continue to Next Step
+  <LinkTo @route="onboarding.start" data-test-next-step class="button button--secondary">Continue to Next Step
   </LinkTo>
 </div>

--- a/ui/app/templates/onboarding/install.hbs
+++ b/ui/app/templates/onboarding/install.hbs
@@ -45,6 +45,6 @@ Common commands:
 <hr />
 
 <div class="onboarding-footer">
-  <LinkTo @route="onboarding.connect" data-test-next-step=true class="button button--secondary">Continue to Next Step
+  <LinkTo @route="onboarding.connect" data-test-next-step class="button button--secondary">Continue to Next Step
   </LinkTo>
 </div>

--- a/ui/app/templates/onboarding/start.hbs
+++ b/ui/app/templates/onboarding/start.hbs
@@ -23,5 +23,5 @@
 <hr />
 
 <div class="onboarding-footer">
-  <LinkTo data-test-next-step=true class="button button--primary" @route="workspaces">Finish Setup</LinkTo>
+  <LinkTo data-test-next-step class="button button--primary" @route="workspaces">Finish Setup</LinkTo>
 </div>

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -24,7 +24,7 @@
   </Pds::CtaLink>
 </PageHeader>
 
-<div data-test-project-list=true>
+<div data-test-project-list>
   {{#each @model as |project|}}
   <Card>
     <LinkTo @route="workspace.projects.project" @model={{project.project}}>

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -1,7 +1,7 @@
-{{#unless (or
-  (eq target.currentRouteName 'workspace.projects.project.app.build')
-  (eq target.currentRouteName 'workspace.projects.project.app.deployment')
-  (eq target.currentRouteName 'workspace.projects.project.app.release')
+{{#if (and
+  (not-eq this.target.currentRouteName 'workspace.projects.project.app.build')
+  (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment')
+  (not-eq this.target.currentRouteName 'workspace.projects.project.app.release')
 )}}
 <PageHeader @iconName="git-repository">
   <div class="title">
@@ -77,6 +77,6 @@
     {{t "nav.exec"}}
   </LinkTo>
 </Pds::TabNav>
-{{/unless}}
+{{/if}}
 
 {{outlet}}

--- a/ui/app/templates/workspace/projects/project/app/builds.hbs
+++ b/ui/app/templates/workspace/projects/project/app/builds.hbs
@@ -1,6 +1,6 @@
 <h3>{{t "page.builds.title"}}</h3>
 
-<ul data-test-build-list=true class="list">
+<ul data-test-build-list class="list">
   {{#each @model as |build|}}
     <AppItem::Build @build={{build}} />
   {{else}}

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -1,7 +1,7 @@
 <h3>Exec</h3>
 
 <div class="output-pane">
-  {{#if hasExec}}
+  {{#if this.hasExec}}
   <div class="output">
     <code>A line of output</code>
     <code>Another line of output</code>

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -16,7 +16,7 @@
   <div class="run-prompt">
     <Pds::Icon @type="chevron-right" class="prompt-icon" />
     <input type="text" class="run-prompt-input" disabled />
-    <button class="button button--primary" disabled>
+    <button type="button" class="button button--primary" disabled>
       <Pds::Icon @type="sub-right" class="icon" />
       <span>Run</span>
     </button>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -3,7 +3,7 @@
     {{! TODO(jgwhite): Make this a real <h1> }}
     <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b> <code>{{ @model.id }}</code></h2>
     <small>
-      <Pds::Icon @type=(icon-for-component @model.component.name) class="icon" />
+      <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
       <span>Released on <b>{{component-name @model.component.name}}</b>
         {{date-format-distance-to-now @model.status.startTime.seconds }}</span>
     </small>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -10,7 +10,7 @@
   </div>
   <div class="actions">
     {{#if @isLatest}}
-    <button class="button button--primary">
+    <button class="button button--primary" type="button">
       <span>{{@model.release.url}}</span>
       <Pds::Icon @type="exit" class="icon" />
     </button>

--- a/ui/app/templates/workspace/projects/project/app/releases.hbs
+++ b/ui/app/templates/workspace/projects/project/app/releases.hbs
@@ -1,6 +1,6 @@
 <h3>{{t "page.releases.title"}}</h3>
 
-<ul data-test-release-list=true class="list">
+<ul data-test-release-list class="list">
   {{#each @model as |release releaseIndex|}}
     <AppItem::Release @release={{release}} @isLatest={{ eq releaseIndex 0}} />
   {{else}}


### PR DESCRIPTION
## Why the change?

These changes all fix violations ember-template-lint rules.

## What does it look like?

Hopefully no user-facing differences.

## How do I test it?

1. `git checkout ui/fix-template-lint-violations`
2. `yarn lint:hbs`
3. Verify you see no errors

To really fine-tooth-comb this change, you may want to test the various pages where changes occur. I’ve been fairly diligent, but you never know.

## Any follow-up work?

After this is merged we can make `yarn lint:hbs` a part of our CI workflow.