### PR TITLE
ui: add `lib` to `.eslintignore`

### DIFF
--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -19,3 +19,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# generated/vendored grpc/protobuf code
+/lib/


### PR DESCRIPTION
## Why the change?

The contents of `ui/lib` are either generated or vendored code that we oughtn’t change, therefore it’s safe for the listing tooling to ignore this directory.