### PR TITLE
add default auth to mirage scenario for mocks mode

### DIFF
--- a/ui/mirage/helpers/login.ts
+++ b/ui/mirage/helpers/login.ts
@@ -1,0 +1,3 @@
+export default function login(token?: string) {
+  window.localStorage.waypointAuthToken = token || 'default-test-token-value';
+}

--- a/ui/mirage/scenarios/default.ts
+++ b/ui/mirage/scenarios/default.ts
@@ -1,6 +1,8 @@
 import { Server } from 'ember-cli-mirage';
+import login from '../helpers/login';
 
 export default function (server: Server): void {
   server.create('project', 'marketing-public');
   server.create('project', 'mutable-deployments');
+  login();
 }


### PR DESCRIPTION
When trying to run the web ui with [mocks as outlined in the readme](https://github.com/hashicorp/waypoint/blob/fdff0ef772cd40293dd8f3ae440f89c7d493ff58/ui/README.md#running-with-mocks) I found I could not make it past the authentication screen. To help make this easier I copied over the fake authentication we're doing in the tests to run by default when mirage boots up.

Certainly possible I'm missing something obvious here though so open to feedback or a 👎 

