### PR TITLE
cli/status: fix broken output when no generated time is set

### DIFF
--- a/.changelog/2047.txt
+++ b/.changelog/2047.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli/status: Display '(unknown)' when the time a status report was generated is
+not known
+```

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -947,12 +947,12 @@ func (c *StatusCommand) FormatStatusReportComplete(
 		statusReportComplete = "? UNKNOWN"
 	}
 
-	t, err := ptypes.Timestamp(statusReport.GeneratedTime)
-	if err != nil {
-		return statusReportComplete, "", err
+	reportTime := "(unknown)"
+	if statusReport.GeneratedTime.IsValid() {
+		reportTime = humanize.Time(statusReport.GeneratedTime.AsTime())
 	}
 
-	return statusReportComplete, humanize.Time(t), nil
+	return statusReportComplete, reportTime, nil
 }
 
 func (c *StatusCommand) getWorkspaceFromProject(pr *pb.GetProjectResponse) (string, error) {


### PR DESCRIPTION
If a status report is returned without `GeneratedTime` set, the CLI will fail to parse it:

```
$ waypoint status -app=nginx-example
Current status for application "nginx-example" in project "example-nginx-ami" in server context "waypoint-server-nlb-774e79e21a01ca87.elb.us-west-2.amazonaws.com:9701".
! CLI failed to format app status:timestamp: nil Timestamp
```

In this PR we check for a valid time. If it's not valid, we insert `(unknown)` as a placeholder