### PR TITLE
internal/cli: detect flags after positional args and error

### DIFF
--- a/.changelog/1849.txt
+++ b/.changelog/1849.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: detect flags after arguments and show user-friendly error
+```

--- a/internal/cli/base_test.go
+++ b/internal/cli/base_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+)
+
+func TestCheckFlagsAfterArgs(t *testing.T) {
+	var boolVal bool
+
+	cases := []struct {
+		Name string
+		Flag func(*flag.Sets)
+		Args []string
+		Err  bool
+	}{
+		{
+			"empty args",
+			func(*flag.Sets) {},
+			[]string{},
+			false,
+		},
+
+		{
+			"flag with space",
+			func(sets *flag.Sets) {
+				s := sets.NewSet("test")
+				s.BoolVar(&flag.BoolVar{Name: "foo", Target: &boolVal})
+			},
+			[]string{"-foo", "bar"},
+			true,
+		},
+
+		{
+			"double hyphen",
+			func(sets *flag.Sets) {
+				s := sets.NewSet("test")
+				s.BoolVar(&flag.BoolVar{Name: "foo", Target: &boolVal})
+			},
+			[]string{"--foo", "bar"},
+			true,
+		},
+
+		{
+			"equals",
+			func(sets *flag.Sets) {
+				s := sets.NewSet("test")
+				s.BoolVar(&flag.BoolVar{Name: "foo", Target: &boolVal})
+			},
+			[]string{"--foo=bar"},
+			true,
+		},
+
+		{
+			"ignores after double hyphen",
+			func(sets *flag.Sets) {
+				s := sets.NewSet("test")
+				s.BoolVar(&flag.BoolVar{Name: "foo", Target: &boolVal})
+			},
+			[]string{"hello", "--", "--foo=bar"},
+			false,
+		},
+
+		{
+			"other flag",
+			func(sets *flag.Sets) {
+				s := sets.NewSet("test")
+				s.BoolVar(&flag.BoolVar{Name: "foo", Target: &boolVal})
+			},
+			[]string{"--bar=bar"},
+			false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			require := require.New(t)
+
+			s := flag.NewSets()
+			tt.Flag(s)
+
+			err := checkFlagsAfterArgs(tt.Args, s)
+			if !tt.Err {
+				require.NoError(err)
+				return
+			}
+			require.Error(err)
+		})
+	}
+}


### PR DESCRIPTION
This introduces a heuristic for detecting flag usage after positional
arguments. This is an error for the stdlib flag package that we use.
This has come up many times before (see #1510) and I believe this will
make the experience smoother.

**Note:** I plan on writing tests for this check function, but want to gauge interest.

Example:

<img width="765" alt="CleanShot 2021-07-13 at 11 45 28@2x" src="https://user-images.githubusercontent.com/1299/125507900-94035bc2-7187-4065-9b61-cf87d5654401.png">
