### PR TITLE
ui: auto-fix linting issues in ui/app/components

### DIFF
--- a/ui/app/components/actions/context.ts
+++ b/ui/app/components/actions/context.ts
@@ -8,9 +8,9 @@ export default class ActionsRelease extends Component {
   @action
   toggleHint() {
     if (this.hintIsVisible === true) {
-      return this.hintIsVisible = false;
+      return (this.hintIsVisible = false);
     } else {
-      return this.hintIsVisible = true;
-    };
+      return (this.hintIsVisible = true);
+    }
   }
 }

--- a/ui/app/components/actions/deploy.ts
+++ b/ui/app/components/actions/deploy.ts
@@ -8,9 +8,9 @@ export default class ActionsDeploy extends Component {
   @action
   toggleHint() {
     if (this.hintIsVisible === true) {
-      return this.hintIsVisible = false;
+      return (this.hintIsVisible = false);
     } else {
-      return this.hintIsVisible = true;
-    };
+      return (this.hintIsVisible = true);
+    }
   }
 }

--- a/ui/app/components/actions/invite.ts
+++ b/ui/app/components/actions/invite.ts
@@ -36,9 +36,9 @@ export default class ActionsInvite extends Component {
 
   @action
   async createToken() {
-    const req = new InviteTokenRequest();
+    let req = new InviteTokenRequest();
     req.setDuration('12h');
-    const resp = await this.api.client.generateInviteToken(req, this.api.WithMeta());
+    let resp = await this.api.client.generateInviteToken(req, this.api.WithMeta());
     this.token = resp.getToken();
   }
 

--- a/ui/app/components/actions/release.ts
+++ b/ui/app/components/actions/release.ts
@@ -8,9 +8,9 @@ export default class ActionsRelease extends Component {
   @action
   toggleHint() {
     if (this.hintIsVisible === true) {
-      return this.hintIsVisible = false;
+      return (this.hintIsVisible = false);
     } else {
-      return this.hintIsVisible = true;
-    };
+      return (this.hintIsVisible = true);
+    }
   }
 }

--- a/ui/app/components/app-footer/index.js
+++ b/ui/app/components/app-footer/index.js
@@ -1,4 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class AppFooter extends Component {
-}

--- a/ui/app/components/app-form/project-settings.ts
+++ b/ui/app/components/app-form/project-settings.ts
@@ -145,7 +145,7 @@ export default class AppFormProjectSettings extends Component<ProjectSettingsArg
   }
 
   populateExistingFields(projectFromArgs, currentModel) {
-    for (const [key, value] of Object.entries(projectFromArgs)) {
+    for (let [key, value] of Object.entries(projectFromArgs)) {
       if (isEmpty(value)) {
         continue;
       }

--- a/ui/app/components/context-create/index.ts
+++ b/ui/app/components/context-create/index.ts
@@ -14,7 +14,7 @@ export default class ContextCreate extends Component {
   }
 
   async createToken() {
-    const resp = await this.api.client.generateLoginToken(new Empty(), this.api.WithMeta());
+    let resp = await this.api.client.generateLoginToken(new Empty(), this.api.WithMeta());
     this.token = resp.getToken();
   }
 

--- a/ui/app/components/log-stream/index.ts
+++ b/ui/app/components/log-stream/index.ts
@@ -33,9 +33,9 @@ export default class LogStream extends Component<LogStreamArgs> {
 
   @action
   followLogs(element: any) {
-    let scrollableElement = element.target ?
-      element.target.closest('.output-scroll-y') :
-      element.closest('.output-scroll-y');
+    let scrollableElement = element.target
+      ? element.target.closest('.output-scroll-y')
+      : element.closest('.output-scroll-y');
 
     scrollableElement.scroll(0, scrollableElement.scrollHeight);
     this.badgeCount = 0;
@@ -50,18 +50,18 @@ export default class LogStream extends Component<LogStreamArgs> {
   }
 
   async start() {
-    const onData = (response: LogBatch) => {
+    let onData = (response: LogBatch) => {
       response.getLinesList().forEach((entry) => {
-        const prefix = formatRFC3339(entry.getTimestamp()!.toDate());
+        let prefix = formatRFC3339(entry.getTimestamp()!.toDate());
         this.addLine(`${prefix}: ${entry.getLine()}`);
       });
     };
 
-    const onStatus = (status: any) => {
+    let onStatus = (status: any) => {
       this.addLine(status.details);
     };
 
-    var stream = this.api.client.getLogStream(this.args.req, this.api.WithMeta());
+    let stream = this.api.client.getLogStream(this.args.req, this.api.WithMeta());
 
     stream.on('data', onData);
     stream.on('status', onStatus);

--- a/ui/app/components/login-invite/index.ts
+++ b/ui/app/components/login-invite/index.ts
@@ -37,9 +37,9 @@ export default class InviteLoginForm extends Component<InviteLoginFormArgs> {
   async login(event?: Event) {
     event?.preventDefault();
 
-    var req = new ConvertInviteTokenRequest();
+    let req = new ConvertInviteTokenRequest();
     req.setToken(this.inviteToken);
-    var resp = await this.api.client.convertInviteToken(req, this.api.WithMeta());
+    let resp = await this.api.client.convertInviteToken(req, this.api.WithMeta());
     await this.session.setToken(resp.getToken());
 
     // If this is an invite for a new user, take them to on-boarding, otherwise, take

--- a/ui/app/components/operation-logs/index.ts
+++ b/ui/app/components/operation-logs/index.ts
@@ -47,9 +47,9 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
 
   @action
   followLogs(element: any) {
-    let scrollableElement = element.target ?
-      element.target.closest('.output-scroll-y') :
-      element.closest('.output-scroll-y');
+    let scrollableElement = element.target
+      ? element.target.closest('.output-scroll-y')
+      : element.closest('.output-scroll-y');
 
     scrollableElement.scroll(0, scrollableElement.scrollHeight);
   }
@@ -63,7 +63,7 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
   }
 
   async start() {
-    const onData = (response: GetJobStreamResponse) => {
+    let onData = (response: GetJobStreamResponse) => {
       let event = response.getEventCase();
 
       // We only care about the terminal event
@@ -75,8 +75,8 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
           }
         } else {
           terminal.getEventsList().forEach((event) => {
-            const line = event.getLine();
-            const step = event.getStep();
+            let line = event.getLine();
+            let step = event.getStep();
 
             if (line && line.getMsg()) {
               console.log(line);
@@ -85,7 +85,7 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
 
             if (step && step.getOutput()) {
               console.log(step);
-              const newStep = step.toObject();
+              let newStep = step.toObject();
 
               if (step.getOutput_asU8().length > 0) {
                 newStep.output = new TextDecoder().decode(step.getOutput_asU8());
@@ -97,13 +97,13 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
         }
       }
       // If it completes with an error, we should surface that in the UI
-      if ((event == GetJobStreamResponse.EventCase.COMPLETE) && (response.getComplete()?.getError())) {
+      if (event == GetJobStreamResponse.EventCase.COMPLETE && response.getComplete()?.getError()) {
         let error = response.getComplete()?.getError()?.toObject();
         this.addLogLine(this.typeLine, { style: this.errorBoldStyle, msg: error.message });
       }
     };
 
-    const onStatus = (status: any) => {
+    let onStatus = (status: any) => {
       if (status.details) {
         this.addLogLine(this.typeStatus, { msg: status.details });
       }


### PR DESCRIPTION
## Why the change?

One more step toward us being able to run the UI linters as part of CI.

## How do I verify it?

This should be entirely stylistic changes thanks to Prettier, so we can be fairly confident it won’t change behavior. If CI passes, we should be good. The one exception is the removal of the `<AppFooter>` backing class. To test this, boot the dev server and check that footer still renders (it appears fine in my testing).