### PR TITLE
ui: de-lint onboarding routes

### DIFF
--- a/ui/app/routes/onboarding/index.ts
+++ b/ui/app/routes/onboarding/index.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class OnboardingIndex extends Route {
-  redirect() {
-    return this.transitionTo('onboarding.install');
+  redirect(): void {
+    this.transitionTo('onboarding.install');
   }
 }

--- a/ui/app/routes/onboarding/install/index.ts
+++ b/ui/app/routes/onboarding/install/index.ts
@@ -2,24 +2,28 @@ import Route from '@ember/routing/route';
 import { UAParser } from 'ua-parser-js';
 
 export default class OnboardingInstallIndex extends Route {
-  redirect() {
+  redirect(): void {
     let parser = new UAParser();
 
     switch (parser.getResult().os.name) {
       case 'Mac OS':
-        return this.transitionTo('onboarding.install.homebrew');
+        this.transitionTo('onboarding.install.homebrew');
+        return;
       // There isn't yet a chocolatey package for Waypoint
       // case 'Windows':
       //   return this.transitionTo('onboarding.install.chocolatey');
       case 'Debian':
       case 'Ubuntu':
-        return this.transitionTo('onboarding.install.linux.ubuntu');
+        this.transitionTo('onboarding.install.linux.ubuntu');
+        return;
       case 'CentOS':
-        return this.transitionTo('onboarding.install.linux.centos');
+        this.transitionTo('onboarding.install.linux.centos');
+        return;
       case 'Fedora':
-        return this.transitionTo('onboarding.install.linux.fedora');
+        this.transitionTo('onboarding.install.linux.fedora');
+        return;
       default:
-        return this.transitionTo('onboarding.install.manual');
+        this.transitionTo('onboarding.install.manual');
     }
   }
 }

--- a/ui/app/routes/onboarding/install/linux/index.ts
+++ b/ui/app/routes/onboarding/install/linux/index.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class OnboardingInstallLinuxIndex extends Route {
-  redirect() {
-    return this.transitionTo('onboarding.install.linux.ubuntu');
+  redirect(): void {
+    this.transitionTo('onboarding.install.linux.ubuntu');
   }
 }


### PR DESCRIPTION
## Why the change?

A couple of small steps closer to running the linters in CI.

## How do I test it?

These are all changes to type annotations, so are inherently safe. The runtime change is removing the `return`, and a close read of [Ember’s docs](https://guides.emberjs.com/release/routing/redirection/#toc_child-routes) confirms it isn’t needed.