### PR TITLE
fix destroy non-latest deployments in ECS

### DIFF
--- a/.changelog/2054.txt
+++ b/.changelog/2054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/aws/ecs: fix destroy non-latest deployments in ECS
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1340,7 +1340,7 @@ func destroyALB(
 			if err != nil {
 				return err
 			}
-		} else if len(def) > 1 && def[0].ForwardConfig != nil {
+		} else if len(def[0].ForwardConfig.TargetGroups) > 1 && def[0].ForwardConfig != nil {
 			// Multiple target groups means we can keep the listener
 			var active bool
 

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1340,7 +1340,7 @@ func destroyALB(
 			if err != nil {
 				return err
 			}
-		} else if len(def[0].ForwardConfig.TargetGroups) > 1 && def[0].ForwardConfig != nil {
+		} else if len(def) > 0 && def[0].ForwardConfig != nil && len(def[0].ForwardConfig.TargetGroups) > 1 {
 			// Multiple target groups means we can keep the listener
 			var active bool
 


### PR DESCRIPTION
This commit fix destroy non-latest deployments in ECS

### Test
[![asciicast](https://asciinema.org/a/wibXMNZJqY0R03QGW8AQcuwdK.svg)](https://asciinema.org/a/wibXMNZJqY0R03QGW8AQcuwdK)