### PR TITLE
ui: de-lint project routes

### DIFF
--- a/ui/app/routes/workspace/projects/project/index.ts
+++ b/ui/app/routes/workspace/projects/project/index.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { Project } from 'waypoint-pb';
 
 export default class ProjectIndex extends Route {
-  redirect(model: Project.AsObject) {
-    return this.transitionTo('workspace.projects.project.apps', model.name);
+  redirect(model: Project.AsObject): void {
+    this.transitionTo('workspace.projects.project.apps', model.name);
   }
 }


### PR DESCRIPTION
## Why the change?

A few small steps closer to running the linters in CI.

## Why the changes related to throwing errors?

It’s helpful not to return `Promise<Model | undefined>` from model hooks. These changes also ease the path for some subsequent de-linting commits (coming later).

## How do I test it?

1. Check out the branch
2. [Visit a project](http://localhost:4200/default/marketing-public)
3. Verify it loads and you land on the `apps` page
4. [Visit a project settings page](http://localhost:4200/default/marketing-public/settings)
5. Verify it loads