### PR TITLE
docs: broken link and caitalization consistency

### DIFF
--- a/internal/cli/auth_method_set_oidc.go
+++ b/internal/cli/auth_method_set_oidc.go
@@ -156,7 +156,7 @@ func (c *AuthMethodSetOIDCCommand) Synopsis() string {
 
 func (c *AuthMethodSetOIDCCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint auth-method set oidc [options] name
+Usage: waypoint auth-method set oidc [options] NAME
 
   Configure an OIDC auth method.
 

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -497,7 +497,7 @@ func (c *ProjectApplyCommand) Synopsis() string {
 
 func (c *ProjectApplyCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint project apply [OPTIONS] NAME
+Usage: waypoint project apply [options] NAME
 
   Create or update a project.
 

--- a/website/content/docs/server/auth.mdx
+++ b/website/content/docs/server/auth.mdx
@@ -14,7 +14,7 @@ Okta, GitLab, and more.
 
 If you're a new user that ran `waypoint install`, the auth token was automatically
 configured for your local CLI. As a next step, we recomend
-[setting up OIDC](/server/auth/oidc).
+[setting up OIDC](/docs/server/auth/oidc).
 
 ## Logging In
 


### PR DESCRIPTION
Our other commands that include a `NAME` after `[options]` capitalize it (e.g. `waypoint context delete [options] NAME`)
Note: related bug #1976