### PR TITLE
Managing grpc and http server agents manually

### DIFF
--- a/.changelog/1761.txt
+++ b/.changelog/1761.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fix an intermittent panic when shutting down the server
+```

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,6 @@ require (
 	github.com/moby/sys/symlink v0.1.0 // indirect
 	github.com/mr-tron/base58 v1.2.0
 	github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09
-	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/oklog/ulid/v2 v2.0.2
 	github.com/olekukonko/tablewriter v0.0.4

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -97,19 +97,19 @@ func (s *grpcServer) close() {
 	gracefulCh := make(chan struct{})
 	go func() {
 		defer close(gracefulCh)
-		log.Info("shutting down gRPC server")
+		log.Debug("stopping")
 		s.server.GracefulStop()
 	}()
 
 	select {
 	case <-gracefulCh:
-		log.Debug("grpc server exited gracefully")
+		log.Debug("exited gracefully")
 
 	// After a timeout we just forcibly exit. Our gRPC endpoints should
 	// be fairly quick and their operations are atomic so we just kill
 	// the connections after a few seconds.
 	case <-time.After(2 * time.Second):
-		log.Debug("stopping gRPC server after waiting unsuccessfully for graceful shutdown")
+		log.Debug("stopping forcefully after waiting unsuccessfully for graceful stop")
 		s.server.Stop()
 	}
 }

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -103,6 +103,7 @@ func (s *grpcServer) close() {
 
 	select {
 	case <-gracefulCh:
+		log.Debug("grpc server exited gracefully")
 
 	// After a timeout we just forcibly exit. Our gRPC endpoints should
 	// be fairly quick and their operations are atomic so we just kill

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -13,8 +13,8 @@ import (
 )
 
 type grpcServer struct {
-	opts *options
-	log hclog.Logger
+	opts   *options
+	log    hclog.Logger
 	server *grpc.Server
 }
 
@@ -65,9 +65,9 @@ func newGrpcServer(opts *options) (*grpcServer, error) {
 	s := grpc.NewServer(so...)
 
 	return &grpcServer{
-		opts: opts,
+		opts:   opts,
 		server: s,
-		log: log,
+		log:    log,
 	}, nil
 }
 

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/oklog/run"
+	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
@@ -12,14 +12,20 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-// grpcInit initializes the gRPC server and adds it to the run group.
-func grpcInit(group *run.Group, opts *options) error {
+type grpcServer struct {
+	opts *options
+	log hclog.Logger
+	server *grpc.Server
+}
+
+// newGrpcServer initializes a new gRPC server
+func newGrpcServer(opts *options) (*grpcServer, error) {
 	log := opts.Logger.Named("grpc")
 
 	// Get our server info immediately
 	resp, err := opts.Service.GetVersionInfo(opts.Context, &empty.Empty{})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var so []grpc.ServerOption
@@ -57,42 +63,53 @@ func grpcInit(group *run.Group, opts *options) error {
 	}
 
 	s := grpc.NewServer(so...)
-	opts.grpcServer = s
 
+	return &grpcServer{
+		opts: opts,
+		server: s,
+		log: log,
+	}, nil
+}
+
+// start starts the grpc server
+func (s *grpcServer) start() error {
 	// Register the reflection service. This makes using tools like grpcurl
 	// easier. It makes it slightly easier for malicious users to know about
 	// the service but I think they'd figure out its a waypoint server
 	// easy enough.
-	reflection.Register(s)
+	reflection.Register(s.server)
 
 	// Register our server
-	pb.RegisterWaypointServer(s, opts.Service)
+	pb.RegisterWaypointServer(s.server, s.opts.Service)
+	// Serve traffic
+	ln := s.opts.GRPCListener
+	s.log.Info("starting gRPC server", "addr", ln.Addr().String())
+	return s.server.Serve(ln)
+}
 
-	// Add our gRPC server to the run group
-	group.Add(func() error {
-		// Serve traffic
-		ln := opts.GRPCListener
-		log.Info("starting gRPC server", "addr", ln.Addr().String())
-		return s.Serve(ln)
-	}, func(err error) {
-		// Graceful in a goroutine so we can timeout
-		gracefulCh := make(chan struct{})
-		go func() {
-			defer close(gracefulCh)
-			log.Info("shutting down gRPC server")
-			s.GracefulStop()
-		}()
+// close stops the grpc server, gracefully if possible.
+// Warning: before closing the GRPC server, the HTTP server must first be closed.
+// Attempting to gracefully stop the GRPC server first will cause it to drain HTTP connections,
+// which will panic.
+func (s *grpcServer) close() {
+	log := s.log
+	// Graceful in a goroutine so we can timeout
+	gracefulCh := make(chan struct{})
+	go func() {
+		defer close(gracefulCh)
+		log.Info("shutting down gRPC server")
+		s.server.GracefulStop()
+	}()
 
-		select {
-		case <-gracefulCh:
+	select {
+	case <-gracefulCh:
 
-		// After a timeout we just forcibly exit. Our gRPC endpoints should
-		// be fairly quick and their operations are atomic so we just kill
-		// the connections after a few seconds.
-		case <-time.After(2 * time.Second):
-			s.Stop()
-		}
-	})
-
-	return nil
+	// After a timeout we just forcibly exit. Our gRPC endpoints should
+	// be fairly quick and their operations are atomic so we just kill
+	// the connections after a few seconds.
+	case <-time.After(2 * time.Second):
+		log.Debug("stopping gRPC server after waiting unsuccessfully for graceful shutdown")
+		s.server.Stop()
+	}
+	return
 }

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -111,5 +111,4 @@ func (s *grpcServer) close() {
 		log.Debug("stopping gRPC server after waiting unsuccessfully for graceful shutdown")
 		s.server.Stop()
 	}
-	return
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -90,20 +90,21 @@ func (s *httpServer) close() {
 	gracefulCh := make(chan struct{})
 	go func() {
 		defer close(gracefulCh)
-		log.Info("shutting down HTTP server")
+		log.Info("stopping")
 		if err := s.server.Shutdown(ctx); err != nil {
-			log.Error("failed gracefully shutting down http server: %s", err)
+			log.Error("failed graceful shutdown: %s", err)
 		}
 	}()
 
 	select {
 	case <-gracefulCh:
+		log.Debug("exited gracefully")
 
 	// After a timeout we just forcibly exit. Our HTTP endpoints should
 	// be fairly quick and their operations are atomic so we just kill
 	// the connections after a few seconds.
 	case <-time.After(2 * time.Second):
-		log.Debug("stopping http server after waiting unsuccessfully for graceful shutdown")
+		log.Debug("stopping forcefully after waiting unsuccessfully for graceful stop")
 		cancelFunc()
 	}
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
 	"net"
 	"net/http"
 	"strings"
@@ -10,11 +12,17 @@ import (
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	"github.com/oklog/run"
 )
 
-// httpInit initializes the HTTP server and adds it to the run group.
-func httpInit(group *run.Group, opts *options) error {
+type httpServer struct {
+	opts *options
+	log hclog.Logger
+	server *http.Server
+}
+
+// newHttpServer initializes a new http server.
+// Uses grpc-web to wrap an existing grpc server.
+func newHttpServer(grpcServer *grpc.Server, opts *options) *httpServer{
 	log := opts.Logger.Named("http")
 	if opts.HTTPListener == nil {
 		log.Info("HTTP listener not specified, HTTP API is disabled")
@@ -22,7 +30,7 @@ func httpInit(group *run.Group, opts *options) error {
 	}
 
 	// Wrap the grpc server so that it is grpc-web compatible
-	grpcWrapped := grpcweb.WrapServer(opts.grpcServer,
+	grpcWrapped := grpcweb.WrapServer(grpcServer,
 		grpcweb.WithCorsForRegisteredEndpointsOnly(false),
 		grpcweb.WithOriginFunc(func(string) bool { return true }),
 		grpcweb.WithAllowNonRootResource(true),
@@ -47,43 +55,55 @@ func httpInit(group *run.Group, opts *options) error {
 	})
 
 	// Create our http server
-	httpSrv := &http.Server{
-		ReadHeaderTimeout: 5 * time.Second,
-		IdleTimeout:       120 * time.Second,
-		Handler:           httpLogHandler(rootHandler, log),
-		BaseContext: func(net.Listener) context.Context {
-			return opts.Context
+	return &httpServer{
+		opts: opts,
+		log: log,
+		server: &http.Server{
+			ReadHeaderTimeout: 5 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			Handler:           httpLogHandler(rootHandler, log),
+			BaseContext: func(net.Listener) context.Context {
+				return opts.Context
+			},
 		},
 	}
+}
 
-	// Add our gRPC server to the run group
-	group.Add(func() error {
-		// Serve traffic
-		ln := opts.HTTPListener
-		log.Info("starting HTTP server", "addr", ln.Addr().String())
-		return httpSrv.Serve(ln)
-	}, func(err error) {
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
+// start starts an http server
+func (s *httpServer) start() error {
+	// Serve traffic
+	ln := s.opts.HTTPListener
+	s.log.Info("starting HTTP server", "addr", ln.Addr().String())
+	return s.server.Serve(ln)
+}
 
-		// Graceful in a goroutine so we can timeout
-		gracefulCh := make(chan struct{})
-		go func() {
-			defer close(gracefulCh)
-			log.Info("shutting down HTTP server")
-			httpSrv.Shutdown(ctx)
-		}()
+// close stops the grpc server, gracefully if possible.
+// Warning: before closing the GRPC server, this HTTP server must first be closed.
+// Attempting to gracefully stop the GRPC server first will cause it to drain HTTP connections,
+// which will panic.
+func (s *httpServer) close() {
+	log := s.log
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
-		select {
-		case <-gracefulCh:
-
-		// After a timeout we just forcibly exit. Our HTTP endpoints should
-		// be fairly quick and their operations are atomic so we just kill
-		// the connections after a few seconds.
-		case <-time.After(2 * time.Second):
-			cancelFunc()
+	// Graceful in a goroutine so we can timeout
+	gracefulCh := make(chan struct{})
+	go func() {
+		defer close(gracefulCh)
+		log.Info("shutting down HTTP server")
+		if err := s.server.Shutdown(ctx); err != nil {
+			log.Error("failed gracefully shutting down http server: %s", err)
 		}
-	})
+	}()
 
-	return nil
+	select {
+	case <-gracefulCh:
+
+	// After a timeout we just forcibly exit. Our HTTP endpoints should
+	// be fairly quick and their operations are atomic so we just kill
+	// the connections after a few seconds.
+	case <-time.After(2 * time.Second):
+		log.Debug("stopping http server after waiting unsuccessfully for graceful shutdown")
+		cancelFunc()
+	}
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -15,14 +15,14 @@ import (
 )
 
 type httpServer struct {
-	opts *options
-	log hclog.Logger
+	opts   *options
+	log    hclog.Logger
 	server *http.Server
 }
 
 // newHttpServer initializes a new http server.
 // Uses grpc-web to wrap an existing grpc server.
-func newHttpServer(grpcServer *grpc.Server, opts *options) *httpServer{
+func newHttpServer(grpcServer *grpc.Server, opts *options) *httpServer {
 	log := opts.Logger.Named("http")
 	if opts.HTTPListener == nil {
 		log.Info("HTTP listener not specified, HTTP API is disabled")
@@ -57,7 +57,7 @@ func newHttpServer(grpcServer *grpc.Server, opts *options) *httpServer{
 	// Create our http server
 	return &httpServer{
 		opts: opts,
-		log: log,
+		log:  log,
 		server: &http.Server{
 			ReadHeaderTimeout: 5 * time.Second,
 			IdleTimeout:       120 * time.Second,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -77,7 +77,7 @@ func (s *httpServer) start() error {
 	return s.server.Serve(ln)
 }
 
-// close stops the grpc server, gracefully if possible.
+// close stops the grpc server, gracefully if possible. Should be called exactly once.
 // Warning: before closing the GRPC server, this HTTP server must first be closed.
 // Attempting to gracefully stop the GRPC server first will cause it to drain HTTP connections,
 // which will panic.
@@ -90,7 +90,7 @@ func (s *httpServer) close() {
 	gracefulCh := make(chan struct{})
 	go func() {
 		defer close(gracefulCh)
-		log.Info("stopping")
+		log.Debug("stopping")
 		if err := s.server.Shutdown(ctx); err != nil {
 			log.Error("failed graceful shutdown: %s", err)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,9 +52,9 @@ func Run(opts ...Option) error {
 	defer cancel()
 
 	select {
-	case err := <- errch:
+	case err := <-errch:
 		return err
-	case <- cfg.Context.Done():
+	case <-cfg.Context.Done():
 		// Must shut down the http server first, as the grpc server can't drain http connections
 		httpServer.close()
 		grpcServer.close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,7 +34,7 @@ func Run(opts ...Option) error {
 		return err
 	}
 
-	errch := make(chan error, 0)
+	errch := make(chan error)
 	go func() {
 		if err := grpcServer.start(); err != nil {
 			errch <- err


### PR DESCRIPTION
This addresses the panic described in https://github.com/hashicorp/waypoint/issues/1476.

We need to create the grpc server first, but close the http server first, which run groups do not allow for. This removes the run groups and manages grpc and http server struct lifecycles directly.

Closes #1476