### PR TITLE
ui: Fix tab styles for dark mode

### DIFF
--- a/.changelog/2053.txt
+++ b/.changelog/2053.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Improve tab styles for dark mode
+```

--- a/ui/app/styles/components/structure/pds-tabnav.scss
+++ b/ui/app/styles/components/structure/pds-tabnav.scss
@@ -20,8 +20,10 @@
   }
 
   @media (prefers-color-scheme: dark) {
+    border-bottom: 1px solid color.$ui-cool-gray-700;
+
     a:hover {
-      background: color.$ui-cool-gray-800;
+      background: color.$ui-cool-gray-800!important;
     }
   }
 }


### PR DESCRIPTION
Fixes the background color and border color of tabs in dark mode

Before
![Safari 2021-08-16 at 14 51 00](https://user-images.githubusercontent.com/51724/129574467-97993def-3e21-4170-8c0b-309382164455.png)


After
![Safari 2021-08-16 at 14 48 37](https://user-images.githubusercontent.com/51724/129574109-9716b1d8-37f2-4fba-b673-a076239db7f3.png)
