### PR TITLE
ui: Use new user token command for auth page

### DIFF
--- a/.changelog/2006.txt
+++ b/.changelog/2006.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update authentication page with new supported `waypoint user token` command.
+```

--- a/ui/app/components/login-token/index.hbs
+++ b/ui/app/components/login-token/index.hbs
@@ -1,10 +1,10 @@
 <form {{on "submit" this.login}} class="login">
   <fieldset>
     <label>{{t 'login.instruction'}}</label>
-    <CopyableCode @ref="waypoint-token-new">
-      <pre><code id="waypoint-token-new">waypoint token new</code></pre>
+    <CopyableCode @ref="waypoint-user-token">
+      <pre><code id="waypoint-user-token">waypoint user token</code></pre>
     </CopyableCode>
-    <small><ExternalLink href="https://waypointproject.io/commands/token-new">Read more in our documentation</ExternalLink></small>
+    <small><ExternalLink href="https://waypointproject.io/commands/user-token">Read more in our documentation</ExternalLink></small>
   </fieldset>
 
   <fieldset>


### PR DESCRIPTION
The `waypoint token new` command has been deprecated in favor of using
`waypoint user token`. The authentication page should suggest using the
new command instead of the old one.

Fixes #2003