### PR TITLE
Feature/nomad consul service opt in

### DIFF
--- a/.changelog/2033.txt
+++ b/.changelog/2033.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad: Add consul service optional flags
+```

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -21,10 +21,13 @@ type NomadInstaller struct {
 }
 
 type nomadConfig struct {
-	authSoftFail       bool              `hcl:"auth_soft_fail,optional"`
-	serverImage        string            `hcl:"server_image,optional"`
-	namespace          string            `hcl:"namespace,optional"`
-	serviceAnnotations map[string]string `hcl:"service_annotations,optional"`
+	authSoftFail             bool              `hcl:"auth_soft_fail,optional"`
+	serverImage              string            `hcl:"server_image,optional"`
+	namespace                string            `hcl:"namespace,optional"`
+	serviceAnnotations       map[string]string `hcl:"service_annotations,optional"`
+	consulService            bool              `hcl:"consul_service,optional"`
+	consulServiceUITags      []string          `hcl:"consul_service_ui_tags:optional"`
+	consulServiceBackendTags []string          `hcl:"consul_service_backend_tags:optional"`
 
 	region         string   `hcl:"namespace,optional"`
 	datacenters    []string `hcl:"datacenters,optional"`
@@ -622,6 +625,23 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	grpcPort, _ := strconv.Atoi(defaultGrpcPort)
 	httpPort, _ := strconv.Atoi(defaultHttpPort)
 
+	// Include services to be registered in Consul, if specified in the server install
+	// One service added for Waypoint UI, and one for Waypoint backend port
+	if c.consulService {
+		tg.Services = []*api.Service{
+			{
+				Name:      "waypoint-ui",
+				PortLabel: "ui",
+				Tags:      c.consulServiceUITags,
+			},
+			{
+				Name:      "waypoint-server",
+				PortLabel: "server",
+				Tags:      c.consulServiceBackendTags,
+			},
+		}
+	}
+
 	tg.Networks = []*api.NetworkResource{
 		{
 			Mode: "host",
@@ -848,6 +868,25 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.config.serverImage,
 		Usage:   "Docker image for the Waypoint server.",
 		Default: defaultServerImage,
+	})
+
+	set.BoolVar(&flag.BoolVar{
+		Name:    "nomad-consul-service",
+		Target:  &i.config.consulService,
+		Usage:   "Create service for Waypoint UI in Consul.",
+		Default: false,
+	})
+
+	set.StringSliceVar(&flag.StringSliceVar{
+		Name:   "nomad-consul-service-ui-tags",
+		Target: &i.config.consulServiceUITags,
+		Usage:  "Tags for the Waypoint UI service generated in Consul.",
+	})
+
+	set.StringSliceVar(&flag.StringSliceVar{
+		Name:   "nomad-consul-service-backend-tags",
+		Target: &i.config.consulServiceBackendTags,
+		Usage:  "Tags for the Waypoint backend service generated in Consul.",
 	})
 }
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -92,5 +92,8 @@ you do not need to accept any terms.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server.
+- `-nomad-consul-service` - Create service for Waypoint UI in Consul.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -92,7 +92,7 @@ you do not need to accept any terms.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-- `-nomad-consul-service=<string>` - Create service for Waypoint UI in Consul.
+- `-nomad-consul-service` - Create service for Waypoint UI in Consul.
 - `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
 - `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul.
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -92,5 +92,8 @@ you do not need to accept any terms.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server.
+- `-nomad-consul-service=<string>` - Create service for Waypoint UI in Consul.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul.
 
 @include "commands/server-install_more.mdx"


### PR DESCRIPTION
Fixup of https://github.com/hashicorp/waypoint/pull/1719

From the original PR:
> Add new CLI options to Waypoint server install for Nomad to 1) support the creation of a service in Consul for the Waypoint UI and Backend, and 2) support the creation of tags for the created services (so that load balancers like Fabio and Traefik can use Consul to access the Waypoint service).
> 
> In reference to #1659

Thank you @paladin-devops !