### PR TITLE
internal/clicontext: parse 127.0.0.1:1234 correctly for server addr

### DIFF
--- a/internal/clicontext/config.go
+++ b/internal/clicontext/config.go
@@ -3,6 +3,7 @@ package clicontext
 import (
 	"io"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -36,6 +37,13 @@ func LoadPath(path string) (*Config, error) {
 // so we want to provide the smoothest experience there at the expense
 // of a slight risk.
 func (c *Config) FromURL(v string) error {
+	// Ensure our value is a valid URL. This turns example.com into
+	// "//example.com" for example. Tests verify this work.
+	// See https://github.com/golang/go/issues/19297
+	if !strings.Contains(v, "/") {
+		v = "//" + v
+	}
+
 	u, err := url.Parse(v)
 	if err != nil {
 		return err

--- a/internal/clicontext/config_test.go
+++ b/internal/clicontext/config_test.go
@@ -50,6 +50,18 @@ func TestConfigFromURL(t *testing.T) {
 		},
 
 		{
+			"IP with port",
+			"127.0.0.1:9701",
+			Config{
+				Server: serverconfig.Client{
+					Address:       "127.0.0.1:9701",
+					Tls:           true,
+					TlsSkipVerify: true,
+				},
+			},
+		},
+
+		{
 			"http",
 			"http://foo.com:1234",
 			Config{


### PR DESCRIPTION
We use net/url.parse which requires a valid URL. We do some sniffing to
try to turn common values into valid URLs. This is backed up by tests.