### PR TITLE
Add enforce-protocol helper

### DIFF
--- a/.changelog/1836.txt
+++ b/.changelog/1836.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix release and deploy links with duplicate or missing URL protocols
+```

--- a/ui/app/components/app-card/deployment.hbs
+++ b/ui/app/components/app-card/deployment.hbs
@@ -25,8 +25,8 @@
   <:actions>
     {{#if @model.preload.deployUrl}}
       <ExternalLink
-        href="https://{{@model.preload.deployUrl}}"
-        title="Visit https://{{@model.preload.deployUrl}}"
+        href={{enforce-protocol @model.preload.deployUrl}}
+        title="Visit {{enforce-protocol @model.preload.deployUrl}}"
         class="button button--secondary button--external-link app-card__launch-link"
       >
         <Pds::Icon @type="exit" class="icon" />

--- a/ui/app/components/app-card/release.hbs
+++ b/ui/app/components/app-card/release.hbs
@@ -25,8 +25,8 @@
   <:actions>
     {{#if @model.url}}
       <ExternalLink
-        href={{@model.url}}
-        title="Visit {{@model.url}}"
+        href={{enforce-protocol @model.url}}
+        title="Visit {{enforce-protocol @model.url}}"
         class="button button--primary app-card__launch-link"
       >
         <Pds::Icon @type="exit" class="icon" />

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -32,7 +32,9 @@
     {{t "page.deployments.replaced_label"}}<b class="badge badge--version">v{{@latest.sequence}}</b>
   </small>
   {{else if (and @deployment.preload.deployUrl (not-eq @deployment.state 4))}}
-    <ExternalLink data-test-external-deployment-button href="https://{{@deployment.preload.deployUrl}}" class="button button--secondary button--external-link">
+    <ExternalLink data-test-external-deployment-button
+      href={{enforce-protocol @deployment.preload.deployUrl}}
+      class="button button--secondary button--external-link">
       <span>{{@deployment.preload.deployUrl}}</span>
       <Pds::Icon @type="exit" class="icon" />
     </ExternalLink>

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -21,7 +21,9 @@
   {{/if}}
 
   {{#if (and @isLatest @release.url)}}
-    <ExternalLink href={{@release.url}} class="button button--primary button--external-link">
+    <ExternalLink
+      href={{enforce-protocol @release.url}}
+      class="button button--primary button--external-link">
       <span>{{@release.url}}</span>
       <Pds::Icon @type="exit" class="icon" />
     </ExternalLink>

--- a/ui/app/components/latest-release-url/index.hbs
+++ b/ui/app/components/latest-release-url/index.hbs
@@ -1,5 +1,5 @@
 {{#if this.firstRelease.url}}
-<ExternalLink href={{this.firstRelease.url}} class="button button--primary button--external-link">
+<ExternalLink href={{enforce-protocol this.firstRelease.url}} class="button button--primary button--external-link">
   <span>{{this.firstRelease.url}}</span>
   <Pds::Icon @type="exit" class="icon" />
 </ExternalLink>

--- a/ui/app/helpers/enforce-protocol.ts
+++ b/ui/app/helpers/enforce-protocol.ts
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+
+export function enforceProtocol(params/*, hash*/) {
+  let str = params[0];
+
+  let isHttps = str.indexOf('https://') !== -1;
+  let isHttp = str.indexOf('http://') !== -1;
+  if (isHttps || isHttp) {
+    return str;
+  } else {
+    return `https://${str}`;
+  }
+}
+
+export default helper(enforceProtocol);

--- a/ui/app/helpers/enforce-protocol.ts
+++ b/ui/app/helpers/enforce-protocol.ts
@@ -3,8 +3,8 @@ import { helper } from '@ember/component/helper';
 export function enforceProtocol(params/*, hash*/) {
   let str = params[0];
 
-  let isHttps = str.indexOf('https://') !== -1;
-  let isHttp = str.indexOf('http://') !== -1;
+  let isHttps = str.startsWith('https://');
+  let isHttp = str.startsWith('http://');
   if (isHttps || isHttp) {
     return str;
   } else {

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -10,7 +10,9 @@
   </div>
   <div class="actions">
     <div class="button-group">
-      <ExternalLink href="https://{{@model.preload.deployUrl}}" class="button button--secondary button--external-link">
+      <ExternalLink
+        href={{enforce-protocol @model.preload.deployUrl}}
+        class="button button--secondary button--external-link">
         <span>{{lowercase @model.preload.deployUrl}}</span>
         <Pds::Icon @type="exit" class="icon" />
       </ExternalLink>

--- a/ui/tests/integration/helpers/enforce-protocol-test.ts
+++ b/ui/tests/integration/helpers/enforce-protocol-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | enforce-protocol', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it adds a protocol to non-protocol urls', async function(assert) {
+    this.set('inputValue', 'some-link.hacker.xyz');
+
+    await render(hbs`{{enforce-protocol inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'https://some-link.hacker.xyz');
+  });
+
+  test('it keeps the protocol on http urls', async function(assert) {
+    this.set('inputValue', 'http://some-link.hacker.xyz');
+
+    await render(hbs`{{enforce-protocol inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'http://some-link.hacker.xyz');
+  });
+
+  test('it keeps the protocol on https urls', async function(assert) {
+    this.set('inputValue', 'https://some-link.hacker.xyz');
+
+    await render(hbs`{{enforce-protocol inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'https://some-link.hacker.xyz');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/1834 

Following https://github.com/hashicorp/waypoint/issues/1827 it seems that URL formatting is not consistent and correctly enforced on the backend. This PR adds a `enforce-protocol` helper to make sure protocols are always added to URLs before displaying them as links. 

This is an interim fix, and as discussed with @briancain yesterday, the URLs should be consistent on the server, and we *should not* be using this helper. 

here's the plan: 
- [ ] merge this and resume normal operations
- [ ] enforce URL consistency on the server in another PR
- [ ] remove the helper from the links
- [ ] profit
