### PR TITLE
Add logging for log streaming, potentially fix infinite loop case.

### DIFF
--- a/.changelog/1868.txt
+++ b/.changelog/1868.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fix infinite loop that could happen in certain log streaming scenarios
+```


### PR DESCRIPTION
We were creating a new "ws" variable meaning that we'd enter an infinite
loop since the last watchset would constantly refire. This is super
subtle not sure how to make it safer.

I added a bunch more logging as well so that if this doesn't fix it we can
better trace what's going on.