### PR TITLE
internal/server: Respect TOS flag for using URL service

### DIFF
--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -227,9 +227,11 @@ func WithSuperuser() Option {
 	}
 }
 
+// WithAcceptURLTerms will either accept or reject the terms of service
+// for using the URL service. Rejecting the TOS will disable the URL service.
 func WithAcceptURLTerms(accept bool) Option {
 	return func(s *service, cfg *config) error {
-		cfg.acceptUrlTerms = true
+		cfg.acceptUrlTerms = accept
 		return nil
 	}
 }

--- a/internal/server/singleprocess/service.go
+++ b/internal/server/singleprocess/service.go
@@ -227,8 +227,10 @@ func WithSuperuser() Option {
 	}
 }
 
-// WithAcceptURLTerms will either accept or reject the terms of service
-// for using the URL service. Rejecting the TOS will disable the URL service.
+// WithAcceptURLTerms will set the config to either accept or reject the terms
+// of service for using the URL service. Rejecting the TOS will disable the
+// URL service. Note that the actual rejection does not occur until the
+// waypoint horizon client attempts to register its guest account.
 func WithAcceptURLTerms(accept bool) Option {
 	return func(s *service, cfg *config) error {
 		cfg.acceptUrlTerms = accept


### PR DESCRIPTION
Prior to this commit, the TOS for using the URL service in Waypoint
would always be true, regardless of the request. This commit fixes that
by respecting the argument passed through.

Note that the CLI server_run would error out before this reuqest if the flag
was false, so we were not auto-accepting despite the function always setting
the terms to true.

Fixes #1843