### PR TITLE
cli/uninstall: Add more validation to requested platform for uninstall

### DIFF
--- a/.changelog/2052.txt
+++ b/.changelog/2052.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+cli/uninstall: Remove hard requirement on platform flag, attempt to read server
+platform from server context. Platform flag overrides anytihng set in a server
+platform context.
+```

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -364,7 +364,7 @@ func (c *InstallCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *InstallCommand) Synopsis() string {
-	return "Install the Waypoint server to Kubernetes, Nomad, or Docker"
+	return "Install the Waypoint server to Kubernetes, Nomad, ECS, or Docker"
 }
 
 func (c *InstallCommand) Help() string {
@@ -373,7 +373,7 @@ Usage: waypoint server install [options]
 Alias: waypoint install
 
   Installs a Waypoint server to an existing platform. The platform should be
-  specified as kubernetes, nomad, or docker.
+  specified as kubernetes, nomad, ecs, or docker.
 
   This will also install a single Waypoint runner by default. This enables
   remote operations out of the box, such as polling a Git repository. This can

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -66,28 +66,43 @@ func (c *UninstallCommand) Run(args []string) int {
 		}
 	}
 
+	// Validate platform requested matches the server contexts platform
 	serverPlatform := c.platform
-	if ctxConfig.Server.Platform == "" && serverPlatform != "" {
-		c.ui.Output(
-			"No platform set on server context. Will attempt to uninstall requested "+
-				"platform %q",
-			serverPlatform,
-			terminal.WithWarningStyle(),
-		)
-	} else if serverPlatform == "" {
-		// attempt to set the server platform so the platform flag isn't required.
-		serverPlatform = ctxConfig.Server.Platform
+	if ctxConfig != nil {
+		if serverPlatform != "" {
+			if ctxConfig.Server.Platform == "" {
+				c.ui.Output(
+					"No platform set on server context. Will attempt to uninstall requested "+
+						"platform %q",
+					serverPlatform,
+					terminal.WithWarningStyle(),
+				)
+			} else if ctxConfig.Server.Platform != serverPlatform {
+				c.ui.Output(
+					"The current server platform is %q but the requested platform through "+
+						"the -platform flag was %q",
+					ctxConfig.Server.Platform,
+					serverPlatform,
+					terminal.WithErrorStyle(),
+				)
 
-		if serverPlatform == "" {
-			// It's still empty
-			c.ui.Output(
-				"Cannot determine what platform to uninstall Waypoint. "+
-					"The -platform flag is required since the server context did not include "+
-					"a server platform.",
-				terminal.WithErrorStyle(),
-			)
+				return 1
+			}
+		} else {
+			// attempt to set the server platform so the platform flag isn't required.
+			serverPlatform = ctxConfig.Server.Platform
 
-			return 1
+			if serverPlatform == "" {
+				// It's still empty
+				c.ui.Output(
+					"Cannot determine what platform to uninstall Waypoint. "+
+						"The -platform flag is required since the server context did not include "+
+						"a server platform.",
+					terminal.WithErrorStyle(),
+				)
+
+				return 1
+			}
 		}
 	}
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -67,21 +67,22 @@ func (c *UninstallCommand) Run(args []string) int {
 	}
 
 	serverPlatform := c.platform
-	if ctxConfig.Server.Platform == "" && c.platform != "" {
+	if ctxConfig.Server.Platform == "" && serverPlatform != "" {
 		c.ui.Output(
 			"No platform set on server context. Will attempt to uninstall requested "+
 				"platform %q",
-			c.platform,
+			serverPlatform,
 			terminal.WithWarningStyle(),
 		)
 	} else if serverPlatform == "" {
 		// attempt to set the server platform so the platform flag isn't required.
 		serverPlatform = ctxConfig.Server.Platform
 
-		if serverPlatform == "" && c.platform == "" {
+		if serverPlatform == "" {
+			// It's still empty
 			c.ui.Output(
 				"Cannot determine what platform to uninstall Waypoint. "+
-					"The -platform flag is required and the server context did not include "+
+					"The -platform flag is required since the server context did not include "+
 					"a server platform.",
 				terminal.WithErrorStyle(),
 			)
@@ -240,7 +241,7 @@ Usage: waypoint server uninstall [options]
   server that was manually run with the 'waypoint server run' CLI, but with
   a Waypoint server that was installed via 'waypoint server install'.
 
-  The platform can be specified as kubernetes, nomad, ecs, or docker. If not,
+  The platform can be specified as kubernetes, nomad, ecs, or docker. If not
   specified, the CLI command will attempt to retrieve the platform defined in
   the server context.
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -2,14 +2,14 @@
 layout: commands
 page_title: 'Commands: Install'
 sidebar_title: 'install'
-description: 'Install the Waypoint server to Kubernetes, Nomad, or Docker'
+description: 'Install the Waypoint server to Kubernetes, Nomad, ECS, or Docker'
 ---
 
 # Waypoint Install
 
 Command: `waypoint install`
 
-Install the Waypoint server to Kubernetes, Nomad, or Docker
+Install the Waypoint server to Kubernetes, Nomad, ECS, or Docker
 
 @include "commands/install_desc.mdx"
 
@@ -20,7 +20,7 @@ Usage: `waypoint server install [options]`
 Alias: `waypoint install`
 
 Installs a Waypoint server to an existing platform. The platform should be
-specified as kubernetes, nomad, or docker.
+specified as kubernetes, nomad, ecs, or docker.
 
 This will also install a single Waypoint runner by default. This enables
 remote operations out of the box, such as polling a Git repository. This can

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -2,14 +2,14 @@
 layout: commands
 page_title: 'Commands: Server install'
 sidebar_title: 'server install'
-description: 'Install the Waypoint server to Kubernetes, Nomad, or Docker'
+description: 'Install the Waypoint server to Kubernetes, Nomad, ECS, or Docker'
 ---
 
 # Waypoint Server install
 
 Command: `waypoint server install`
 
-Install the Waypoint server to Kubernetes, Nomad, or Docker
+Install the Waypoint server to Kubernetes, Nomad, ECS, or Docker
 
 @include "commands/server-install_desc.mdx"
 
@@ -20,7 +20,7 @@ Usage: `waypoint server install [options]`
 Alias: `waypoint install`
 
 Installs a Waypoint server to an existing platform. The platform should be
-specified as kubernetes, nomad, or docker.
+specified as kubernetes, nomad, ecs, or docker.
 
 This will also install a single Waypoint runner by default. This enables
 remote operations out of the box, such as polling a Git repository. This can

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -17,8 +17,15 @@ Uninstall the Waypoint server
 
 Usage: `waypoint server uninstall [options]`
 
-Uninstall the Waypoint server. The platform should be specified as kubernetes,
-nomad, or docker. '-auto-approve' is required.
+Uninstall the Waypoint server. This command is not intended to uninstall a
+server that was manually run with the 'waypoint server run' CLI, but with
+a Waypoint server that was installed via 'waypoint server install'.
+
+The platform can be specified as kubernetes, nomad, ecs, or docker. If not,
+specified, the CLI command will attempt to retrieve the platform defined in
+the server context.
+
+'-auto-approve' is required.
 
 By default, this command deletes the default server's context and creates
 a server snapshot.

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -21,7 +21,7 @@ Uninstall the Waypoint server. This command is not intended to uninstall a
 server that was manually run with the 'waypoint server run' CLI, but with
 a Waypoint server that was installed via 'waypoint server install'.
 
-The platform can be specified as kubernetes, nomad, ecs, or docker. If not,
+The platform can be specified as kubernetes, nomad, ecs, or docker. If not
 specified, the CLI command will attempt to retrieve the platform defined in
 the server context.
 


### PR DESCRIPTION
Prior to this commit, the CLI uninstall command assumed that the
platform requested matched the server platform. This could be confusing
if a user has both a docker platform server and a local server from
`waypoint server run`. This commit adds some extra validation with the
platform requested by loading the server platform and taking into
account what platform was requested.

This commit also changes the hard requirement that the uninstall
command needs a platform flag. If a server context has a platform set,
and no platform flag was requested, use that platform instead. Note
that the platform flag, if requested, always overrides what the server
context has. This is because some early versions of Waypoint do
not set the Platform context. If the flag and server platform conflict,
we'll print a note to say we're honoring the platform flag requested.

Fixes #2046

Screenshot of an example when no server platform was set or requested, and then the warning for if no server platform was set but a platform flag was requested:

![Screenshot from 2021-08-13 16-33-30](https://user-images.githubusercontent.com/810277/129427072-1f08db59-581a-4a7a-995a-e62706558a36.png)