### PR TITLE
ui: `yarn lint:js --fix` remaining files

### DIFF
--- a/ui/app/helpers/strip-ansi.ts
+++ b/ui/app/helpers/strip-ansi.ts
@@ -4,12 +4,12 @@ import { helper } from '@ember/component/helper';
 export function stripAnsi([text]: [string]): string {
   if (!text) return '';
 
-  const pattern = [
+  let pattern = [
     '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
     '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
   ].join('|');
 
-  const regex = new RegExp(pattern, 'g');
+  let regex = new RegExp(pattern, 'g');
   return text.replace(regex, '');
 }
 

--- a/ui/app/routes/onboarding/install/index.ts
+++ b/ui/app/routes/onboarding/install/index.ts
@@ -3,7 +3,7 @@ import { UAParser } from 'ua-parser-js';
 
 export default class OnboardingInstallIndex extends Route {
   redirect() {
-    const parser = new UAParser();
+    let parser = new UAParser();
 
     switch (parser.getResult().os.name) {
       case 'Mac OS':

--- a/ui/app/routes/workspace/projects/project/app/logs.ts
+++ b/ui/app/routes/workspace/projects/project/app/logs.ts
@@ -8,15 +8,15 @@ export default class Logs extends Route {
   @service api!: ApiService;
 
   async model() {
-    const app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
+    let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let ws = this.modelFor('workspace') as Ref.Workspace.AsObject;
-    const req = new GetLogStreamRequest();
-    const appReq = new GetLogStreamRequest.Application();
+    let req = new GetLogStreamRequest();
+    let appReq = new GetLogStreamRequest.Application();
 
-    const appRef = new Ref.Application();
+    let appRef = new Ref.Application();
     appRef.setApplication(app.application.application);
     appRef.setProject(app.application.project);
-    const wsRef = new Ref.Workspace();
+    let wsRef = new Ref.Workspace();
     wsRef.setWorkspace(ws.workspace);
 
     appReq.setApplication(appRef);

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -113,7 +113,10 @@ export default class ApiService extends Service {
     return resp.getStatusReportsList().map((d) => d.toObject());
   }
 
-  async getLatestStatusReport(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<StatusReport|undefined>{
+  async getLatestStatusReport(
+    _wsRef: Ref.Workspace,
+    appRef: Ref.Application
+  ): Promise<StatusReport | undefined> {
     let req = new GetLatestStatusReportRequest();
     req.setApplication(appRef);
     // We have to try/catch to avoid failing the hash request because the api errors if no statusReport is available

--- a/ui/app/services/breadcrumbs.js
+++ b/ui/app/services/breadcrumbs.js
@@ -13,15 +13,15 @@ export default class BreadcrumbsService extends Service {
   // model occurs.
   @computed('router.{currentURL,currentRouteName}')
   get breadcrumbs() {
-    const owner = getOwner(this);
-    const allRoutes = (this.router.currentRouteName || '')
+    let owner = getOwner(this);
+    let allRoutes = (this.router.currentRouteName || '')
       .split('.')
       .without('')
       .map((segment, index, allSegments) => allSegments.slice(0, index + 1).join('.'));
 
     let crumbs = [];
     allRoutes.forEach((routeName) => {
-      const route = owner.lookup(`route:${routeName}`);
+      let route = owner.lookup(`route:${routeName}`);
 
       // Routes can reset the breadcrumb trail to start anew even
       // if the route is deeply nested.

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
     'ember-toggle': {
       includedThemes: ['light'],
       defaultTheme: 'light',
-    }
+    },
   };
 
   if (environment === 'development') {

--- a/ui/tests/acceptance/onboarding-test.ts
+++ b/ui/tests/acceptance/onboarding-test.ts
@@ -9,9 +9,9 @@ import { setUa } from '../helpers/set-ua';
 const userAgent = window.navigator.userAgent;
 
 module('Acceptance | onboarding index', function (hooks) {
-  const onboardingUrl = '/onboarding';
+  let onboardingUrl = '/onboarding';
 
-  const page = create({
+  let page = create({
     visit: visitable(onboardingUrl),
     nextStep: clickable('[data-test-next-step]'),
   });
@@ -40,9 +40,9 @@ module('Acceptance | onboarding index', function (hooks) {
 });
 
 module('Acceptance | onboarding connect', function (hooks) {
-  const connectUrl = '/onboarding/connect';
+  let connectUrl = '/onboarding/connect';
 
-  const page = create({
+  let page = create({
     visit: visitable(connectUrl),
     nextStep: clickable('[data-test-next-step]'),
     token: text('[data-test-token]'),
@@ -66,9 +66,9 @@ module('Acceptance | onboarding connect', function (hooks) {
 });
 
 module('Acceptance | onboarding start', function (hooks) {
-  const startUrl = '/onboarding/start';
+  let startUrl = '/onboarding/start';
 
-  const page = create({
+  let page = create({
     visit: visitable(startUrl),
     nextStep: clickable('[data-test-next-step]'),
   });

--- a/ui/tests/unit/controllers/workspace/projects/new-test.ts
+++ b/ui/tests/unit/controllers/workspace/projects/new-test.ts
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | workspace/projects/new', function(hooks) {
+module('Unit | Controller | workspace/projects/new', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:workspace/projects/new');
     assert.ok(controller);
   });

--- a/ui/tests/unit/controllers/workspace/projects/project/app/deployments-test.ts
+++ b/ui/tests/unit/controllers/workspace/projects/project/app/deployments-test.ts
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | workspace/projects/project/app/deployments', function(hooks) {
+module('Unit | Controller | workspace/projects/project/app/deployments', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:workspace/projects/project/app/deployments');
     assert.ok(controller);
   });

--- a/ui/tests/unit/routes/workspace/projects/new-test.ts
+++ b/ui/tests/unit/routes/workspace/projects/new-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | workspace/projects/new', function(hooks) {
+module('Unit | Route | workspace/projects/new', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let route = this.owner.lookup('route:workspace/projects/new');
     assert.ok(route);
   });

--- a/ui/tests/unit/routes/workspace/projects/project/settings-test.ts
+++ b/ui/tests/unit/routes/workspace/projects/project/settings-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | workspace/projects/project/settings', function(hooks) {
+module('Unit | Route | workspace/projects/project/settings', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let route = this.owner.lookup('route:workspace/projects/project/settings');
     assert.ok(route);
   });


### PR DESCRIPTION
## Why the change?

One more step towards running ESLint in CI.

## What does it look like?

A mixture of Prettier whitespace changes, preferring `let` to `const`, and not very much more.

## How do I test it?

Eyeball the diff. These changes really are cosmetic, so if CI passes then we should be good to go.