### PR TITLE
UI: Change layout of status-row

### DIFF
--- a/.changelog/2036.txt
+++ b/.changelog/2036.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Improve design of status row on Build/Deployment/Release detail pages
+```

--- a/ui/app/components/status-report-bar/index.hbs
+++ b/ui/app/components/status-report-bar/index.hbs
@@ -2,6 +2,11 @@
   {{#if this.statusReport}}
     <div class="item">
       <StatusReportIndicator @statusReport={{this.statusReport}} />
+      {{#if this.statusReport.status.completeTime.seconds}}
+      <div data-test-complete-time-status-report>
+        Last checked {{date-format-distance-to-now this.statusReport.status.completeTime.seconds }}
+      </div>
+      {{/if}}
     </div>
   {{/if}}
 
@@ -14,13 +19,11 @@
     </div>
   {{/if}}
   {{yield}}
-  {{#if this.statusReport.status.completeTime.seconds}}
-    <div class="item" data-test-complete-time-status-report>
-      Last checked {{date-format-distance-to-now this.statusReport.status.completeTime.seconds }}
-    </div>
-  {{/if}}
+
+  
   {{#if this.statusReport}}
     <div class="item">
+
       <Pds::Button @variant="ghost" @iconStart="refresh-default" disabled={{this.isRefreshRunning}} {{on "click" this.refreshHealthCheck}}>
         Re-run health check
       </Pds::Button>

--- a/ui/app/styles/_layout.scss
+++ b/ui/app/styles/_layout.scss
@@ -85,6 +85,7 @@ ul.list {
   @include Typography.Interface(M);
 
   .item {
+    display: flex;
     a {
       text-decoration: none;
 
@@ -93,8 +94,13 @@ ul.list {
       }
     }
 
+    .status-report-indicator__label,
+    .operation-status-indicator__label {
+      @include Typography.Interface(M);
+      margin-right: scale.$lg-1;
+    }
+
     .badge {
-      font-size: 0.75rem;
       padding: scale.$sm-3 scale.$sm-2;
     }
   }


### PR DESCRIPTION
Some minor changes to fix alignment and type rhythm of the `status-row`. This PR makes the `status-indicator` text the same size as the supporting text on this screen and also moves the status text next to the indicator to avoid uneven whitespace.

Before:
![Safari 2021-08-12 at 11 18 42](https://user-images.githubusercontent.com/51724/129180672-d2976f84-7ffd-4eef-ac91-2d8309940248.png)

After:
![Safari 2021-08-12 at 11 14 51](https://user-images.githubusercontent.com/51724/129180689-a1162753-ef82-4631-8110-6319c4dd87f9.png)

![Safari 2021-08-12 at 11 14 47](https://user-images.githubusercontent.com/51724/129180702-d6dfa1bd-bd3e-486f-9157-5d3787c7213c.png)
