### PR TITLE
core: fix error handling to check for nil value

### DIFF
--- a/internal/config/variables/testdata/no_default.hcl
+++ b/internal/config/variables/testdata/no_default.hcl
@@ -1,0 +1,3 @@
+variable "dinosaur" {
+  type = string
+}

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -400,8 +400,8 @@ func EvaluateVariables(
 
 	// check that all variables have a set value, including default of null
 	for name := range vs {
-		value := iv[name]
-		if value == nil {
+		v, ok := iv[name]
+		if !ok || v == nil {
 			return nil, append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Unset variable %q", name),

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -290,7 +290,6 @@ func EvaluateVariables(
 ) (Values, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	iv := Values{}
-
 	for v, def := range vs {
 		iv[v] = def.Default
 	}
@@ -400,8 +399,8 @@ func EvaluateVariables(
 
 	// check that all variables have a set value, including default of null
 	for name := range vs {
-		_, found := iv[name]
-		if !found {
+		value, _ := iv[name]
+		if value == nil {
 			return nil, append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Unset variable %q", name),

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -290,6 +290,7 @@ func EvaluateVariables(
 ) (Values, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	iv := Values{}
+
 	for v, def := range vs {
 		iv[v] = def.Default
 	}

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -400,7 +400,7 @@ func EvaluateVariables(
 
 	// check that all variables have a set value, including default of null
 	for name := range vs {
-		value, _ := iv[name]
+		value := iv[name]
 		if value == nil {
 			return nil, append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/internal/config/variables/variables_test.go
+++ b/internal/config/variables/variables_test.go
@@ -279,6 +279,13 @@ func TestVariables_EvalInputValues(t *testing.T) {
 			expected: Values{},
 			err:      "Undefined variable",
 		},
+		{
+			name:        "no assigned or default value",
+			file:        "no_default.hcl",
+			inputValues: []*pb.Variable{},
+			expected:    Values{},
+			err:         "Unset variable",
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Writing docs is a great way to find bugs!

Before, we were checking if the key existed for a variable (which it always will at this point; error handling for missing keys is earlier). Now, we are actually checking if the value is nil or not.

Before:
```
$ waypoint init
⠙ Validating configuration file...panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe17198]

goroutine 67 [running]:
github.com/hashicorp/waypoint/internal/config/variables.Values.values(0xc000964030, 0xc000b13b78)
	/home/rae/waypoint-project/waypoint/internal/config/variables/variables.go:592 +0xb8
```

After _(note the links for [docs] is still WIP and is OK for now)_:
```
$ wdi
✓ Configuration file appears valid
✓ Connection to Waypoint server was successful
✓ Project "example-python" and all apps are registered with the server.
❌ Failed to load and validate plugins!

! This validation check ensures that you have all the required plugins available
  and the configuration for each plugin (if it exists) is valid. The error message
  below should tell you which plugin(s) failed.

! <nil>: Unset variable "port"; A variable must be set or have a default value;
  see [docs] for details.
```