### PR TITLE
ui: reduce the impact of our app’s CSS on QUnit’s runner UI

### DIFF
--- a/ui/app/styles/components/input.scss
+++ b/ui/app/styles/components/input.scss
@@ -67,4 +67,12 @@ input {
     border: 1px solid;
     border-color: rgb(var(--input-disabled-border));
   }
+
+  #qunit & {
+    width: unset;
+    padding: unset;
+    font-family: unset;
+    font-size: unset;
+    line-height: unset;
+  }
 }


### PR DESCRIPTION
## Why the change?

At the moment, our app’s CSS affects QUnit’s UI in way that makes the module-selector unusable and also makes other things look broken and untrustworthy.

This is not a complete solution, but is the quickest stopgap I could think of makes the QUnit UI usable again without requiring too many other changes.

## What does it look like?

### Before

<img width="1024" alt="before" src="https://user-images.githubusercontent.com/34030/124127735-60d05d00-da7c-11eb-9d1d-0133e5975ab1.png">

### After

<img width="1024" alt="after" src="https://user-images.githubusercontent.com/34030/124127754-64fc7a80-da7c-11eb-8918-2301d5a21d10.png">

## How do I test it?

1. `git checkout ui/qunit-inputs`
2. `cd ui && yarn start`
3. Visit [http://localhost:4200/tests](http://localhost:4200/tests)
4. Verify that the module selector is usable