### PR TITLE
Server/client: Add keepalive to RPC connections

### DIFF
--- a/.changelog/1735.txt
+++ b/.changelog/1735.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+server/client: configure keepalive properties to RPC connections to persist
+connections even after inactivity
+```

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/oklog/run"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
@@ -37,6 +38,15 @@ func grpcInit(group *run.Group, opts *options) error {
 			// Protocol version negotiation
 			versionStreamInterceptor(resp.Info),
 		),
+		grpc.KeepaliveEnforcementPolicy(
+			keepalive.EnforcementPolicy{
+				// connections need to wait at least 20s before sending a
+				// keepalive ping
+				MinTime: 20 * time.Second,
+				// allow runners to send keeplive pings even if there are no
+				// active RCP streams.
+				PermitWithoutStream: true,
+			}),
 	)
 
 	if opts.AuthChecker != nil {

--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/protocolversion"
@@ -56,6 +57,13 @@ func Connect(ctx context.Context, opts ...ConnectOption) (*grpc.ClientConn, erro
 		grpc.WithBlock(),
 		grpc.WithUnaryInterceptor(protocolversion.UnaryClientInterceptor(protocolversion.Current())),
 		grpc.WithStreamInterceptor(protocolversion.StreamClientInterceptor(protocolversion.Current())),
+		grpc.WithKeepaliveParams(
+			keepalive.ClientParameters{
+				// ping after this amount of time of inactivity
+				Time: 30 * time.Second,
+				// send keepalive pings even if there is no active streams
+				PermitWithoutStream: true,
+			}),
 	}
 
 	if !cfg.Tls {


### PR DESCRIPTION
Depending on the environment, certain network load balancers et. al. may terminate idle connections if no activity is detected after some time. EKS specifically uses a classic load balancer for the Waypoint server service and will by default terminate connections after 60s of inactivity. This results in the waypoint runner crash loop shown in #1398.

In this PR we configure [keepalive][grpc-keepalive] properties on both the server and the client, to maintain the connection even if there is no activity in the stream. I believe these are the only 2 locations where the client is created, but please let me know if I missed on. 

*Note: the numbers used here are fairly arbitrary and worked for AWS EKS. The client `Time` has a minimum of 10s. From my testing it needs to be greater than the server enforcement's `MinTime`. 

Fixes #1398

[grpc-keepalive]: https://pkg.go.dev/google.golang.org/grpc/keepalive