### PR TITLE
internal/server: Ensure ExpediteStatusReport sets a default workspace

### DIFF
--- a/internal/server/singleprocess/service_status_report.go
+++ b/internal/server/singleprocess/service_status_report.go
@@ -146,6 +146,13 @@ func (s *service) ExpediteStatusReport(
 		return nil, err
 	}
 
+	var workspace string
+	if req.Workspace == nil {
+		workspace = "default"
+	} else {
+		workspace = req.Workspace.Workspace
+	}
+
 	// build job
 	jobRequest := &pb.QueueJobRequest{
 		Job: &pb.Job{
@@ -160,7 +167,7 @@ func (s *service) ExpediteStatusReport(
 			// needed to query the deploy or release
 			DataSource: project.DataSource,
 
-			Workspace: &pb.Ref_Workspace{Workspace: req.Workspace.Workspace},
+			Workspace: &pb.Ref_Workspace{Workspace: workspace},
 
 			// Generate a status report
 			Operation: statusReportJob,

--- a/internal/server/singleprocess/service_status_report_test.go
+++ b/internal/server/singleprocess/service_status_report_test.go
@@ -298,5 +298,20 @@ func TestServiceStatusReport_ExpediteStatusReport(t *testing.T) {
 		require.NotNil(t, jobResp.JobId)
 	})
 
+	t.Run("Expedite Status Report with no workspace uses default and doesn't error", func(t *testing.T) {
+		require := require.New(t)
+
+		jobResp, err := client.ExpediteStatusReport(ctx, &pb.ExpediteStatusReportRequest{
+			Target: &pb.ExpediteStatusReportRequest_Deployment{
+				Deployment: &pb.Ref_Operation{
+					Target: &pb.Ref_Operation_Id{Id: resp.Deployment.Id},
+				},
+			},
+		})
+		require.NoError(err)
+		require.NotEmpty(t, jobResp)
+		require.NotNil(t, jobResp.JobId)
+	})
+
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Prior to this commit, if a caller requests a status report job but
doesn't specify a workspace, the server would panic on the Workspace ref
being unset when it attempted to build the job. This commit fixes it by
defaulting to the default workspace if the caller does not specify which
workspace the report should run in.