### PR TITLE
Improvement: Plugin/Docker: Enables image build for specified platform

### DIFF
--- a/.changelog/1949.txt
+++ b/.changelog/1949.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugin/docker: Enables image build for specified platform
+```

--- a/.changelog/1949.txt
+++ b/.changelog/1949.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 plugin/docker: Enables image build for specified platform
 ```

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -143,9 +143,9 @@ build {
 
 	doc.SetField(
 		"platform",
-		"set platform if server is multi-platform capable",
+		"set target platform to build container if server is multi-platform capable",
 		docs.Summary(
-			"Recommended usage with buildkit enabled.",
+			"Must enable Docker buildkit to use the 'platform' flag.",
 		),
 	)
 

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -88,9 +88,9 @@ Set this when the Dockerfile is not APP-PATH/Dockerfile.
 
 #### platform
 
-Set platform if server is multi-platform capable.
+Set target platform to build container if server is multi-platform capable.
 
-Recommended usage with buildkit enabled.
+Must enable Docker buildkit to use the 'platform' flag.
 
 - Type: **string**
 - **Optional**

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -86,6 +86,15 @@ Set this when the Dockerfile is not APP-PATH/Dockerfile.
 - Type: **string**
 - **Optional**
 
+#### platform
+
+Set platform if server is multi-platform capable.
+
+Recommended usage with buildkit enabled.
+
+- Type: **string**
+- **Optional**
+
 ### Output Attributes
 
 Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/1881. Enables a platform HCL arg that is equivalent to `docker build --platform` flag. This only works with buildkit on (will fail with error).

Usage:

Add platform in `waypoint.hcl`
```project = "nginx-project"

app "web" {
  build {
    use "docker" {
        platform = "linux/arm64/v8"
    }
  }

  deploy {
    use "docker" {
    }
  }
}
```

How to verify this works:

`waypoint build`
`docker inspect <docker image>` output should contain
``` 
"Architecture": "arm64",
        "Variant": "v8",
        "Os": "linux",
```

Merge after https://github.com/hashicorp/waypoint/pull/1937.

[Issue filed with Docker/Moby ](https://github.com/moby/moby/issues/42689)so that it may work without buildkit in the future.

🍐 with @izaaklauer thanks!