### PR TITLE
ui: fix ember-cli-flash types

### DIFF
--- a/ui/app/services/flash-messages.ts
+++ b/ui/app/services/flash-messages.ts
@@ -1,3 +1,24 @@
 import FlashMessages from 'ember-cli-flash/services/flash-messages';
 
-export default class PdsFlashMessages extends FlashMessages {}
+type BaseFlashFunction = FlashMessages['info'];
+type FlashFunctionParams = Parameters<BaseFlashFunction>;
+
+type FlashFunction = (
+  message: FlashFunctionParams[0],
+  // This allows the “throw any property you like on the flash object”
+  // behavior of ember-cli-flash to type check.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: FlashFunctionParams[1] & Record<string, any>
+) => ReturnType<BaseFlashFunction>;
+
+class PdsFlashMessages extends FlashMessages {
+  // This is the one custom convenience method we register in
+  // config/environment.js.
+  //
+  // The superclass will dynamically initialize this method when the
+  // service is created (thus the extra exclamation to reassure
+  // TypeScript).
+  error!: FlashFunction;
+}
+
+export default PdsFlashMessages;

--- a/ui/tests/integration/components/project-input-variables-list-test.ts
+++ b/ui/tests/integration/components/project-input-variables-list-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
+import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { create, collection, clickable, isPresent, fillable, text } from 'ember-cli-page-object';
 
@@ -25,6 +26,11 @@ const page = create({
 module('Integration | Component | project-input-variables-list', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(function (this: TestContext) {
+    // We have to register any types we expect to use in this component
+    this.owner.lookup('service:flash-messages').registerTypes(['success', 'error']);
+  });
 
   test('it renders', async function (assert) {
     let dbproj = await this.server.create('project', 'with-input-variables', { name: 'Proj1' });

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -21,6 +21,7 @@
     "module": "es6",
     "experimentalDecorators": true,
     "paths": {
+      "ember-cli-flash/*": ["node_modules/ember-cli-flash/index.d.ts"],
       "waypoint/tests/*": ["tests/*"],
       "waypoint/*": ["app/*"],
       // Ensure that types from libraries are included


### PR DESCRIPTION
## Why the change?

Helps us trust type information for ember-cli-flash.

## What does it look like?

### Before

<img width="931" alt="CleanShot 2021-08-30 at 12 08 39@2x" src="https://user-images.githubusercontent.com/34030/131323950-d913a1ff-4955-43ff-93e2-16448d7cdd7a.png">

### After

<img width="931" alt="CleanShot 2021-08-30 at 12 09 04@2x" src="https://user-images.githubusercontent.com/34030/131323959-9edde02f-c14e-46d7-bd46-12fb32fb357e.png">

## How do I test it?

This only affects type definitions, so is safe. You may want to test it in your editor to see that the types show up.