### PR TITLE
internal/server: disallow deleting the default user

### DIFF
--- a/internal/server/singleprocess/auth.go
+++ b/internal/server/singleprocess/auth.go
@@ -20,16 +20,17 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
 const (
 	// The username of the initial user created during bootstrapping. This
 	// also is the user that Waypoint server versions prior to 0.5 used with
 	// their token, so we use this to detect that scenario as well.
-	DefaultUser = "waypoint"
+	DefaultUser = state.DefaultUser
 
 	// The ID of the initial user created during bootstrapping.
-	DefaultUserId = "00000000000000000000000001"
+	DefaultUserId = state.DefaultUserId
 
 	// The identifier for the default key to use to generating tokens.
 	DefaultKeyId = "k1"

--- a/internal/server/singleprocess/state/user.go
+++ b/internal/server/singleprocess/state/user.go
@@ -21,6 +21,12 @@ func init() {
 	schemas = append(schemas, userIndexSchema)
 }
 
+// See the docs in singleprocess.
+const (
+	DefaultUser   = "waypoint"
+	DefaultUserId = "00000000000000000000000001"
+)
+
 // UserPut creates or updates the given user. If the user has no ID set
 // then an ID will be written directly to the parameter.
 func (s *State) UserPut(user *pb.User) error {
@@ -300,6 +306,14 @@ func (s *State) userDelete(
 		}
 
 		return err
+	}
+
+	// If the user is the default user, then we can't delete them for now
+	if u.Id == DefaultUserId {
+		return status.Errorf(codes.FailedPrecondition,
+			"The initial Waypoint user can't currently be deleted. The initial "+
+				"user is used by deployments and runners for authentication. "+
+				"A future version of Waypoint will remove this restriction.")
 	}
 
 	// We can't delete the final user or the system will get into a state

--- a/internal/server/singleprocess/state/user_test.go
+++ b/internal/server/singleprocess/state/user_test.go
@@ -206,6 +206,31 @@ func TestUser(t *testing.T) {
 		}
 	})
 
+	t.Run("Delete default user fails", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		// Set
+		err := s.UserPut(serverptypes.TestUser(t, &pb.User{
+			Id:       DefaultUserId,
+			Username: "foo",
+		}))
+		require.NoError(err)
+
+		// Delete
+		{
+			err := s.UserDelete(&pb.Ref_User{
+				Ref: &pb.Ref_User_Id{
+					Id: &pb.Ref_UserId{Id: DefaultUserId},
+				},
+			})
+			require.Error(err)
+			require.Equal(codes.FailedPrecondition, status.Code(err))
+		}
+	})
+
 	t.Run("User lookup by OIDC", func(t *testing.T) {
 		require := require.New(t)
 


### PR DESCRIPTION
Runners and deployments currently use the default user for API calls
(Runner or Entrypoint API). We need to support the concept of a "service
account" for each of these that we don't currently support today.

For now, we'll prevent deleting this user. You can update the user if
you want cause all that matters is the ID and the ID is immutable.