### PR TITLE
internal/config/variables: improve error messaging

### DIFF
--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -127,6 +127,7 @@ func DecodeVariableBlocks(content *hcl.BodyContent) (map[string]*Variable, hcl.D
 				Severity: hcl.DiagError,
 				Summary:  "Duplicate variable",
 				Detail:   "Duplicate " + v.Name + " variable definition found.",
+				Subject:  &v.Range,
 				Context:  block.DefRange.Ptr(),
 			}}
 		}
@@ -305,6 +306,7 @@ func EvaluateVariables(
 					"but was not found in known variables. To declare variable "+
 					"%q, place a variable definition block in your waypoint.hcl file.",
 					pbv.Name, pbv.Name),
+				Subject: &hcl.Range{},
 			})
 			continue
 		}
@@ -342,6 +344,7 @@ func EvaluateVariables(
 				Severity: hcl.DiagError,
 				Summary:  "Invalid value type for variable",
 				Detail:   "The variable type was not set as a string, number, bool, or hcl expression",
+				Subject:  &variable.Range,
 			})
 			return nil, diags
 		}
@@ -386,6 +389,7 @@ func EvaluateVariables(
 						valType,
 						err,
 					),
+					Subject: &variable.Range,
 				})
 				val = cty.DynamicVal
 			}
@@ -408,6 +412,7 @@ func EvaluateVariables(
 				Detail: "A variable must be set or have a default value; see " +
 					"https://www.waypointproject.io/docs/waypoint-hcl/variables/input " +
 					"for details.",
+				Subject: &hcl.Range{},
 			})
 		}
 	}
@@ -522,6 +527,7 @@ func readFileValues(filename string) (*hcl.File, hcl.Diagnostics) {
 			Severity: hcl.DiagError,
 			Summary:  "Failed to read variable values from file",
 			Detail:   errStr,
+			Subject:  &hcl.Range{},
 		})
 	}
 

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -402,7 +402,7 @@ func EvaluateVariables(
 	for name := range vs {
 		v, ok := iv[name]
 		if !ok || v == nil {
-			return nil, append(diags, &hcl.Diagnostic{
+			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Unset variable %q", name),
 				Detail: "A variable must be set or have a default value; see " +

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -306,7 +306,9 @@ func EvaluateVariables(
 					"but was not found in known variables. To declare variable "+
 					"%q, place a variable definition block in your waypoint.hcl file.",
 					pbv.Name, pbv.Name),
-				Subject: &hcl.Range{},
+				Subject: &hcl.Range{
+					Filename: "waypoint.hcl",
+				},
 			})
 			continue
 		}
@@ -403,7 +405,7 @@ func EvaluateVariables(
 	}
 
 	// check that all variables have a set value, including default of null
-	for name := range vs {
+	for name, variable := range vs {
 		v, ok := iv[name]
 		if !ok || v == nil {
 			diags = append(diags, &hcl.Diagnostic{
@@ -412,7 +414,7 @@ func EvaluateVariables(
 				Detail: "A variable must be set or have a default value; see " +
 					"https://www.waypointproject.io/docs/waypoint-hcl/variables/input " +
 					"for details.",
-				Subject: &hcl.Range{},
+				Subject: &variable.Range,
 			})
 		}
 	}
@@ -527,7 +529,9 @@ func readFileValues(filename string) (*hcl.File, hcl.Diagnostics) {
 			Severity: hcl.DiagError,
 			Summary:  "Failed to read variable values from file",
 			Detail:   errStr,
-			Subject:  &hcl.Range{},
+			Subject: &hcl.Range{
+				Filename: filename,
+			},
 		})
 	}
 


### PR DESCRIPTION
Things done:
* Complete the entire `for name := range vs {` loop, appending error diags as we go, so we can return a complete set of diags to the user if they have multiple unset variables
* Add `Subject` to the hcl diags that didn't have it, which removes the `nil` that was showing up in some of our error messaging (HCL formats errors as `Subject: Summary; Detail`)

Before:
```
$ waypoint init
✓ Configuration file appears valid
✓ Connection to Waypoint server was successful
✓ Project "example-inputvars-go-project" and all apps are registered with the server.
❌ Failed to load and validate plugins!
...
! <nil>: Unset variable "image"; A variable must be set or have a default value;
  see https://www.waypointproject.io/docs/waypoint-hcl/variables/input for details.
...
```

After:
```
$ wdi
✓ Configuration file appears valid
✓ Connection to Waypoint server was successful
✓ Project "example-inputvars-go-project" and all apps are registered with the server.
❌ Failed to load and validate plugins!
...
! /home/rae/waypoint-project/waypoint-examples/learn/input-variables/waypoint.hcl:25,1-17:
  Unset variable "image"; A variable must be set or have a default value; see
  https://www.waypointproject.io/docs/waypoint-hcl/variables/input for details.,
  and 1 other diagnostic(s)
...
```