### PR TITLE
ui: Incorporate pushed artifacts into build display

### DIFF
--- a/.changelog/1840.txt
+++ b/.changelog/1840.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Incorporate pushed artifacts into build display
+```

--- a/ui/app/components/app-card/build.hbs
+++ b/ui/app/components/app-card/build.hbs
@@ -9,28 +9,25 @@
     >
       <b class="badge badge--version">v{{@model.sequence}}</b>
     </LinkTo>
-    <OperationStatusIndicator @status={{@model.status}} />
+    <OperationStatusIndicator @status={{or @model.pushedArtifact.status @model.status}} />
   </:meta-primary>
 
   <:meta-secondary>
-    <Pds::Icon
-      @type={{icon-for-component @model.component.name}}
-      class="icon app-card__component-icon"
-    />
-
-    <span>
-      {{#if (eq @model.status.state 2)}}
-        Built with
-        <b>{{component-name @model.component.name}}</b>
-        in
-        {{date-format-distance @model.status.startTime.seconds @model.status.completeTime.seconds }}
-      {{else if (eq @model.status.state 3)}}
-        Failed to build with
-        <b>{{component-name @model.component.name}}</b>
-      {{else}}
-        Building with
-        <b>{{component-name @model.component.name}}</b>
-      {{/if}}
-    </span>
+    {{#let (or @model.pushedArtifact @model) as |operation|}}
+      <Pds::Icon
+        @type={{icon-for-component operation.component.name}}
+        class="icon app-card__component-icon"
+      />
+      <span>
+        {{t
+          (concat
+            "app_card_build.label.prefix"
+            ".type-" operation.component.type
+            ".state-" operation.status.state
+          )
+        }}
+        <b>{{component-name operation.component.name}}</b>
+      </span>
+    {{/let}}
   </:meta-secondary>
 </AppCard>

--- a/ui/app/components/app-card/build.hbs
+++ b/ui/app/components/app-card/build.hbs
@@ -21,7 +21,7 @@
       <span>
         {{t
           (concat
-            "app_card_build.label.prefix"
+            "build_status"
             ".type-" operation.component.type
             ".state-" operation.status.state
           )

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -11,7 +11,7 @@
         <span>
           {{t
             (concat
-              "app_item_build.label.prefix"
+              "build_status"
               ".type-" operation.component.type
               ".state-" operation.status.state
             )

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -1,34 +1,39 @@
-<li class="app-item">
+<li class="app-item" data-test-app-item-build>
   <LinkTo @route="workspace.projects.project.app.build" @models={{array @build.sequence}}>
-    <p>
-      <b class="badge badge--version">v{{@build.sequence}}</b>
-    </p>
+    <b class="badge badge--version">v{{@build.sequence}}</b>
     <small class="app-item__meta__secondary">
-      <Pds::Icon @type={{icon-for-component @build.component.name}} class="icon" />
-      <span>{{if (eq @model.status.state 1) 'Building' 'Built'}} with
-        <b>{{titleize @build.component.name}}</b>
-        {{#if (eq @build.status.state 1)}}
-          (Started {{date-format-distance-to-now @build.status.startTime.seconds }})
-        {{else}}
-          {{date-format-distance-to-now @build.status.completeTime.seconds }}
-        {{/if}}
-      </span>
+      {{#let (or @build.pushedArtifact @build) as |operation|}}
+        <Pds::Icon
+          @type={{icon-for-component operation.component.name}}
+          class="icon"
+        />
+
+        <span>
+          {{t
+            (concat
+              "app_item_build.label.prefix"
+              ".type-" operation.component.type
+              ".state-" operation.status.state
+            )
+          }}
+          <b>{{component-name operation.component.name}}</b>
+          <OperationStatusIndicator @status={{operation.status}} @matchTypography={{true}} />
+        </span>
+      {{/let}}
     </small>
   </LinkTo>
-  {{#if (eq @build.status.state 1)}}
-    <b class="badge">
+
+  {{#if (and (eq @build.status.state 2) (eq @build.pushedArtifact.status.state 2))}}
+    <b class="badge badge--info">
       <Pds::Icon @type="clock-outline" class="icon" />
-      <span>Building...</span>
-    </b>
-  {{else if (eq @build.status.state 2)}}
-    <b class="badge badge--success">
-      <Pds::Icon @type="check-plain" class="icon" />
-      <span>Built in {{date-format-distance @build.status.startTime.seconds @build.status.completeTime.seconds }}</span>
-    </b>
-  {{else if (eq @build.status.state 3)}}
-    <b class="badge badge--error">
-      <Pds::Icon @type="alert-triangle" class="icon" />
-      <span>Build failed</span>
+      <span>
+        {{t "app_item_build.built_in"
+          duration=(date-format-distance
+            @build.status.startTime.seconds
+            @build.status.completeTime.seconds
+          )
+        }}
+      </span>
     </b>
   {{/if}}
 </li>

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -32,7 +32,7 @@
   as |vars|
 }}
   <span
-    data-test-operation-status-indicator
+    data-test-operation-status-indicator={{vars.state}}
     class="
       operation-status-indicator
       operation-status-indicator--{{vars.state}}

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -1,3 +1,21 @@
+{{!--
+
+  ## Usage
+
+  <OperationStatusIndicator
+    @status={{build.status}}
+  />
+
+  If you would like the indicator to match the surrounding typography,
+  pass `@matchTypography={{true}}`:
+
+  <OperationStatusIndicator
+    @status={{build.status}}
+    @matchTypography={{true}}
+  />
+
+--}}
+
 {{#let
   (hash
     state=(or
@@ -18,6 +36,7 @@
     class="
       operation-status-indicator
       operation-status-indicator--{{vars.state}}
+      {{if @matchTypography "operation-status-indicator--match-typography"}}
       focus-ring
     "
     tabindex="0"

--- a/ui/app/helpers/component-name.ts
+++ b/ui/app/helpers/component-name.ts
@@ -16,7 +16,13 @@ export function componentName([component]: [string]): string {
   });
 
   // Replace any separators that are not human readable
-  return result.replace(replace, ' ');
+  result = result.replace(replace, ' ');
+
+  // Replace brand initialisms
+  result = result.replace('Aws', 'AWS');
+  result = result.replace('Ecr', 'ECR');
+
+  return result;
 }
 
 export default helper(componentName);

--- a/ui/app/helpers/icon-for-component.ts
+++ b/ui/app/helpers/icon-for-component.ts
@@ -4,8 +4,8 @@ import { helper } from '@ember/component/helper';
 export function iconForComponent([component]: [string]): string {
   switch (component) {
     case 'aws-ec2':
-      return 'logo-aws-color';
     case 'aws-ecs':
+    case 'aws-ecr':
       return 'logo-aws-color';
     case 'azure-container-instances':
       return 'logo-azure-color';

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -19,6 +19,8 @@ import {
   ListStatusReportsRequest,
   ListStatusReportsResponse,
   GetLatestStatusReportRequest,
+  ListPushedArtifactsRequest,
+  PushedArtifact,
 } from 'waypoint-pb';
 import config from 'waypoint/config/environment';
 
@@ -82,6 +84,25 @@ export default class ApiService extends Service {
     let resp: ListBuildsResponse = await this.client.listBuilds(req, this.WithMeta());
 
     return resp.getBuildsList().map((d) => d.toObject());
+  }
+
+  async listPushedArtifacts(
+    wsRef: Ref.Workspace,
+    appRef: Ref.Application
+  ): Promise<PushedArtifact.AsObject[]> {
+    let request = new ListPushedArtifactsRequest();
+
+    request.setApplication(appRef);
+    request.setWorkspace(wsRef);
+
+    // TODO(jgwhite): request.setIncludeBuild
+    // TODO(jgwhite): request.setOrder
+    // TODO(jgwhite): request.setStatusList
+
+    let response = await this.client.listPushedArtifacts(request, this.WithMeta());
+    let result = response.getArtifactsList().map((pa) => pa.toObject());
+
+    return result;
   }
 
   async listReleases(wsRef: Ref.Workspace, appRef: Ref.Application): Promise<Release.AsObject[]> {

--- a/ui/app/styles/components/badge.scss
+++ b/ui/app/styles/components/badge.scss
@@ -27,6 +27,13 @@
     background: rgb(var(--warning));
   }
 
+  &--info {
+    @media (prefers-color-scheme: light) {
+      color: color.$ui-cool-gray-700;
+      background: color.$ui-cool-gray-100;
+    }
+  }
+
   .icon {
     width: scale.$base;
     height: scale.$base;

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -6,4 +6,9 @@
   &--error {
     color: rgb(var(--error-text));
   }
+
+  &--match-typography {
+    font-size: inherit;
+    font-weight: inherit;
+  }
 }

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -1,49 +1,37 @@
-<PageHeader @iconName="build">
-  <div class="title">
-    <h2>
-      <b class="badge badge--version">v{{@model.sequence}}</b>
-    </h2>
-    <small>
-      <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
-      <span>{{if (eq @model.status.state 1) 'Building' 'Built'}} with
-        <b>{{titleize @model.component.name}}</b>
-        {{#if (eq @model.status.state 1)}}
-        (Started {{date-format-distance-to-now @model.status.startTime.seconds }})
-        {{else}}
-        {{date-format-distance-to-now @model.status.completeTime.seconds }}
-        {{/if}}
-      </span>
-    </small>
-  </div>
-  <div class="actions">
-    <Actions::Deploy @sequence={{@model.sequence}} />
-  </div>
-</PageHeader>
+{{#let (or @model.pushedArtifact @model) as |operation|}}
+  <PageHeader @iconName="build">
+    <div class="title">
+      <h2>
+        <b class="badge badge--version">v{{@model.sequence}}</b>
+      </h2>
+      <small>
+        <Pds::Icon
+          @type={{icon-for-component operation.component.name}}
+          class="icon"
+        />
 
-<div class="status-row">
-  <div class="item">
-    {{#if (eq @model.status.state 1)}}
-    <b class="badge">
-      <Pds::Icon @type="clock-outline" class="icon" />
-      <span>Build running...</span>
-    </b>
-    {{else if (eq @model.status.state 2)}}
-    <b class="badge badge--success">
-      <Pds::Icon @type="check-plain" class="icon" />
-      <span>Built in {{date-format-distance @model.status.startTime.seconds @model.status.completeTime.seconds }}</span>
-    </b>
-    {{else if (eq @model.status.state 3)}}
-    <b class="badge badge--error">
-      <Pds::Icon @type="alert-triangle" class="icon" />
-      <span>
-        Build failed
-        {{#if @model.status.error.message}}
-          : {{@model.status.error.message}}
-        {{/if}}
-      </span>
-    </b>
-    {{/if}}
+        <span>
+          {{t
+            (concat
+              "build_status"
+              ".type-" operation.component.type
+              ".state-" operation.status.state
+            )
+          }}
+          <b>{{component-name operation.component.name}}</b>
+        </span>
+      </small>
+    </div>
+    <div class="actions">
+      <Actions::Deploy @sequence={{@model.sequence}} />
+    </div>
+  </PageHeader>
+
+  <div class="status-row">
+    <div class="item">
+      <OperationStatusIndicator @status={{operation.status}} />
+    </div>
   </div>
-</div>
+{{/let}}
 
 <OperationLogs @jobId={{@model.jobId}} />

--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -13,6 +13,7 @@ import * as versionInfo from './services/version-info';
 import * as statusReport from './services/status-report';
 import * as job from './services/job';
 import * as log from './services/log';
+import * as pushedArtifact from './services/pushed-artifact';
 
 export default function (this: Server) {
   this.namespace = 'hashicorp.waypoint.Waypoint';
@@ -48,6 +49,7 @@ export default function (this: Server) {
   this.post('/GetLatestStatusReport', statusReport.getLatest);
   this.post('/GetJobStream', job.stream);
   this.post('/GetLogStream', log.stream);
+  this.post('/ListPushedArtifacts', pushedArtifact.list);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/factories/component.ts
+++ b/ui/mirage/factories/component.ts
@@ -48,6 +48,10 @@ export default Factory.extend({
     name: 'kubernetes-apply',
   }),
 
+  'aws-ecr': trait({
+    name: 'aws-ecr',
+  }),
+
   'with-random-name': trait({
     afterCreate(component) {
       component.update('name', randomNameForType(component.type));

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -93,30 +93,37 @@ export default Factory.extend({
         server.create('build', 'docker', 'days-old-success', {
           application,
           sequence: 1,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'days-old-success'),
         }),
         server.create('build', 'docker', 'days-old-success', {
           application,
           sequence: 2,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'days-old-success'),
         }),
         server.create('build', 'docker', 'hours-old-success', {
           application,
           sequence: 3,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'hours-old-success'),
         }),
         server.create('build', 'docker', 'hours-old-success', {
           application,
           sequence: 4,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'hours-old-success'),
         }),
         server.create('build', 'docker', 'minutes-old-success', {
           application,
           sequence: 5,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'minutes-old-success'),
         }),
         server.create('build', 'docker', 'minutes-old-success', {
           application,
           sequence: 6,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'minutes-old-success'),
         }),
         server.create('build', 'docker', 'seconds-old-success', {
           application,
           sequence: 7,
+          pushedArtifact: server.create('pushed-artifact', 'docker', 'seconds-old-success'),
         }),
       ];
 

--- a/ui/mirage/factories/pushed-artifact.ts
+++ b/ui/mirage/factories/pushed-artifact.ts
@@ -1,41 +1,37 @@
-import { Factory, trait, association } from 'ember-cli-mirage';
+import { Factory, association, trait } from 'ember-cli-mirage';
 import { fakeId } from '../utils';
 
 export default Factory.extend({
   id: () => fakeId(),
   sequence: (i) => i + 1,
 
-  afterCreate(build, server) {
-    if (!build.workspace) {
+  afterCreate(pushedArtifact, server) {
+    if (!pushedArtifact.workspace) {
       let workspace =
         server.schema.workspaces.findBy({ name: 'default' }) || server.create('workspace', 'default');
-      build.update('workspace', workspace);
+      pushedArtifact.update('workspace', workspace);
     }
-
-    build.pushedArtifact?.update('application', build.application);
-    build.pushedArtifact?.update('workspace', build.workspace);
   },
 
   random: trait({
-    labels: () => ({
-      'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
-      'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
-    }),
-    component: association('builder', 'with-random-name'),
+    component: association('registry', 'with-random-name'),
     status: association('random'),
-    pushedArtifact: association('random'),
   }),
 
   docker: trait({
-    component: association('builder', 'docker'),
+    component: association('registry', 'docker'),
   }),
 
-  pack: trait({
-    component: association('builder', 'pack'),
+  'aws-ecr': trait({
+    component: association('registry', 'aws-ecr'),
   }),
 
   'seconds-old-success': trait({
     status: association('random', 'success', 'seconds-old'),
+  }),
+
+  'seconds-old-error': trait({
+    status: association('random', 'error', 'seconds-old'),
   }),
 
   'minutes-old-success': trait({

--- a/ui/mirage/factories/status.ts
+++ b/ui/mirage/factories/status.ts
@@ -20,6 +20,10 @@ export default Factory.extend({
     state: 'SUCCESS',
   }),
 
+  error: trait({
+    state: 'ERROR',
+  }),
+
   'seconds-old': trait({
     completeTime: () => new Date(),
   }),

--- a/ui/mirage/models/pushed-artifact.ts
+++ b/ui/mirage/models/pushed-artifact.ts
@@ -1,31 +1,27 @@
-import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
-import { Build } from 'waypoint-pb';
+import { Model, belongsTo } from 'miragejs';
+import { PushedArtifact } from 'waypoint-pb';
 
 export default Model.extend({
   application: belongsTo(),
-  workspace: belongsTo(),
+  build: belongsTo({ inverse: 'pushedArtifact' }),
   component: belongsTo({ inverse: 'owner' }),
   status: belongsTo({ inverse: 'owner' }),
-  deployments: hasMany(),
-  pushedArtifact: belongsTo({ inverse: 'build' }),
+  workspace: belongsTo(),
 
-  toProtobuf(): Build {
-    let result = new Build();
+  toProtobuf(): PushedArtifact {
+    let result = new PushedArtifact();
 
     result.setApplication(this.application?.toProtobufRef());
-    // TODO: result.setArtifact(...)
+    // TODO: result.setArtifact
+    result.setBuild(this.build?.toProtobuf());
+    result.setBuildId(this.build?.id);
     result.setComponent(this.component?.toProtobuf());
-    // TODO: result.setExtension(...)
     result.setId(this.id);
-    result.setJobId(this.JobId);
+    result.setJobId(this.jobId);
     result.setSequence(this.sequence);
     result.setStatus(this.status?.toProtobuf());
     result.setTemplateData(this.templateData);
     result.setWorkspace(this.workspace?.toProtobufRef());
-
-    for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
-      result.getLabelsMap().set(key, value);
-    }
 
     return result;
   },

--- a/ui/mirage/services/pushed-artifact.ts
+++ b/ui/mirage/services/pushed-artifact.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'miragejs';
+import { ListPushedArtifactsRequest, ListPushedArtifactsResponse } from 'waypoint-pb';
+import { decode } from '../helpers/protobufs';
+
+export function list(schema: any, request: Request): Response {
+  let requestMsg = decode(ListPushedArtifactsRequest, request.requestBody);
+  let projectName = requestMsg.getApplication().getProject();
+  let appName = requestMsg.getApplication().getApplication();
+  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let project = schema.projects.findBy({ name: projectName });
+  let application = schema.applications.findBy({ name: appName, projectId: project.id });
+  let workspace = schema.workspaces.findBy({ name: workspaceName });
+  let pushedArtifacts = schema.pushedArtifacts.where({
+    applicationId: application?.id,
+    workspaceId: workspace?.id,
+  });
+  let pushedArtifactProtobufs = pushedArtifacts.models.map((b) => b.toProtobuf());
+  let resp = new ListPushedArtifactsResponse();
+
+  pushedArtifactProtobufs.sort((a, b) => b.getSequence() - a.getSequence());
+
+  resp.setArtifactsList(pushedArtifactProtobufs);
+
+  return this.serialize(resp, 'application');
+}

--- a/ui/tests/integration/components/app-item/build-test.ts
+++ b/ui/tests/integration/components/app-item/build-test.ts
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { getUnixTime, subMinutes } from 'date-fns';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+
+module('Integration | Component | app-item/build', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('with a build and a push', async function (assert) {
+    this.set('build', {
+      sequence: 3,
+      status: {
+        state: 2,
+        startTime: minutesAgo(3),
+        completeTime: minutesAgo(2),
+      },
+      component: {
+        type: 1,
+        name: 'docker',
+      },
+      pushedArtifact: {
+        component: {
+          type: 2,
+          name: 'docker',
+        },
+        status: {
+          state: 2,
+          startTime: minutesAgo(2),
+          completeTime: minutesAgo(1),
+        },
+      },
+    });
+
+    await render(hbs`
+      <ul>
+        <AppItem::Build @build={{this.build}} />
+      </ul>
+    `);
+    await a11yAudit();
+
+    assert.dom('[data-test-app-item-build]').includesText('v3');
+    assert.dom('[data-test-icon-type="logo-docker-color"]').exists();
+    assert.dom('[data-test-app-item-build]').includesText('Pushed to Docker');
+    assert.dom('[data-test-operation-status-indicator="success"]').exists();
+    assert.dom('[data-test-app-item-build]').includesText('1 minute ago');
+    assert.dom('[data-test-app-item-build]').includesText('Built in 1 minute');
+  });
+
+  test('with no push', async function (assert) {
+    this.set('build', {
+      sequence: 3,
+      status: {
+        state: 2,
+        startTime: minutesAgo(3),
+        completeTime: minutesAgo(2),
+      },
+      component: {
+        type: 1,
+        name: 'docker',
+      },
+      pushedArtifact: null,
+    });
+
+    await render(hbs`
+      <ul>
+        <AppItem::Build @build={{this.build}} />
+      </ul>
+    `);
+    await a11yAudit();
+
+    assert.dom('[data-test-app-item-build]').includesText('v3');
+    assert.dom('[data-test-icon-type="logo-docker-color"]').exists();
+    assert.dom('[data-test-app-item-build]').includesText('Built with Docker');
+    assert.dom('[data-test-operation-status-indicator="success"]').exists();
+    assert.dom('[data-test-app-item-build]').includesText('2 minutes ago');
+  });
+});
+
+function minutesAgo(n: number): Timestamp.AsObject {
+  let now = new Date();
+  let date = subMinutes(now, n);
+  let result = {
+    seconds: getUnixTime(date),
+    nanos: 0,
+  };
+
+  return result;
+}

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -162,3 +162,18 @@ app_card_build:
         state-1: Pushing to # RUNNING
         state-2: Pushed to # SUCCESS
         state-3: Failed to push to # ERROR
+
+app_item_build:
+  label:
+    prefix:
+      type-1: # BUILDER
+        state-0: Building with # UNKNOWN
+        state-1: Building with # RUNNING
+        state-2: Built with # SUCCESS
+        state-3: Failed to build with # ERROR
+      type-2: # REGISTRY
+        state-0: Pushing to # UNKNOWN
+        state-1: Pushing to # RUNNING
+        state-2: Pushed to # SUCCESS
+        state-3: Failed to push to # ERROR
+  built_in: Built in {duration}

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -148,3 +148,17 @@ status_report_indicator:
     checking_now: Checking now…
     last_checked: Last checked
     unknown: Status unknown
+
+app_card_build:
+  label:
+    prefix:
+      type-1: # BUILDER
+        state-0: Building with # UNKNOWN
+        state-1: Building with # RUNNING
+        state-2: Built with # SUCCESS
+        state-3: Failed to build with # ERROR
+      type-2: # REGISTRY
+        state-0: Pushing to # UNKNOWN
+        state-1: Pushing to # RUNNING
+        state-2: Pushed to # SUCCESS
+        state-3: Failed to push to # ERROR

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -149,31 +149,17 @@ status_report_indicator:
     last_checked: Last checked
     unknown: Status unknown
 
-app_card_build:
-  label:
-    prefix:
-      type-1: # BUILDER
-        state-0: Building with # UNKNOWN
-        state-1: Building with # RUNNING
-        state-2: Built with # SUCCESS
-        state-3: Failed to build with # ERROR
-      type-2: # REGISTRY
-        state-0: Pushing to # UNKNOWN
-        state-1: Pushing to # RUNNING
-        state-2: Pushed to # SUCCESS
-        state-3: Failed to push to # ERROR
-
 app_item_build:
-  label:
-    prefix:
-      type-1: # BUILDER
-        state-0: Building with # UNKNOWN
-        state-1: Building with # RUNNING
-        state-2: Built with # SUCCESS
-        state-3: Failed to build with # ERROR
-      type-2: # REGISTRY
-        state-0: Pushing to # UNKNOWN
-        state-1: Pushing to # RUNNING
-        state-2: Pushed to # SUCCESS
-        state-3: Failed to push to # ERROR
   built_in: Built in {duration}
+
+build_status:
+  type-1: # BUILDER
+    state-0: Building with # UNKNOWN
+    state-1: Building with # RUNNING
+    state-2: Built with # SUCCESS
+    state-3: Failed to build with # ERROR
+  type-2: # REGISTRY
+    state-0: Pushing to # UNKNOWN
+    state-1: Pushing to # RUNNING
+    state-2: Pushed to # SUCCESS
+    state-3: Failed to push to # ERROR


### PR DESCRIPTION
## Why the change?

Primarily to address #1287, though adding the foundations for artifact-awareness will likely be useful for other features.

## Could we load pushed artifacts in a more efficient manner?

“Yes, but not yet…”

We’re currently exploring the idea of adding dedicated aggregate API methods for aspects of the UI such as this. Watch this space. Until we have such a thing, this load-and-cross-reference approach is the only one available.

## What’s the plan?

- [x] Add changelog entry
- [x] Add pushed artifacts to Mirage
- [x] Refactor app route
- [x] Load pushed artifacts in app route
- [x] Incorporate push status into `<AppCard::Build>`
- [x] Incorporate push status into `<AppItem::Build>`
- [x] Fix capitalization of initialisms (i.e. AWS)
- [x] Add aws-ecr to icon-for-component
- [x] Write some test steps
- [x] Improve design

## What does it look like?

<img width="1392" alt="2-1-building" src="https://user-images.githubusercontent.com/34030/126171871-542aacb8-700f-4bac-9c27-eadb83d23ccb.png">
<img width="1392" alt="2-2-built" src="https://user-images.githubusercontent.com/34030/126171882-e6298e2a-a138-4886-8b24-267527fc699d.png">
<img width="1392" alt="2-3-pushing" src="https://user-images.githubusercontent.com/34030/126171886-d6dfcfd3-7a68-4f3e-85c6-ddd806cd40c2.png">
<img width="1392" alt="2-4-pushed" src="https://user-images.githubusercontent.com/34030/126171890-357d95d4-6717-412d-9037-60fdcbb34f2b.png">
<img width="1392" alt="2-8-build-error" src="https://user-images.githubusercontent.com/34030/126171895-4cddba16-16c6-46e6-b6e8-36ea8838a7af.png">
<img width="1392" alt="2-9-push-error" src="https://user-images.githubusercontent.com/34030/126171900-de78c794-900c-4f24-b6c2-dcf338dc4c2a.png">

Obligatory video:

https://user-images.githubusercontent.com/34030/126233744-a8fdbf9b-8c62-4318-934e-d55e1ba432f4.mov

## How do I test it?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/pushed-artifacts
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the app](http://localhost:4200/default/marketing-public/app/wp-matrix/builds)
4. Verify you see information about pushed artifacts in addition to builds
5. Verify that the UI makes sense

### For realsies

1. Check out the branch:
   ```sh
   git checkout ui/pushed-artifacts
   ```
2. Build the ember app
   ```sh
   (cd ui && make)
   ```
3. Bundle the static assets
   ```sh
   make static-assets
   ```
4. Build the dev server
   ```sh
   make docker/server
   ```
5. Build the CLI
   ```sh
   make bin
   ```
6. Install waypoint on your platform of choice, i.e.
   ```sh
   ./waypoint install -platform=kubernetes -accept-tos -k8s-server-image=waypoint:dev
   ```
7. Open the UI
   ```
   ./waypoint ui -authenticate
   ```
8. Try out an example app of your choice (i.e. [kubernetes/nodejs](https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs))
9. Verify that you see information about pushed artifacts in the UI
10. Trying triggering a failed push (see #1287 for an example)
11. Verify you see the overall state of the build is failed