### PR TITLE
website: quote input var label example with docker

### DIFF
--- a/website/content/docs/waypoint-hcl/variables/input.mdx
+++ b/website/content/docs/waypoint-hcl/variables/input.mdx
@@ -42,8 +42,8 @@ variable "docker_labels" {
     log_level   = string
   })
   default = {
-      environment = test
-      log_level   = debug
+      environment = "test"
+      log_level   = "debug"
   }
 }
 ```


### PR DESCRIPTION
Found a fixup needed as I ran through the input vars docs.