### PR TITLE
Build poll jobs for the latest deployment and release

### DIFF
--- a/.changelog/2039.txt
+++ b/.changelog/2039.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Always generate status reports for latest deployment and release if present
+```

--- a/.changelog/2039.txt
+++ b/.changelog/2039.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-core: Always generate status reports for latest deployment and release if present
+core: App status polling will always queue status reports refresh jobs for latest deployment and release if present
 ```

--- a/internal/server/singleprocess/poll.go
+++ b/internal/server/singleprocess/poll.go
@@ -164,7 +164,7 @@ func (s *service) runPollQueuer(
 		log.Trace("queueing jobs for poller", "job_total", totalRequests)
 
 		// Note: We queue all poll jobs transactionally and return any
-		// errors that occured
+		// errors that occurred
 		_, err = s.queueJobMulti(ctx, queueJobRequests)
 		if err != nil {
 			log.Warn("error queueing a poll job", "err", err)

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -142,7 +142,7 @@ func (a *applicationPoll) buildPollJobs(
 			},
 
 			// Application polling requires a data source to be configured for the project
-			// Otherwise a status report can't properly eval the projects hcl context
+			// Otherwise a status report can't properly eval the project's hcl context
 			// needed to query the deploy or release
 			DataSource: project.DataSource,
 
@@ -184,7 +184,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		deploymentJob.Job.SingletonId = fmt.Sprintf("app-status-poll/%s/deployment", app.Name)
+		deploymentJob.Job.SingletonId = appStatusPollSingletonId(app.Name, appStatusPollOperationTypeDeployment)
 
 		jobs = append(jobs, deploymentJob)
 	}
@@ -203,7 +203,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		releaseJob.Job.SingletonId = fmt.Sprintf("app-status-poll/%s/release", app.Name)
+		releaseJob.Job.SingletonId = appStatusPollSingletonId(app.Name, appStatusPollOperationTypeRelease)
 
 		jobs = append(jobs, releaseJob)
 	}
@@ -235,4 +235,18 @@ func (a *applicationPoll) Complete(
 		return err
 	}
 	return nil
+}
+
+// The name of an operation type that status polling is possible for
+type appStatusPollOperationType string
+
+const (
+	appStatusPollOperationTypeDeployment appStatusPollOperationType = "deployment"
+	appStatusPollOperationTypeRelease    appStatusPollOperationType = "release"
+)
+
+// appStatusPollSingletonId generates an application status polling job singleton ID
+// for the given app and operation type.
+func appStatusPollSingletonId(appName string, operationType appStatusPollOperationType) string {
+	return fmt.Sprintf("app-status-poll/%s/%s", appName, operationType)
 }

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -184,7 +184,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		deploymentJob.Job.SingletonId = fmt.Sprintf("appl-poll/%s/deployment", app.Name)
+		deploymentJob.Job.SingletonId = fmt.Sprintf("app-status-poll/%s/deployment", app.Name)
 
 		jobs = append(jobs, deploymentJob)
 	}

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -203,7 +203,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		releaseJob.Job.SingletonId = fmt.Sprintf("appl-poll/%s/release", app.Name)
+		releaseJob.Job.SingletonId = fmt.Sprintf("app-status-poll/%s/release", app.Name)
 
 		jobs = append(jobs, releaseJob)
 	}

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -102,7 +102,7 @@ func (a *applicationPoll) buildPollJobs(
 	// an error so we fail early instead of queueing an already broken job
 	if project.DataSource == nil {
 		log.Debug("cannot poll a job without a remote data source configured.")
-		return nil, status.Error(codes.FailedPrecondition, "application polling requires a remote data source")
+		return nil, status.Error(codes.FailedPrecondition, "application status polling requires a remote data source")
 	}
 
 	// Determine the latest deployment or release to poll for a status report

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mitchellh/copystructure"
-
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+	"github.com/mitchellh/copystructure"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -101,7 +101,7 @@ func (a *applicationPoll) buildPollJobs(
 	// cannot be generated without a project and its hcl context. This returns
 	// an error so we fail early instead of queueing an already broken job
 	if project.DataSource == nil {
-		log.Debug("cannot poll a job without a remote data source configured.")
+		log.Debug("cannot build an application poll job without a remote data source configured.")
 		return nil, status.Error(codes.FailedPrecondition, "application status polling requires a remote data source")
 	}
 

--- a/internal/server/singleprocess/poll_application.go
+++ b/internal/server/singleprocess/poll_application.go
@@ -97,7 +97,7 @@ func (a *applicationPoll) buildPollJobs(
 		return nil, err
 	}
 
-	// Application polling requires a remote data source, otherwise a status report
+	// Application status polling requires a remote data source, otherwise a status report
 	// cannot be generated without a project and its hcl context. This returns
 	// an error so we fail early instead of queueing an already broken job
 	if project.DataSource == nil {

--- a/internal/server/singleprocess/poll_test.go
+++ b/internal/server/singleprocess/poll_test.go
@@ -668,7 +668,7 @@ func TestApplicationPollHandler_turnoff(t *testing.T) {
 		raw, err := testServiceImpl(impl).state.JobList()
 		for _, j := range raw {
 			if j.State != pb.Job_ERROR &&
-				j.SingletonId == fmt.Sprintf("appl-poll/%s", appName) {
+				j.SingletonId == fmt.Sprintf("appl-poll/%s/deployment", appName) {
 				// App status polling should only have this singleton id
 				jobs = append(jobs, j)
 			}

--- a/internal/server/singleprocess/poll_test.go
+++ b/internal/server/singleprocess/poll_test.go
@@ -3,7 +3,6 @@ package singleprocess
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -469,121 +468,6 @@ func TestApplicationPollHandler(t *testing.T) {
 	require.NoError(err)
 	client := server.TestServer(t, impl)
 
-	// Create a project with an application
-	respProj, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{
-		Project: serverptypes.TestProject(t, &pb.Project{
-			Name: "Example",
-			DataSource: &pb.Job_DataSource{
-				Source: &pb.Job_DataSource_Local{
-					Local: &pb.Job_Local{},
-				},
-			},
-			DataSourcePoll: &pb.Project_Poll{
-				Enabled:  true,
-				Interval: "15ms",
-			},
-			StatusReportPoll: &pb.Project_AppStatusPoll{
-				Enabled:  false,
-				Interval: "15ms",
-			},
-			Applications: []*pb.Application{
-				{
-					Project: &pb.Ref_Project{Project: "Example"},
-					Name:    "apple-app",
-				},
-			},
-		}),
-	})
-	require.NoError(err)
-	project := respProj.Project
-
-	// Grab next poll time
-	state := testServiceImpl(impl).state
-	a, _, err := state.ApplicationPollPeek(nil)
-	require.NoError(err)
-	require.Nil(a) // Apps Next Poll should be 0 since not started yet
-
-	// Wait a bit. The interval is so low that this should trigger
-	// multiple loops through the poller. But we want to ensure we
-	// have only one poll job queued.
-	time.Sleep(50 * time.Millisecond)
-
-	// Do a deployment
-	resp, err := client.UpsertDeployment(ctx, &pb.UpsertDeploymentRequest{
-		Deployment: serverptypes.TestValidDeployment(t, &pb.Deployment{
-			Component: &pb.Component{
-				Name: "testapp",
-			},
-			Application: &pb.Ref_Application{
-				Application: "apple-app",
-				Project:     "Example",
-			},
-		}),
-	})
-	require.NoError(err)
-	require.NotNil(resp)
-
-	// Update the app to start polling
-	project.StatusReportPoll = &pb.Project_AppStatusPoll{
-		Enabled: true,
-	}
-	_, err = client.UpsertProject(ctx, &pb.UpsertProjectRequest{
-		Project: project,
-	})
-	require.NoError(err)
-
-	// App poll time should be set
-	a, pollTime, err := state.ApplicationPollPeek(nil)
-	require.NoError(err)
-	require.NotNil(pollTime)
-	require.NotNil(a) // Apps Next Poll should be set
-
-	// Wait a bit. The interval is so low that this should trigger
-	// multiple loops through the poller. But we want to ensure we
-	// have only one poll job queued.
-	time.Sleep(50 * time.Millisecond)
-
-	// Check for our condition, we do eventually here because if we're
-	// in a slow environment then this may still be empty.
-	require.Eventually(func() bool {
-		// We should have a single poll job
-		var jobs []*pb.Job
-		raw, err := testServiceImpl(impl).state.JobList()
-		for _, j := range raw {
-			if j.State != pb.Job_ERROR {
-				jobs = append(jobs, j)
-			}
-		}
-
-		if err != nil {
-			t.Logf("err: %s", err)
-			return false
-		}
-
-		return len(jobs) == 1
-	}, 5*time.Second, 50*time.Millisecond)
-
-	// Cancel our poller to ensure it stops
-	testServiceImpl(impl).Close()
-
-	// ensure the next poll is after the initial poll before waiting
-	// next poll time gets set when a app poll is marked complete
-	a, nextPollTime, err := state.ApplicationPollPeek(nil)
-	require.NoError(err)
-	require.NotNil(a)
-	require.NotNil(nextPollTime)
-	require.True(nextPollTime.After(pollTime))
-}
-
-func TestApplicationPollHandler_turnoff(t *testing.T) {
-	require := require.New(t)
-	ctx := context.Background()
-
-	// Create our server
-	impl, err := New(WithDB(testDB(t)))
-	require.NoError(err)
-	client := server.TestServer(t, impl)
-
 	appName := "apple-app"
 
 	// Create a project with an application
@@ -594,10 +478,6 @@ func TestApplicationPollHandler_turnoff(t *testing.T) {
 				Source: &pb.Job_DataSource_Local{
 					Local: &pb.Job_Local{},
 				},
-			},
-			DataSourcePoll: &pb.Project_Poll{
-				Enabled:  true,
-				Interval: "15ms",
 			},
 			StatusReportPoll: &pb.Project_AppStatusPoll{
 				Enabled:  false,
@@ -665,10 +545,129 @@ func TestApplicationPollHandler_turnoff(t *testing.T) {
 	require.Eventually(func() bool {
 		// We should have a single poll job
 		var jobs []*pb.Job
+
+		raw, err := testServiceImpl(impl).state.JobList()
+		for _, j := range raw {
+			if j.State != pb.Job_ERROR && j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
+				jobs = append(jobs, j)
+			}
+		}
+
+		if err != nil {
+			t.Logf("err: %s", err)
+			return false
+		}
+
+		return len(jobs) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Cancel our poller to ensure it stops
+	testServiceImpl(impl).Close()
+
+	// ensure the next poll is after the initial poll before waiting
+	// next poll time gets set when a app poll is marked complete
+	a, nextPollTime, err := state.ApplicationPollPeek(nil)
+	require.NoError(err)
+	require.NotNil(a)
+	require.NotNil(nextPollTime)
+	require.True(nextPollTime.After(pollTime))
+}
+
+func TestApplicationPollHandler_fullLifecycle(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	// Create our server
+	impl, err := New(WithDB(testDB(t)))
+	require.NoError(err)
+	client := server.TestServer(t, impl)
+
+	appName := "apple-app"
+
+	// Create a project with an application
+	respProj, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{
+		Project: serverptypes.TestProject(t, &pb.Project{
+			Name: "Example",
+			DataSource: &pb.Job_DataSource{
+				Source: &pb.Job_DataSource_Local{
+					Local: &pb.Job_Local{},
+				},
+			},
+			//DataSourcePoll: &pb.Project_Poll{
+			//	Enabled:  true,
+			//	Interval: "15ms",
+			//},
+			StatusReportPoll: &pb.Project_AppStatusPoll{
+				Enabled:  false,
+				Interval: "15ms",
+			},
+			Applications: []*pb.Application{
+				{
+					Project: &pb.Ref_Project{Project: "Example"},
+					Name:    appName,
+				},
+			},
+		}),
+	})
+	require.NoError(err)
+	project := respProj.Project
+
+	// Grab next poll time
+	state := testServiceImpl(impl).state
+	a, _, err := state.ApplicationPollPeek(nil)
+	require.NoError(err)
+	require.Nil(a) // Apps Next Poll should be 0 since not started yet
+
+	// Wait a bit. The interval is so low that this should trigger
+	// multiple loops through the poller. But we want to ensure we
+	// have only one poll job queued.
+	time.Sleep(50 * time.Millisecond)
+
+	// Do a deployment
+	deployResp, err := client.UpsertDeployment(ctx, &pb.UpsertDeploymentRequest{
+		Deployment: serverptypes.TestValidDeployment(t, &pb.Deployment{
+			Component: &pb.Component{
+				Name: "testapp",
+			},
+			Application: &pb.Ref_Application{
+				Application: appName,
+				Project:     "Example",
+			},
+		}),
+	})
+	require.NoError(err)
+	require.NotNil(deployResp)
+
+	// Update the app to start polling
+	project.StatusReportPoll = &pb.Project_AppStatusPoll{
+		Enabled:  true,
+		Interval: "15ms",
+	}
+	_, err = client.UpsertProject(ctx, &pb.UpsertProjectRequest{
+		Project: project,
+	})
+	require.NoError(err)
+
+	// App poll time should be set
+	a, pollTime, err := state.ApplicationPollPeek(nil)
+	require.NoError(err)
+	require.NotNil(pollTime)
+	require.NotNil(a) // Apps Next Poll should be set
+
+	// Wait a bit. The interval is so low that this should trigger
+	// multiple loops through the poller. But we want to ensure we
+	// have only one poll job queued.
+	time.Sleep(50 * time.Millisecond)
+
+	// Check for our condition, we do eventually here because if we're
+	// in a slow environment then this may still be empty.
+	require.Eventually(func() bool {
+		// We should have a single poll job for just the deployment
+		var jobs []*pb.Job
 		raw, err := testServiceImpl(impl).state.JobList()
 		for _, j := range raw {
 			if j.State != pb.Job_ERROR &&
-				j.SingletonId == fmt.Sprintf("appl-poll/%s/deployment", appName) {
+				j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
 				// App status polling should only have this singleton id
 				jobs = append(jobs, j)
 			}
@@ -680,6 +679,56 @@ func TestApplicationPollHandler_turnoff(t *testing.T) {
 		}
 
 		return len(jobs) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Do a release
+	releaseResp, err := client.UpsertRelease(ctx, &pb.UpsertReleaseRequest{
+		Release: serverptypes.TestValidRelease(t, &pb.Release{
+			Component: &pb.Component{
+				Name: "testapp",
+			},
+			Application: &pb.Ref_Application{
+				Application: appName,
+				Project:     "Example",
+			},
+		}),
+	})
+	require.NoError(err)
+	require.NotNil(releaseResp)
+
+	// Wait a bit. The interval is so low that this should trigger
+	// multiple loops through the poller. But we want to ensure we
+	// have only one poll job queued.
+	time.Sleep(50 * time.Millisecond)
+
+	// Make sure we're polling on two status reports
+
+	// Check for our condition, we do eventually here because if we're
+	// in a slow environment then this may still be empty.
+	require.Eventually(func() bool {
+		// We should have a poll job for a deployment and another for a release
+
+		raw, err := testServiceImpl(impl).state.JobList()
+		releaseJobs := 0
+		deployJobs := 0
+		for _, j := range raw {
+			t.Logf("Found job in state %s with id %s", j.State, j.SingletonId)
+			if j.State != pb.Job_ERROR {
+				if j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeRelease) {
+					releaseJobs++
+				}
+				if j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
+					deployJobs++
+				}
+			}
+		}
+
+		if err != nil {
+			t.Logf("err: %s", err)
+			return false
+		}
+
+		return releaseJobs == 1 && deployJobs == 1
 	}, 5*time.Second, 50*time.Millisecond)
 
 	// Update the app to stop polling

--- a/internal/server/singleprocess/state/app_operation.go
+++ b/internal/server/singleprocess/state/app_operation.go
@@ -358,7 +358,7 @@ func (op *appOperation) Latest(
 		}
 	}
 
-	return nil, status.Errorf(codes.NotFound, "No application named %q is available!", ref.Application)
+	return nil, status.Errorf(codes.NotFound, "No application named %q is available, or application has no successful operations", ref.Application)
 }
 
 // get reads the value from the database. This populates any computed fields

--- a/internal/server/singleprocess/state/application.go
+++ b/internal/server/singleprocess/state/application.go
@@ -58,7 +58,7 @@ func (s *State) AppGet(ref *pb.Ref_Application) (*pb.Application, error) {
 	return result, err
 }
 
-// AppPollPeek peeks at the next available project that will be polled against,
+// ApplicationPollPeek peeks at the next available project that will be polled against,
 // and returns the project as the result along with the poll time. The poll queuer
 // will queue a job against every defined application for the given project.
 // For more information on how ProjectPollPeek works, refer to the ProjectPollPeek
@@ -80,7 +80,7 @@ func (s *State) ApplicationPollPeek(
 	return result, pollTime, err
 }
 
-// AppPollComplete sets the next poll time for a given project given the app
+// ApplicationPollComplete sets the next poll time for a given project given the app
 // reference along with the time interval "t".
 func (s *State) ApplicationPollComplete(
 	project *pb.Project,
@@ -128,7 +128,7 @@ func (s *State) appPut(
 		return err
 	}
 
-	// If we have a matching app, then modify that that.
+	// If we have a matching app, then modify that.
 	pt := &serverptypes.Project{Project: p}
 	if idx := pt.App(value.Name); idx >= 0 {
 		p.Applications[idx] = value
@@ -161,7 +161,7 @@ func (s *State) appDelete(
 		return err
 	}
 
-	// If we have a matching app, then modify that that.
+	// If we have a matching app, then modify that.
 	pt := &serverptypes.Project{Project: p}
 	if i := pt.App(ref.Application); i >= 0 {
 		s := p.Applications
@@ -223,7 +223,7 @@ func (s *State) appPollPeek(
 	}
 	ws.Add(iter.WatchCh())
 
-	// Get the projects app with the lowest "next poll" time.
+	// Get the project's app with the lowest "next poll" time.
 	iter, err = memTxn.LowerBound(
 		projectIndexTableName,
 		appIndexNextPollIndexName,
@@ -242,18 +242,14 @@ func (s *State) appPollPeek(
 
 	rec := raw.(*projectIndexRecord)
 	if rec.AppStatusNextPoll.IsZero() {
-		// This happens if this applications poller hasn't been switched on
+		// This happens if this application's poller hasn't been switched on
 		return nil, time.Time{}, nil
 	}
 
 	var result *pb.Project
-	err = s.db.View(func(dbTxn *bolt.Tx) error {
-		var err error
-		result, err = s.projectGet(dbTxn, memTxn, &pb.Ref_Project{
-			Project: rec.Id,
-		})
 
-		return err
+	result, err = s.projectGet(dbTxn, memTxn, &pb.Ref_Project{
+		Project: rec.Id,
 	})
 
 	return result, rec.AppStatusNextPoll, err


### PR DESCRIPTION
Previously, if a release was present, we would stop polling on the latest deployment. This means we would stop looking at the statuses of instances, which are managed (and polled) by the deployments, and are most likely to have status that changes over time.

### How to verify this

- Make a k8s project with a releaser (e.x.: https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/java)

- Init the project

- Set app polling on the project (e.x. `waypoint project apply -app-status-poll-interval=10s -data-source=git -git-url=https://github.com/hashicorp/waypoint-examples -git-path=kubernetes/java -app-status-poll example-java`)

- Run a `waypoint up`

- Watch the status reports for 30 seconds or so. You should notice the latest deployment _and_ the latest release reports update every 10 seconds:

<img width="1086" alt="Screen Shot 2021-08-12 at 12 55 20 PM" src="https://user-images.githubusercontent.com/8404559/129237267-c95277bd-c9ee-4f28-9ab4-eb5b07d08ee0.png">
