### PR TITLE
feat: add status and status-check, improve StatusReportList

### DIFF
--- a/.changelog/1959.txt
+++ b/.changelog/1959.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: add `status` and `status check` commands
+```

--- a/builtin/k8s/status_report_util.go
+++ b/builtin/k8s/status_report_util.go
@@ -64,7 +64,7 @@ func buildStatusReport(
 	result.External = true
 	var resources []*sdk.StatusReport_Resource
 
-	// Build health for every possible pod for overal health report
+	// Build health for every possible pod for overall health report
 	var ready, alive, down, unknown int
 
 	// Report on most recently observed status of a deployments pod

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -370,6 +370,16 @@ func Commands(
 				baseCommand: baseCommand,
 			}, nil
 		},
+		"status": func() (cli.Command, error) {
+			return &StatusCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
+		"status check": func() (cli.Command, error) {
+			return &StatusCheckCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
 		"token": func() (cli.Command, error) {
 			return &helpCommand{
 				SynopsisText: helpText["token"][0],

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/dustin/go-humanize"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/posener/complete"
+	"sort"
+	"time"
+)
+
+type StatusCommand struct {
+	*baseCommand
+}
+
+type deploymentNameSequenceSorted []deploymentStatusReport
+
+func (d deploymentNameSequenceSorted) Len() int {
+	return len(d)
+}
+
+func (d deploymentNameSequenceSorted) Less(i, j int) bool {
+	if d[i].Deployment.Application.Application == d[j].Deployment.Application.Application {
+		return d[i].Sequence > d[j].Sequence // We want newer sequences first
+	}
+
+	return d[i].Deployment.Application.Application < d[j].Deployment.Application.Application
+}
+
+func (d deploymentNameSequenceSorted) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+
+type deploymentStatusReport struct {
+	*pb.Deployment
+	*pb.StatusReport
+}
+
+var _ sort.Interface = (*deploymentNameSequenceSorted)(nil)
+
+func (c *StatusCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithSingleApp(),
+	); err != nil {
+		return 1
+	}
+
+	resp, err := c.project.Client().ListStatusReports(c.Ctx, &pb.ListStatusReportsRequest{
+		Application: c.refApp,
+		Workspace: c.refWorkspace,
+		Order: &pb.OperationOrder{
+			Order: pb.OperationOrder_COMPLETE_TIME,
+			Desc: true,
+		},
+	})
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	c.ui.Output("Deployments Status", terminal.WithHeaderStyle())
+	err = c.listDeploymentsStatus(resp)
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+	return 0
+}
+
+func (c *StatusCommand) listDeploymentsStatus(resp *pb.ListStatusReportsResponse) error {
+	table := terminal.NewTable("Name", "Version", "Health", "Message", "Last Check")
+	var dsr []deploymentStatusReport
+
+	for _, sr := range resp.StatusReports {
+		// Get Deployment
+		dep, err := c.project.Client().GetDeployment(c.Ctx, &pb.GetDeploymentRequest{
+			Ref: &pb.Ref_Operation{
+				Target: &pb.Ref_Operation_Id{Id: sr.GetDeploymentId()},
+			},
+		})
+
+		if err != nil {
+			return fmt.Errorf(
+				"unable to get deployment: %v",
+				err,
+			)
+		}
+
+		dsr = append(dsr, deploymentStatusReport{
+			Deployment:   dep,
+			StatusReport: sr,
+		})
+
+	}
+
+	sort.Sort(deploymentNameSequenceSorted(dsr))
+
+	for _, dsrVal := range dsr {
+		table.Rich([]string{
+			dsrVal.StatusReport.Application.Application,
+			fmt.Sprintf("v%d", dsrVal.Deployment.Sequence),
+			dsrVal.StatusReport.Health.HealthStatus,
+			dsrVal.StatusReport.Health.HealthMessage,
+			humanize.Time(
+				time.Unix(
+					dsrVal.StatusReport.Status.CompleteTime.Seconds,
+					int64(dsrVal.StatusReport.Status.CompleteTime.Nanos),
+				),
+			),
+		}, nil)
+	}
+
+	c.ui.Table(table)
+	return nil
+}
+
+func (c *StatusCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
+}
+
+func (c *StatusCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *StatusCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *StatusCommand) Synopsis() string {
+	return "List status for the current project."
+}
+
+func (c *StatusCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint status
+
+  Show the status for the current project.
+
+  This shows a detailed structure of the project resources and
+  the current reported health associated with them.
+
+`)
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -54,10 +54,10 @@ func (c *StatusCommand) Run(args []string) int {
 
 	resp, err := c.project.Client().ListStatusReports(c.Ctx, &pb.ListStatusReportsRequest{
 		Application: c.refApp,
-		Workspace: c.refWorkspace,
+		Workspace:   c.refWorkspace,
 		Order: &pb.OperationOrder{
 			Order: pb.OperationOrder_COMPLETE_TIME,
-			Desc: true,
+			Desc:  true,
 		},
 	})
 	if err != nil {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -80,6 +80,10 @@ func (c *StatusCommand) listDeploymentsStatus(resp *pb.ListStatusReportsResponse
 	var dsr []deploymentStatusReport
 
 	for _, sr := range resp.StatusReports {
+		if sr.TargetId == nil {
+			continue
+		}
+
 		// Get Deployment
 		dep, err := c.project.Client().GetDeployment(c.Ctx, &pb.GetDeploymentRequest{
 			Ref: &pb.Ref_Operation{

--- a/internal/cli/status_check.go
+++ b/internal/cli/status_check.go
@@ -28,8 +28,8 @@ func (c *StatusCheckCommand) Run(args []string) int {
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		deployments, err := c.project.Client().ListDeployments(c.Ctx, &pb.ListDeploymentsRequest{
-			Application: c.refApp,
-			Workspace: c.refWorkspace,
+			Application:   c.refApp,
+			Workspace:     c.refWorkspace,
 			PhysicalState: pb.Operation_CREATED,
 		})
 		if err != nil {
@@ -55,7 +55,7 @@ func (c *StatusCheckCommand) Run(args []string) int {
 					dep.Sequence,
 					resp.StatusReport.Health.HealthStatus,
 					resp.StatusReport.Health.HealthMessage,
-			), terminal.WithInfoStyle())
+				), terminal.WithInfoStyle())
 		}
 
 		return nil
@@ -65,10 +65,6 @@ func (c *StatusCheckCommand) Run(args []string) int {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
-
-
-
-
 
 	c.ui.Output("Status report successfully requested",
 		terminal.WithSuccessStyle(),

--- a/internal/cli/status_check.go
+++ b/internal/cli/status_check.go
@@ -89,7 +89,7 @@ func (c *StatusCheckCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *StatusCheckCommand) Synopsis() string {
-	return "List status for the current project."
+	return "Performs an health check for the current project."
 }
 
 func (c *StatusCheckCommand) Help() string {

--- a/internal/cli/status_check.go
+++ b/internal/cli/status_check.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/posener/complete"
+)
+
+type StatusCheckCommand struct {
+	*baseCommand
+}
+
+func (c *StatusCheckCommand) Run(args []string) int {
+	// Initialize. If we fail, we just exit since Init handles the UI.
+	if err := c.Init(
+		WithArgs(args),
+		WithFlags(c.Flags()),
+		WithNoConfig(),
+		WithSingleApp(),
+	); err != nil {
+		return 1
+	}
+
+	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+		deployments, err := c.project.Client().ListDeployments(c.Ctx, &pb.ListDeploymentsRequest{
+			Application: c.refApp,
+			Workspace: c.refWorkspace,
+			PhysicalState: pb.Operation_CREATED,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to get deployments for this project")
+		}
+
+		if len(deployments.Deployments) == 0 {
+			return fmt.Errorf("this project has no deployments in this workspace")
+		}
+		// Query a check for each deployment
+		for _, dep := range deployments.Deployments {
+			resp, err := app.StatusReport(c.Ctx, &pb.Job_StatusReportOp{
+				Target: &pb.Job_StatusReportOp_Deployment{
+					Deployment: dep,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			c.ui.Output(
+				fmt.Sprintf("%s v%d is %s: %s",
+					resp.StatusReport.Application.Application,
+					dep.Sequence,
+					resp.StatusReport.Health.HealthStatus,
+					resp.StatusReport.Health.HealthMessage,
+			), terminal.WithInfoStyle())
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return 1
+	}
+
+
+
+
+
+	c.ui.Output("Status report successfully requested",
+		terminal.WithSuccessStyle(),
+	)
+	return 0
+}
+
+func (c *StatusCheckCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
+}
+
+func (c *StatusCheckCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *StatusCheckCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *StatusCheckCommand) Synopsis() string {
+	return "List status for the current project."
+}
+
+func (c *StatusCheckCommand) Help() string {
+	return formatHelp(`
+Usage: waypoint status check
+
+  Trigger a status check on the project.
+
+  This command triggers a status check on the project,
+  so that you can on a subsequent run of "waypoint status"
+  see the updated status.
+
+`)
+}

--- a/internal/server/gen/server.pb.go
+++ b/internal/server/gen/server.pb.go
@@ -9054,7 +9054,7 @@ func (x *GetStatusReportRequest) GetRef() *Ref_Operation {
 	return nil
 }
 
-// StatusReport is the report genrated when querying the overall health of
+// StatusReport is the report generated when querying the overall health of
 // a deployed or released application. This report is generated after the
 // an Up Operation, DeployOp or ReleaseOp. In the future Waypoint will be able
 // to generate these reports on demand in the UI, or on an interval using a poller.

--- a/internal/server/proto/server.proto
+++ b/internal/server/proto/server.proto
@@ -2828,7 +2828,7 @@ message GetStatusReportRequest {
   // a report by deployment or release operation id
 }
 
-// StatusReport is the report genrated when querying the overall health of
+// StatusReport is the report generated when querying the overall health of
 // a deployed or released application. This report is generated after the
 // an Up Operation, DeployOp or ReleaseOp. In the future Waypoint will be able
 // to generate these reports on demand in the UI, or on an interval using a poller.

--- a/internal/server/singleprocess/state/status_report.go
+++ b/internal/server/singleprocess/state/status_report.go
@@ -76,7 +76,6 @@ func (s *State) StatusReportList(
 		result = append(result, v)
 	}
 
-
 	return result, nil
 }
 

--- a/internal/server/singleprocess/state/status_report.go
+++ b/internal/server/singleprocess/state/status_report.go
@@ -61,6 +61,11 @@ func (s *State) StatusReportList(
 		} else {
 			theId = resId
 		}
+
+		if sr.Status.CompleteTime == nil {
+			continue
+		}
+
 		if mVal, ok := resMap[theId]; ok {
 			srTime := protoTimestampToTime(sr.Status.CompleteTime)
 			mValTime := protoTimestampToTime(mVal.Status.CompleteTime)


### PR DESCRIPTION
This commit adds a `waypoint status` and `waypoint status check`
command intended to provide more insights on the project.

Currently, this commit only shows the status of the deployments
(health check), in a similar way as `waypoint deployment list`
and adds a `status check` command to trigger an Health Check
on the deployments.

### `waypoint status`

```
» Deployments Status
  NAME  | VERSION | HEALTH |              MESSAGE              |   LAST CHECK    
--------+---------+--------+-----------------------------------+-----------------
  app-1 | v2      | READY  | all processes are reporting ready | 51 minutes ago  
  app-1 | v1      | READY  | all processes are reporting ready | 51 minutes ago  
```

In the future, this `status` command should display the project associated resources and include the releases.

### `waypoint status check`

Currently the Health Check is performed only after a deployment or release. This is useful, but you might end up with super-old health checks (e.g: health checks from 2 weeks ago). I guess this solution will be anyways be tackled by a periodic Health Probe with the runners, but it's nice to have a local status check too, hence the feature.

```
$ waypoint status check
waypoint status check
 + Gathering health report for Cloud Foundry platform...
 + Connecting to Cloud Foundry at https://api.cf.swisscom.ch
  app-1 v2 is READY: all processes are reporting ready
 + Gathering health report for Cloud Foundry platform...
 + Connecting to Cloud Foundry at https://api.cf.swisscom.ch
  app-1 v1 is READY: all processes are reporting ready
Status report successfully requested
```

```
$ waypoint status
» Deployments Status
  NAME  | VERSION | HEALTH |              MESSAGE              |   LAST CHECK
--------+---------+--------+-----------------------------------+-----------------
  app-1 | v2      | READY  | all processes are reporting ready | 15 seconds ago
  app-1 | v1      | READY  | all processes are reporting ready | 14 seconds ago
```

The `status check` command should in the future also include releases, and let the user choose which check to perform.
In addition to this, the check should be done remotely on the runner somehow (periodically?).


### UI / Server Bug Fix

This commit also fixes an issue with the list of status reports being returned by the `StatusReportList` method: when multiple
checks are performed on the same deployment, the UI doesn't always pick up the correct `StatusReport` (most recent). 
We're now handling this case in the StatusReport method itself, so that we only return one StatusReport per Deployment.

Related Hashicorp Waypoint issues:
- hashicorp/waypoint#1501