### PR TITLE
builtin/nomad: fix dropped error

### DIFF
--- a/.changelog/1723.txt
+++ b/.changelog/1723.txt
@@ -1,0 +1,3 @@
+se-note:bug
+plugin/nomad: Fix case where nomad error would be ignored during a status check
+```

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -259,7 +259,9 @@ func (p *Platform) Status(
 	log.Debug("querying nomad for job health")
 
 	job, _, err := jobclient.Info(deployment.Name, &api.QueryOptions{})
-
+	if err != nil {
+		return nil, err
+	}
 	if *job.Status == "running" {
 		result.Health = sdk.StatusReport_READY
 		result.HealthMessage = fmt.Sprintf("Job %q is reporting ready!", deployment.Name)


### PR DESCRIPTION
This fixes a dropped `err` variable in `builtin/nomad`.