### PR TITLE
UI: Default URLS for details pages use sequence #

### DIFF
--- a/.changelog/1863.txt
+++ b/.changelog/1863.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Updated URL format for artifact detail pages to align with CLI UX focusing on sequence # over ULIDs
+```

--- a/ui/app/components/app-card/build.hbs
+++ b/ui/app/components/app-card/build.hbs
@@ -4,7 +4,7 @@
   <:meta-primary>
     <LinkTo
       @route="workspace.projects.project.app.build"
-      @models={{array @model.id}}
+      @models={{array @model.sequence}}
       class="app-card__sequence-link"
     >
       <b class="badge badge--version">v{{@model.sequence}}</b>

--- a/ui/app/components/app-card/deployment.hbs
+++ b/ui/app/components/app-card/deployment.hbs
@@ -4,7 +4,7 @@
   <:meta-primary>
     <LinkTo
       @route="workspace.projects.project.app.deployment"
-      @models={{array @model.id}}
+      @models={{array @model.sequence}}
       class="app-card__sequence-link"
     >
       <b class="badge badge--version">v{{@model.sequence}}</b>

--- a/ui/app/components/app-card/release.hbs
+++ b/ui/app/components/app-card/release.hbs
@@ -4,7 +4,7 @@
   <:meta-primary>
     <LinkTo
       @route="workspace.projects.project.app.release"
-      @models={{array @model.id}}
+      @models={{array @model.sequence}}
       class="app-card__sequence-link"
     >
       <b class="badge badge--version">v{{@model.sequence}}</b>

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -1,5 +1,5 @@
 <li class="app-item">
-  <LinkTo @route="workspace.projects.project.app.build" @models={{array @build.id}}>
+  <LinkTo @route="workspace.projects.project.app.build" @models={{array @build.sequence}}>
     <p>
       <b class="badge badge--version">v{{@build.sequence}}</b>
     </p>

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -3,7 +3,7 @@
   {{if (not-eq @deployment.sequence @latest.sequence) "app-item--previous"}}
   {{if (eq @deployment.state 4) "app-item--destroyed"}}"
 >
-  <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @deployment.id}}>
+  <LinkTo @route="workspace.projects.project.app.deployment" @models={{array @deployment.sequence}}>
     <p>
       <b class="badge badge--version">v{{@deployment.sequence}}</b>
     </p>

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -1,5 +1,5 @@
 <li class="app-item">
-  <LinkTo @route="workspace.projects.project.app.release" @models={{array @release.id}}>
+  <LinkTo @route="workspace.projects.project.app.release" @models={{array @release.sequence}}>
     <p>
       <b class="badge badge--version">v{{@release.sequence}}</b>
     </p>

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -39,7 +39,8 @@ Router.map(function () {
         });
         this.route('app', { path: '/app/:app_id' }, function () {
           this.route('builds');
-          this.route('build', { path: '/build/:build_id' });
+          this.route('build-id', { path: '/build/:build_id' });
+          this.route('build', { path: '/build/seq/:sequence' });
           this.route('deployments');
           this.route('deployment', { path: '/deployment/:deployment_id' });
           this.route('releases');

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -42,9 +42,11 @@ Router.map(function () {
           this.route('build-id', { path: '/build/:build_id' });
           this.route('build', { path: '/build/seq/:sequence' });
           this.route('deployments');
-          this.route('deployment', { path: '/deployment/:deployment_id' });
+          this.route('deployment-id', { path: '/deployment/:deployment_id' });
+          this.route('deployment', { path: '/deployment/seq/:sequence' });
           this.route('releases');
-          this.route('release', { path: '/release/:release_id' });
+          this.route('release-id', { path: '/release/:release_id' });
+          this.route('release', { path: '/release/seq/:sequence' });
           this.route('logs');
           this.route('exec');
         });

--- a/ui/app/routes/workspace/projects/project/app/build-id.ts
+++ b/ui/app/routes/workspace/projects/project/app/build-id.ts
@@ -1,0 +1,25 @@
+import { Ref, GetBuildRequest } from 'waypoint-pb';
+import BuildDetail from './build';
+
+interface BuildModelIdParams {
+  build_id: string;
+}
+
+export default class WorkspaceProjectsProjectAppBuildId extends BuildDetail {
+  renderTemplate() {
+    this.render('workspace/projects/project/app/build', {
+      into: 'workspace/projects/project',
+    });
+  }
+
+  async model(params: BuildModelIdParams) {
+    // Setup the build request
+    let ref = new Ref.Operation();
+    ref.setId(params.build_id);
+    let req = new GetBuildRequest();
+    req.setRef(ref);
+
+    let build = await this.api.client.getBuild(req, this.api.WithMeta());
+    return build.toObject();
+  }
+}

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -29,11 +29,13 @@ export default class BuildDetail extends Route {
   async model(params: BuildModelParams) {
     // Setup the build request
     let { builds } = this.modelFor('workspace.projects.project.app');
-    let { id: build_id } = builds.find((obj) => obj.sequence == params.sequence);
+    let { id: build_id } = builds.find((obj) => obj.sequence === Number(params.sequence));
+
     let ref = new Ref.Operation();
     ref.setId(build_id);
     let req = new GetBuildRequest();
     req.setRef(ref);
+
     let build = await this.api.client.getBuild(req, this.api.WithMeta());
     return build.toObject();
   }

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -5,7 +5,7 @@ import { Ref, GetBuildRequest } from 'waypoint-pb';
 import { AppRouteModel } from '../app';
 
 interface BuildModelParams {
-  build_id: string;
+  sequence: number;
 }
 export default class BuildDetail extends Route {
   @service api!: ApiService;
@@ -28,11 +28,12 @@ export default class BuildDetail extends Route {
 
   async model(params: BuildModelParams) {
     // Setup the build request
+    let { builds } = this.modelFor('workspace.projects.project.app');
+    let { id: build_id } = builds.find((obj) => obj.sequence == params.sequence);
     let ref = new Ref.Operation();
-    ref.setId(params.build_id);
+    ref.setId(build_id);
     let req = new GetBuildRequest();
     req.setRef(ref);
-
     let build = await this.api.client.getBuild(req, this.api.WithMeta());
     return build.toObject();
   }

--- a/ui/app/routes/workspace/projects/project/app/deployment-id.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment-id.ts
@@ -1,0 +1,25 @@
+import DeploymentDetail from './deployment';
+import { GetDeploymentRequest, Deployment, Ref } from 'waypoint-pb';
+
+interface DeploymentIdModelParams {
+  deployment_id: string;
+}
+
+export default class DeploymentIdDetail extends DeploymentDetail {
+  renderTemplate() {
+    this.render('workspace/projects/project/app/deployment', {
+      into: 'workspace/projects/project',
+    });
+  }
+
+  async model(params: DeploymentIdModelParams): Promise<Deployment.AsObject> {
+    let ref = new Ref.Operation();
+    ref.setId(params.deployment_id);
+    let req = new GetDeploymentRequest();
+    req.setRef(ref);
+
+    let resp = await this.api.client.getDeployment(req, this.api.WithMeta());
+    let deploy: Deployment = resp;
+    return deploy.toObject();
+  }
+}

--- a/ui/app/routes/workspace/projects/project/app/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment.ts
@@ -5,7 +5,7 @@ import { GetDeploymentRequest, Deployment, Ref, StatusReport } from 'waypoint-pb
 import { AppRouteModel, ResolvedModel as ResolvedAppRouteModel } from '../app';
 
 interface DeploymentModelParams {
-  deployment_id: string;
+  sequence: number;
 }
 
 interface Breadcrumb {
@@ -38,8 +38,11 @@ export default class DeploymentDetail extends Route {
   }
 
   async model(params: DeploymentModelParams): Promise<Deployment.AsObject> {
+    let { deployments } = this.modelFor('workspace.projects.project.app');
+    let { id: deployment_id } = deployments.find((obj) => obj.sequence == Number(params.sequence));
+
     let ref = new Ref.Operation();
-    ref.setId(params.deployment_id);
+    ref.setId(deployment_id);
     let req = new GetDeploymentRequest();
     req.setRef(ref);
 

--- a/ui/app/routes/workspace/projects/project/app/release-id.ts
+++ b/ui/app/routes/workspace/projects/project/app/release-id.ts
@@ -1,0 +1,25 @@
+import ReleaseDetail from './release';
+import { GetReleaseRequest, Release, Ref } from 'waypoint-pb';
+
+interface ReleaseModelParams {
+  release_id: string;
+}
+
+export default class ReleaseIdDetail extends ReleaseDetail {
+  renderTemplate() {
+    this.render('workspace/projects/project/app/release', {
+      into: 'workspace/projects/project',
+    });
+  }
+
+  async model(params: ReleaseModelParams): Promise<Release.AsObject> {
+    let ref = new Ref.Operation();
+    ref.setId(params.release_id);
+    let req = new GetReleaseRequest();
+    req.setRef(ref);
+
+    let release: Release = await this.api.client.getRelease(req, this.api.WithMeta());
+
+    return release.toObject();
+  }
+}

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -5,7 +5,7 @@ import { GetReleaseRequest, Release, Ref, StatusReport } from 'waypoint-pb';
 import { AppRouteModel, ResolvedModel as ResolvedAppRouteModel } from '../app';
 
 interface ReleaseModelParams {
-  release_id: string;
+  sequence: number;
 }
 
 interface Breadcrumb {
@@ -38,13 +38,15 @@ export default class ReleaseDetail extends Route {
   }
 
   async model(params: ReleaseModelParams): Promise<Release.AsObject> {
+    let { releases } = this.modelFor('workspace.projects.project.app');
+    let { id: release_id } = releases.find((obj) => obj.sequence === Number(params.sequence));
+
     let ref = new Ref.Operation();
-    ref.setId(params.release_id);
+    ref.setId(release_id);
     let req = new GetReleaseRequest();
     req.setRef(ref);
 
     let release: Release = await this.api.client.getRelease(req, this.api.WithMeta());
-
     return release.toObject();
   }
 


### PR DESCRIPTION
Additional tweaks for #1513

### Notes
- The current URL format for artifact detail pages (`.../[deployment OR build OR release]/[ULID]`) still works (to support users who may have bookmarked these pages and also users who are more interested in using ULIDs than sequence #s)
- The new format is `.../[deployment OR build OR release]/seq/[SEQUENCE]` to differentiate what identifier is being used