### PR TITLE
AWS ECS: validate memory + cpu pairs

### DIFF
--- a/.changelog/1872.txt
+++ b/.changelog/1872.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+serverinstall/ecs: validate memory and cpu values
+```
+
+```release-note:bug
+plugin/aws/ecs: validate memory and cpu values
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1065,9 +1065,6 @@ func (p *Platform) Launch(
 		runtime = aws.String("EC2")
 		cpuShares = p.config.CPU
 	} else {
-		// if p.config.Memory == 0 {
-		// 	return nil, fmt.Errorf("memory value required for fargate")
-		// }
 		if err := utils.ValidateEcsMemCPUPair(p.config.Memory, p.config.CPU); err != nil {
 			return nil, err
 		}

--- a/builtin/aws/utils/validations_test.go
+++ b/builtin/aws/utils/validations_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestValidateEcsMemCPUPair(t *testing.T) {
+	// test values based off of
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+	// circa July 15, 2021
+
+	cases := map[string]struct {
+		mem       int
+		cpu       int
+		shouldErr bool
+	}{
+		"zeros": {
+			shouldErr: true,
+		},
+		"512/0": {
+			mem: 512,
+		},
+		"512/256": {
+			mem: 512,
+			cpu: 256,
+		},
+		"4096": {
+			mem: 4096,
+		},
+		"4096/512": {
+			mem: 4096,
+			cpu: 512,
+		},
+		"4096/256": {
+			mem:       4096,
+			cpu:       256,
+			shouldErr: true,
+		},
+		"512/512": {
+			mem:       512,
+			cpu:       512,
+			shouldErr: true,
+		},
+		"nonsense": {
+			mem:       7,
+			shouldErr: true,
+		},
+		"bad_pair": {
+			mem:       512,
+			cpu:       512,
+			shouldErr: true,
+		},
+		"zero_mem": {
+			cpu:       7,
+			shouldErr: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateEcsMemCPUPair(c.mem, c.cpu); err != nil {
+				if !c.shouldErr {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
AWS ECS / Fargate require the memory and cpu values for containers to be agreeable, and will error when trying to create a container or task definition if they do not match the prescribed values. See this article for more information:

- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html

The Waypoint ECS deployment already validated these to a point, but the ECS Server install did not. This PR refactors that validation into a shared utility and uses it for both the platform and server install.

UX for using bad memory value in an ECS deploy:

<img width="1399" alt="Screen Shot 2021-07-15 at 16 19 17" src="https://user-images.githubusercontent.com/61721/125862152-535a9aa8-0c00-459c-b253-ed75d0ce3114.png">

UX for using bad memory / cpu values for server install:

<img width="1267" alt="Screen Shot 2021-07-15 at 16 49 04" src="https://user-images.githubusercontent.com/61721/125862323-37f6ee01-efba-4bde-9877-4fcaf16154f5.png">
