### PR TITLE
Internal function to queue multiple jobs transactionally

### DIFF
--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -60,10 +60,45 @@ func (s *service) CancelJob(
 	return &empty.Empty{}, nil
 }
 
-func (s *service) QueueJob(
+// queueJobMulti queues multiple jobs transactionally. The return value
+// are the responses for each in the same order as the requests.
+//
+// Postcondition: len(result) == len(req) iff err == nil
+func (s *service) queueJobMulti(
+	ctx context.Context,
+	req []*pb.QueueJobRequest,
+) ([]*pb.QueueJobResponse, error) {
+	jobs := make([]*pb.Job, len(req))
+	for i, single := range req {
+		job, err := s.queueJobReqToJob(ctx, single)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs[i] = job
+	}
+
+	// Queue the jobs
+	if err := s.state.JobCreate(jobs...); err != nil {
+		return nil, err
+	}
+
+	// Get the response
+	resp := make([]*pb.QueueJobResponse, len(jobs))
+	for i, job := range jobs {
+		resp[i] = &pb.QueueJobResponse{JobId: job.Id}
+	}
+
+	return resp, nil
+
+}
+
+// queueJobReqToJob converts a QueueJobRequest to a job to queue, but
+// does not queue it.
+func (s *service) queueJobReqToJob(
 	ctx context.Context,
 	req *pb.QueueJobRequest,
-) (*pb.QueueJobResponse, error) {
+) (*pb.Job, error) {
 	job := req.Job
 
 	// Validation
@@ -123,6 +158,18 @@ func (s *service) QueueJob(
 		if err != nil {
 			return nil, status.Errorf(codes.Aborted, "error configuring expiration: %s", err)
 		}
+	}
+
+	return job, nil
+}
+
+func (s *service) QueueJob(
+	ctx context.Context,
+	req *pb.QueueJobRequest,
+) (*pb.QueueJobResponse, error) {
+	job, err := s.queueJobReqToJob(ctx, req)
+	if err != nil {
+		return nil, err
 	}
 
 	// Queue the job

--- a/internal/server/singleprocess/state/job.go
+++ b/internal/server/singleprocess/state/job.go
@@ -188,13 +188,23 @@ type Job struct {
 	Blocked bool
 }
 
-// JobCreate queues the given job.
-func (s *State) JobCreate(jobpb *pb.Job) error {
+// JobCreate queues the given jobs. If any job fails to queue, no jobs
+// are queued. If partial failures are acceptible, call this multiple times
+// with a single job.
+func (s *State) JobCreate(jobs ...*pb.Job) error {
 	txn := s.inmem.Txn(true)
 	defer txn.Abort()
 
 	err := s.db.Update(func(dbTxn *bolt.Tx) error {
-		return s.jobCreate(dbTxn, txn, jobpb)
+		// Go through each job one at a time. If any fail, the transaction
+		// is aborted so the whole thing will fail.
+		for _, job := range jobs {
+			if err := s.jobCreate(dbTxn, txn, job); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 	if err == nil {
 		txn.Commit()

--- a/internal/server/singleprocess/state/job_test.go
+++ b/internal/server/singleprocess/state/job_test.go
@@ -35,6 +35,27 @@ func TestJobCreate_singleton(t *testing.T) {
 		require.Len(jobs, 1)
 	})
 
+	t.Run("create multiple with no existing", func(t *testing.T) {
+		require := require.New(t)
+
+		s := TestState(t)
+		defer s.Close()
+
+		// Create a job
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id:          "A",
+			SingletonId: "1",
+		}), serverptypes.TestJobNew(t, &pb.Job{
+			Id:          "B",
+			SingletonId: "2",
+		})))
+
+		// Exactly one job should exist
+		jobs, err := s.JobList()
+		require.NoError(err)
+		require.Len(jobs, 2)
+	})
+
 	t.Run("create with an existing queued", func(t *testing.T) {
 		require := require.New(t)
 


### PR DESCRIPTION
This exposes `queueJobMulti` in `internal/server/singleprocess` and modifies the state store to support queueing multiple jobs transactionally: either all queue, or all do not queue. This is useful in @briancain's queueing work and probably useful in the future as well.

I chose to not expose this publicly as an RPC API since we don't need it right now, but all the primitives are there for when we do.