### PR TITLE
ui: add `key` to build and release lists

### DIFF
--- a/ui/app/templates/workspace/projects/project/app/builds.hbs
+++ b/ui/app/templates/workspace/projects/project/app/builds.hbs
@@ -1,7 +1,7 @@
 <h3>{{t "page.builds.title"}}</h3>
 
 <ul data-test-build-list class="list">
-  {{#each @model as |build|}}
+  {{#each @model key="id" as |build|}}
     <AppItem::Build @build={{build}} />
   {{else}}
     <EmptyState>

--- a/ui/app/templates/workspace/projects/project/app/releases.hbs
+++ b/ui/app/templates/workspace/projects/project/app/releases.hbs
@@ -1,7 +1,7 @@
 <h3>{{t "page.releases.title"}}</h3>
 
 <ul data-test-release-list class="list">
-  {{#each @model as |release releaseIndex|}}
+  {{#each @model key="id" as |release releaseIndex|}}
     <AppItem::Release @release={{release}} @isLatest={{ eq releaseIndex 0}} />
   {{else}}
     <EmptyState>


### PR DESCRIPTION
## Why the change?

Extracted from #1668 

Adding a `key` to these lists makes rendering more “stable”. Without the `key`, Ember removes and recreates list items whenever new data arrives (the data being a brand new set of JS objects). With the `key`, Ember can reuse chunks of for builds/releases that it has already rendered.

This is not a massive deal from the end-user perspective (the list is too small to incur a performance penalty), but is a small win for developer experience, best illustrated by before/after videos:

**Before:**

https://user-images.githubusercontent.com/34030/124588105-b9c33b00-de58-11eb-926f-1173e30dc083.mp4

Note how the `<a>` keeps disappearing while I’m trying the inspect/edit it? That’s because Ember is unnecessarily removing and recreating it.

**After:**

https://user-images.githubusercontent.com/34030/124588147-c5aefd00-de58-11eb-8d3a-3a17b4da186a.mp4

We see a flash of the parent `ul` but nothing else.

## How do I test it?

This is a pretty safe change. Eyeballing the diff should be sufficient.