### PR TITLE
remove duplicate svg path used in svgJar

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -40,7 +40,7 @@ module.exports = function (defaults) {
       optimize: false,
     },
     svgJar: {
-      sourceDirs: ['node_modules/@hashicorp/structure-icons/dist', 'public/images', 'public/images/icons'],
+      sourceDirs: ['node_modules/@hashicorp/structure-icons/dist', 'public/images'],
     },
     autoImport: {
       // allows use of a CSP without 'unsafe-eval' directive

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -35,10 +35,6 @@ module.exports = function (defaults) {
         },
       },
     },
-    svg: {
-      paths: ['node_modules/@hashicorp/structure-icons/dist', 'public/images', 'public/images/icons'],
-      optimize: false,
-    },
     svgJar: {
       sourceDirs: ['node_modules/@hashicorp/structure-icons/dist', 'public/images'],
     },


### PR DESCRIPTION
- removes duplicated svg paths for svgJar
- removes unused config for ember-inline-svg (unused since we removed it in https://github.com/hashicorp/waypoint/pull/1534)

I mistakenly added both the `/images` and `images/icons` paths to the `svgJar` configuration, mimicking the ones found for [the `svg` config](https://github.com/hashicorp/waypoint/blob/main/ui/ember-cli-build.js#L39) (previously used for ember-inline-svg) and those were causing build warnings: 

<img width="664" alt="Screen Shot 2021-07-08 at 17 48 56" src="https://user-images.githubusercontent.com/1416421/124955751-985c7d80-e017-11eb-96d7-944cad17ca8a.png">
