### PR TITLE
test: Increase timeout due to slow circle-ci

### DIFF
--- a/internal/server/singleprocess/service_logs_test.go
+++ b/internal/server/singleprocess/service_logs_test.go
@@ -342,7 +342,7 @@ func TestServiceGetLogStreamCases(t *testing.T) {
 }
 
 func TestServiceGetLogStream_depPlugin(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Create our server


### PR DESCRIPTION
This test has failed multiple times today due to a timeout. This commit
bumps the timeout to decrease test flake failures in CI.

From circle:

> TestServiceGetLogStream_depPlugin - github.com/hashicorp/waypoint/internal/server/singleprocess

```
=== RUN   TestServiceGetLogStream_depPlugin
2021-07-07T21:55:16.142Z [INFO]  poll_queuer.project: starting
2021-07-07T21:55:16.142Z [INFO]  poll_queuer.application_statusreport: starting
2021-07-07T21:55:16.142Z [INFO]  prune: starting
2021-07-07T21:55:16.142Z [INFO]  http: HTTP listener not specified, HTTP API is disabled
2021-07-07T21:55:16.142Z [INFO]  grpc: starting gRPC server: addr=127.0.0.1:40895
2021-07-07T21:55:16.143Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/BootstrapToken request
2021-07-07T21:55:16.143Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/BootstrapToken response: error=<nil> duration=370.691µs
2021-07-07T21:55:16.144Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/UpsertDeployment request
2021-07-07T21:55:16.144Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/UpsertDeployment response: error=<nil> duration=385.38µs
2021-07-07T21:55:16.145Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/GetLogStream request
2021-07-07T21:55:16.145Z [INFO]  grpc: spawning logs plugin via job: deployment_id=01FA1FFKHGFXDG07F939R40B1J instance-id=01FA1FFKHHVQ1F9QD94WFYXKRK deployment=01FA1FFKHGFXDG07F939R40B1J
2021-07-07T21:55:17.145Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/RunnerConfig request
2021-07-07T21:55:17.146Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/RunnerJobStream request
2021-07-07T21:55:17.146Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/EntrypointLogStream request
2021-07-07T21:55:17.148Z [INFO]  grpc: no Instance found, attempting to lookup InstanceLogs record instead: instance_id=01FA1FFKHHVQ1F9QD94WFYXKRK
2021-07-07T21:55:17.148Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/EntrypointLogStream response: error="rpc error: code = NotFound desc = instance exec ID not found" duration=1.752761ms
2021-07-07T21:55:21.140Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/RunnerJobStream response: error=<nil> duration=3.994255054s
    service_logs_test.go:442: 
        	Error Trace:	service_logs_test.go:442
        	Error:      	Received unexpected error:
        	            	rpc error: code = DeadlineExceeded desc = context deadline exceeded
        	Test:       	TestServiceGetLogStream_depPlugin
2021-07-07T21:55:21.140Z [INFO]  grpc: shutting down gRPC server
2021-07-07T21:55:21.140Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/GetLogStream response: error="context deadline exceeded" duration=4.995821805s
2021-07-07T21:55:21.140Z [INFO]  grpc: /hashicorp.waypoint.Waypoint/RunnerConfig response: error="context canceled" duration=3.995130043s
--- FAIL: TestServiceGetLogStream_depPlugin (5.00s)
```

Not sure if this should be backported.