### PR TITLE
cli/project_apply: Return error if polling requested but no data source

### DIFF
--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -277,6 +277,27 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 	case "":
 		// Do nothing, we aren't updating this information for this project.
 
+		// Some basic error handling if polling is requested but was not explicit
+		// about a data source for the project
+		if c.flagPoll {
+			c.ui.Output(
+				"To enable polling, you must specify a git data source for the project with -data-source=git",
+				terminal.WithErrorStyle(),
+			)
+			return 1
+		}
+
+		// Some basic error handling if app status polling is requested but was not explicit
+		// about a data source for the project
+		if c.flagAppStatusPoll {
+			c.ui.Output(
+				"To enable application status polling, you must specify a git data "+
+					"source for the project with -data-source=git",
+				terminal.WithErrorStyle(),
+			)
+			return 1
+		}
+
 	default:
 		s.Abort()
 


### PR DESCRIPTION
This commit adds some extra error messaging if a user requests to enable
project or app status polling without specifying the data source of the
project. Being explicit here ensures that app polling is only turned on
with the projects data source is git since neither of these polling
features work with local data sources.