### PR TITLE
Adjusted font size of view all button in card headers

### DIFF
--- a/ui/app/styles/components/card.scss
+++ b/ui/app/styles/components/card.scss
@@ -107,3 +107,7 @@
     @include Typography.Interface(M);
   }
 }
+
+.card-header {
+  font-size: scale.$sm-1;
+}


### PR DESCRIPTION
## Explanation
This PR fixes a small unexpected change in CSS with the refactor. The font size increased of the buttons in the card headers (ie "View all deployments/builds/releases")

## Screenshots
### Before fix
![localhost_4200_default_marketing-public_app_wp-matrix_logs (1)](https://user-images.githubusercontent.com/60155296/124024105-c0ffca00-d9bc-11eb-917c-cf7e18ac1724.png)

### After fix
![localhost_4200_default_marketing-public_app_wp-matrix_logs](https://user-images.githubusercontent.com/60155296/124024262-f6a4b300-d9bc-11eb-8f48-91b111d550ac.png)
