### PR TITLE
Allow users to provide k8s namespace for uninstall

### DIFF
--- a/.changelog/1730.txt
+++ b/.changelog/1730.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serverinstall/k8s: accept k8s-namespace when uninstalling server
+```

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1409,6 +1409,13 @@ func (i *K8sInstaller) UninstallFlags(set *flag.Set) {
 			" unset, Waypoint will use the current Kubernetes context.",
 		Default: "",
 	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "k8s-namespace",
+		Target:  &i.config.namespace,
+		Usage:   "Namespace in Kubernetes to uninstall the Waypoint server from.",
+		Default: "",
+	})
 }
 
 func int32Ptr(i int32) *int32 {
@@ -1467,8 +1474,7 @@ func (i *K8sInstaller) newClient() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-var (
-	warnK8SKind = strings.TrimSpace(`
+var warnK8SKind = strings.TrimSpace(`
 Kind cluster detected!
 
 Installing Waypoint to a Kind cluster requires that the cluster has
@@ -1476,4 +1482,3 @@ LoadBalancer capabilities (such as metallb). If Kind isn't configured
 in this way, then the install may hang. If this happens, please delete
 all the Waypoint resources and try again.
 `)
-)


### PR DESCRIPTION
Installing the waypoint server into a Kube cluster takes a flag `k8s-namespace` to install the server, however `uninstall` doesn't offer the same flag. As a result the uninstall process doesn't find the installation and instead gives a false positive successful destroy message. 

Here we accept `k8s-namespace` in `uninstall` and actually delete everything. 

Example before/after output in the details below

<details>

Before:

```console
$ waypoint version
CLI: v0.4.0 (3b3dd831)
Server: v0.4.0

$ waypoint server uninstall --platform=kubernetes -auto-approve -k8s-namespace waypoint
! flag provided but not defined: -k8s-namespace

$ waypoint server uninstall --platform=kubernetes -auto-approve
Uninstalling Waypoint server with context "install-1624910915"
✓ Snapshot "waypoint-server-snapshot-1624910954" generated
✓ No runners installed.
✓ Inspecting Kubernetes cluster...
Waypoint server successfully uninstalled for kubernetes platform

// see that kubectl still reports things
$ kubectl get all -n waypoint                                                          
NAME                                   READY   STATUS    RESTARTS   AGE
pod/waypoint-runner-6944b98ddb-qbl74   1/1     Running   0          32s
pod/waypoint-server-0                  1/1     Running   0          47s

NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)                         AGE
service/waypoint   LoadBalancer   10.105.0.42   localhost     9701:30561/TCP,9702:30080/TCP   47s

NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/waypoint-runner   1/1     1            1           32s

NAME                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/waypoint-runner-6944b98ddb   1         1         1       32s

NAME                               READY   AGE
statefulset.apps/waypoint-server   1/1     47s
```

After:

```console
$ waypoint version
CLI: v0.4.0-145-g793a312e (793a312e+CHANGES)
Server: v0.4.0

$ waypoint server uninstall --platform=kubernetes -auto-approve -k8s-namespace waypoint
Uninstalling Waypoint server with context "install-1624911092"
✓ Snapshot "waypoint-server-snapshot-1624911156" generated
✓ Runner deployment deleted
✓ Statefulset and pods deleted
✓ Persistent Volume Claim deleted
✓ Service deleted
Waypoint server successfully uninstalled for kubernetes platform

$ kubectl get all -n waypoint
No resources found in waypoint namespace.
```

</details>