### PR TITLE
plugin/aws/ecs add alb subnets

### DIFF
--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -69,6 +69,14 @@ Set along with alb.domain_name to have DNS automatically setup for the ALB.
 - Type: **string**
 - **Optional**
 
+##### alb.subnets
+
+The VPC subnets to use for the ALB.
+
+- Type: **list of string**
+- **Optional**
+- Default: public subnets in the default VPC
+
 #### logging (category)
 
 Provides additional configuration for logging flags for ECS.

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -60,6 +60,14 @@ When this is set, no ALB or Listener is created. Instead the application is conf
 - Type: **string**
 - **Optional**
 
+##### alb.subnets
+
+The VPC subnets to use for the ALB.
+
+- Type: **list of string**
+- **Optional**
+- Default: public subnets in the default VPC
+
 ##### alb.zone_id
 
 Route53 ZoneID to create a DNS record into.
@@ -68,14 +76,6 @@ Set along with alb.domain_name to have DNS automatically setup for the ALB.
 
 - Type: **string**
 - **Optional**
-
-##### alb.subnets
-
-The VPC subnets to use for the ALB.
-
-- Type: **list of string**
-- **Optional**
-- Default: public subnets in the default VPC
 
 #### logging (category)
 


### PR DESCRIPTION
This commit adds the ability to pass subnets in ALB, for example
```
app "vole" {
 
  ...
  ...
  ...

  deploy {
    use "aws-ecs" {
      region = var.aws_region
      memory = var.memory
      cluster = "${var.env}-${var.namespace}"
      subnets = ["subnet-XXXXXXXXXXXXXX", "subnet-XXXXXXXXXXXXXX", "subnet-XXXXXXXXXXXXXX"]
      alb {
        subnets = ["subnet-XXXXXXXXXXXXXX", "subnet-XXXXXXXXXXXXXX", "subnet-XXXXXXXXXXXXXX"]
      }
    }
  }
}
```


### Test 
[![asciicast](https://asciinema.org/a/A94wkDDTItGJvPFsR1fZZyETG.svg)](https://asciinema.org/a/A94wkDDTItGJvPFsR1fZZyETG)