### PR TITLE
ui/mirage: add stub GetLogStream handler

### DIFF
--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -12,6 +12,7 @@ import * as release from './services/release';
 import * as versionInfo from './services/version-info';
 import * as statusReport from './services/status-report';
 import * as job from './services/job';
+import * as log from './services/log';
 
 export default function (this: Server) {
   this.namespace = 'hashicorp.waypoint.Waypoint';
@@ -45,6 +46,7 @@ export default function (this: Server) {
   this.post('/ListStatusReports', statusReport.list);
   this.post('/GetLatestStatusReport', statusReport.getLatest);
   this.post('/GetJobStream', job.stream);
+  this.post('/GetLogStream', log.stream);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/services/log.ts
+++ b/ui/mirage/services/log.ts
@@ -1,0 +1,22 @@
+import { LogBatch } from 'waypoint-pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+import { Response } from 'miragejs';
+import { getUnixTime } from 'date-fns';
+
+export function stream(): Response {
+  // TODO(jgwhite): Implement GetLogStream handler (+ models & factories)
+
+  let result = new LogBatch();
+  let entry = new LogBatch.Entry();
+  let ts = new Timestamp();
+
+  ts.setSeconds(getUnixTime(new Date(2021, 0, 1)));
+
+  entry.setSource(LogBatch.Entry.Source.APP);
+  entry.setTimestamp(ts);
+  entry.setLine('Example log line');
+
+  result.addLines(entry);
+
+  return this.serialize(result, 'application');
+}


### PR DESCRIPTION
## Why the change?

We hadn’t added a Mirage handler for `GetLogStream` yet so even in Mirage-mode the app is making a real request to the API.

## What’s the plan?

- [x] Add minimum-viable `GetLogStream` handler

## What’s not part of the plan?

Adding the models and factories for simulating log streams more extensively. I suggest we implement this when we really need it.

## What does it look like?

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/34030/124468777-d5b3d780-dd99-11eb-8099-b94dfeaffdbd.png) | ![after](https://user-images.githubusercontent.com/34030/124468766-d3ea1400-dd99-11eb-8d84-7acc41c0ef06.png) |

## How do I verify it?

1. Check out the branch
2. Boot the ui dev server in mirage-mode (`cd ui; yarn start`)
3. Visit [http://localhost:4200](http://localhost:4200/default/marketing-public/app/wp-matrix/logs)
4. Verify that you see “Example log line” under “Application logs”