### PR TITLE
Small doc update to fix data source paths

### DIFF
--- a/website/content/docs/projects/git.mdx
+++ b/website/content/docs/projects/git.mdx
@@ -91,7 +91,7 @@ runner {
 
   data_source "git" {
     url  = "https://github.com/hashicorp/waypoint-examples.git"
-    path = "docker/node-js"
+    path = "docker/nodejs"
   }
 }
 

--- a/website/content/docs/waypoint-hcl/runner.mdx
+++ b/website/content/docs/waypoint-hcl/runner.mdx
@@ -26,7 +26,7 @@ runner {
 
   data_source "git" {
     url  = "https://github.com/hashicorp/waypoint-examples.git"
-    path = "docker/node-js"
+    path = "docker/nodejs"
   }
 }
 ```


### PR DESCRIPTION
The data source path in the [waypoint-examples repo][repo] is `docker/nodejs` not `docker/node-js`





[repo]: https://github.com/hashicorp/waypoint-examples/tree/main/docker/nodejs