### PR TITLE
"waypoint user" CLI

### DIFF
--- a/.changelog/1864.txt
+++ b/.changelog/1864.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: new "waypoint user" CLI for user management
+```

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -521,6 +521,19 @@ func Commands(
 				baseCommand: baseCommand,
 			}, nil
 		},
+
+		"user": func() (cli.Command, error) {
+			return &helpCommand{
+				SynopsisText: helpText["user"][0],
+				HelpText:     helpText["user"][1],
+			}, nil
+		},
+
+		"user token": func() (cli.Command, error) {
+			return &UserTokenCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
 	}
 
 	// register our aliases
@@ -842,6 +855,18 @@ Authenticate and invite collaborators.
 
 Tokens are the primary form of authentication to Waypoint. Everyone who
 accesses a Waypoint server requires a token.
+`,
+	},
+
+	"user": {
+		"User information and management",
+		`
+View, manage, and invite users.
+
+Everyone who uses Waypoint is represented as a Waypoint user, including
+token authentication. This subcommand can be used to inspect information
+about the currently logged in user, generate new access, and invite new
+users directly into the Waypoint server.
 `,
 	},
 }

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -529,6 +529,12 @@ func Commands(
 			}, nil
 		},
 
+		"user invite": func() (cli.Command, error) {
+			return &UserInviteCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+
 		"user token": func() (cli.Command, error) {
 			return &UserTokenCommand{
 				baseCommand: baseCommand,

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -532,6 +532,12 @@ func Commands(
 			}, nil
 		},
 
+		"user inspect": func() (cli.Command, error) {
+			return &UserInspectCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+
 		"user invite": func() (cli.Command, error) {
 			return &UserInviteCommand{
 				baseCommand: baseCommand,

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -538,6 +538,12 @@ func Commands(
 			}, nil
 		},
 
+		"user modify": func() (cli.Command, error) {
+			return &UserModifyCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+
 		"user invite": func() (cli.Command, error) {
 			return &UserInviteCommand{
 				baseCommand: baseCommand,

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -48,6 +48,9 @@ var (
 	// hiddenCommands are not shown in CLI help output.
 	hiddenCommands = map[string]struct{}{
 		"plugin": {},
+
+		// Deprecated:
+		"token": {}, // replaced by "user"
 	}
 
 	ExposeDocs bool
@@ -873,6 +876,8 @@ Everyone who uses Waypoint is represented as a Waypoint user, including
 token authentication. This subcommand can be used to inspect information
 about the currently logged in user, generate new access, and invite new
 users directly into the Waypoint server.
+
+If you are looking to log in to Waypoint, use "waypoint login".
 `,
 	},
 }

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -38,6 +39,9 @@ func (c *GetInviteCommand) Run(args []string) int {
 		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
+
+	// Warn of deprecation
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(warnTokenDeprecated)+"\n\n")
 
 	// We use fmt here and not the UI helpers because UI helpers will
 	// trim tokens horizontally on terminals that are narrow.
@@ -113,6 +117,9 @@ func (c *ExchangeInviteCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Warn of deprecation
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(warnTokenDeprecated)+"\n\n")
+
 	// We use fmt here and not the UI helpers because UI helpers will
 	// trim tokens horizontally on terminals that are narrow.
 	fmt.Println(resp.Token)
@@ -174,6 +181,9 @@ func (c *GetTokenCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Warn of deprecation
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(warnTokenDeprecated)+"\n\n")
+
 	// We use fmt here and not the UI helpers because UI helpers will
 	// trim tokens horizontally on terminals that are narrow.
 	fmt.Println(resp.Token)
@@ -206,3 +216,10 @@ Usage: waypoint token new [options]
 
 	return strings.TrimSpace(helpText)
 }
+
+const warnTokenDeprecated = `
+The "waypoint token" commands are deprecated. They have been replaced with
+the "waypoint user" set of commands. Everything that was possible with
+"waypoint token" is now possible with "waypoint user". For example,
+"waypoint token new" is now "waypoint user token".
+`

--- a/internal/cli/user_inspect.go
+++ b/internal/cli/user_inspect.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/posener/complete"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+type UserInspectCommand struct {
+	*baseCommand
+
+	flagUsername string
+}
+
+func (c *UserInspectCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithNoAutoServer(), // local mode has no need for tokens
+	); err != nil {
+		return 1
+	}
+	client := c.project.Client()
+
+	var refUser *pb.Ref_User
+	if c.flagUsername != "" {
+		refUser = &pb.Ref_User{
+			Ref: &pb.Ref_User_Username{
+				Username: &pb.Ref_UserUsername{
+					Username: c.flagUsername,
+				},
+			},
+		}
+	}
+
+	userResp, err := client.GetUser(c.Ctx, &pb.GetUserRequest{User: refUser})
+	if err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+	user := userResp.User
+
+	// This isn't the most user friendly output but it gets the job done at the moment.
+	c.ui.Output(proto.MarshalTextString(user))
+	return 0
+}
+
+func (c *UserInspectCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+		f.StringVar(&flag.StringVar{
+			Name:   "username",
+			Target: &c.flagUsername,
+			Usage: "The user to lookup. This defaults to the currently logged in user.",
+		})
+	})
+}
+
+func (c *UserInspectCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *UserInspectCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *UserInspectCommand) Synopsis() string {
+	return "Show details about a single user"
+}
+
+func (c *UserInspectCommand) Help() string {
+	helpText := `
+Usage: waypoint user inspect [options]
+
+  Show details about a single user, defaulting to the currently logged in user.
+
+  This shows details about the currently logged in user or any user that
+  is specified via flags.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}

--- a/internal/cli/user_inspect.go
+++ b/internal/cli/user_inspect.go
@@ -59,7 +59,7 @@ func (c *UserInspectCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:   "username",
 			Target: &c.flagUsername,
-			Usage: "The user to lookup. This defaults to the currently logged in user.",
+			Usage:  "The user to lookup. This defaults to the currently logged in user.",
 		})
 	})
 }

--- a/internal/cli/user_invite.go
+++ b/internal/cli/user_invite.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/posener/complete"
+)
+
+type UserInviteCommand struct {
+	*baseCommand
+
+	flagDuration time.Duration
+	flagUsername string
+}
+
+func (c *UserInviteCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithNoAutoServer(), // local mode has no need for tokens
+	); err != nil {
+		return 1
+	}
+	client := c.project.Client()
+
+	req := &pb.InviteTokenRequest{
+		Duration: c.flagDuration.String(),
+	}
+
+	if c.flagUsername != "" {
+		req.Signup = &pb.Token_Invite_Signup{
+			InitialUsername: c.flagUsername,
+		}
+	} else {
+		// Invite ourselves, an existing user
+		userResp, err := client.GetUser(c.Ctx, &pb.GetUserRequest{})
+		if err != nil {
+			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+			return 1
+		}
+		user := userResp.User
+
+		req.Login = &pb.Token_Login{
+			UserId: user.Id,
+		}
+	}
+
+	// Generate the token
+	resp, err := client.GenerateInviteToken(c.Ctx, req)
+	if err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	// We use fmt here and not the UI helpers because UI helpers will
+	// trim tokens horizontally on terminals that are narrow.
+	fmt.Println(resp.Token)
+	return 0
+}
+
+func (c *UserInviteCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+		f.DurationVar(&flag.DurationVar{
+			Name:    "expires-in",
+			Target:  &c.flagDuration,
+			Usage:   "The duration until the token expires. i.e. '5m'.",
+			Default: 24 * time.Hour,
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "username",
+			Target: &c.flagUsername,
+			Usage: "Invite a new user and provide a username hint. The user " +
+				"may still change their username after signing up. If this " +
+				"isn't specified, an invite token for your current user will be " +
+				"generated and no new user signup is performed.",
+		})
+	})
+}
+
+func (c *UserInviteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *UserInviteCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *UserInviteCommand) Synopsis() string {
+	return "Invite a user to join the Waypoint server"
+}
+
+func (c *UserInviteCommand) Help() string {
+	helpText := `
+Usage: waypoint user invite [options]
+
+  Generate an invite token that can be used to log in.
+
+  You must be logged in already to generate an invite token. If you need to
+  log in, use the "waypoint login" command.
+
+  This generates a new invite token. An invite token can be exchanged for
+  a login token. If your Waypoint server has OIDC (non-token) auth enabled,
+  it is recommended to instead invite users using your UI URL or directly
+  via "waypoint login".
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}

--- a/internal/cli/user_modify.go
+++ b/internal/cli/user_modify.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/posener/complete"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+type UserModifyCommand struct {
+	*baseCommand
+
+	flagUsername    string
+	flagNewUsername string
+	flagDisplay     string
+}
+
+func (c *UserModifyCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithNoAutoServer(), // local mode has no need for tokens
+	); err != nil {
+		return 1
+	}
+	client := c.project.Client()
+
+	// Get the user we're modifying.
+	var refUser *pb.Ref_User
+	if c.flagUsername != "" {
+		refUser = &pb.Ref_User{
+			Ref: &pb.Ref_User_Username{
+				Username: &pb.Ref_UserUsername{
+					Username: c.flagUsername,
+				},
+			},
+		}
+	}
+	userResp, err := client.GetUser(c.Ctx, &pb.GetUserRequest{User: refUser})
+	if err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+	user := userResp.User
+
+	// Perform modifications
+	if v := c.flagNewUsername; v != "" {
+		user.Username = v
+	}
+	if v := c.flagDisplay; v != "" {
+		user.Display = v
+	}
+
+	if _, err := client.UpdateUser(c.Ctx, &pb.UpdateUserRequest{User: user}); err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	// This isn't the most user friendly output but it gets the job done at the moment.
+	c.ui.Output("User modification successful.", terminal.WithSuccessStyle())
+	return 0
+}
+
+func (c *UserModifyCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+		f.StringVar(&flag.StringVar{
+			Name:   "username",
+			Target: &c.flagUsername,
+			Usage:  "The user to modify. This defaults to the currently logged in user.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "new-username",
+			Target: &c.flagNewUsername,
+			Usage:  "Set a new username for this user. This must be unique to the server.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "display-name",
+			Target: &c.flagDisplay,
+			Usage: "The display name for a user. If this is set, this is used in some " +
+				"places in the CLI and UI. This does not have to be unique.",
+		})
+	})
+}
+
+func (c *UserModifyCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *UserModifyCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *UserModifyCommand) Synopsis() string {
+	return "Modify details about a user"
+}
+
+func (c *UserModifyCommand) Help() string {
+	helpText := `
+Usage: waypoint user modify [options]
+
+  Modify details about a user.
+
+  Some details such as username and display name may be updated.
+  Use "waypoint user inspect" to see the current attributes for a user.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}

--- a/internal/cli/user_token.go
+++ b/internal/cli/user_token.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/posener/complete"
+)
+
+type UserTokenCommand struct {
+	*baseCommand
+
+	flagDuration time.Duration
+	flagUsername string
+}
+
+func (c *UserTokenCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithNoAutoServer(), // local mode has no need for tokens
+	); err != nil {
+		return 1
+	}
+
+	var refUser *pb.Ref_User
+	if c.flagUsername != "" {
+		refUser = &pb.Ref_User{
+			Ref: &pb.Ref_User_Username{
+				Username: &pb.Ref_UserUsername{
+					Username: c.flagUsername,
+				},
+			},
+		}
+	}
+
+	// Generate the token
+	client := c.project.Client()
+	resp, err := client.GenerateLoginToken(c.Ctx, &pb.LoginTokenRequest{
+		Duration: c.flagDuration.String(),
+		User:     refUser,
+	})
+	if err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	// We use fmt here and not the UI helpers because UI helpers will
+	// trim tokens horizontally on terminals that are narrow.
+	fmt.Println(resp.Token)
+	return 0
+}
+
+func (c *UserTokenCommand) Flags() *flag.Sets {
+	return c.flagSet(0, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+		f.DurationVar(&flag.DurationVar{
+			Name:    "expires-in",
+			Target:  &c.flagDuration,
+			Usage:   "The duration until the token expires. i.e. '5m'.",
+			Default: 720 * time.Hour, // 30 days
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "username",
+			Target: &c.flagUsername,
+			Usage: "Username to generate the login token for. This defaults " +
+				"to the currently logged in user.",
+		})
+	})
+}
+
+func (c *UserTokenCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *UserTokenCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *UserTokenCommand) Synopsis() string {
+	return "Request a new token to access the server"
+}
+
+func (c *UserTokenCommand) Help() string {
+	helpText := `
+Usage: waypoint user token [options]
+
+  Request a new login token for a user.
+
+  You must be logged in already to generate a token. If you need to
+  log in, use the "waypoint login" command.
+
+  This generates a new token that can be used to authenticate directly
+  to the Waypoint server. If you're inviting a new user to Waypoint,
+  its recommended to generate an invite token with "waypoint user invite"
+  or share the UI URL for logging in.
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}


### PR DESCRIPTION
This introduces a "waypoint user" CLI that is more user-oriented. This deprecates `waypoint token`. I kept the `waypoint token` command around so it works still but it is now hidden.

This exposes the user system introduced in #1752 and available as part of #1831.

