### PR TITLE
Adding make command to generate and format website mdx files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ gen/doc:
 		--doc_out=./doc --doc_opt=html,index.html \
 		./internal/server/proto/server.proto
 
+.PHONY: gen/website-mdx
+gen/website-mdx:
+	go run ./cmd/waypoint docs -website-mdx
+	go run ./tools/gendocs
+	cd ./website; npx --no-install next-hashicorp format
+
 .PHONY: tools
 tools: # install dependencies and tools required to build
 	@echo "Fetching tools..."


### PR DESCRIPTION
Previously, our release docs called for us to generate the website-mdx and cli docs manually. These generate huge diffs, because we rely on a pre-commit hook to format them for us.

This simplifies website mdx generation to 1 command. It also runs the same formatter that the pre-commit uses, so you can inspect your changes before you commit, which would have been very useful over the last few releases.

Corresponding docs change: https://github.com/hashicorp/waypoint-releases/pull/39