### PR TITLE
internal/cli: waypoint login supports tokens

### DIFF
--- a/.changelog/1848.txt
+++ b/.changelog/1848.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: can login with a token using the new `waypoint login` command
+```

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -78,6 +78,12 @@ func (c *LoginCommand) Run(args []string) int {
 	// which is already configured with the basic server connection stuff
 	// from this command.
 	newContext := c.flagConnection
+	if c.clientContext != nil {
+		// clientContext is always set to our actual context we used to
+		// create our client. So this will accurately grab non-flag based
+		// access i.e. loading our default context.
+		newContext = *c.clientContext
+	}
 	newContext.Server.AuthToken = token
 	newContext.Server.RequireAuth = true
 

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -285,7 +285,7 @@ Usage: waypoint login [server address]
 const (
 	errNoAuthMethods = `
 Only token-based authentication is allowed by this server. To login using
-a token, use the "waypoint context create" command.
+a token, use the "waypoint login" command with the "-token" flag.
 `
 
 	errManyAuthMethods = `


### PR DESCRIPTION
This builds on `waypoint login` introduced in #1831 for OIDC to provide a much nicer token-based login experience.

Prior to this, users had to use `waypoint context create` and specifically had to use a _login_ token with that. If they had an _invite_ token, they first had to convert it using `waypoint token exchange`. This is all friction and not obvious to users (though the underlying machinery is important).

Users can now use `waypoint login` with just the server address and ANY token and the CLI automatically does the right thing. It checks if the token is an invite token and automatically exchanges it. It also infers all the TLS and server connection settings based on the hostname (same as OIDC).

## Demo

https://user-images.githubusercontent.com/1299/125501910-bd673d5f-7221-43a3-a732-057e2210f2bf.mp4

