### PR TITLE
ui: de-lint remaining routes

### DIFF
--- a/ui/app/routes/workspace/projects/project/app/builds.ts
+++ b/ui/app/routes/workspace/projects/project/app/builds.ts
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { Model as AppRouteModel } from '../app';
 
+type Model = AppRouteModel['builds'];
+
 export default class Builds extends Route {
-  async model() {
+  async model(): Promise<Model> {
     let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     return app.builds;
   }

--- a/ui/app/routes/workspace/projects/project/app/deployments.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployments.ts
@@ -2,13 +2,15 @@ import Route from '@ember/routing/route';
 import { Model as AppRouteModel } from '../app';
 import DeploymentsController from 'waypoint/controllers/workspace/projects/project/app/deployments';
 
+type Model = AppRouteModel['deployments'];
+
 export default class Deployments extends Route {
-  async model() {
+  async model(): Promise<Model> {
     let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     return app.deployments;
   }
 
-  resetController(controller: DeploymentsController, isExiting: boolean) {
+  resetController(controller: DeploymentsController, isExiting: boolean): void {
     if (isExiting) {
       controller.set('isShowingDestroyed', null);
     }

--- a/ui/app/routes/workspace/projects/project/app/exec.ts
+++ b/ui/app/routes/workspace/projects/project/app/exec.ts
@@ -5,7 +5,7 @@ import ApiService from 'waypoint/services/api';
 export default class Exec extends Route {
   @service api!: ApiService;
 
-  async model() {
+  async model(): Promise<void> {
     // todo(pearkes): construct GetExecStreamRequest
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/index.ts
+++ b/ui/app/routes/workspace/projects/project/app/index.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { Model as AppRouteModel } from '../app';
 
 export default class AppIndex extends Route {
-  redirect(model: AppRouteModel) {
-    return this.transitionTo('workspace.projects.project.app.logs', model.application.application);
+  redirect(model: AppRouteModel): void {
+    this.transitionTo('workspace.projects.project.app.logs', model.application.application);
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/logs.ts
+++ b/ui/app/routes/workspace/projects/project/app/logs.ts
@@ -3,13 +3,16 @@ import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { GetLogStreamRequest, Ref } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
+import { Model as WorkspaceRouteModel } from 'waypoint/routes/workspace';
+
+type Model = GetLogStreamRequest;
 
 export default class Logs extends Route {
   @service api!: ApiService;
 
-  async model() {
+  async model(): Promise<Model> {
     let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
-    let ws = this.modelFor('workspace') as Ref.Workspace.AsObject;
+    let ws = this.modelFor('workspace') as WorkspaceRouteModel;
     let req = new GetLogStreamRequest();
     let appReq = new GetLogStreamRequest.Application();
 

--- a/ui/app/routes/workspace/projects/project/app/releases.ts
+++ b/ui/app/routes/workspace/projects/project/app/releases.ts
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { Model as AppRouteModel } from '../app';
 
+type Model = AppRouteModel['releases'];
+
 export default class Releases extends Route {
-  async model() {
+  async model(): Promise<Model> {
     let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     return app.releases;
   }

--- a/ui/app/routes/workspace/projects/project/apps.ts
+++ b/ui/app/routes/workspace/projects/project/apps.ts
@@ -1,20 +1,13 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-import ApiService from 'waypoint/services/api';
-import { Project, Application } from 'waypoint-pb';
+import { Model as ProjectRouteModel } from 'waypoint/routes/workspace/projects/project';
+
+type Model = ProjectRouteModel;
 
 export default class Apps extends Route {
-  @service api!: ApiService;
-
-  async model() {
-    let proj = this.modelFor('workspace.projects.project') as Project.AsObject;
-    return proj;
-  }
-
-  afterModel(model: Application.AsObject[]) {
-    if (model.length == 1) {
-      return this.transitionTo('workspace.projects.project.app', model[0].name);
-    }
-    return;
+  async model(): Promise<Model> {
+    // Technically we get this behavior for free because, in Ember, if a
+    // route doesn’t define a model hook then it automatically receives
+    // the model of its parent. Still, it doesn’t hurt to be explicit.
+    return this.modelFor('workspace.projects.project') as ProjectRouteModel;
   }
 }


### PR DESCRIPTION
## Why the change?

A few steps closer to running the linters in CI.

## How do I test it?

These are mostly changes to type annotations with the notable exception of the first commit in the batch, which removes a piece of non-functioning logic. To verify this change:

1. Check out the branch
2. Visit a project with only app (by directly entering the URL into the browser)
3. Verify you see the application list (as we currently do on main)