### PR TITLE
Wiring declared resources into release functions, with k8s reference impl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210729135349-62df318a2458
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210804234639-71cf81c85c9d
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/jinzhu/now v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -888,8 +888,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef h1:YKouRHFf
 github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210729135349-62df318a2458 h1:zosh+5Cpmi01f+0D3/Uw5MaUbnwRzF5Ci5xC2RcyUDE=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210729135349-62df318a2458/go.mod h1:l5rxDV4JfLCnMb/+0DxIjE40tHXPWbDyerz+f2Oul3I=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210804234639-71cf81c85c9d h1:r/XJNLUqZTEUfOeXhwp6zFKqBgqQTCYlWZPG7JqqgZQ=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210804234639-71cf81c85c9d/go.mod h1:l5rxDV4JfLCnMb/+0DxIjE40tHXPWbDyerz+f2Oul3I=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
Depends on https://github.com/hashicorp/waypoint-plugin-sdk/pull/49

Releases can declare resources too! Now that we've proved out the pattern with deployments, this makes the declared resources component outparam available to release functions.

It also updates the k8s releaser to use the new declared resources

### How to verify

Run a kubernetes deployment (i.e. run `waypoint up` from within https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs), then use grpcurl to view the api response for the releases like so:

```
SEQ_NUM=1; grpcurl -d '{"ref": {"sequence": { "application": {"application": "example-nodejs", "project": "example-nodejs"}, "number": '$SEQ_NUM' }}, "load_details": "0"}' --insecure -H "client-api-protocol: 1,1" -H "Authorization: `waypoint token new`" localhost:9701 hashicorp.waypoint.Waypoint/GetRelease
```

And look for a new DeclaredResources field on the response:

Example:
```
{
  "id": "01FC9RRRRDYZV0K97MSSX4TW8K",
  "status": {
    "state": "SUCCESS",
    "startTime": "2021-08-04T23:42:52.684874Z",
    "completeTime": "2021-08-04T23:43:08.695683Z"
  },
  "component": {
    "type": "RELEASEMANAGER",
    "name": "kubernetes"
  },
  "release": {"@type":"type.googleapis.com/k8s.Release","Url":"http://10.110.0.251:80","resourceState":{"@type":"type.googleapis.com/hashicorp.waypoint.sdk.Framework.ResourceManagerState","createOrder":["service"],"resources":[{"name":"service","raw":{"@type":"type.googleapis.com/k8s.Resource.Service","name":"example-nodejs-k8s"},"json":"{\n\t\"name\": \"example-nodejs-k8s\"\n}"}]},"serviceName":"example-nodejs-k8s"},
  "deploymentId": "01FC9RRAMVYZS6SGAKGF5MFKF6",
  "labels": {
    "env": "dev",
    "service": "example-nodejs-k8s",
    "waypoint/workspace": "default"
  },
  "application": {
    "application": "example-nodejs-k8s",
    "project": "example-k8s-multi"
  },
  "workspace": {
    "workspace": "default"
  },
  "url": "http://10.110.0.251:80",
  "sequence": "2",
  "state": "CREATED",
  "preload": {
    
  },
  "jobId": "01FC9RRREYA11XCDC0A4GF04F4",
  "templateData": "eyJyZXNvdXJjZV9zdGF0ZSI6eyJ0eXBlX3VybCI6InR5cGUuZ29vZ2xlYXBpcy5jb20vaGFzaGljb3JwLndheXBvaW50LnNkay5GcmFtZXdvcmsuUmVzb3VyY2VNYW5hZ2VyU3RhdGUiLCJ2YWx1ZSI6IkNtNEtCM05sY25acFkyVVNRQW9vZEhsd1pTNW5iMjluYkdWaGNHbHpMbU52YlM5ck9ITXVVbVZ6YjNWeVkyVXVVMlZ5ZG1salpSSVVDaEpsZUdGdGNHeGxMVzV2WkdWcWN5MXJPSE1hSVhzS0NTSnVZVzFsSWpvZ0ltVjRZVzF3YkdVdGJtOWtaV3B6TFdzNGN5SUtmUklIYzJWeWRtbGpaUT09In0sInNlcnZpY2VfbmFtZSI6ImV4YW1wbGUtbm9kZWpzLWs4cyIsInVybCI6Imh0dHA6Ly8xMC4xMTAuMC4yNTE6ODAifQ==",
  "unimplemented": true,
  "declaredResources": [
    {
      "name": "service",
      "state": {"@type":"type.googleapis.com/k8s.Resource.Service","name":"example-nodejs-k8s"},
      "stateJson": "{\"name\":\"example-nodejs-k8s\"}",
      "type": "01FC9RS0Y5065DF6EYXKSGZHMZ"
    }
  ]
}

```