### PR TITLE
Fix the exec/platform and pack/builder docs

### DIFF
--- a/builtin/exec/platform.go
+++ b/builtin/exec/platform.go
@@ -290,7 +290,7 @@ template. The top of the documentation there has details on the format.
 
 The following template values are always available:
 
-  - ".Env" (map<string>string) - These are environment variables that should
+  - ".Env" (map<string\>string) - These are environment variables that should
     be set on the deployed workload. These enable the entrypoint to work so
     you should set these if able.
 

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -322,8 +322,8 @@ build {
 		"ignore",
 		"file patterns to match files which will not be included in the build",
 		docs.Summary(
-			"Each pattern follows the semantics of .gitignore. This is a summarized version:",
-			strings.TrimSpace(`
+			`Each pattern follows the semantics of .gitignore. This is a summarized version:
+
 1. A blank line matches no files, so it can serve as a separator
 	 for readability.
 
@@ -362,6 +362,7 @@ build {
 
 9. Two consecutive asterisks ("**") in patterns matched against full
 	 pathname may have special meaning:
+
 		i.   A leading "**" followed by a slash means match in all directories.
 				 For example, "** /foo" matches file or directory "foo" anywhere,
 				 the same as pattern "foo". "** /foo/bar" matches file or directory
@@ -376,7 +377,6 @@ build {
 				 "a/x/b", "a/x/y/b" and so on.
 
 		iv.  Other consecutive asterisks are considered invalid.`),
-		),
 	)
 
 	doc.SetField(

--- a/website/content/commands/index.mdx
+++ b/website/content/commands/index.mdx
@@ -5,12 +5,12 @@ page_title: 'Waypoint Commands (CLI)'
 
 # Waypoint Commands (CLI)
 
-Waypoint is controlled via a very easy to use command-line interface (CLI). Waypoint 
-is only a single command-line application: `waypoint`. This application then takes a 
-subcommand such as `artifact` or `deployment`. The complete list of subcommands is in 
+Waypoint is controlled via a very easy to use command-line interface (CLI). Waypoint
+is only a single command-line application: `waypoint`. This application then takes a
+subcommand such as `artifact` or `deployment`. The complete list of subcommands is in
 the navigation to the left.
 
-The waypoint CLI is a well-behaved command line application. In erroneous cases, a 
+The waypoint CLI is a well-behaved command line application. In erroneous cases, a
 non-zero exit status will be returned. It also responds to -h and --help as you'd most
 likely expect.
 
@@ -46,7 +46,7 @@ Other commands:
     version         Prints the version of this Waypoint CLI.
 ```
 
-To get help for any specific command, pass the -h flag to the relevant subcommand. 
+To get help for any specific command, pass the -h flag to the relevant subcommand.
 For example, to see help about the up subcommand:
 
 ```shell-session
@@ -75,7 +75,7 @@ Operation Options:
       is used for example to set a specific Git ref to run against.
 ```
 
-Running `waypoint -autocomplete-install` will add the waypoint autocomplete capability 
-so you can do `waypoint <tab>` on commands. Running `waypoint -autocomplete-uninstall` 
-will remove it. Please note that this will modify your shell init script, so you will 
+Running `waypoint -autocomplete-install` will add the waypoint autocomplete capability
+so you can do `waypoint <tab>` on commands. Running `waypoint -autocomplete-uninstall`
+will remove it. Please note that this will modify your shell init script, so you will
 need to reload your shell.

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -73,51 +73,59 @@ File patterns to match files which will not be included in the build.
 
 Each pattern follows the semantics of .gitignore. This is a summarized version:
 
-1. A blank line matches no files, so it can serve as a separator
-   for readability.
-2. A line starting with # serves as a comment. Put a backslash ("\")
-   in front of the first hash for patterns that begin with a hash.
-3. Trailing spaces are ignored unless they are quoted with backslash ("\").
-4. An optional prefix "!" which negates the pattern; any matching file
-   excluded by a previous pattern will become included again. It is not
-   possible to re-include a file if a parent directory of that file is
-   excluded. Git doesn’t list excluded directories for performance reasons,
-   so any patterns on contained files have no effect, no matter where they
-   are defined. Put a backslash ("\") in front of the first "!" for
-   patterns that begin with a literal "!", for example, "\!important!.txt".
-5. If the pattern ends with a slash, it is removed for the purpose of the
-   following description, but it would only find a match with a directory.
-   In other words, foo/ will match a directory foo and paths underneath it,
-   but will not match a regular file or a symbolic link foo (this is
-   consistent with the way how pathspec works in general in Git).
-6. If the pattern does not contain a slash /, Git treats it as a shell glob
-   pattern and checks for a match against the pathname relative to the
-   location of the .gitignore file (relative to the top level of the work
-   tree if not from a .gitignore file).
-7. Otherwise, Git treats the pattern as a shell glob suitable for
-   consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the
-   pattern will not match a / in the pathname. For example,
-   "Documentation/\*.html" matches "Documentation/git.html" but not
-   "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
-8. A leading slash matches the beginning of the pathname. For example,
-   "/\*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
-9. Two consecutive asterisks ("\*\*") in patterns matched against full
-   pathname may have special meaning:
+1.  A blank line matches no files, so it can serve as a separator
+    for readability.
 
-i. A leading "\*\*" followed by a slash means match in all directories.
-For example, "\*\* /foo" matches file or directory "foo" anywhere,
-the same as pattern "foo". "\*\* /foo/bar" matches file or directory
-"bar" anywhere that is directly under directory "foo".
+2.  A line starting with # serves as a comment. Put a backslash ("\")
+    in front of the first hash for patterns that begin with a hash.
 
-ii. A trailing "/\*\*" matches everything inside. For example, "abc/\*\*"
-matches all files inside directory "abc", relative to the location
-of the .gitignore file, with infinite depth.
+3.  Trailing spaces are ignored unless they are quoted with backslash ("\").
 
-iii. A slash followed by two consecutive asterisks then a slash matches
-zero or more directories. For example, "a/\*\* /b" matches "a/b",
-"a/x/b", "a/x/y/b" and so on.
+4.  An optional prefix "!" which negates the pattern; any matching file
+    excluded by a previous pattern will become included again. It is not
+    possible to re-include a file if a parent directory of that file is
+    excluded. Git doesn’t list excluded directories for performance reasons,
+    so any patterns on contained files have no effect, no matter where they
+    are defined. Put a backslash ("\") in front of the first "!" for
+    patterns that begin with a literal "!", for example, "\!important!.txt".
 
-iv. Other consecutive asterisks are considered invalid.
+5.  If the pattern ends with a slash, it is removed for the purpose of the
+    following description, but it would only find a match with a directory.
+    In other words, foo/ will match a directory foo and paths underneath it,
+    but will not match a regular file or a symbolic link foo (this is
+    consistent with the way how pathspec works in general in Git).
+
+6.  If the pattern does not contain a slash /, Git treats it as a shell glob
+    pattern and checks for a match against the pathname relative to the
+    location of the .gitignore file (relative to the top level of the work
+    tree if not from a .gitignore file).
+
+7.  Otherwise, Git treats the pattern as a shell glob suitable for
+    consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the
+    pattern will not match a / in the pathname. For example,
+    "Documentation/\*.html" matches "Documentation/git.html" but not
+    "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
+
+8.  A leading slash matches the beginning of the pathname. For example,
+    "/\*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+
+9.  Two consecutive asterisks ("\*\*") in patterns matched against full
+    pathname may have special meaning:
+
+        i.   A leading "**" followed by a slash means match in all directories.
+        		 For example, "** /foo" matches file or directory "foo" anywhere,
+        		 the same as pattern "foo". "** /foo/bar" matches file or directory
+        		 "bar" anywhere that is directly under directory "foo".
+
+        ii.  A trailing "/**" matches everything inside. For example, "abc/**"
+        		 matches all files inside directory "abc", relative to the location
+        		 of the .gitignore file, with infinite depth.
+
+        iii. A slash followed by two consecutive asterisks then a slash matches
+        		 zero or more directories. For example, "a/** /b" matches "a/b",
+        		 "a/x/b", "a/x/y/b" and so on.
+
+        iv.  Other consecutive asterisks are considered invalid.
 
 - Type: **list of string**
 - **Optional**


### PR DESCRIPTION
For the last few releases, we've been massaging these mdx files by hand at the last minute, because our automation produced broken mdx files. With these changes, the automation produces good mdx files.

Here's what the pack/builder complex docs section looks like after this change:

<img width="623" alt="Screen Shot 2021-07-07 at 4 51 45 PM" src="https://user-images.githubusercontent.com/8404559/124833472-d8eac700-df43-11eb-9a11-4e8b10a5449f.png">

index.mdx also had some minor whitespace changes that i'm not going to question too much.