### PR TITLE
ui: Refactor app route

### DIFF
--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { Ref, GetBuildRequest } from 'waypoint-pb';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 interface BuildModelParams {
   build_id: string;

--- a/ui/app/routes/workspace/projects/project/app/builds.ts
+++ b/ui/app/routes/workspace/projects/project/app/builds.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 export default class Builds extends Route {
   async model() {

--- a/ui/app/routes/workspace/projects/project/app/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetDeploymentRequest, Deployment, Ref, StatusReport } from 'waypoint-pb';
-import { AppRouteModel, ResolvedModel as ResolvedAppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 interface DeploymentModelParams {
   deployment_id: string;
@@ -49,7 +49,7 @@ export default class DeploymentDetail extends Route {
   }
 
   afterModel(model: Deployment.AsObject & WithStatusReport): void {
-    let { statusReports } = this.modelFor('workspace.projects.project.app') as ResolvedAppRouteModel;
+    let { statusReports } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let statusReport = statusReports.find((sr) => sr.deploymentId === model.id);
 
     model.statusReport = statusReport;

--- a/ui/app/routes/workspace/projects/project/app/deployments.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployments.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 import DeploymentsController from 'waypoint/controllers/workspace/projects/project/app/deployments';
 
 export default class Deployments extends Route {

--- a/ui/app/routes/workspace/projects/project/app/index.ts
+++ b/ui/app/routes/workspace/projects/project/app/index.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 export default class AppIndex extends Route {
   redirect(model: AppRouteModel) {

--- a/ui/app/routes/workspace/projects/project/app/logs.ts
+++ b/ui/app/routes/workspace/projects/project/app/logs.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetLogStreamRequest, Ref } from 'waypoint-pb';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 export default class Logs extends Route {
   @service api!: ApiService;

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetReleaseRequest, Release, Ref, StatusReport } from 'waypoint-pb';
-import { AppRouteModel, ResolvedModel as ResolvedAppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 interface ReleaseModelParams {
   release_id: string;
@@ -49,7 +49,7 @@ export default class ReleaseDetail extends Route {
   }
 
   afterModel(model: Release.AsObject & WithStatusReport): void {
-    let { statusReports } = this.modelFor('workspace.projects.project.app') as ResolvedAppRouteModel;
+    let { statusReports } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let statusReport = statusReports.find((sr) => sr.releaseId === model.id);
 
     model.statusReport = statusReport;

--- a/ui/app/routes/workspace/projects/project/app/releases.ts
+++ b/ui/app/routes/workspace/projects/project/app/releases.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { AppRouteModel } from '../app';
+import { Model as AppRouteModel } from '../app';
 
 export default class Releases extends Route {
   async model() {


### PR DESCRIPTION
## Why the change?

To improve clarity in this route without changing behavior. Extracted from #1840.

## What’s the plan?

- [x] Remove `ObjectPromiseProxy` (this is complex pattern and we weren’t seeing the benefits)
- [x] Simplify type declarations

## How do I test it?

I recommend a smoke test for this one.

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/refactor-app-route
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the app](http://localhost:4200)
4. Click around
5. Verify nothing is broken

### For realsies

1. Check out the branch:
   ```sh
   git checkout ui/refactor-app-route
   ```
2. Build the ember app
   ```sh
   (cd ui && make)
   ```
3. Bundle the static assets
   ```sh
   make static-assets
   ```
4. Build the dev server
   ```sh
   make docker/server
   ```
5. Build the CLI
   ```sh
   make bin
   ```
6. Install waypoint on your platform of choice, i.e.
   ```sh
   ./waypoint install -platform=kubernetes -accept-tos -k8s-server-image=waypoint:dev
   ```
7. Open the UI
   ```
   ./waypoint ui -authenticate
   ```
8. Try out an example app of your choice (i.e. [kubernetes/nodejs](https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs))
9. Click around
10. Verify nothing is broken