### PR TITLE
UI: Add on-demand status reports (health checks) to app

### DIFF
--- a/.changelog/1911.txt
+++ b/.changelog/1911.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: added button on individual artifact (deployments + releases) page for on demand health checks
+```

--- a/ui/app/components/status-report-bar/index.hbs
+++ b/ui/app/components/status-report-bar/index.hbs
@@ -1,0 +1,26 @@
+{{#if this._statusReport}}
+  <div class="status-row">
+    <div class="item">
+      <StatusReportIndicator @statusReport={{this._statusReport}} />
+    </div>
+
+    {{#if @model.build}}
+    <div class="item">
+      <small>
+        Build <a href="#"><b class="badge badge--version">#{{@model.build.sequence}}</b>
+          <code>{{@model.build.id}}</code></a>
+      </small>
+    </div>
+    {{/if}}
+    {{#if this._statusReport.status.completeTime.seconds}}
+      <div class="item" data-test-complete-time-status-report>
+        Last checked {{date-format-distance-to-now this._statusReport.status.completeTime.seconds }}
+      </div>
+    {{/if}}
+    <div class="item">
+      <Pds::Button @variant="ghost" @iconStart="refresh-default" disabled={{this.isRefreshRunning}} {{on "click" this.refreshHealthCheck}}>
+        Re-run health check
+      </Pds::Button>
+    </div>
+  </div>
+{{/if}}

--- a/ui/app/components/status-report-bar/index.hbs
+++ b/ui/app/components/status-report-bar/index.hbs
@@ -1,26 +1,29 @@
-{{#if this._statusReport}}
-  <div class="status-row">
+<div class="status-row">
+  {{#if this.statusReport}}
     <div class="item">
-      <StatusReportIndicator @statusReport={{this._statusReport}} />
+      <StatusReportIndicator @statusReport={{this.statusReport}} />
     </div>
+  {{/if}}
 
-    {{#if @model.build}}
+  {{#if @model.build}}
     <div class="item">
       <small>
         Build <a href="#"><b class="badge badge--version">#{{@model.build.sequence}}</b>
           <code>{{@model.build.id}}</code></a>
       </small>
     </div>
-    {{/if}}
-    {{#if this._statusReport.status.completeTime.seconds}}
-      <div class="item" data-test-complete-time-status-report>
-        Last checked {{date-format-distance-to-now this._statusReport.status.completeTime.seconds }}
-      </div>
-    {{/if}}
+  {{/if}}
+  {{yield}}
+  {{#if this.statusReport.status.completeTime.seconds}}
+    <div class="item" data-test-complete-time-status-report>
+      Last checked {{date-format-distance-to-now this.statusReport.status.completeTime.seconds }}
+    </div>
+  {{/if}}
+  {{#if this.statusReport}}
     <div class="item">
       <Pds::Button @variant="ghost" @iconStart="refresh-default" disabled={{this.isRefreshRunning}} {{on "click" this.refreshHealthCheck}}>
         Re-run health check
       </Pds::Button>
     </div>
-  </div>
-{{/if}}
+  {{/if}}
+</div>

--- a/ui/app/components/status-report-bar/index.ts
+++ b/ui/app/components/status-report-bar/index.ts
@@ -1,0 +1,82 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import ApiService from 'waypoint/services/api';
+import {
+  Deployment,
+  Ref,
+  ExpediteStatusReportRequest,
+  StatusReport,
+  GetJobStreamRequest,
+  GetJobStreamResponse,
+  Job,
+} from 'waypoint-pb';
+
+interface StatusReportBarArgs {
+  model: Deployment.AsObject & WithStatusReport;
+  artifactType: string;
+}
+
+interface WithStatusReport {
+  statusReport?: StatusReport.AsObject;
+}
+
+export default class StatusReportBar extends Component<StatusReportBarArgs> {
+  @service api!: ApiService;
+  @tracked isRefreshRunning = false;
+  @tracked _statusReport?: StatusReport.AsObject;
+
+  constructor(owner: any, args: any) {
+    super(owner, args);
+    this._statusReport = this.args.model.statusReport;
+  }
+
+  get artifactType() {
+    return this.args.artifactType;
+  }
+
+  @action
+  async refreshHealthCheck(e: Event) {
+    e.preventDefault();
+
+    let ref = new Ref.Operation();
+    ref.setId(this.args.model.id);
+
+    let workspace = new Ref.Workspace();
+    let wkspName = this.args.model.workspace?.workspace || 'default';
+    workspace.setWorkspace(wkspName);
+
+    let req = new ExpediteStatusReportRequest();
+    req.setWorkspace(workspace);
+
+    if (this.artifactType === 'Deployment') {
+      req.setDeployment(ref);
+    } else if (this.artifactType === 'Release') {
+      req.setRelease(ref);
+    }
+
+    let resp = await this.api.client.expediteStatusReport(req, this.api.WithMeta());
+
+    if (resp?.getJobId()) {
+      this.isRefreshRunning = true;
+
+      let streamReq = new GetJobStreamRequest();
+      streamReq.setJobId(resp.getJobId());
+      let jobStream = await this.api.client.getJobStream(streamReq, this.api.WithMeta());
+
+      // handler for job stream when receiving data
+      let onData = async (response: GetJobStreamResponse) => {
+        let event = response.getEventCase();
+        if (event === GetJobStreamResponse.EventCase.STATE) {
+          let state = response.getState()?.getCurrent() as Job.State;
+          if (state === 5) {
+            this.isRefreshRunning = false;
+          }
+        }
+      };
+
+      jobStream.on('data', onData);
+    }
+  }
+}

--- a/ui/app/components/status-report-bar/index.ts
+++ b/ui/app/components/status-report-bar/index.ts
@@ -27,15 +27,21 @@ export default class StatusReportBar extends Component<StatusReportBarArgs> {
   @service api!: ApiService;
   @service flashMessages!: FlashMessagesService;
   @tracked isRefreshRunning = false;
-  @tracked _statusReport?: StatusReport.AsObject;
 
   constructor(owner: any, args: any) {
     super(owner, args);
-    this._statusReport = this.args.model.statusReport;
   }
 
   get artifactType() {
     return this.args.artifactType;
+  }
+
+  get model() {
+    return this.args.model;
+  }
+
+  get statusReport() {
+    return this.model.statusReport;
   }
 
   @action

--- a/ui/app/components/status-report-bar/index.ts
+++ b/ui/app/components/status-report-bar/index.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ApiService from 'waypoint/services/api';
+import FlashMessagesService from 'waypoint/services/flash-messages';
 import {
   Deployment,
   Ref,
@@ -24,6 +25,7 @@ interface WithStatusReport {
 
 export default class StatusReportBar extends Component<StatusReportBarArgs> {
   @service api!: ApiService;
+  @service flashMessages!: FlashMessagesService;
   @tracked isRefreshRunning = false;
   @tracked _statusReport?: StatusReport.AsObject;
 
@@ -56,7 +58,9 @@ export default class StatusReportBar extends Component<StatusReportBarArgs> {
       req.setRelease(ref);
     }
 
-    let resp = await this.api.client.expediteStatusReport(req, this.api.WithMeta());
+    let resp = await this.api.client.expediteStatusReport(req, this.api.WithMeta()).catch((error) => {
+      this.flashMessages.error(error.message);
+    });
 
     if (resp?.getJobId()) {
       this.isRefreshRunning = true;

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -76,14 +76,17 @@ function injectStatusReports(model: Model): void {
   let { deployments, releases, statusReports } = model;
 
   for (let statusReport of statusReports) {
+    let statusTime = statusReport.generatedTime?.seconds || 0;
     if (statusReport.deploymentId) {
       let deployment = deployments.find((d) => d.id === statusReport.deploymentId);
-      if (deployment) {
+      let deploymentTime = deployment?.statusReport?.generatedTime?.seconds || 0;
+      if (deployment && statusTime >= deploymentTime) {
         deployment.statusReport = statusReport;
       }
     } else if (statusReport.releaseId) {
       let release = releases.find((d) => d.id === statusReport.releaseId);
-      if (release) {
+      let releaseTime = release?.statusReport?.generatedTime?.seconds || 0;
+      if (release && statusTime >= releaseTime) {
         release.statusReport = statusReport;
       }
     }

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -22,21 +22,6 @@
   </div>
 </PageHeader>
 
-<div class="status-row">
-  <div class="item">
-    {{#if @model.statusReport}}
-      <StatusReportIndicator @statusReport={{@model.statusReport}} />
-    {{/if}}
-  </div>
-
-  {{#if @model.build}}
-  <div class="item">
-    <small>
-      Build <a href="#"><b class="badge badge--version">#{{@model.build.sequence}}</b>
-        <code>{{@model.build.id}}</code></a>
-    </small>
-  </div>
-  {{/if}}
-</div>
+<StatusReportBar @model={{@model}} @artifactType="Deployment"/>
 
 <OperationLogs @jobId={{@model.jobId}} />

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -20,25 +20,19 @@
   </div>
 </PageHeader>
 
-<div class="status-row">
-  <div class="item">
-    {{#if @model.statusReport}}
-      <StatusReportIndicator @statusReport={{@model.statusReport}} />
-    {{/if}}
-  </div>
-
+<StatusReportBar @model={{@model}} @artifactType="Release">
   {{!-- todo(pearkes): API doesn't return this object but just a string of it, so wait for that to be fixed --}}
   {{#if @model.deployment }}
-  <div class="item">
-    <small>
-      Released deployment <LinkTo @route="workspace.projects.project.app.deployment"
-        @models={{array @model.deployment.id}}>
-        <b class="badge badge--version">v{{@model.deployment.sequence}}</b>
-        <code>{{@model.deployment.id}}</code>
-      </LinkTo>
-    </small>
-  </div>
+    <div class="item">
+      <small>
+        Released deployment <LinkTo @route="workspace.projects.project.app.deployment"
+          @models={{array @model.deployment.id}}>
+          <b class="badge badge--version">v{{@model.deployment.sequence}}</b>
+          <code>{{@model.deployment.id}}</code>
+        </LinkTo>
+      </small>
+    </div>
   {{/if}}
-</div>
+</StatusReportBar>
 
 <OperationLogs @jobId={{@model.jobId}} />

--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -50,6 +50,7 @@ export default function (this: Server): void {
   this.post('/GetJobStream', job.stream);
   this.post('/GetLogStream', log.stream);
   this.post('/ListPushedArtifacts', pushedArtifact.list);
+  this.post('/ExpediteStatusReport', statusReport.expediteStatusReport);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from 'miragejs';
-import { ListStatusReportsRequest, ListStatusReportsResponse } from 'waypoint-pb';
+import {
+  ListStatusReportsRequest,
+  ListStatusReportsResponse,
+  ExpediteStatusReportRequest,
+  ExpediteStatusReportResponse,
+} from 'waypoint-pb';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { decode } from '../helpers/protobufs';
 
@@ -23,4 +28,14 @@ export function list(schema: any, { requestBody }: Request): Response {
 
 export function getLatest(): Response {
   return this.serialize(new Empty(), 'application');
+}
+
+export function expediteStatusReport(schema: any, { requestBody }: Request): Response {
+  // while this is not being used in the current implementation to generate the mocked job id response
+  // i'm leaving this here in case we want to update this to handle specific requests
+  // let requestMsg = decode(ExpediteStatusReportRequest, requestBody);
+  // let ref = requestMsg.getRef();
+  let result = new ExpediteStatusReportResponse();
+  result.setId('JOB_ID');
+  return this.serialize(result, 'application');
 }

--- a/ui/tests/integration/components/status-report-bar-test.ts
+++ b/ui/tests/integration/components/status-report-bar-test.ts
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { getUnixTime, subDays } from 'date-fns';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | status-report-bar', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('does not render when no status report', async function (assert) {
+    this.set('model', {
+      statusReport: undefined,
+    });
+
+    await render(hbs`<StatusReportBar @model={{this.model}}/>`);
+
+    assert.equal(this.element.textContent?.trim(), '');
+  });
+
+  test('does render when status report exists', async function (assert) {
+    this.set('model', {
+      statusReport: {
+        health: {
+          healthStatus: 'ALIVE',
+          healthMessage: 'Test health message',
+        },
+        status: {
+          completeTime: {
+            seconds: getUnixTime(subDays(new Date(), 1)),
+          },
+          state: 2,
+        },
+      },
+    });
+
+    await render(hbs`<StatusReportBar @model={{this.model}}/>`);
+
+    assert.dom('[data-test-status-report-indicator]').hasClass('status-report-indicator--alive');
+    assert.dom('[data-test-complete-time-status-report]').exists();
+  });
+});

--- a/ui/tests/integration/components/status-report-bar-test.ts
+++ b/ui/tests/integration/components/status-report-bar-test.ts
@@ -7,14 +7,14 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | status-report-bar', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('does not render when no status report', async function (assert) {
+  test('does not render indicator when no status report', async function (assert) {
     this.set('model', {
       statusReport: undefined,
     });
 
     await render(hbs`<StatusReportBar @model={{this.model}}/>`);
 
-    assert.equal(this.element.textContent?.trim(), '');
+    assert.dom('[data-test-status-report-indicator]').doesNotExist();
   });
 
   test('does render when status report exists', async function (assert) {


### PR DESCRIPTION
### Related PRs
#1943 + #1982

### Overview
This is a PR for implementing a button in the UI for refreshing health checks (aka status reports). This is a MVP implementation, will further quality-of-life improvements to be added during 0.5.x updates.

### Testing
1. Pull down this branch to your machine
2. From `waypoint` directory cd into `contrib/waypoint-local`
3. `sh setup-waypoint-local.sh`
4. `waypoint ui -authenticate`
    1. NOTE: I've had issues with authenticating when directed to `127.0.0.1:9702` so also visit `localhost:9702` if you cannot successfully log in with the ember test environment
4. Navigate to the `waypoint/ui` directory
5. `ember serve local` + `waypoint user token`
6. Create new project with git repo settings as in picture: <img width="895" alt="Screen Shot 2021-08-10 at 11 20 05 AM" src="https://user-images.githubusercontent.com/60155296/128893747-f13b514e-80ce-4fc8-90f2-cac1417f91b2.png">  
7. Wait for Waypoint to do an auto `waypoint up`
8. Check the individual page for the deployment that was created from this process
9. Click `re-run health check` button
    1. NOTE: as this is an MVP, the status does not update in real time, refresh the page to see new status once re-run button is no longer disabled (means job is completed)
10. Stop the docker container generated on your machine by the waypoint server
11. Rerun the health check again, see that it is reporting as down now
12. Check project page to ensure status shows correctly there as well