### PR TITLE
serverinstall/k8s: update log msg and add terminal warn for RollingUpdate

### DIFF
--- a/.changelog/1886.txt
+++ b/.changelog/1886.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+serverinstall/k8s: add information to cli output for upgrade path
+```

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -443,10 +443,6 @@ func (i *K8sInstaller) Upgrade(
 		log.Info("Pod(s) deleted, k8s will now restart waypoint server ", serverName)
 	} else if waypointStatefulSet.Spec.UpdateStrategy.Type == "RollingUpdate" {
 		log.Info("Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image")
-		s.Update("Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image")
-		s.Status(terminal.StatusWarn)
-		s.Done()
-		s = sg.Add("")
 	} else {
 		log.Warn("Update Strategy is not recognized, so no action is taken", "UpdateStrategy",
 			waypointStatefulSet.Spec.UpdateStrategy.Type)
@@ -566,7 +562,13 @@ func (i *K8sInstaller) Upgrade(
 
 	if waypointStatefulSet.Spec.UpdateStrategy.Type == "RollingUpdate" {
 		ui.Output("\nKubernetes is now set to upgrade waypoint server image with its\n" +
-			"'RollingUpdate' strategy. This means the pod might not be updated immediately.")
+			"'RollingUpdate' strategy. This means the pod might not be updated immediately.",
+			terminal.WithWarningStyle(),
+		)
+		s.Update("Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image")
+		s.Status(terminal.StatusWarn)
+		s.Done()
+		s = sg.Add("")
 	}
 	s.Update("Upgrade complete!")
 	s.Done()

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -561,7 +561,7 @@ func (i *K8sInstaller) Upgrade(
 	}
 
 	if waypointStatefulSet.Spec.UpdateStrategy.Type == "RollingUpdate" {
-		ui.Output("\nKubernetes is now set to upgrade waypoint server image with its\n" +
+		ui.Output("\nKubernetes is now set to upgrade waypoint server image with its\n"+
 			"'RollingUpdate' strategy. This means the pod might not be updated immediately.",
 			terminal.WithWarningStyle(),
 		)

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -442,7 +442,11 @@ func (i *K8sInstaller) Upgrade(
 
 		log.Info("Pod(s) deleted, k8s will now restart waypoint server ", serverName)
 	} else if waypointStatefulSet.Spec.UpdateStrategy.Type == "RollingUpdate" {
-		log.Info("Update Strategy is 'RollingUpdate', no further action required")
+		log.Info("Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image")
+		s.Update("Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image")
+		s.Status(terminal.StatusWarn)
+		s.Done()
+		s = sg.Add("")
 	} else {
 		log.Warn("Update Strategy is not recognized, so no action is taken", "UpdateStrategy",
 			waypointStatefulSet.Spec.UpdateStrategy.Type)


### PR DESCRIPTION
Fixes #1795

If a user does not specify a `-k8s-server-image` or `-k8s-pull-policy` on the initial install, then we default to K8S defaults, which is to use an imagePullPolicy of `Always` for images tagged `latest`. Rather than force a restart of the pod during a `waypoint upgrade`, we are adding a note in the CLI output to alert users to these settings so they can take appropriate action per their cluster settings and needs.

```
$ waypoint server upgrade -platform=kubernetes -auto-approve
✓ Context "install-1626724718" validated and connected successfully.
✓ Snapshot of server written to: 'waypoint-server-snapshot-1626728262'

» Upgrading...
  Waypoint server will now upgrade from version "v0.4.0-663-g4bc86276"
✓ Gathering information about the Kubernetes cluster...
⚠️ Update Strategy is 'RollingUpdate'; once the upgrade completes, you may need to restart the pod to update the server image
✓ Image set to update!
✓ Upgrade complete!
...
```