### PR TITLE
plugin/nomad: only use non-empty `job.StatusDescription` for `HealthMessage`

### DIFF
--- a/.changelog/2093.txt
+++ b/.changelog/2093.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/nomad: only use non-empty job.StatusDescription for HealthMessage
+```

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -352,7 +352,9 @@ func (p *Platform) Status(
 		result.HealthMessage = fmt.Sprintf("Job %q is reporting unknown!", deployment.Name)
 	}
 
-	result.HealthMessage = *job.StatusDescription
+	if *job.StatusDescription != "" {
+		result.HealthMessage = *job.StatusDescription
+	}
 
 	result.GeneratedTime = ptypes.TimestampNow()
 


### PR DESCRIPTION
## Why the change?

Closes #2069

## What’s the plan?

- [x] Only assign `job.StatusDescription` to `result.HealthMessage` if non-empty
- [x] Verify it fixes the issue
- [x] Add changelog entry

## What does it look like?

<img width="567" alt="CleanShot 2021-08-24 at 00 01 52@2x" src="https://user-images.githubusercontent.com/34030/130525588-5be05608-fb90-410d-8f46-aacb52fcab2b.png">

## How do I test this?

1. Check out the branch
2. Deploy a nomad project
3. Check the UI
4. Verify that the nomad deployment status shows up as expected