### PR TITLE
ui: Fixed linting errors and updated API definitions

### DIFF
--- a/ui/app/components/app-form/project-repository-settings.hbs
+++ b/ui/app/components/app-form/project-repository-settings.hbs
@@ -220,8 +220,8 @@
             spellcheck="false"
             rows="14"
             value={{this.decodedWaypointHcl}}
-            required={{this.this.serverHcl}}
-            {{on "input" (fn this.setWaypointHcl)}}
+            required={{this.serverHcl}}
+            {{on "input" (this.setWaypointHcl)}}
           />
         </div>
       {{else}}

--- a/ui/app/components/operation-logs/index.ts
+++ b/ui/app/components/operation-logs/index.ts
@@ -99,7 +99,7 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
       // If it completes with an error, we should surface that in the UI
       if (event == GetJobStreamResponse.EventCase.COMPLETE && response.getComplete()?.getError()) {
         let error = response.getComplete()?.getError()?.toObject();
-        this.addLogLine(this.typeLine, { style: this.errorBoldStyle, msg: error.message });
+        this.addLogLine(this.typeLine, { style: this.errorBoldStyle, msg: error?.message });
       }
     };
 

--- a/ui/app/components/project-input-variables/list-item.ts
+++ b/ui/app/components/project-input-variables/list-item.ts
@@ -30,7 +30,7 @@ export default class ProjectInputVariablesListComponent extends Component<Variab
     this.variable = variable;
     this.isEditing = isEditing;
     this.isCreating = isCreating;
-    this.storeInitialVariable();
+    this.initialVariable = JSON.parse(JSON.stringify(this.variable));
   }
 
   get isHcl(): boolean {

--- a/ui/app/components/project-input-variables/list.ts
+++ b/ui/app/components/project-input-variables/list.ts
@@ -14,7 +14,7 @@ interface ProjectSettingsArgs {
 export default class ProjectInputVariablesListComponent extends Component<ProjectSettingsArgs> {
   @service api!: ApiService;
   @service router!: RouterService;
-  @service flashMessages: PdsFlashMessages;
+  @service flashMessages!: PdsFlashMessages;
   @tracked project: Project.AsObject;
   @tracked variablesList: Array<Variable.AsObject>;
   @tracked isCreating: boolean;
@@ -66,7 +66,7 @@ export default class ProjectInputVariablesListComponent extends Component<Projec
         this.variablesList
       );
 
-      this.project = resp;
+      this.project = resp as Project.AsObject;
       this.flashMessages.success('Settings saved');
       this.activeVariable = null;
       this.isCreating = false;


### PR DESCRIPTION
~~Notably had to update `Ref.Component`'s namespace to include `Type` in the `ui/lib/waypoint-pb/server_pb.d.ts` file. Type existed in the `Component` namespace, but for some reason did not carry over when under the `Ref` namespace. This was causing some linting errors~~
_See comments from @jgwhite below_