### PR TITLE
ui: refactor breadcrumbs

### DIFF
--- a/ui/app/components/app-breadcrumbs/index.hbs
+++ b/ui/app/components/app-breadcrumbs/index.hbs
@@ -3,7 +3,7 @@
     {{#if breadcrumb.isPending}}
       <a href="#" aria-label="loading" data-test-breadcrumb="loading">&hellip;</a>
     {{else}}
-      <LinkTo @params={{breadcrumb.args}} data-test-breadcrumb={{breadcrumb.args.firstObject}}>
+      <LinkTo @route={{breadcrumb.route}} data-test-breadcrumb={{breadcrumb.route}}>
         {{#if breadcrumb.icon}}
           <Pds::Icon @type={{breadcrumb.icon}} />
         {{/if}}

--- a/ui/app/routes/workspace/projects/new.ts
+++ b/ui/app/routes/workspace/projects/new.ts
@@ -1,14 +1,16 @@
 import Route from '@ember/routing/route';
 import { Project } from 'waypoint-pb';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
+
 export default class WorkspaceProjectsNew extends Route {
-  breadcrumbs = [
+  breadcrumbs: Breadcrumb[] = [
     {
       label: 'Projects',
-      args: ['workspace.projects'],
+      route: 'workspace.projects',
     },
     {
       label: 'New Project',
-      args: ['workspace.projects.new'],
+      route: 'workspace.projects.new',
     },
   ];
 

--- a/ui/app/routes/workspace/projects/project.ts
+++ b/ui/app/routes/workspace/projects/project.ts
@@ -3,6 +3,8 @@ import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { Ref, GetProjectRequest } from 'waypoint-pb';
 import PollModelService from 'waypoint/services/poll-model';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
+
 interface ProjectModelParams {
   project_id: string;
 }
@@ -11,10 +13,10 @@ export default class ProjectDetail extends Route {
   @service api!: ApiService;
   @service pollModel!: PollModelService;
 
-  breadcrumbs = [
+  breadcrumbs: Breadcrumb[] = [
     {
       label: 'Projects',
-      args: ['workspace.projects'],
+      route: 'workspace.projects',
     },
   ];
 

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -4,6 +4,7 @@ import ApiService from 'waypoint/services/api';
 import { Ref, Deployment, Build, Release, Project, StatusReport, PushedArtifact } from 'waypoint-pb';
 import PollModelService from 'waypoint/services/poll-model';
 import { hash } from 'rsvp';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
 export interface Params {
   app_id: string;
@@ -26,12 +27,6 @@ interface WithPushedArtifact {
   pushedArtifact?: PushedArtifact.AsObject;
 }
 
-interface Breadcrumb {
-  label: string;
-  icon: string;
-  args: string[];
-}
-
 export default class App extends Route {
   @service api!: ApiService;
   @service pollModel!: PollModelService;
@@ -43,7 +38,7 @@ export default class App extends Route {
       {
         label: model.application.project,
         icon: 'folder-outline',
-        args: ['workspace.projects.project.apps'],
+        route: 'workspace.projects.project.apps',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { Ref, GetBuildRequest, Build, PushedArtifact } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
 interface BuildModelParams {
   sequence: number;
@@ -17,18 +18,18 @@ type BuildWithArtifact = Build.AsObject & WithPushedArtifact;
 export default class BuildDetail extends Route {
   @service api!: ApiService;
 
-  breadcrumbs(model: AppRouteModel) {
+  breadcrumbs(model: AppRouteModel): Breadcrumb[] {
     if (!model) return [];
     return [
       {
         label: model.application.application,
         icon: 'git-repository',
-        args: ['workspace.projects.project.app'],
+        route: 'workspace.projects.project.app',
       },
       {
         label: 'Builds',
         icon: 'build',
-        args: ['workspace.projects.project.app.builds'],
+        route: 'workspace.projects.project.app.builds',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment.ts
@@ -3,15 +3,10 @@ import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetDeploymentRequest, Deployment, Ref, StatusReport } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
 interface DeploymentModelParams {
   sequence: number;
-}
-
-interface Breadcrumb {
-  label: string;
-  icon: string;
-  args: string[];
 }
 
 interface WithStatusReport {
@@ -27,12 +22,12 @@ export default class DeploymentDetail extends Route {
       {
         label: model.application.application,
         icon: 'git-repository',
-        args: ['workspace.projects.project.app'],
+        route: 'workspace.projects.project.app',
       },
       {
         label: 'Deployments',
         icon: 'upload',
-        args: ['workspace.projects.project.app.deployments'],
+        route: 'workspace.projects.project.app.deployments',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -3,15 +3,10 @@ import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetReleaseRequest, Release, Ref, StatusReport } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
 interface ReleaseModelParams {
   sequence: number;
-}
-
-interface Breadcrumb {
-  label: string;
-  icon: string;
-  args: string[];
 }
 
 interface WithStatusReport {
@@ -27,12 +22,12 @@ export default class ReleaseDetail extends Route {
       {
         label: model.application.application,
         icon: 'git-repository',
-        args: ['workspace.projects.project.app'],
+        route: 'workspace.projects.project.app',
       },
       {
         label: 'Releases',
         icon: 'public-default',
-        args: ['workspace.projects.project.app.releases'],
+        route: 'workspace.projects.project.app.releases',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/settings.ts
+++ b/ui/app/routes/workspace/projects/project/settings.ts
@@ -1,28 +1,28 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
-import { Ref, GetProjectRequest } from 'waypoint-pb';
+import { Ref, GetProjectRequest, Project } from 'waypoint-pb';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
+
 interface ProjectModelParams {
   project_id: string;
 }
 
-
-
 export default class WorkspaceProjectsProjectSettings extends Route {
   @service api!: ApiService;
 
-  breadcrumbs(model: Project) {
+  breadcrumbs(model: Project.AsObject): Breadcrumb[] {
     if (!model) return [];
     return [
       {
         label: model.name,
         icon: 'folder-outline',
-        args: ['workspace.projects.project.index'],
+        route: 'workspace.projects.project.index',
       },
       {
         label: 'Settings',
         icon: 'settings',
-        args: ['workspace.projects.project.settings'],
+        route: 'workspace.projects.project.settings',
       },
     ];
   }

--- a/ui/app/services/breadcrumbs.ts
+++ b/ui/app/services/breadcrumbs.ts
@@ -3,6 +3,15 @@ import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import classic from 'ember-classic-decorator';
 
+export interface Breadcrumb {
+  label: string;
+  route: string;
+  icon?: string;
+  isPending?: boolean;
+}
+
+type BreadcrumbBuilder = (model: unknown) => Breadcrumb[];
+
 @classic
 export default class BreadcrumbsService extends Service {
   @service router;
@@ -12,14 +21,14 @@ export default class BreadcrumbsService extends Service {
   // but it doesn't change when a transition to the same route with a different
   // model occurs.
   @computed('router.{currentURL,currentRouteName}')
-  get breadcrumbs() {
+  get breadcrumbs(): Breadcrumb[] {
     let owner = getOwner(this);
     let allRoutes = (this.router.currentRouteName || '')
       .split('.')
       .without('')
-      .map((segment, index, allSegments) => allSegments.slice(0, index + 1).join('.'));
+      .map((_segment, index, allSegments) => allSegments.slice(0, index + 1).join('.'));
 
-    let crumbs = [];
+    let crumbs: Breadcrumb[] = [];
     allRoutes.forEach((routeName) => {
       let route = owner.lookup(`route:${routeName}`);
 
@@ -32,7 +41,7 @@ export default class BreadcrumbsService extends Service {
       // Breadcrumbs are either an array of static crumbs
       // or a function that returns breadcrumbs given the current
       // model for the route's controller.
-      let breadcrumbs = route.breadcrumbs || [];
+      let breadcrumbs: BreadcrumbBuilder | Breadcrumb[] = route.breadcrumbs || [];
 
       if (typeof breadcrumbs === 'function') {
         breadcrumbs = breadcrumbs(route.get('controller.model')) || [];


### PR DESCRIPTION
## Why the change?

A few reasons:

1. We were using private API (`@params`) which might disappear in future.
2. This clears the way to #1532 
3. Makes the interface to breadcrumbs clearer

## Any other notes?

We might want to reintroduce the ability to specify explicit `models` at some point:

```ts
breadcrumbs: Breadcrumb[] = [
  {
    label: 'Example',
    route: 'example',
    models: ['some-id']
  }
];
```

But for now I don’t think we need it.

## How do I test this?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/refactor-breadcrumbs
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the app](http://localhost:4200)
4. Browse around
5. Verify the breadcrumbs work as production