### PR TITLE
cli: update confusing message on waypoint destroy for GCP

### DIFF
--- a/builtin/google/cloudrun/platform.go
+++ b/builtin/google/cloudrun/platform.go
@@ -456,7 +456,7 @@ func (p *Platform) resourceServiceDestroy(
 	if cs.Status == "True" {
 		st.Step(
 			terminal.StatusWarn,
-			fmt.Sprintf(" Cannot destroy deployment with revision %q, as revision is actively receiving traffic. Disregard if destroying workspace.", rn),
+			fmt.Sprintf("Cannot destroy deployment with revision %q, as revision is actively receiving traffic. Disregard if destroying workspace.", rn),
 		)
 		return nil
 	}


### PR DESCRIPTION
https://github.com/hashicorp/waypoint/issues/2126

Per discussion, we decided to add a clarifying message.
I tried a few methods to get a terminal print out on the `if isWorkspaceDestroy {` conditional, or modifying the error message to only run when not destroying a workspace, to no avail. This was the easiest change in the end.