### PR TITLE
cli: friendlier error handling on input variable panic

### DIFF
--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -130,10 +130,9 @@ func (c *genericConfig) envVars() ([]*pb.ConfigVar, error) {
 
 				// We have to escape any HCL we find in the string so that we don't
 				// evaluate it down-stream.
-				// First, we need to check if the value can be evaluated as a string,
-				// since we allow `null` defaults for input variables, and a user
-				// may forget to provide a value to an input variable that they
-				// reference inside of app config
+				// First, we need to check if the value is not null, since we allow
+				// `null` defaults for input variables, and a user may forget to
+				// provide a value to an input variable
 				if val.IsNull() {
 					return nil, fmt.Errorf("could not evaluate %q in app config with `null` value", newVar.Name)
 				}

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -107,7 +108,7 @@ func (c *genericConfig) envVars() ([]*pb.ConfigVar, error) {
 			// g = unknown()
 			// s = "ok"
 			//
-			// After running the algorith, we want b to still be 'more: ${a}', NOT
+			// After running the algorithm, we want b to still be 'more: ${a}', NOT
 			// 'more: ${g} ok'. The reason being the 2nd one confuses the escaping
 			// as it appears like it might be data that was returned from a file or
 			// something.
@@ -129,6 +130,13 @@ func (c *genericConfig) envVars() ([]*pb.ConfigVar, error) {
 
 				// We have to escape any HCL we find in the string so that we don't
 				// evaluate it down-stream.
+				// First, we need to check if the value can be evaluated as a string,
+				// since we allow `null` defaults for input variables, and a user
+				// may forget to provide a value to an input variable that they
+				// reference inside of app config
+				if val.IsNull() {
+					return nil, fmt.Errorf("could not evaluate %q in app config with `null` value", newVar.Name)
+				}
 				newVar.Value = &pb.ConfigVar_Static{
 					Static: hclEscaper.Replace(val.AsString()),
 				}


### PR DESCRIPTION
We allow `null` default values for input variables since a user may want to run a specific stage without setting values for all stages.
This leaves open the possibility for the config to attempt to evaluate null values. This fix captures one such panic.

Before:
```
$ waypoint deploy

» Deploying...panic: value is null

goroutine 22 [running]:
github.com/zclconf/go-cty/cty.Value.AsString(0x3239728, 0xc00012c24b, 0x0, 0x0, 0x3239728, 0xc00012c24b)
	/home/rae/go/pkg/mod/github.com/zclconf/go-cty@v1.8.4/cty/value_ops.go:1259 +0x185
...
```

After:
```
$ waypoint deploy

» Deploying...
! could not evaluate "SALE_PERCENT" in app config with `null` value
```

waypoint.hcl from `waypoint-examples/learn/static-application-configuration`:
```
project = "example-go"

app "example-go" {
  labels = {
    "service" = "example-go",
    "env"     = "dev"
  }

  config {
    env = {
      SALE_PERCENT = var.sale
    }
  }

  build {
    use "pack" {}
  }

  deploy {
    use "docker" {}
  }
}

variable "sale" {
  default = null
}
```