### PR TITLE
ui/mirage: de-lint

### DIFF
--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -15,7 +15,7 @@ import * as job from './services/job';
 import * as log from './services/log';
 import * as pushedArtifact from './services/pushed-artifact';
 
-export default function (this: Server) {
+export default function (this: Server): void {
   this.namespace = 'hashicorp.waypoint.Waypoint';
   this.urlPrefix = '/grpc';
   this.timing = 0;

--- a/ui/mirage/factories/variable.ts
+++ b/ui/mirage/factories/variable.ts
@@ -1,4 +1,4 @@
-import { Factory, trait, association } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import faker from '../faker';
 
 export default Factory.extend({

--- a/ui/mirage/helpers/login.ts
+++ b/ui/mirage/helpers/login.ts
@@ -1,3 +1,3 @@
-export default function login(token?: string) {
+export default function login(token?: string): void {
   window.localStorage.waypointAuthToken = token || 'default-test-token-value';
 }

--- a/ui/mirage/services/build.ts
+++ b/ui/mirage/services/build.ts
@@ -2,6 +2,7 @@ import { ListBuildsRequest, ListBuildsResponse, GetBuildRequest } from 'waypoint
 import { Request, Response } from 'miragejs';
 import { decode } from '../helpers/protobufs';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListBuildsRequest, requestBody);
   let projectName = requestMsg.getApplication().getProject();
@@ -21,6 +22,7 @@ export function list(schema: any, { requestBody }: Request): Response {
   return this.serialize(resp, 'application');
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function get(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetBuildRequest, requestBody);
   let id = requestMsg.getRef().getId();

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -2,6 +2,7 @@ import { GetDeploymentRequest, ListDeploymentsRequest, ListDeploymentsResponse }
 import { Request, Response } from 'ember-cli-mirage';
 import { decode } from '../helpers/protobufs';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListDeploymentsRequest, requestBody);
   let projectName = requestMsg.getApplication().getProject();
@@ -21,6 +22,7 @@ export function list(schema: any, { requestBody }: Request): Response {
   return this.serialize(resp, 'application');
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function get(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetDeploymentRequest, requestBody);
   let id = requestMsg.getRef().getId();

--- a/ui/mirage/services/invite-token.ts
+++ b/ui/mirage/services/invite-token.ts
@@ -1,4 +1,5 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
+import { Response } from 'miragejs';
 
 function createToken(): Token {
   let token = new Token();
@@ -10,7 +11,7 @@ function createToken(): Token {
   return token;
 }
 
-export function create(schema: any, { params, requestHeaders }) {
+export function create(): Response {
   let resp = new NewTokenResponse();
   resp.setToken(createToken().getAccessorId_asB64());
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/project.ts
+++ b/ui/mirage/services/project.ts
@@ -3,6 +3,7 @@ import { decode } from '../helpers/protobufs';
 import { GetProjectRequest, UpsertProjectRequest } from 'waypoint-pb';
 import { Request, Response } from 'miragejs';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(schema: any): Response {
   let resp = new ListProjectsResponse();
   let projectRefs = schema.projects.all().models.map((p) => p.toProtobufRef());
@@ -12,6 +13,7 @@ export function list(schema: any): Response {
   return this.serialize(resp, 'application');
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function get(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetProjectRequest, requestBody);
   let name = requestMsg.getProject().getProject();
@@ -24,6 +26,7 @@ export function get(schema: any, { requestBody }: Request): Response {
   return this.serialize(resp, 'application');
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function update(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(UpsertProjectRequest, requestBody);
   let name = requestMsg.getProject().getName();

--- a/ui/mirage/services/pushed-artifact.ts
+++ b/ui/mirage/services/pushed-artifact.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'miragejs';
 import { ListPushedArtifactsRequest, ListPushedArtifactsResponse } from 'waypoint-pb';
 import { decode } from '../helpers/protobufs';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(schema: any, request: Request): Response {
   let requestMsg = decode(ListPushedArtifactsRequest, request.requestBody);
   let projectName = requestMsg.getApplication().getProject();

--- a/ui/mirage/services/release.ts
+++ b/ui/mirage/services/release.ts
@@ -2,6 +2,7 @@ import { ListReleasesRequest, ListReleasesResponse, GetReleaseRequest } from 'wa
 import { Request, Response } from 'ember-cli-mirage';
 import { decode } from '../helpers/protobufs';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListReleasesRequest, requestBody);
   let projectName = requestMsg.getApplication().getProject();
@@ -21,7 +22,8 @@ export function list(schema: any, { requestBody }: Request): Response {
   return this.serialize(resp, 'application');
 }
 
-export function get(schema: any, { requestBody }: Request) {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+export function get(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetReleaseRequest, requestBody);
   let id = requestMsg.getRef().getId();
   let model = schema.releases.find(id);

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -3,6 +3,7 @@ import { ListStatusReportsRequest, ListStatusReportsResponse } from 'waypoint-pb
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { decode } from '../helpers/protobufs';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function list(schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListStatusReportsRequest, requestBody);
   let projectName = requestMsg.getApplication().getProject();

--- a/ui/mirage/services/token.ts
+++ b/ui/mirage/services/token.ts
@@ -1,7 +1,5 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
-import { fakeId, fakeComponentForKind } from '../utils';
-import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
-import { subMinutes } from 'date-fns';
+import { Response } from 'miragejs';
 
 function createToken(): Token {
   let token = new Token();
@@ -11,7 +9,7 @@ function createToken(): Token {
   return token;
 }
 
-export function create(schema: any, { params, requestHeaders }) {
+export function create(): Response {
   let resp = new NewTokenResponse();
   resp.setToken(createToken().getAccessorId_asB64());
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/version-info.ts
+++ b/ui/mirage/services/version-info.ts
@@ -1,4 +1,5 @@
 import { VersionInfo, GetVersionInfoResponse } from 'waypoint-pb';
+import { Response } from 'miragejs';
 
 function createVersionInfo(): VersionInfo {
   let versionInfo = new VersionInfo();
@@ -10,7 +11,7 @@ function createVersionInfo(): VersionInfo {
   return versionInfo;
 }
 
-export function get(schema: any, { params, requestHeaders }) {
+export function get(): Response {
   let resp = new GetVersionInfoResponse();
   let versionInfo = createVersionInfo();
   resp.setInfo(versionInfo);

--- a/ui/mirage/utils.ts
+++ b/ui/mirage/utils.ts
@@ -73,7 +73,7 @@ export function fakeComponentForKind(kind: Component.Type): string {
  * request and response bodies for debugging. This is only partially helpful and
  * dependent on the readability of the data being sent.
  */
-export function logRequestConsole(verb: string, path: string, request: FakeXMLHttpRequest) {
+export function logRequestConsole(verb: string, path: string, request: FakeXMLHttpRequest): void {
   console.groupCollapsed(`Mock: ${verb} ${path}`);
 
   let { requestBody, responseText } = request;


### PR DESCRIPTION
## Why the change?

One step closer to running the linters in CI.

## How do I test this?

These changes do not impact production code. No need to manually test.

## What’s with all the `eslint-disable-next-line` stuff?

I spent about 20 minutes trying to define a `Schema` type so we don’t have to use `any` all over the place. Unfortunately, it seems to be devilishly difficult so I gave up. Mirage ships with some pretty sophisticated type information but there are still weird corner cases the are potential time sinks. More expedient to use `any` for now.