### PR TITLE
docs: add note on how ECS servers perform their upgrade

### DIFF
--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -75,6 +75,7 @@ When the upgrade command is executed, Waypoint does the following:
     requested version shortly after running the Waypoint upgrade command.
   - `nomad` - This platform will update the waypoint server job with the server
     image requested.
+  - `ecs` - This platform will locate the existing cluster, update task definitions, and upgrade the image to the latest.
 - Verifies that waypoint CLI can still connected and speak to Waypoint server
 
 If you wish to use the automated upgrade command line approach, follow the


### PR DESCRIPTION
Add brief description of how ECS servers perform waypoint server upgrade.

Based on https://github.com/hashicorp/waypoint/blob/main/internal/serverinstall/ecs.go#L399