### PR TITLE
cli/docs: Generate usage text from commands Help() func

### DIFF
--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -837,10 +837,10 @@ func (c *AppDocsCommand) Help() string {
 	helpText := `
 Usage: waypoint docs [options]
 
-  Output documentation about the plugins. By default, it lists the documentation
-	for the plugins configured by this project.
+Output documentation about the plugins. By default, it lists the documentation
+for the plugins configured by this project.
 
-	The flags can change which plugins are listed and in which format.
+The flags can change which plugins are listed and in which format.
 
 ` + c.Flags().Help()
 

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -73,7 +73,7 @@ func (c *ArtifactBuildCommand) Synopsis() string {
 func (c *ArtifactBuildCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint artifact build [options]
-Alias: waypoint build
+Alias: waypoint build [options]
 
   Build a new versioned artifact from source.
 

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -76,7 +76,7 @@ func (c *ArtifactPushCommand) Synopsis() string {
 func (c *ArtifactPushCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint artifact push [options]
-Alias: waypoint push
+Alias: waypoint push [options]
 
   Push a local build to a registry. This will push the most recent
   successful local build by default. You can view a list of the recent

--- a/internal/cli/build_list.go
+++ b/internal/cli/build_list.go
@@ -134,7 +134,10 @@ func (c *BuildListCommand) Synopsis() string {
 func (c *BuildListCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint artifact list-builds [options]
-  List builds.
+
+List artifacts created from a build. An artifact is the result of a build or
+registry. This is the metadata only. The binary contents of an artifact are
+expected to be stored in a registry.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -223,7 +223,7 @@ func (c *ConfigGetCommand) Synopsis() string {
 
 func (c *ConfigGetCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint config-get [prefix]
+Usage: waypoint config get [prefix]
 
   Retrieve and print all config variables previously configured that have
   the given prefix. If no prefix is given, all variables are returned.

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -131,7 +131,8 @@ description: "%s"
 				}
 			}
 		} else {
-			// Fail over to simple docs gen
+			// Fail over to simple docs gen. These are for top level commands
+			// like `waypoint context` that don't work without a subcommand and fail the regex match.
 			fmt.Fprintf(w, "## Usage\n\nUsage: `waypoint %s [options]`\n", name)
 		}
 

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -129,7 +129,7 @@ description: "%s"
 				if len(matchAlias) > 0 {
 					hasAlias = true
 					aliasMatch := reUsage.FindStringSubmatch(optionalAlias)
-					fmt.Fprintf(w, fmt.Sprintf("Alias: `waypoint %s`\n", aliasMatch[1]))
+					fmt.Fprintf(w, fmt.Sprintf("\nAlias: `waypoint %s`\n", aliasMatch[1]))
 				}
 			}
 
@@ -159,6 +159,11 @@ description: "%s"
 				// Strip any color formatting
 				reAsciColor := regexp.MustCompile(ansi)
 				helpMsg = reAsciColor.ReplaceAllString(helpMsg, "")
+
+				// Trim any left leading whitespace, if any. We do this because any
+				// chunk of text that's indented in markdown will be rendered as a
+				// code block rather than a paragraph of text.
+				helpMsg = strings.TrimLeft(helpMsg, " ")
 				fmt.Fprintf(w, "\n%s", helpMsg)
 			}
 		} else {

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -121,14 +121,40 @@ description: "%s"
 		matches := reUsage.FindStringSubmatch(usage)
 
 		if len(matches) > 0 {
-			fmt.Fprintf(w, fmt.Sprintf("## Usage\n\nUsage: `waypoint %s`", matches[1]))
+			fmt.Fprintf(w, fmt.Sprintf("## Usage\n\nUsage: `waypoint %s`\n", matches[1]))
 
+			hasAlias := false
 			if optionalAlias != "" {
 				matchAlias := reAlias.FindStringSubmatch(optionalAlias)
 				if len(matchAlias) > 0 {
+					hasAlias = true
 					aliasMatch := reUsage.FindStringSubmatch(optionalAlias)
-					fmt.Fprintf(w, fmt.Sprintf("\nAlias: `waypoint %s`", aliasMatch[1]))
+					fmt.Fprintf(w, fmt.Sprintf("Alias: `waypoint %s`\n", aliasMatch[1]))
 				}
+			}
+
+			// Don't include flag options, we do this later. We trim it here because
+			// most commands include it in the help text.
+			reOptions := regexp.MustCompile(` Options:`)
+			optionsIndex := 0
+			for i, opt := range helpText {
+				optMatch := reOptions.FindStringSubmatch(opt)
+				if len(optMatch) > 0 {
+					optionsIndex = i
+					break
+				}
+			}
+
+			if optionsIndex > 1 {
+				startIndex := 1
+				helpMsg := ""
+
+				if hasAlias {
+					startIndex = 2
+				}
+
+				helpMsg = strings.Join(helpText[startIndex:optionsIndex], "\n")
+				fmt.Fprintf(w, "\n%s", helpMsg)
 			}
 		} else {
 			// Fail over to simple docs gen. These are for top level commands

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -146,6 +146,7 @@ description: "%s"
 			}
 
 			if optionsIndex > 1 {
+				// Assume all commands have at least "Global Options"
 				startIndex := 1
 				helpMsg := ""
 
@@ -154,6 +155,10 @@ description: "%s"
 				}
 
 				helpMsg = strings.Join(helpText[startIndex:optionsIndex], "\n")
+
+				// Strip any color formatting
+				reAsciColor := regexp.MustCompile(ansi)
+				helpMsg = reAsciColor.ReplaceAllString(helpMsg, "")
 				fmt.Fprintf(w, "\n%s", helpMsg)
 			}
 		} else {
@@ -224,3 +229,8 @@ func (c *DocsCommand) Help() string {
 func (c *DocsCommand) Synopsis() string {
 	return "Generate docs"
 }
+
+const (
+	// NOTE: adapted from https://github.com/acarl005/stripansi
+	ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+)

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -124,7 +124,7 @@ func (c *FmtCommand) Synopsis() string {
 
 func (c *FmtCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint fmt [FILE]
+Usage: waypoint fmt [options] [FILE]
 
   Rewrite a waypoint.hcl file to a canonical format.
 

--- a/internal/cli/snapshot_backup.go
+++ b/internal/cli/snapshot_backup.go
@@ -93,10 +93,10 @@ func (c *SnapshotBackupCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint server snapshot [<filename>]
 
-	Generate a snapshot from the current server and write it to a file specified
-	by the given name. If no name is specified and standard out is not a terminal,
-	the backup will be written to standard out. Using a name of '-' will force writing
-	to standard out.
+Generate a snapshot from the current server and write it to a file specified
+by the given name. If no name is specified and standard out is not a terminal,
+the backup will be written to standard out. Using a name of '-' will force writing
+to standard out.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/snapshot_restore.go
+++ b/internal/cli/snapshot_restore.go
@@ -105,18 +105,18 @@ func (c *SnapshotRestoreCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint server restore [-exit] [<filename>]
 
-	Stage a backup snapshot within the current server. The data in the snapshot is not restored
-	immediately, but rather staged such that on the next server start, it will be restored.
+Stage a backup snapshot within the current server. The data in the snapshot is not restored
+immediately, but rather staged such that on the next server start, it will be restored.
 
-	If -exit is passed, the server process will exit after staging the data. This allows a process
-	monitor to restart the server, where it will see the staged snapshot and restore the data.
+If -exit is passed, the server process will exit after staging the data. This allows a process
+monitor to restart the server, where it will see the staged snapshot and restore the data.
 
-	If -exit is not passed, an operator must restart the server manually to finish the restoration
-	process.
+If -exit is not passed, an operator must restart the server manually to finish the restoration
+process.
 
-	The argument should be to a file written previously by 'waypoint server snapshot'.
-	If no name is specified and standard input is not a terminal, the backup will read from
-	standard input. Using a name of '-' will force reading from standard input.
+The argument should be to a file written previously by 'waypoint server snapshot'.
+If no name is specified and standard input is not a terminal, the backup will read from
+standard input. Using a name of '-' will force reading from standard input.
 
 ` + c.Flags().Help())
 }

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -16,6 +16,7 @@ Build a new versioned artifact from source
 ## Usage
 
 Usage: `waypoint artifact build [options]`
+Alias: `waypoint build [options]`
 
 #### Global Options
 

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -18,6 +18,8 @@ Build a new versioned artifact from source
 Usage: `waypoint artifact build [options]`
 Alias: `waypoint build [options]`
 
+Build a new versioned artifact from source.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -16,6 +16,7 @@ Build a new versioned artifact from source
 ## Usage
 
 Usage: `waypoint artifact build [options]`
+
 Alias: `waypoint build [options]`
 
 Build a new versioned artifact from source.

--- a/website/content/commands/artifact-list-builds.mdx
+++ b/website/content/commands/artifact-list-builds.mdx
@@ -17,6 +17,8 @@ List builds.
 
 Usage: `waypoint artifact list-builds [options]`
 
+List builds.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/artifact-list-builds.mdx
+++ b/website/content/commands/artifact-list-builds.mdx
@@ -17,7 +17,9 @@ List builds.
 
 Usage: `waypoint artifact list-builds [options]`
 
-List builds.
+List artifacts created from a build. An artifact is the result of a build or
+registry. This is the metadata only. The binary contents of an artifact are
+expected to be stored in a registry.
 
 #### Global Options
 

--- a/website/content/commands/artifact-list.mdx
+++ b/website/content/commands/artifact-list.mdx
@@ -17,6 +17,9 @@ List pushed artifacts.
 
 Usage: `waypoint artifact list [options]`
 
+Lists the artifacts that are pushed to a registry. This does not
+list the artifacts that are just part of local builds.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -18,6 +18,10 @@ Push a build's artifact to a registry
 Usage: `waypoint artifact push [options]`
 Alias: `waypoint push [options]`
 
+Push a local build to a registry. This will push the most recent
+successful local build by default. You can view a list of the recent
+local builds using "artifact list-builds" command.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -16,6 +16,7 @@ Push a build's artifact to a registry
 ## Usage
 
 Usage: `waypoint artifact push [options]`
+Alias: `waypoint push [options]`
 
 #### Global Options
 

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -16,6 +16,7 @@ Push a build's artifact to a registry
 ## Usage
 
 Usage: `waypoint artifact push [options]`
+
 Alias: `waypoint push [options]`
 
 Push a local build to a registry. This will push the most recent

--- a/website/content/commands/auth-method-delete.mdx
+++ b/website/content/commands/auth-method-delete.mdx
@@ -15,7 +15,7 @@ Delete a previously configured auth method.
 
 ## Usage
 
-Usage: `waypoint auth-method delete [options]`
+Usage: `waypoint auth-method delete NAME`
 
 #### Global Options
 

--- a/website/content/commands/auth-method-inspect.mdx
+++ b/website/content/commands/auth-method-inspect.mdx
@@ -15,7 +15,7 @@ Show detailed information about a configured auth method
 
 ## Usage
 
-Usage: `waypoint auth-method inspect [options]`
+Usage: `waypoint auth-method inspect NAME`
 
 #### Global Options
 

--- a/website/content/commands/auth-method-list.mdx
+++ b/website/content/commands/auth-method-list.mdx
@@ -15,7 +15,7 @@ List all configured auth methods
 
 ## Usage
 
-Usage: `waypoint auth-method list [options]`
+Usage: `waypoint auth-method list`
 
 #### Global Options
 

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -15,7 +15,7 @@ Configure an OIDC auth method
 
 ## Usage
 
-Usage: `waypoint auth-method set oidc [options]`
+Usage: `waypoint auth-method set oidc [options] NAME`
 
 #### Global Options
 

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -17,6 +17,8 @@ Configure an OIDC auth method
 
 Usage: `waypoint auth-method set oidc [options] NAME`
 
+Configure an OIDC auth method.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -18,6 +18,8 @@ Build a new versioned artifact from source
 Usage: `waypoint artifact build [options]`
 Alias: `waypoint build [options]`
 
+Build a new versioned artifact from source.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -16,6 +16,7 @@ Build a new versioned artifact from source
 ## Usage
 
 Usage: `waypoint artifact build [options]`
+
 Alias: `waypoint build [options]`
 
 Build a new versioned artifact from source.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -15,7 +15,8 @@ Build a new versioned artifact from source
 
 ## Usage
 
-Usage: `waypoint build [options]`
+Usage: `waypoint artifact build [options]`
+Alias: `waypoint build [options]`
 
 #### Global Options
 

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -20,7 +20,7 @@ Usage: `waypoint config get [prefix]`
 Retrieve and print all config variables previously configured that have
 the given prefix. If no prefix is given, all variables are returned.
 
-By specifying the "[95m-app[0m" flag you can look at config variables for
+By specifying the "-app" flag you can look at config variables for
 a specific application rather than the project.
 
 #### Global Options

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -15,7 +15,7 @@ Get config variables.
 
 ## Usage
 
-Usage: `waypoint config get [options]`
+Usage: `waypoint config get [prefix]`
 
 #### Global Options
 

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -17,6 +17,12 @@ Get config variables.
 
 Usage: `waypoint config get [prefix]`
 
+Retrieve and print all config variables previously configured that have
+the given prefix. If no prefix is given, all variables are returned.
+
+By specifying the "[95m-app[0m" flag you can look at config variables for
+a specific application rather than the project.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -17,6 +17,12 @@ Set a config variable.
 
 Usage: `waypoint config set <name>=<value>`
 
+Set a config variable that will be available to deployments as an
+environment variable.
+
+This will scope the variable to the entire project by default.
+Specify the "[95m-app[0m" flag to set a config variable for a specific app.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -15,7 +15,7 @@ Set a config variable.
 
 ## Usage
 
-Usage: `waypoint config set [options]`
+Usage: `waypoint config set <name>=<value>`
 
 #### Global Options
 

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -21,7 +21,7 @@ Set a config variable that will be available to deployments as an
 environment variable.
 
 This will scope the variable to the entire project by default.
-Specify the "[95m-app[0m" flag to set a config variable for a specific app.
+Specify the "-app" flag to set a config variable for a specific app.
 
 #### Global Options
 

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -17,6 +17,14 @@ Get the configuration for a dynamic source plugin
 
 Usage: `waypoint config source-get [options]`
 
+Get the configuration for a dynamic configuration source plugin.
+
+This does not list the dynamic configuration variables for an application.
+This command is for configuring the plugin that is used to fetch dynamic
+configurations globally for the server.
+
+To use this command, you must specify a "[95m-type[0m" flag.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -23,7 +23,7 @@ This does not list the dynamic configuration variables for an application.
 This command is for configuring the plugin that is used to fetch dynamic
 configurations globally for the server.
 
-To use this command, you must specify a "[95m-type[0m" flag.
+To use this command, you must specify a "-type" flag.
 
 #### Global Options
 

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -17,6 +17,17 @@ Set the configuration for a dynamic source plugin
 
 Usage: `waypoint config source-set [options]`
 
+Set the configuration for a dynamic configuration source plugin.
+
+This does not add a dynamic configuration variable to your application.
+This command is for configuring the plugin that is used to fetch dynamic
+configurations globally. For example, configuring authentication information
+or server addresses and so on.
+
+To use this command, you should specify a "[95m-type[0m" flag along with one or more
+"[95m-config[0m" values. Please see the documentation for the config source type
+you're configuring for details on what configuration fields are available.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -24,8 +24,8 @@ This command is for configuring the plugin that is used to fetch dynamic
 configurations globally. For example, configuring authentication information
 or server addresses and so on.
 
-To use this command, you should specify a "[95m-type[0m" flag along with one or more
-"[95m-config[0m" values. Please see the documentation for the config source type
+To use this command, you should specify a "-type" flag along with one or more
+"-config" values. Please see the documentation for the config source type
 you're configuring for details on what configuration fields are available.
 
 #### Global Options

--- a/website/content/commands/config-sync.mdx
+++ b/website/content/commands/config-sync.mdx
@@ -17,6 +17,13 @@ Synchronize declared variables in waypoint.hcl
 
 Usage: `waypoint config sync [options]`
 
+Synchronize declared application configuration in the waypoint.hcl file
+for existing and new deployments.
+
+Conflicting configuration keys will be overwritten. Configuration keys
+that do not exist in the waypoint.hcl file but exist on the server will not
+be deleted.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-clear.mdx
+++ b/website/content/commands/context-clear.mdx
@@ -17,6 +17,16 @@ Unset the default context.
 
 Usage: `waypoint context clear`
 
+This unsets any default context.
+
+This does not delete any contexts. There are two use cases to not have
+a default set: (1) forcing yourself to specify a context to use or
+(2) operating in local (non-server) mode.
+
+For (2), you may also set the value of the "WAYPOINT_CONTEXT" environment
+variable to "-" which will force a local mode operation if supported by
+the project.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-clear.mdx
+++ b/website/content/commands/context-clear.mdx
@@ -15,7 +15,7 @@ Unset the default context.
 
 ## Usage
 
-Usage: `waypoint context clear [options]`
+Usage: `waypoint context clear`
 
 #### Global Options
 

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -17,6 +17,8 @@ Create a context.
 
 Usage: `waypoint context create [options] NAME`
 
+Creates a new context.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -15,7 +15,7 @@ Create a context.
 
 ## Usage
 
-Usage: `waypoint context create [options]`
+Usage: `waypoint context create [options] NAME`
 
 #### Global Options
 

--- a/website/content/commands/context-delete.mdx
+++ b/website/content/commands/context-delete.mdx
@@ -17,6 +17,8 @@ Delete a context.
 
 Usage: `waypoint context delete [options] NAME`
 
+Deletes a context. This will succeed if the context is already deleted.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-delete.mdx
+++ b/website/content/commands/context-delete.mdx
@@ -15,7 +15,7 @@ Delete a context.
 
 ## Usage
 
-Usage: `waypoint context delete [options]`
+Usage: `waypoint context delete [options] NAME`
 
 #### Global Options
 

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -15,7 +15,7 @@ Output context info.
 
 ## Usage
 
-Usage: `waypoint context inspect [options]`
+Usage: `waypoint context inspect [<name>]`
 
 #### Global Options
 

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -17,6 +17,8 @@ Output context info.
 
 Usage: `waypoint context inspect [<name>]`
 
+Output information about a waypoint context or general context info.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-list.mdx
+++ b/website/content/commands/context-list.mdx
@@ -17,6 +17,8 @@ List contexts.
 
 Usage: `waypoint context list [options]`
 
+Lists the contexts available to the CLI.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-rename.mdx
+++ b/website/content/commands/context-rename.mdx
@@ -17,6 +17,11 @@ Rename a context.
 
 Usage: `waypoint context rename [options] FROM TO`
 
+Rename a context FROM to TO.
+
+This will error if FROM does not exist. This will overwrite TO if it
+exists. If the current default is FROM, the default will be set to TO.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-rename.mdx
+++ b/website/content/commands/context-rename.mdx
@@ -15,7 +15,7 @@ Rename a context.
 
 ## Usage
 
-Usage: `waypoint context rename [options]`
+Usage: `waypoint context rename [options] FROM TO`
 
 #### Global Options
 

--- a/website/content/commands/context-use.mdx
+++ b/website/content/commands/context-use.mdx
@@ -17,6 +17,8 @@ Set the default context.
 
 Usage: `waypoint context use [options] NAME`
 
+Set the default context for the CLI.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-use.mdx
+++ b/website/content/commands/context-use.mdx
@@ -15,7 +15,7 @@ Set the default context.
 
 ## Usage
 
-Usage: `waypoint context use [options]`
+Usage: `waypoint context use [options] NAME`
 
 #### Global Options
 

--- a/website/content/commands/context-verify.mdx
+++ b/website/content/commands/context-verify.mdx
@@ -17,6 +17,12 @@ Verify server access with a context
 
 Usage: `waypoint context verify [options] [NAME]`
 
+Verify the connection information for a context is valid.
+
+This will use the provided context (or default) configuration,
+connect to the server, and perform test API calls to ensure the
+connection information is valid.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/context-verify.mdx
+++ b/website/content/commands/context-verify.mdx
@@ -15,7 +15,7 @@ Verify server access with a context
 
 ## Usage
 
-Usage: `waypoint context verify [options]`
+Usage: `waypoint context verify [options] [NAME]`
 
 #### Global Options
 

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -15,7 +15,8 @@ Deploy a pushed artifact
 
 ## Usage
 
-Usage: `waypoint deploy [options]`
+Usage: `waypoint deployment deploy [options]`
+Alias: `waypoint deploy`
 
 #### Global Options
 

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -18,6 +18,10 @@ Deploy a pushed artifact
 Usage: `waypoint deployment deploy [options]`
 Alias: `waypoint deploy`
 
+Deploy an application. This will deploy the most recent successful
+pushed artifact by default. You can view a list of recent artifacts
+using the "artifact list" command.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -16,6 +16,7 @@ Deploy a pushed artifact
 ## Usage
 
 Usage: `waypoint deployment deploy [options]`
+
 Alias: `waypoint deploy`
 
 Deploy an application. This will deploy the most recent successful

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -18,6 +18,10 @@ Deploy a pushed artifact
 Usage: `waypoint deployment deploy [options]`
 Alias: `waypoint deploy`
 
+Deploy an application. This will deploy the most recent successful
+pushed artifact by default. You can view a list of recent artifacts
+using the "artifact list" command.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -16,6 +16,7 @@ Deploy a pushed artifact
 ## Usage
 
 Usage: `waypoint deployment deploy [options]`
+
 Alias: `waypoint deploy`
 
 Deploy an application. This will deploy the most recent successful

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -16,6 +16,7 @@ Deploy a pushed artifact
 ## Usage
 
 Usage: `waypoint deployment deploy [options]`
+Alias: `waypoint deploy`
 
 #### Global Options
 

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -17,6 +17,13 @@ Destroy one or more deployments.
 
 Usage: `waypoint deployment destroy [options] [id...]`
 
+Destroy one or more deployments. This will "undeploy" this specific
+instance of an application.
+
+When no arguments are given, this will default to destroying ALL
+unreleased deployments. This will require interactive confirmation
+by the user unless the force flag (-force) is specified.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -15,7 +15,7 @@ Destroy one or more deployments.
 
 ## Usage
 
-Usage: `waypoint deployment destroy [options]`
+Usage: `waypoint deployment destroy [options] [id...]`
 
 #### Global Options
 

--- a/website/content/commands/deployment-list.mdx
+++ b/website/content/commands/deployment-list.mdx
@@ -17,6 +17,8 @@ List deployments.
 
 Usage: `waypoint deployment list [options]`
 
+Lists the deployments that were created.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -17,6 +17,19 @@ Delete all the resources created for an app
 
 Usage: `waypoint destroy [options]`
 
+Delete all resources created for an app in the current workspace.
+
+The workspace can continue to be used after this call, this just deletes
+all the resources created for this app up to this point.
+
+This functionality must be supported by the plugins in use and is dependent
+on their behavior. The expected behavior is that any physical resources created
+as part of deploys and releases are destroyed. For example, any load balancers,
+VMs, containers, etc.
+
+This targets one app in one workspace. You must call this for each workspace
+you've used if you want to destroy everything.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -20,7 +20,7 @@ Usage: `waypoint docs [options]`
 Output documentation about the plugins. By default, it lists the documentation
 for the plugins configured by this project.
 
-    The flags can change which plugins are listed and in which format.
+The flags can change which plugins are listed and in which format.
 
 #### Global Options
 

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -17,6 +17,11 @@ Show documentation for components
 
 Usage: `waypoint docs [options]`
 
+Output documentation about the plugins. By default, it lists the documentation
+for the plugins configured by this project.
+
+    The flags can change which plugins are listed and in which format.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -17,6 +17,8 @@ Execute a command in the context of a running application instance
 
 Usage: `waypoint exec [options]`
 
+Execute a command in the context of a running application instance.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -17,6 +17,18 @@ Rewrite waypoint.hcl configuration to a canonical format
 
 Usage: `waypoint fmt [options] [FILE]`
 
+Rewrite a waypoint.hcl file to a canonical format.
+
+This only works for HCL-formatted Waypoint configuration files. JSON-formatted
+files do not work and will result in an error.
+
+If FILE is not specified, then the current directory will be searched
+for a "waypoint.hcl" file. If FILE is "-" then the content will be read
+from stdin.
+
+This command does not validate the waypoint.hcl configuration. This will
+work for older and newer configuration formats.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -15,7 +15,7 @@ Rewrite waypoint.hcl configuration to a canonical format
 
 ## Usage
 
-Usage: `waypoint fmt [options]`
+Usage: `waypoint fmt [options] [FILE]`
 
 #### Global Options
 

--- a/website/content/commands/hostname-delete.mdx
+++ b/website/content/commands/hostname-delete.mdx
@@ -15,7 +15,7 @@ Delete a previously registered hostname.
 
 ## Usage
 
-Usage: `waypoint hostname delete [options]`
+Usage: `waypoint hostname delete HOSTNAME`
 
 #### Global Options
 

--- a/website/content/commands/hostname-list.mdx
+++ b/website/content/commands/hostname-list.mdx
@@ -15,7 +15,7 @@ List all registered hostnames.
 
 ## Usage
 
-Usage: `waypoint hostname list [options]`
+Usage: `waypoint hostname list`
 
 #### Global Options
 

--- a/website/content/commands/hostname-register.mdx
+++ b/website/content/commands/hostname-register.mdx
@@ -15,7 +15,7 @@ Register a hostname to route to your apps.
 
 ## Usage
 
-Usage: `waypoint hostname register [options]`
+Usage: `waypoint hostname register [hostname]`
 
 #### Global Options
 

--- a/website/content/commands/init.mdx
+++ b/website/content/commands/init.mdx
@@ -17,6 +17,15 @@ Initialize and validate a project
 
 Usage: `waypoint init [options]`
 
+Initialize and validate a project.
+
+This is the first command that should be run for any new or existing
+Waypoint project per machine. This sets up the project if required and
+also validates that operations such as "up" will most likely work.
+
+This command is always safe to run multiple times. This command will never
+delete your configuration or any data in the server.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -26,11 +26,11 @@ remote operations out of the box, such as polling a Git repository. This can
 be disabled by specifying "-runner=false".
 
 By default, this will also automatically create a new default CLI context
-(see "[95mwaypoint context[0m") so the CLI will be configured to use the newly
+(see "waypoint context") so the CLI will be configured to use the newly
 installed server.
 
 This command will require you to accept the Waypoint Terms of Service
-and Privacy Policy for the Waypoint URL service by specifying the "[95m-accept-tos[0m"
+and Privacy Policy for the Waypoint URL service by specifying the "-accept-tos"
 flag. This only applies to the Waypoint URL service. You may disable the
 URL service by manually running the server. If you disable the URL service,
 you do not need to accept any terms.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -16,6 +16,7 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 ## Usage
 
 Usage: `waypoint server install [options]`
+
 Alias: `waypoint install`
 
 Installs a Waypoint server to an existing platform. The platform should be

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -15,7 +15,8 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 
 ## Usage
 
-Usage: `waypoint install [options]`
+Usage: `waypoint server install [options]`
+Alias: `waypoint install`
 
 #### Global Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -18,6 +18,23 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 Usage: `waypoint server install [options]`
 Alias: `waypoint install`
 
+Installs a Waypoint server to an existing platform. The platform should be
+specified as kubernetes, nomad, or docker.
+
+This will also install a single Waypoint runner by default. This enables
+remote operations out of the box, such as polling a Git repository. This can
+be disabled by specifying "-runner=false".
+
+By default, this will also automatically create a new default CLI context
+(see "[95mwaypoint context[0m") so the CLI will be configured to use the newly
+installed server.
+
+This command will require you to accept the Waypoint Terms of Service
+and Privacy Policy for the Waypoint URL service by specifying the "[95m-accept-tos[0m"
+flag. This only applies to the Waypoint URL service. You may disable the
+URL service by manually running the server. If you disable the URL service,
+you do not need to accept any terms.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -17,6 +17,19 @@ Log in to a Waypoint server
 
 Usage: `waypoint login [server address]`
 
+Log in to a Waypoint server.
+
+This is usually the first command a new user runs to gain CLI access to
+an existing Waypoint server.
+
+If the server address is not specified and you have an active
+context (see "[95mwaypoint context[0m"), then this command will reauthenticate
+to the currently active server.
+
+This command can be used for token-based authentication as well as
+other forms such as OIDC. You can use "[95m-token[0m" to specify a login or
+invite token and configure the CLI to access the server.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -15,7 +15,7 @@ Log in to a Waypoint server
 
 ## Usage
 
-Usage: `waypoint login [options]`
+Usage: `waypoint login [server address]`
 
 #### Global Options
 

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -23,11 +23,11 @@ This is usually the first command a new user runs to gain CLI access to
 an existing Waypoint server.
 
 If the server address is not specified and you have an active
-context (see "[95mwaypoint context[0m"), then this command will reauthenticate
+context (see "waypoint context"), then this command will reauthenticate
 to the currently active server.
 
 This command can be used for token-based authentication as well as
-other forms such as OIDC. You can use "[95m-token[0m" to specify a login or
+other forms such as OIDC. You can use "-token" to specify a login or
 invite token and configure the CLI to access the server.
 
 #### Global Options

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -17,6 +17,15 @@ Show log output from the current application deployment
 
 Usage: `waypoint logs [options]`
 
+Show log output from all current deployments.
+
+The logs will include output from deployments that aren't released.
+As new deployments are made, their logs will appear automatically.
+
+The six character text after the date on a log line is the last six
+characters of the instance ID. This can be used to trace any logs back
+to a specific deployment or filter out certain log messages.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -17,6 +17,19 @@ Create or update a project.
 
 Usage: `waypoint project apply [options] NAME`
 
+Create or update a project.
+
+This will create a new project with the given options. If a project with
+the same name already exists, this will update the existing project using
+the fields that are set.
+
+This command should be used to create a new project pointing to a VCS
+repo. If you have a "waypoint.hcl" file and a local repository, you can
+also use "[95mwaypoint init[0m" in the directory of the project.
+
+You may create a project from a waypoint.hcl file and optionally overwrite
+some fields using flags by specifying the [95m-waypoint-hcl[0m flag.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -25,10 +25,10 @@ the fields that are set.
 
 This command should be used to create a new project pointing to a VCS
 repo. If you have a "waypoint.hcl" file and a local repository, you can
-also use "[95mwaypoint init[0m" in the directory of the project.
+also use "waypoint init" in the directory of the project.
 
 You may create a project from a waypoint.hcl file and optionally overwrite
-some fields using flags by specifying the [95m-waypoint-hcl[0m flag.
+some fields using flags by specifying the -waypoint-hcl flag.
 
 #### Global Options
 

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -15,7 +15,7 @@ Create or update a project.
 
 ## Usage
 
-Usage: `waypoint project apply [options]`
+Usage: `waypoint project apply [options] NAME`
 
 #### Global Options
 

--- a/website/content/commands/project-list.mdx
+++ b/website/content/commands/project-list.mdx
@@ -15,7 +15,7 @@ List all registered projects.
 
 ## Usage
 
-Usage: `waypoint project list [options]`
+Usage: `waypoint project list`
 
 #### Global Options
 

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -17,6 +17,11 @@ Release a deployment
 
 Usage: `waypoint release [options] [id]`
 
+Open a deployment to traffic.
+
+This defaults to the latest deployment. Other deployments can be
+specified by sequence number or long ID.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -15,7 +15,7 @@ Release a deployment
 
 ## Usage
 
-Usage: `waypoint release [options]`
+Usage: `waypoint release [options] [id]`
 
 #### Global Options
 

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -17,6 +17,8 @@ Run a runner for executing remote operations.
 
 Usage: `waypoint runner agent [options]`
 
+Run a runner for executing remote operations.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -17,6 +17,21 @@ Bootstrap the server and retrieve the initial auth token
 
 Usage: `waypoint server bootstrap [options]`
 
+Bootstrap a new server and retrieve the initial auth token.
+
+When a server is started for the first time against an empty database,
+it is able to be bootstrapped. The bootstrap process retrieves the initial
+auth token for the server. After the auth token is retrieved, it can never
+be bootstrapped again.
+
+This command is only required for manually run servers. For servers
+installed with "[95mwaypoint install[0m", the bootstrap is done automatically
+during the install process.
+
+The easiest way to run this command against a new server is by using
+flags to specify server connection information. This command will setup
+a CLI context by default.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -25,7 +25,7 @@ auth token for the server. After the auth token is retrieved, it can never
 be bootstrapped again.
 
 This command is only required for manually run servers. For servers
-installed with "[95mwaypoint install[0m", the bootstrap is done automatically
+installed with "waypoint install", the bootstrap is done automatically
 during the install process.
 
 The easiest way to run this command against a new server is by using

--- a/website/content/commands/server-config-set.mdx
+++ b/website/content/commands/server-config-set.mdx
@@ -17,6 +17,16 @@ Set the server online configuration
 
 Usage: `waypoint server config-set [options]`
 
+Set the online configuration for a running Waypoint server.
+
+The configuration that can be set here is different from the configuration
+given via the startup file. This configuration is persisted in the server
+database.
+
+Each flag represents a setting and all settings are transmitted to the server
+on submission. To correctly set the configuration, provide all flags
+together in one call.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -16,6 +16,7 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 ## Usage
 
 Usage: `waypoint server install [options]`
+Alias: `waypoint install`
 
 #### Global Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -26,11 +26,11 @@ remote operations out of the box, such as polling a Git repository. This can
 be disabled by specifying "-runner=false".
 
 By default, this will also automatically create a new default CLI context
-(see "[95mwaypoint context[0m") so the CLI will be configured to use the newly
+(see "waypoint context") so the CLI will be configured to use the newly
 installed server.
 
 This command will require you to accept the Waypoint Terms of Service
-and Privacy Policy for the Waypoint URL service by specifying the "[95m-accept-tos[0m"
+and Privacy Policy for the Waypoint URL service by specifying the "-accept-tos"
 flag. This only applies to the Waypoint URL service. You may disable the
 URL service by manually running the server. If you disable the URL service,
 you do not need to accept any terms.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -16,6 +16,7 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 ## Usage
 
 Usage: `waypoint server install [options]`
+
 Alias: `waypoint install`
 
 Installs a Waypoint server to an existing platform. The platform should be

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -18,6 +18,23 @@ Install the Waypoint server to Kubernetes, Nomad, or Docker
 Usage: `waypoint server install [options]`
 Alias: `waypoint install`
 
+Installs a Waypoint server to an existing platform. The platform should be
+specified as kubernetes, nomad, or docker.
+
+This will also install a single Waypoint runner by default. This enables
+remote operations out of the box, such as polling a Git repository. This can
+be disabled by specifying "-runner=false".
+
+By default, this will also automatically create a new default CLI context
+(see "[95mwaypoint context[0m") so the CLI will be configured to use the newly
+installed server.
+
+This command will require you to accept the Waypoint Terms of Service
+and Privacy Policy for the Waypoint URL service by specifying the "[95m-accept-tos[0m"
+flag. This only applies to the Waypoint URL service. You may disable the
+URL service by manually running the server. If you disable the URL service,
+you do not need to accept any terms.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -17,6 +17,19 @@ Stage a snapshot on the current server for data restoration
 
 Usage: `waypoint server restore [-exit] [<filename>]`
 
+    Stage a backup snapshot within the current server. The data in the snapshot is not restored
+    immediately, but rather staged such that on the next server start, it will be restored.
+
+    If [95m-exit[0m is passed, the server process will exit after staging the data. This allows a process
+    monitor to restart the server, where it will see the staged snapshot and restore the data.
+
+    If [95m-exit[0m is not passed, an operator must restart the server manually to finish the restoration
+    process.
+
+    The argument should be to a file written previously by 'waypoint server snapshot'.
+    If no name is specified and standard input is not a terminal, the backup will read from
+    standard input. Using a name of '-' will force reading from standard input.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -20,10 +20,10 @@ Usage: `waypoint server restore [-exit] [<filename>]`
     Stage a backup snapshot within the current server. The data in the snapshot is not restored
     immediately, but rather staged such that on the next server start, it will be restored.
 
-    If [95m-exit[0m is passed, the server process will exit after staging the data. This allows a process
+    If -exit is passed, the server process will exit after staging the data. This allows a process
     monitor to restart the server, where it will see the staged snapshot and restore the data.
 
-    If [95m-exit[0m is not passed, an operator must restart the server manually to finish the restoration
+    If -exit is not passed, an operator must restart the server manually to finish the restoration
     process.
 
     The argument should be to a file written previously by 'waypoint server snapshot'.

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -15,7 +15,7 @@ Stage a snapshot on the current server for data restoration
 
 ## Usage
 
-Usage: `waypoint server restore [options]`
+Usage: `waypoint server restore [-exit] [<filename>]`
 
 #### Global Options
 

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -17,18 +17,18 @@ Stage a snapshot on the current server for data restoration
 
 Usage: `waypoint server restore [-exit] [<filename>]`
 
-    Stage a backup snapshot within the current server. The data in the snapshot is not restored
-    immediately, but rather staged such that on the next server start, it will be restored.
+Stage a backup snapshot within the current server. The data in the snapshot is not restored
+immediately, but rather staged such that on the next server start, it will be restored.
 
-    If -exit is passed, the server process will exit after staging the data. This allows a process
-    monitor to restart the server, where it will see the staged snapshot and restore the data.
+If -exit is passed, the server process will exit after staging the data. This allows a process
+monitor to restart the server, where it will see the staged snapshot and restore the data.
 
-    If -exit is not passed, an operator must restart the server manually to finish the restoration
-    process.
+If -exit is not passed, an operator must restart the server manually to finish the restoration
+process.
 
-    The argument should be to a file written previously by 'waypoint server snapshot'.
-    If no name is specified and standard input is not a terminal, the backup will read from
-    standard input. Using a name of '-' will force reading from standard input.
+The argument should be to a file written previously by 'waypoint server snapshot'.
+If no name is specified and standard input is not a terminal, the backup will read from
+standard input. Using a name of '-' will force reading from standard input.
 
 #### Global Options
 

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -17,6 +17,12 @@ Manually run the builtin server
 
 Usage: `waypoint server run [options]`
 
+Run the builtin server.
+
+The easier way to run a server is to use the "[95mwaypoint install[0m" command.
+This command is for people who are manually running the server in any
+environment.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint server run [options]`
 
 Run the builtin server.
 
-The easier way to run a server is to use the "[95mwaypoint install[0m" command.
+The easier way to run a server is to use the "waypoint install" command.
 This command is for people who are manually running the server in any
 environment.
 

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -15,7 +15,7 @@ Write a backup of the server data
 
 ## Usage
 
-Usage: `waypoint server snapshot [options]`
+Usage: `waypoint server snapshot [<filename>]`
 
 #### Global Options
 

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -17,6 +17,11 @@ Write a backup of the server data
 
 Usage: `waypoint server snapshot [<filename>]`
 
+    Generate a snapshot from the current server and write it to a file specified
+    by the given name. If no name is specified and standard out is not a terminal,
+    the backup will be written to standard out. Using a name of '-' will force writing
+    to standard out.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -17,10 +17,10 @@ Write a backup of the server data
 
 Usage: `waypoint server snapshot [<filename>]`
 
-    Generate a snapshot from the current server and write it to a file specified
-    by the given name. If no name is specified and standard out is not a terminal,
-    the backup will be written to standard out. Using a name of '-' will force writing
-    to standard out.
+Generate a snapshot from the current server and write it to a file specified
+by the given name. If no name is specified and standard out is not a terminal,
+the backup will be written to standard out. Using a name of '-' will force writing
+to standard out.
 
 #### Global Options
 

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -26,8 +26,8 @@ a server snapshot.
 This command does not destroy Waypoint resources, such as deployments and
 releases. Clear all workspaces prior to uninstall to prevent hanging resources.
 
-If a runner was installed via "[95mwaypoint install[0m", the runner will also be
-uninstalled. Manually installed runners (outside of the "[95mwaypoint install[0m"
+If a runner was installed via "waypoint install", the runner will also be
+uninstalled. Manually installed runners (outside of the "waypoint install"
 command) will not be affected.
 
 #### Global Options

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -17,6 +17,19 @@ Uninstall the Waypoint server
 
 Usage: `waypoint server uninstall [options]`
 
+Uninstall the Waypoint server. The platform should be specified as kubernetes,
+nomad, or docker. '-auto-approve' is required.
+
+By default, this command deletes the default server's context and creates
+a server snapshot.
+
+This command does not destroy Waypoint resources, such as deployments and
+releases. Clear all workspaces prior to uninstall to prevent hanging resources.
+
+If a runner was installed via "[95mwaypoint install[0m", the runner will also be
+uninstalled. Manually installed runners (outside of the "[95mwaypoint install[0m"
+command) will not be affected.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -22,7 +22,7 @@ server image version specified. By default, Waypoint will upgrade to server
 version "hashicorp/waypoint:latest". Before upgrading, a snapshot of the
 server will be taken in case of any upgrade failures.
 
-If a runner was installed via "[95mwaypoint install[0m" then that runner will also
+If a runner was installed via "waypoint install" then that runner will also
 be upgraded to the latest version after the server is upgraded. Any other
 manually installed runners will not be automatically upgraded.
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -17,6 +17,15 @@ Upgrades Waypoint server in the current context to the latest version
 
 Usage: `waypoint server upgrade [options]`
 
+Upgrade Waypoint server in the current context to the latest version or the
+server image version specified. By default, Waypoint will upgrade to server
+version "hashicorp/waypoint:latest". Before upgrading, a snapshot of the
+server will be taken in case of any upgrade failures.
+
+If a runner was installed via "[95mwaypoint install[0m" then that runner will also
+be upgraded to the latest version after the server is upgraded. Any other
+manually installed runners will not be automatically upgraded.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -17,6 +17,8 @@ List statuses.
 
 Usage: `waypoint status [options] [project]`
 
+View the current status of projects and applications managed by Waypoint.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -15,7 +15,7 @@ List statuses.
 
 ## Usage
 
-Usage: `waypoint status [options]`
+Usage: `waypoint status [options] [project]`
 
 #### Global Options
 

--- a/website/content/commands/token-exchange.mdx
+++ b/website/content/commands/token-exchange.mdx
@@ -17,6 +17,13 @@ Exchange an invite token.
 
 Usage: `waypoint token exchange [options]`
 
+Exchange an invite token for a normal token for login.
+
+The "[95mwaypoint token[0m" commands are deprecated. They have been replaced with
+the "[95mwaypoint user[0m" set of commands. Everything that was possible with
+"[95mwaypoint token[0m" is now possible with "[95mwaypoint user[0m". For example,
+"[95mwaypoint token new[0m" is now "[95mwaypoint user token[0m".
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/token-exchange.mdx
+++ b/website/content/commands/token-exchange.mdx
@@ -19,10 +19,10 @@ Usage: `waypoint token exchange [options]`
 
 Exchange an invite token for a normal token for login.
 
-The "[95mwaypoint token[0m" commands are deprecated. They have been replaced with
-the "[95mwaypoint user[0m" set of commands. Everything that was possible with
-"[95mwaypoint token[0m" is now possible with "[95mwaypoint user[0m". For example,
-"[95mwaypoint token new[0m" is now "[95mwaypoint user token[0m".
+The "waypoint token" commands are deprecated. They have been replaced with
+the "waypoint user" set of commands. Everything that was possible with
+"waypoint token" is now possible with "waypoint user". For example,
+"waypoint token new" is now "waypoint user token".
 
 #### Global Options
 

--- a/website/content/commands/token-invite.mdx
+++ b/website/content/commands/token-invite.mdx
@@ -19,10 +19,10 @@ Usage: `waypoint token invite [options]`
 
 Request a new invite token. This token can be exchanged for a normal token to login.
 
-The "[95mwaypoint token[0m" commands are deprecated. They have been replaced with
-the "[95mwaypoint user[0m" set of commands. Everything that was possible with
-"[95mwaypoint token[0m" is now possible with "[95mwaypoint user[0m". For example,
-"[95mwaypoint token new[0m" is now "[95mwaypoint user token[0m".
+The "waypoint token" commands are deprecated. They have been replaced with
+the "waypoint user" set of commands. Everything that was possible with
+"waypoint token" is now possible with "waypoint user". For example,
+"waypoint token new" is now "waypoint user token".
 
 #### Global Options
 

--- a/website/content/commands/token-invite.mdx
+++ b/website/content/commands/token-invite.mdx
@@ -17,6 +17,13 @@ Request a new invite token.
 
 Usage: `waypoint token invite [options]`
 
+Request a new invite token. This token can be exchanged for a normal token to login.
+
+The "[95mwaypoint token[0m" commands are deprecated. They have been replaced with
+the "[95mwaypoint user[0m" set of commands. Everything that was possible with
+"[95mwaypoint token[0m" is now possible with "[95mwaypoint user[0m". For example,
+"[95mwaypoint token new[0m" is now "[95mwaypoint user token[0m".
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/token-new.mdx
+++ b/website/content/commands/token-new.mdx
@@ -17,6 +17,13 @@ Request a new token to access the server
 
 Usage: `waypoint token new [options]`
 
+Request a new token to log into the server.
+
+The "waypoint token" commands are deprecated. They have been replaced with
+the "waypoint user" set of commands. Everything that was possible with
+"waypoint token" is now possible with "waypoint user". For example,
+"waypoint token new" is now "waypoint user token".
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/ui.mdx
+++ b/website/content/commands/ui.mdx
@@ -17,6 +17,9 @@ Open the web UI
 
 Usage: `waypoint ui [options]`
 
+Opens the new UI. When provided a flag, will automatically open the
+token invite page with an invite token for authentication.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -17,6 +17,8 @@ Perform the build, deploy, and release steps for the app
 
 Usage: `waypoint up [options]`
 
+Perform the build, deploy, and release steps for the app.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/user-inspect.mdx
+++ b/website/content/commands/user-inspect.mdx
@@ -17,6 +17,11 @@ Show details about a single user
 
 Usage: `waypoint user inspect [options]`
 
+Show details about a single user, defaulting to the currently logged in user.
+
+This shows details about the currently logged in user or any user that
+is specified via flags.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/user-invite.mdx
+++ b/website/content/commands/user-invite.mdx
@@ -17,6 +17,16 @@ Invite a user to join the Waypoint server
 
 Usage: `waypoint user invite [options]`
 
+Generate an invite token that can be used to log in.
+
+You must be logged in already to generate an invite token. If you need to
+log in, use the "waypoint login" command.
+
+This generates a new invite token. An invite token can be exchanged for
+a login token. If your Waypoint server has OIDC (non-token) auth enabled,
+it is recommended to instead invite users using your UI URL or directly
+via "waypoint login".
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/user-modify.mdx
+++ b/website/content/commands/user-modify.mdx
@@ -17,6 +17,11 @@ Modify details about a user
 
 Usage: `waypoint user modify [options]`
 
+Modify details about a user.
+
+Some details such as username and display name may be updated.
+Use "waypoint user inspect" to see the current attributes for a user.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/user-token.mdx
+++ b/website/content/commands/user-token.mdx
@@ -17,6 +17,21 @@ Request a new token to access the server
 
 Usage: `waypoint user token [options]`
 
+Request a new login token for a user.
+
+You must be logged in already to generate a token. If you need to
+log in, use the "waypoint login" command.
+
+This generates a new token that can be used to authenticate directly
+to the Waypoint server. If you're inviting a new user to Waypoint,
+its recommended to generate an invite token with "waypoint user invite"
+or share the UI URL for logging in.
+
+The "waypoint token" commands are deprecated. They have been replaced with
+the "waypoint user" set of commands. Everything that was possible with
+"waypoint token" is now possible with "waypoint user". For example,
+"waypoint token new" is now "waypoint user token".
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/version.mdx
+++ b/website/content/commands/version.mdx
@@ -15,7 +15,7 @@ Prints the version of this Waypoint CLI
 
 ## Usage
 
-Usage: `waypoint version [options]`
+Usage: `waypoint version`
 
 #### Global Options
 


### PR DESCRIPTION
Prior to this pull request, our CLI docs auto-gen would manually format the
Usage string based on the command name. This would leave out various
command line arguments or other custom formatting. This pull request fixes
this behavior by looking at the output from the commands `Help()` function
and attempt to parse and format its Usage string in the way it would show
up on a terminal with `-help`.