### PR TITLE
ui: de-lint services

### DIFF
--- a/ui/app/services/poll-model.ts
+++ b/ui/app/services/poll-model.ts
@@ -11,19 +11,19 @@ const INTERVAL = 15000;
 export default class PollModelService extends Service {
   route!: Route;
 
-  setup(route: Route) {
+  setup(route: Route): void {
     this.route = route;
 
     // Start polling
     this.start();
   }
 
-  willDestroy() {
+  willDestroy(): void {
     this.stop();
     super.willDestroy();
   }
 
-  start() {
+  start(): void {
     if (taskFor(this.poll).isRunning) {
       return;
     }
@@ -31,7 +31,7 @@ export default class PollModelService extends Service {
     taskFor(this.poll).perform();
   }
 
-  stop() {
+  stop(): void {
     taskFor(this.poll).cancelAll();
   }
 
@@ -39,7 +39,8 @@ export default class PollModelService extends Service {
     restartable: true,
     maxConcurrency: 1,
   })
-  async poll() {
+  async poll(): Promise<void> {
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       if (Ember.testing) {
         return;

--- a/ui/app/services/session.ts
+++ b/ui/app/services/session.ts
@@ -6,8 +6,8 @@ export default class SessionService extends Service {
   @service api!: ApiService;
   @tracked authConfigured: boolean;
 
-  constructor(owner: any) {
-    super(owner);
+  constructor(...args: ConstructorParameters<typeof Service>) {
+    super(...args);
 
     this.authConfigured = false;
     if (this.token) {
@@ -19,12 +19,12 @@ export default class SessionService extends Service {
     return window.localStorage.waypointAuthToken;
   }
 
-  async setToken(value: string) {
+  async setToken(value: string): Promise<void> {
     this.authConfigured = true;
     window.localStorage.waypointAuthToken = value;
   }
 
-  async removeToken() {
+  async removeToken(): Promise<void> {
     this.authConfigured = false;
     window.localStorage.removeItem('waypointAuthToken');
   }


### PR DESCRIPTION
## Why the change?

One step closer to running linters in CI.

## How do I test it?

Most of these are self-evidently fine, but the change to `services/api.ts` are a little more significant. Probably worth a smoke test against the real server to verify metadata is still being generated correctly.