### PR TITLE
Runner: Listen for context cancellation and exit liveness listener

### DIFF
--- a/.changelog/1732.txt
+++ b/.changelog/1732.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-server/runner: correctly exit liveness listener when context is cancelled
+server/runner: correctly exit liveness listener when connection is closed
 ```

--- a/.changelog/1732.txt
+++ b/.changelog/1732.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server/runner: correctly exit liveness listener when context is cancelled
+```

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -129,7 +129,6 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 				"Error starting liveness server: %s", err.Error(),
 				terminal.WithErrorStyle(),
 			)
-			cancel()
 			return 1
 		}
 		defer ln.Close()


### PR DESCRIPTION
Gracefully quit the liveness listener if accepting a job errors and the context gets cancelled. Before this change, the liveness server would continue to operate and spew errors in the logs.

Example based off my findings from debugging  https://github.com/hashicorp/waypoint/issues/1398:

<details>

Before:

```
2021-06-24T17:58:03.538Z [INFO]  waypoint.runner.agent: initializing the runner
2021-06-24T17:58:03.538Z [INFO]  waypoint.runner.agent: starting runner
2021-06-24T17:58:03.538Z [DEBUG] waypoint.runner.agent.runner: registering runner
2021-06-24T17:58:03.539Z [TRACE] waypoint.runner.agent.runner: runner connected, waiting for initial config
2021-06-24T17:58:03.541Z [INFO]  waypoint.runner.agent.runner: runner registered with server
2021-06-24T17:58:03.541Z [DEBUG] waypoint.runner.agent.runner: opening job stream
2021-06-24T17:58:03.541Z [TRACE] waypoint.runner.agent.runner: sending job request
2021-06-24T17:58:03.542Z [INFO]  waypoint.runner.agent.runner: waiting for job assignment
2021-06-24T17:59:02.612Z [ERROR] waypoint.runner.agent: error running job: err="rpc error: code = Unavailable desc = transport is closing"
2021-06-24T17:59:02.612Z [WARN]  waypoint.runner.agent: server unavailable, sleeping before retry
2021-06-24T17:59:02.612Z [ERROR] waypoint.runner.agent.runner.config_recv: error receiving configuration, exiting: err="rpc error: code = Unavailable desc = transport is closing"
2021-06-24T17:59:02.612Z [TRACE] waypoint.runner.agent.runner.config_recv: exiting receive goroutine
2021-06-24T17:59:04.612Z [DEBUG] waypoint.runner.agent.runner: opening job stream
2021-06-24T17:59:04.613Z [TRACE] waypoint.runner.agent.runner: sending job request
2021-06-24T17:59:04.613Z [INFO]  waypoint.runner.agent.runner: waiting for job assignment
2021-06-24T17:59:04.615Z [ERROR] waypoint.runner.agent: error running job: err="rpc error: code = NotFound desc = runner ID not found"
2021-06-24T17:59:04.615Z [ERROR] waypoint.runner.agent: runner unexpectedly deregistered, exiting
2021-06-24T17:59:04.615Z [INFO]  waypoint.runner.agent: quit request received, gracefully stopping runner
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-24T17:59:04.615Z [TRACE] waypoint: stopping signal listeners and cancelling the context
2021-06-24T17:59:04.615Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
```

After:

```
2021-06-28T21:16:31.202Z [INFO]  waypoint.runner.agent: initializing the runner
2021-06-28T21:16:31.202Z [INFO]  waypoint.runner.agent: starting runner
2021-06-28T21:16:31.202Z [DEBUG] waypoint.runner.agent.runner: registering runner
2021-06-28T21:16:31.202Z [TRACE] waypoint.runner.agent.runner: runner connected, waiting for initial config
2021-06-28T21:16:31.206Z [INFO]  waypoint.runner.agent.runner: runner registered with server
2021-06-28T21:16:31.208Z [DEBUG] waypoint.runner.agent.runner: opening job stream
2021-06-28T21:16:31.208Z [TRACE] waypoint.runner.agent.runner: sending job request
2021-06-28T21:16:31.209Z [INFO]  waypoint.runner.agent.runner: waiting for job assignment
2021-06-28T21:17:30.669Z [ERROR] waypoint.runner.agent: error running job: err="rpc error: code = Unavailable desc = transport is closing"
2021-06-28T21:17:30.669Z [WARN]  waypoint.runner.agent: server unavailable, sleeping before retry
2021-06-28T21:17:30.670Z [ERROR] waypoint.runner.agent.runner.config_recv: error receiving configuration, exiting: err="rpc error: code = Unavailable desc = transport is closing"
2021-06-28T21:17:30.670Z [TRACE] waypoint.runner.agent.runner.config_recv: exiting receive goroutine
2021-06-28T21:17:32.671Z [DEBUG] waypoint.runner.agent.runner: opening job stream
2021-06-28T21:17:32.671Z [TRACE] waypoint.runner.agent.runner: sending job request
2021-06-28T21:17:32.671Z [INFO]  waypoint.runner.agent.runner: waiting for job assignment
2021-06-28T21:17:32.673Z [ERROR] waypoint.runner.agent: error running job: err="rpc error: code = NotFound desc = runner ID not found"
2021-06-28T21:17:32.673Z [ERROR] waypoint.runner.agent: runner unexpectedly deregistered, exiting
2021-06-28T21:17:32.673Z [INFO]  waypoint.runner.agent: quit request received, gracefully stopping runner
2021-06-28T21:17:32.673Z [WARN]  waypoint.runner.agent: error accepting liveness connection: err="accept tcp [::]:1234: use of closed network connection"
2021-06-28T21:17:32.673Z [TRACE] waypoint: stopping signal listeners and cancelling the context

```

</details>