### PR TITLE
builtin/docker: use proper full image name resolution

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -725,7 +726,12 @@ func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.U
 		}
 	*/
 
-	in = makeImageCanonical(in)
+	named, err := reference.ParseNormalizedNamed(in)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "unable to parse image name: %s", in)
+	}
+
+	in = named.Name()
 	log.Debug("pulling image", "image", in)
 
 	out, err := cli.ImagePull(context.Background(), in, ipo)
@@ -751,20 +757,6 @@ func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.U
 	s.Done()
 
 	return nil
-}
-
-// makeImageCanonical makes sure the image reference uses full canonical name i.e.
-// consul:1.6.1 -> docker.io/library/consul:1.6.1
-func makeImageCanonical(image string) string {
-	imageParts := strings.Split(image, "/")
-	switch len(imageParts) {
-	case 1:
-		return fmt.Sprintf("docker.io/library/%s", imageParts[0])
-	case 2:
-		return fmt.Sprintf("docker.io/%s/%s", imageParts[0], imageParts[1])
-	}
-
-	return image
 }
 
 // Config is the configuration structure for the Platform.

--- a/builtin/docker/task.go
+++ b/builtin/docker/task.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -190,7 +191,12 @@ func (b *TaskLauncher) setupImage(
 		}
 	}
 
-	img = makeImageCanonical(img)
+	named, err := reference.ParseNormalizedNamed(img)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "unable to parse image name: %s", img)
+	}
+
+	img = named.Name()
 
 	out, err := cli.ImagePull(context.Background(), img, types.ImagePullOptions{})
 	if err != nil {


### PR DESCRIPTION
The previous makeImageCanonical incorrectly handled urls like `myreg.domain.com:8080/foo`. Using the reference implementation of this resolution fixes the issue.