### PR TITLE
ui: Add dynamic page titles

### DIFF
--- a/.changelog/1916.txt
+++ b/.changelog/1916.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add dynamic page titles
+```

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,3 +1,4 @@
+{{page-title "Waypoint"}}
 <SvgPatterns />
 <Header />
 

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -1,3 +1,5 @@
+{{page-title "Projects"}}
+
 {{#if this.cli}}
 <div class="flash flash--success">
   <div class="flash-header">

--- a/ui/app/templates/workspace/projects/new.hbs
+++ b/ui/app/templates/workspace/projects/new.hbs
@@ -1,3 +1,5 @@
+{{page-title (t 'form.project_new.title')}}
+
 <AppBreadcrumbs/>
 <PageHeader @iconName="plus-plain">
   <div class="title">

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -1,3 +1,5 @@
+{{page-title @model.application.application}}
+
 {{#if (and
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.build')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment')

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat "Build" " v" @model.sequence)}}
+
 {{#let (or @model.pushedArtifact @model) as |operation|}}
   <PageHeader @iconName="build">
     <div class="title">

--- a/ui/app/templates/workspace/projects/project/app/builds.hbs
+++ b/ui/app/templates/workspace/projects/project/app/builds.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat @model.application.application "Builds")}}
+
 <h3>{{t "page.builds.title"}}</h3>
 
 <ul data-test-build-list class="list">

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat "Deployment" " v" @model.sequence)}}
+
 <PageHeader @iconName="upload">
   <div class="title">
     <h1><b class="badge badge--version">v{{@model.sequence}}</b></h1>

--- a/ui/app/templates/workspace/projects/project/app/deployments.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployments.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat @model.application.application "Deployments")}}
+
 <h3>
   {{t "page.deployments.title"}}
 </h3>

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat @model.application.application "Exec")}}
+
 <h3>Exec</h3>
 
 <div class="output-pane">

--- a/ui/app/templates/workspace/projects/project/app/logs.hbs
+++ b/ui/app/templates/workspace/projects/project/app/logs.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat @model.application.application "Logs")}}
+
 <h3>Application logs</h3>
 
 <LogStream @req={{@model}}></LogStream>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat "Release" " v" @model.sequence)}}
+
 <PageHeader @iconName="public-default">
   <div class="title">
     {{! TODO(jgwhite): Make this a real <h1> }}

--- a/ui/app/templates/workspace/projects/project/app/releases.hbs
+++ b/ui/app/templates/workspace/projects/project/app/releases.hbs
@@ -1,3 +1,5 @@
+{{page-title (concat @model.application.application "Releases")}}
+
 <h3>{{t "page.releases.title"}}</h3>
 
 <ul data-test-release-list class="list">

--- a/ui/app/templates/workspace/projects/project/apps.hbs
+++ b/ui/app/templates/workspace/projects/project/apps.hbs
@@ -1,3 +1,5 @@
+{{page-title @model.name}}
+
 <PageHeader @iconName="folder-outline">
   <div class="title">
     <h1>{{@model.name}}</h1>

--- a/ui/package.json
+++ b/ui/package.json
@@ -79,7 +79,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-named-blocks-polyfill": "^0.2.4",
-    "ember-page-title": "^6.0.3",
+    "ember-page-title": "^6.2.2",
     "ember-qunit": "^5.1.1",
     "ember-resolver": "^8.0.2",
     "ember-router-service-refresh-polyfill": "^0.1.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8809,12 +8809,12 @@ ember-native-dom-helpers@^0.7.0:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-page-title@^6.0.3:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-6.2.0.tgz#d79f7422299ebb8f8ac819399596e8f54f01a0e9"
-  integrity sha512-mgzI59rVH6Q00uG1OnsbrSfic+MxFQbtsjX3BuDWGgU7hWahDhAAgaQrKIFx99aEqWoiL+OiX4tQLPnxyZEceA==
+ember-page-title@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-6.2.2.tgz#980838c44e96cba1d00f42435d707936af627324"
+  integrity sha512-YTXA+cylZrh9zO0zwjlaAGReT2MVOxAMnVO1OOygFrs1JBs4D6CKV3tImoilg3AvIXFBeJfFNNUbJOdRd9IGGg==
   dependencies:
-    ember-cli-babel "^7.22.1"
+    ember-cli-babel "^7.23.1"
 
 ember-qunit@^5.1.1:
   version "5.1.2"


### PR DESCRIPTION
Addresses https://github.com/hashicorp/waypoint/issues/1853

Adds `ember-page-title` and names all our major routes. Follows a11y guidelines of having most unique information at the beginning of the page title.  Some examples;

![Safari 2021-07-22 at 14 25 50](https://user-images.githubusercontent.com/51724/126646440-ed748fc5-3ee1-43bd-9b66-9460fd74a516.png)
![Safari 2021-07-22 at 14 25 44](https://user-images.githubusercontent.com/51724/126646443-158ddd77-018a-4ba0-bfa7-d5ee9142fdca.png)
![Safari 2021-07-22 at 14 25 41](https://user-images.githubusercontent.com/51724/126646449-fbb2d1a1-8dc2-400c-b30f-f1f961f6ca7e.png)
