### PR TITLE
contrib/severinstall/kind-k8s: Include optional support for k8s ingress

### DIFF
--- a/contrib/serverinstall/kind-k8s/README.md
+++ b/contrib/serverinstall/kind-k8s/README.md
@@ -41,13 +41,18 @@ and the rest should be taken care of.
 ./setup-k8s.sh
 ```
 
+##### Env Var options
+
+- `WP_K8S_INGRESS` - setting this var will include ingress configuration for the
+setup k8s cluster.
+
 After this script runs, you should be ready to run a `waypoint install` for
 the kubernetes platform!
 
 #### Manual
 
 1) docker run -d --restart=always -p "127.0.0.1:5000:5000" --name "kind-registry"
-2) kind create cluster --config configs/cluster-config.yaml
+2) kind create cluster --config configs/cluster-config.yaml (or optionally with ingress `--config configs/cluster-ingress-config.yaml`)
 3) docker network connect "kind" "kind-registry"
 4) kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
 5) kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
@@ -66,6 +71,9 @@ the kubernetes platform!
   * Update the range inside the `configs/metallb-config.yaml` file. If your
   container IP Address was `172.18.0.4` for example, you might set the range to `172.18.0.20-172.18.0.50`.
 8) kubectl apply -f configs/metallb-config.yaml
+9) If ingress support is desired:
+	* kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+	* kubectl patch daemonsets -n projectcontour envoy -p '{"spec":{"template":{"spec":{"nodeSelector":{"ingress-ready":"true"},"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Equal","effect":"NoSchedule"}]}}}}'
 
 ### Setup waypoint
 

--- a/contrib/serverinstall/kind-k8s/README.md
+++ b/contrib/serverinstall/kind-k8s/README.md
@@ -43,7 +43,7 @@ and the rest should be taken care of.
 
 ##### Env Var options
 
-- `WP_K8S_INGRESS` - setting this var will include ingress configuration for the
+- `WP_K8S_INGRESS` - setting this var to any non-empty value will include ingress configuration for the
 setup k8s cluster.
 
 After this script runs, you should be ready to run a `waypoint install` for

--- a/contrib/serverinstall/kind-k8s/configs/cluster-ingress-config.yaml
+++ b/contrib/serverinstall/kind-k8s/configs/cluster-ingress-config.yaml
@@ -1,0 +1,22 @@
+# three node (two workers) cluster config
+# https://kind.sigs.k8s.io/docs/user/quick-start/#multinode-clusters
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -23,7 +23,7 @@ fi
 echo "Setting up kubernetes with kind and metallb..."
 echo
 
-if [ "${setupIngress}" != '' ]; then
+if [ -n "${setupIngress}" ]; then
   echo "Creating kind cluster with ingress controller..."
   echo
 cat <<EOF | kind create cluster --config=-

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -119,7 +119,7 @@ sed s/%ADDR_RANGE%/$IPADDR_RANGE/g \
 echo "Applying metallb-config-set.yaml with ip address range applied..."
 kubectl apply -f configs/metallb-config-set.yaml
 
-if [ "${setupIngress}" != '' ]; then
+if [ -n "${setupIngress}" ]; then
 	echo
 	echo "Setting up Contour ingress controller..."
 	echo

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
+
+# NOTE(briancain): This script uses 'kind' to automatically bring up a local
+# kubernetes cluster. It includes optional support for configuring an
+# Ingress controller node.
+
 set -o errexit
+
+setupIngress=$WP_K8S_INGRESS
 
 echo "Setting up local docker registry..."
 echo
@@ -16,16 +23,46 @@ fi
 echo "Setting up kubernetes with kind and metallb..."
 echo
 
-echo "Creating kind cluster with cluster-config.yaml..."
-echo
+if [ "${setupIngress}" != '' ]; then
+  echo "Creating kind cluster with ingress controller..."
+  echo
 cat <<EOF | kind create cluster --config=-
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-      endpoint = ["http://${reg_name}:${reg_port}"]
+  kind: Cluster
+  apiVersion: kind.x-k8s.io/v1alpha4
+  containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+        endpoint = ["http://${reg_name}:${reg_port}"]
+  nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+    - |
+      kind: InitConfiguration
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "ingress-ready=true"
+    extraPortMappings:
+    - containerPort: 80
+      hostPort: 80
+      protocol: TCP
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP
 EOF
+
+else
+  echo "Creating kind cluster with cluster-config.yaml..."
+  echo
+cat <<EOF | kind create cluster --config=-
+  kind: Cluster
+  apiVersion: kind.x-k8s.io/v1alpha4
+  containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+        endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+fi
 
 echo "Connecting registry to cluster network..."
 echo
@@ -46,9 +83,10 @@ data:
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 
+echo
 echo "Applying metallb namespace..."
 echo
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.1/manifests/namespace.yaml
 
 echo "Create secret for metallb-system node..."
 echo
@@ -56,7 +94,7 @@ kubectl create secret generic -n metallb-system memberlist --from-literal=secret
 
 echo "Applying metallb manifest..."
 echo
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.1/manifests/metallb.yaml
 
 echo
 echo
@@ -66,7 +104,12 @@ IPADDR=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{en
 
 echo "IP Address of networked container is ${IPADDR}"
 echo
-read -p "Enter a range to define for metallb IP Addresses based on this container (like 172.18.0.20-172.18.0.50):`echo $'\n> '` " IPADDR_RANGE
+
+echo "Automatically picking an IP range based on networked contianer IP..."
+
+IPADDR_RANGE="$(awk -F"." '{print $1"."$2"."$3".20"}'<<<$IPADDR)-$(awk -F"." '{print $1"."$2"."$3".50"}'<<<$IPADDR)"
+
+#read -p "Enter a range to define for metallb IP Addresses based on this container (like 172.18.0.20-172.18.0.50):`echo $'\n> '` " IPADDR_RANGE
 echo "IP Address range is ${IPADDR_RANGE}"
 echo
 
@@ -76,5 +119,15 @@ sed s/%ADDR_RANGE%/$IPADDR_RANGE/g \
 echo "Applying metallb-config-set.yaml with ip address range applied..."
 kubectl apply -f configs/metallb-config-set.yaml
 
+if [ "${setupIngress}" != '' ]; then
+	echo
+	echo "Setting up Contour ingress controller..."
+	echo
+
+	kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+	kubectl patch daemonsets -n projectcontour envoy -p '{"spec":{"template":{"spec":{"nodeSelector":{"ingress-ready":"true"},"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Equal","effect":"NoSchedule"}]}}}}'
+fi
+
+echo
 echo "Done! You should be ready to 'waypoint install -platform=kubernetes -accept-tos' on a local kubernetes!"
 exit 0


### PR DESCRIPTION
This commit updates the contrib bash helper for setting up k8s to
optionally include an ingress controller config. It also updates to use
a newer version of `metallb` and now automatically picks an IP to use
rather than asking for user input.