### PR TITLE
ui: Add fallback when status report is unavailable

### DIFF
--- a/ui/app/components/app-card/deployment.hbs
+++ b/ui/app/components/app-card/deployment.hbs
@@ -17,9 +17,7 @@
       @type={{icon-for-component @model.component.name}}
       class="icon app-card__component-icon"
     />
-    {{#if @model.statusReport}}
-      <StatusReportIndicator @statusReport={{@model.statusReport}} />
-    {{/if}}
+    <StatusReportIndicator @statusReport={{@model.statusReport}} />
   </:meta-secondary>
 
   <:actions>

--- a/ui/app/components/app-card/release.hbs
+++ b/ui/app/components/app-card/release.hbs
@@ -17,9 +17,7 @@
       @type={{icon-for-component @model.component.name}}
       class="icon app-card__component-icon"
     />
-    {{#if @model.statusReport}}
-      <StatusReportIndicator @statusReport={{@model.statusReport}} />
-    {{/if}}
+    <StatusReportIndicator @statusReport={{@model.statusReport}} />
   </:meta-secondary>
 
   <:actions>

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -46,6 +46,7 @@
           modifiers=(hash
             preventOverflow=(hash
               escapeWithReference=false
+              boundariesElement="viewport"
             )
           )
         }}

--- a/ui/app/components/status-report-indicator.hbs
+++ b/ui/app/components/status-report-indicator.hbs
@@ -28,6 +28,7 @@
         modifiers=(hash
           preventOverflow=(hash
             escapeWithReference=false
+            boundariesElement="viewport"
           )
         )
       }}

--- a/ui/app/components/status-report-indicator.hbs
+++ b/ui/app/components/status-report-indicator.hbs
@@ -1,6 +1,6 @@
 {{#let
   (hash
-    status=(downcase @statusReport.health.healthStatus)
+    status=(or (downcase @statusReport.health.healthStatus) "unknown")
     message=@statusReport.health.healthMessage
     isReportRunning=(eq @statusReport.status.state 1)
     completeTime=@statusReport.status.completeTime
@@ -36,7 +36,7 @@
       {{#if vars.isReportRunning}}
         {{t "status_report_indicator.tooltip.checking_now"}}
       {{else}}
-        {{vars.message}}
+        {{or vars.message (t "status_report_indicator.tooltip.unknown")}}
 
         {{#if vars.completeTime}}
           <small>

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -147,3 +147,4 @@ status_report_indicator:
   tooltip:
     checking_now: Checking now…
     last_checked: Last checked
+    unknown: Status unknown


### PR DESCRIPTION
## Why the change?

Closes #1824 

## What does it look like?

| Before | After |
| --- | --- |
| <img alt="deployment with dead space where status report should be" src="https://user-images.githubusercontent.com/34030/125462955-0716b896-d380-4148-9bb3-6975dd19f0ef.png"> | <img alt="deployment with fallback status report" src="https://user-images.githubusercontent.com/34030/125463033-71e58d66-a462-49c1-a184-fa876706358d.png"> |

## How do I verify it?

1. Check out the branch
2. Boot the dev server
   ```
   cd ui && yarn start
   ```
3. Visit [http://localhost:4200/default/mutable-project/app/mutable-application](http://localhost:4200/default/mutable-project/app/mutable-application)
4. Verify you see something reasonable next to the little Nomad icons
5. Visit [http://localhost:4200/default/marketing-public/app/wp-matrix/logs](http://localhost:4200/default/marketing-public/app/wp-matrix/logs)
6. Verify you see the proper statuses