### PR TITLE
internal/plugin: fix muliple imports

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/waypoint/builtin/aws/ecs"
 	"github.com/hashicorp/waypoint/builtin/aws/lambda"
 	"github.com/hashicorp/waypoint/builtin/aws/ssm"
-	pluginAWSSSM "github.com/hashicorp/waypoint/builtin/aws/ssm"
 	"github.com/hashicorp/waypoint/builtin/azure/aci"
 	"github.com/hashicorp/waypoint/builtin/docker"
 	dockerpull "github.com/hashicorp/waypoint/builtin/docker/pull"
@@ -26,7 +25,6 @@ import (
 	"github.com/hashicorp/waypoint/builtin/pack"
 	"github.com/hashicorp/waypoint/builtin/tfc"
 	"github.com/hashicorp/waypoint/builtin/vault"
-	pluginVault "github.com/hashicorp/waypoint/builtin/vault"
 )
 
 var (
@@ -73,13 +71,13 @@ var (
 	// hardcode them. This is used by the CEB.
 	ConfigSourcers = map[string]*Instance{
 		"aws-ssm": {
-			Component: &pluginAWSSSM.ConfigSourcer{},
+			Component: &ssm.ConfigSourcer{},
 		},
 		"kubernetes": {
 			Component: &k8s.ConfigSourcer{},
 		},
 		"vault": {
-			Component: &pluginVault.ConfigSourcer{},
+			Component: &vault.ConfigSourcer{},
 		},
 		"terraform-cloud": {
 			Component: &tfc.ConfigSourcer{},


### PR DESCRIPTION
`ssm` and `vault` were being imported twice each in `internal/plugin`. This fixes that.

Could someone add a "no-changelog" label?