### PR TITLE
Fix link to Input variables tutorial

### DIFF
--- a/website/content/docs/waypoint-hcl/variables/input.mdx
+++ b/website/content/docs/waypoint-hcl/variables/input.mdx
@@ -16,7 +16,7 @@ You can parameterize your configuration by declaring variables in the
 waypoint.hcl file, and setting their values using CLI options, environment variables,
 `auto` files, and the Waypoint server UI.
 
-> **Hands-on:** Try the [Input Variables](https://learn.hashicorp.com/collections/waypoint/input-variables)
+> **Hands-on:** Try the [Input Variables](https://learn.hashicorp.com/tutorials/waypoint/input-variables)
 > tutorial on HashiCorp Learn.
 
 ## Declaring an Input Variable


### PR DESCRIPTION
Fix link to Input variables tutorial