### PR TITLE
Bug: allow nomad runner and server memory to be configurable

### DIFF
--- a/.changelog/1895.txt
+++ b/.changelog/1895.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/nomad: Fix broken -nomad-runner-memory and -nomad-server-memory flags
+```

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -824,7 +824,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-server-memory",
-		Target:  &i.config.serverResourcesCPU,
+		Target:  &i.config.serverResourcesMemory,
 		Usage:   "MB of Memory to allocate to the Server job task.",
 		Default: strconv.Itoa(defaultResourcesMemory),
 	})
@@ -838,7 +838,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 
 	set.StringVar(&flag.StringVar{
 		Name:    "nomad-runner-memory",
-		Target:  &i.config.runnerResourcesCPU,
+		Target:  &i.config.runnerResourcesMemory,
 		Usage:   "MB of Memory to allocate to the runner job task.",
 		Default: strconv.Itoa(defaultResourcesMemory),
 	})


### PR DESCRIPTION
We had the wrong target for the nomad memory flags - it was overwriting CPU config.