### PR TITLE
docs/plugin Update GCP documentation

### DIFF
--- a/builtin/google/cloudrun/platform.go
+++ b/builtin/google/cloudrun/platform.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/framework/resource"
@@ -737,13 +737,18 @@ app "wpmini" {
 	)
 
 	doc.SetField(
-		"vpc_access.connector",
-		"Set VPC Access Connector for the Cloud Run instance.",
-	)
-
-	doc.SetField(
-		"vpc_access.egress",
-		"Set VPC egress. Supported values are 'all' and 'private-ranges-only'.",
+		"vpc_access",
+		"VPCAccess details",
+		docs.SubFields(func(doc *docs.SubFieldDoc) {
+			doc.SetField(
+				"connector",
+				"Set VPC Access Connector for the Cloud Run instance.",
+			)
+			doc.SetField(
+				"egress",
+				"Set VPC egress. Supported values are 'all' and 'private-ranges-only'.",
+			)
+		}),
 	)
 
 	return doc, nil

--- a/website/content/partials/components/platform-google-cloud-run.mdx
+++ b/website/content/partials/components/platform-google-cloud-run.mdx
@@ -114,17 +114,23 @@ GCP project ID where the Cloud Run instance will be deployed.
 
 - Type: **string**
 
-#### vpc_access
+#### vpc_access (category)
 
-- Type: **cloudrun.VPCAccess**
+VPCAccess details.
 
-#### vpc_access.connector
+##### vpc_access.connector
 
 Set VPC Access Connector for the Cloud Run instance.
 
-#### vpc_access.egress
+- Type: **string**
+- **Optional**
+
+##### vpc_access.egress
 
 Set VPC egress. Supported values are 'all' and 'private-ranges-only'.
+
+- Type: **string**
+- **Optional**
 
 ### Optional Parameters
 


### PR DESCRIPTION
`vpc_access` was marked as required even though it's optional, which  caused confusion.

example:
https://github.com/hashicorp/waypoint/issues/1942

Moved nested fields to generate as optional nested fields in the documentation. Will open another issue to change how we parse optional blocks (there is currently no way to make the block optional, only the nested fields.)