### PR TITLE
ui: fix some linting issues in typescript declaration files

### DIFF
--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -4,10 +4,14 @@ declare module 'ember-cli-mirage/test-support' {
 
 declare module 'ember-test-helpers' {
   interface TestContext {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     server: any;
   }
 }
 
 declare module 'ember-a11y-testing/test-support/audit' {
-  export default function a11yAudit(target?: string | Element, axeOptions?: object): Promise<void>;
+  export default function a11yAudit(
+    target?: string | Element,
+    axeOptions?: Record<string, unknown>
+  ): Promise<void>;
 }

--- a/ui/types/waypoint/index.d.ts
+++ b/ui/types/waypoint/index.d.ts
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface Array<T> extends Ember.ArrayPrototypeExtensions<T> {}
   // interface Function extends Ember.FunctionPrototypeExtensions {}
 }


### PR DESCRIPTION
## Why the change?

Clear a couple of simple linting issues so that we can eventually incorporate the linter in CI.

## How do I verify it?

These are all annotations with no runtime impact. If the tests pass, we should be good.