### PR TITLE
internal/server: harden git path validation

### DIFF
--- a/.changelog/1822.txt
+++ b/.changelog/1822.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: git datasource `path` field has more validation
+```

--- a/internal/server/ptypes/job.go
+++ b/internal/server/ptypes/job.go
@@ -57,6 +57,9 @@ func ValidateJob(job *pb.Job) error {
 		validation.Field(&job.Workspace, validation.Required),
 		validation.Field(&job.TargetRunner, validation.Required),
 		validation.Field(&job.Operation, validation.Required),
+		validationext.StructField(&job.DataSource, func() []*validation.FieldRules {
+			return ValidateJobDataSourceRules(job.DataSource)
+		}),
 	))
 }
 
@@ -161,7 +164,9 @@ func isSSHKey(v *pb.Job_Git_Ssh) validation.Rule {
 }
 
 func hasNoDotDot(v interface{}) error {
-	for _, part := range filepath.SplitList(v.(string)) {
+	path := v.(string)
+	path = filepath.ToSlash(path)
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
 		if part == ".." {
 			return errors.New("must not contain '..'")
 		}

--- a/internal/server/ptypes/job_test.go
+++ b/internal/server/ptypes/job_test.go
@@ -25,7 +25,81 @@ func TestValidateJob(t *testing.T) {
 			func(j *pb.Job) { j.Id = "nope" },
 			"id: must be empty",
 		},
-	}
+
+		{
+			"git: path good",
+			func(j *pb.Job) {
+				j.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url:  "example.com",
+							Path: "foo",
+						},
+					},
+				}
+			},
+			"",
+		},
+
+		{
+			"git: path has a ..",
+			func(j *pb.Job) {
+				j.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url:  "example.com",
+							Path: "../foo",
+						},
+					},
+				}
+			},
+			"path: must not contain",
+		},
+
+		{
+			"git: path is absolute",
+			func(j *pb.Job) {
+				j.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url:  "example.com",
+							Path: "/foo/bar",
+						},
+					},
+				}
+			},
+			"path: must be relative",
+		},
+
+		{
+			"git: path starts with ./",
+			func(j *pb.Job) {
+				j.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url:  "example.com",
+							Path: "./foo/bar",
+						},
+					},
+				}
+			},
+			"path: relative path shouldn't",
+		},
+
+		{
+			"git: path has repeating /",
+			func(j *pb.Job) {
+				j.DataSource = &pb.Job_DataSource{
+					Source: &pb.Job_DataSource_Git{
+						Git: &pb.Job_Git{
+							Url:  "example.com",
+							Path: "foo//bar",
+						},
+					},
+				}
+			},
+			"path: path should not contain repeated",
+		}}
 
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {


### PR DESCRIPTION
This adds more validation to ensure that the path specified for a git
repository is what we expect. There are no bugs I've seen related to
this and users seem to be using subpaths fine, but working on #1821 made
me realize the need to be confident our paths are normalized.