### PR TITLE
builtin/aws: add ability to add AWS tags to resources

### DIFF
--- a/.changelog/1879.txt
+++ b/.changelog/1879.txt
@@ -1,0 +1,2 @@
+```release-note:improvement
+plugin/aws: add ability to add AWS tags to resources

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1619,7 +1619,7 @@ type Config struct {
 	TaskRoleName string `hcl:"task_role_name,optional"`
 
 	// Tags key/values to pass to the ECS resources.
-	Tags map[string]string `hcl:"tags"`
+	Tags map[string]string `hcl:"tags,optional"`
 
 	// Subnets to place the service into. Defaults to the subnets in the default VPC.
 	Subnets []string `hcl:"subnets,optional"`


### PR DESCRIPTION
This commit adds ability to add AWS tags to resources, for example
```
app "vole" {
 
  ...
  ...
  ...

  deploy {
    use "aws-ecs" {
      region = "us-east-2"
      memory = "512"
      cluster = "dev-nutcorp"
      tags = {
        test_tag="test-tag"
        test_tag2="test-tag2"
      }
    }
  }
}
```
![image](https://user-images.githubusercontent.com/47272597/125958197-e9781c3e-9c91-4216-9693-1e5914c27591.png)
