### PR TITLE
ui: de-lint base routes

### DIFF
--- a/ui/app/routes/application.ts
+++ b/ui/app/routes/application.ts
@@ -9,7 +9,7 @@ const ErrInvalidToken = 'invalid authentication token';
 export default class Application extends Route {
   @service session!: SessionService;
 
-  async beforeModel(transition: Transition) {
+  async beforeModel(transition: Transition): Promise<void> {
     await super.beforeModel(transition);
     if (!this.session.authConfigured && !transition.to.name.startsWith('auth')) {
       this.transitionTo('auth');
@@ -17,7 +17,7 @@ export default class Application extends Route {
   }
 
   @action
-  error(error: Error) {
+  error(error: Error): boolean | void {
     console.log(error);
 
     if (error.message.includes(ErrInvalidToken)) {

--- a/ui/app/routes/workspace.ts
+++ b/ui/app/routes/workspace.ts
@@ -1,12 +1,11 @@
 import Route from '@ember/routing/route';
 import { Ref } from 'waypoint-pb';
 
-interface WSModelParams {
-  workspace_id: string;
-}
+export type Params = { workspace_id: string };
+export type Model = Ref.Workspace.AsObject;
 
 export default class Workspace extends Route {
-  async model(params: WSModelParams): Promise<Ref.Workspace.AsObject> {
+  async model(params: Params): Promise<Model> {
     // Workspace "id" which is a name, based on URL param
     let ws = new Ref.Workspace();
     ws.setWorkspace(params.workspace_id);

--- a/ui/app/routes/workspaces.ts
+++ b/ui/app/routes/workspaces.ts
@@ -5,8 +5,8 @@ import ApiService from 'waypoint/services/api';
 export default class Workspaces extends Route {
   @service api!: ApiService;
 
-  redirect() {
+  redirect(): void {
     // For now, we just support the default workspace
-    return this.transitionTo('workspace', 'default');
+    this.transitionTo('workspace', 'default');
   }
 }


### PR DESCRIPTION
## Why the change?

A couple of small steps closer to running the linters in CI.

## How do I test it?

These are all changes to type annotations, so are inherently safe. The runtime change is removing the `return`, and a close read of [Ember’s docs](https://guides.emberjs.com/release/routing/redirection/#toc_child-routes) confirms it isn’t needed.