### PR TITLE
cli/odr: Fix panic if requested runner id not found

### DIFF
--- a/internal/cli/ondemand_runner_apply.go
+++ b/internal/cli/ondemand_runner_apply.go
@@ -58,7 +58,7 @@ func (c *OnDemandRunnerConfigApplyCommand) Run(args []string) int {
 	)
 
 	if c.flagId != "" {
-		s = sg.Add("Checking for an existing ondemand runner config: %s", c.flagId)
+		s = sg.Add("Checking for an existing on-demand runner config: %s", c.flagId)
 		// Check for an existing project of the same name.
 		resp, err := c.project.Client().GetOnDemandRunnerConfig(ctx, &pb.GetOnDemandRunnerConfigRequest{
 			Config: &pb.Ref_OnDemandRunnerConfig{
@@ -83,7 +83,7 @@ func (c *OnDemandRunnerConfigApplyCommand) Run(args []string) int {
 		s.Update("Updating ondemand runner config %q...", od.Id)
 		updated = true
 	} else {
-		s = sg.Add("Creating new ondemand runner config")
+		s = sg.Add("Creating new on-demand runner config")
 		od = &pb.OnDemandRunnerConfig{}
 	}
 
@@ -167,7 +167,7 @@ func (c *OnDemandRunnerConfigApplyCommand) Run(args []string) int {
 	})
 	if err != nil {
 		c.ui.Output(
-			"Error upserting ondemand runner config: %s", clierrors.Humanize(err),
+			"Error upserting on-demand runner config: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
 		return 1
@@ -191,20 +191,20 @@ func (c *OnDemandRunnerConfigApplyCommand) Flags() *flag.Sets {
 			Name:    "id",
 			Target:  &c.flagId,
 			Default: "",
-			Usage:   "The id of an existing ondemand runner to update.",
+			Usage:   "The id of an existing on-demand runner to update.",
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "oci-url",
 			Target:  &c.flagOCIUrl,
 			Default: "hashicorp/waypoint:stable",
-			Usage:   "The url for the OCI image to launch for the ondemand runner.",
+			Usage:   "The url for the OCI image to launch for the on-demand runner.",
 		})
 
 		f.StringSliceVar(&flag.StringSliceVar{
 			Name:   "env-vars",
 			Target: &c.flagEnvVars,
-			Usage: "Environment variable to expose to the ondemand runner. Typically used to " +
+			Usage: "Environment variable to expose to the on-demand runner. Typically used to " +
 				"introduce configuration for the plugins that the runner will execute.",
 		})
 
@@ -212,7 +212,7 @@ func (c *OnDemandRunnerConfigApplyCommand) Flags() *flag.Sets {
 			Name:    "plugin-type",
 			Target:  &c.flagPluginType,
 			Default: "",
-			Usage:   "The type of the plugin to launch for the ondemand runner, such as aws-ecs, kubernetes, etc.",
+			Usage:   "The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.",
 		})
 
 		f.StringVar(&flag.StringVar{
@@ -221,15 +221,15 @@ func (c *OnDemandRunnerConfigApplyCommand) Flags() *flag.Sets {
 			Default: "",
 			Usage: "Path to an hcl file that contains the configuration for the plugin. " +
 				"This is only necessary when the plugin's defaults need to be adjusted for " +
-				"the environment the plugin will launch the ondemand runner in.",
+				"the environment the plugin will launch the on-demand runner in.",
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "default",
 			Target:  &c.flagDefault,
 			Default: false,
-			Usage: "Indicates that this ondemand runner should be used by any project that doesn't " +
-				"otherwise specify its own ondemand runner.",
+			Usage: "Indicates that this on-demand runner should be used by any project that doesn't " +
+				"otherwise specify its own on-demand runner.",
 		})
 	})
 }
@@ -243,20 +243,20 @@ func (c *OnDemandRunnerConfigApplyCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *OnDemandRunnerConfigApplyCommand) Synopsis() string {
-	return "Create or update an ondemand runner configuration."
+	return "Create or update an on-demand runner configuration."
 }
 
 func (c *OnDemandRunnerConfigApplyCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint runner on-demand set [OPTIONS]
 
-  Create or update an ondemand runner configuration.
+  Create or update an on-demand runner configuration.
 
-  This will register a new ondemand runner config with the given options. If
-  a ondemand runner config with the same id already exists, this will update the
+  This will register a new on-demand runner config with the given options. If
+  a on-demand runner config with the same id already exists, this will update the
   existing runner config using the fields that are set.
   
-  Waypoint will use an ondemand runner configuration to spawn containers for
+  Waypoint will use an on-demand runner configuration to spawn containers for
   various kinds of work as needed on the platform requested during any given
   lifecycle operation.
 

--- a/internal/cli/ondemand_runner_apply.go
+++ b/internal/cli/ondemand_runner_apply.go
@@ -79,9 +79,14 @@ func (c *OnDemandRunnerConfigApplyCommand) Run(args []string) int {
 			return 1
 		}
 
-		od = resp.Config
-		s.Update("Updating ondemand runner config %q...", od.Id)
-		updated = true
+		if resp != nil {
+			od = resp.Config
+			s.Update("Updating on-demand runner config %q...", od.Id)
+			updated = true
+		} else {
+			s.Update("No existing on-demand runner config found for id %q...command will create a new config", c.flagId)
+			od = &pb.OnDemandRunnerConfig{}
+		}
 	} else {
 		s = sg.Add("Creating new on-demand runner config")
 		od = &pb.OnDemandRunnerConfig{}

--- a/internal/cli/ondemand_runner_apply.go
+++ b/internal/cli/ondemand_runner_apply.go
@@ -164,6 +164,16 @@ func (c *OnDemandRunnerConfigApplyCommand) Run(args []string) int {
 		}
 	}
 
+	if c.flagPluginType == "" {
+		c.ui.Output(
+			"Flag '-plugin-type' must be set to a valid plugin type like 'docker' or 'kubernetes'.\n\n%s",
+			c.Help(),
+			terminal.WithErrorStyle(),
+		)
+
+		return 1
+	}
+
 	od.PluginType = c.flagPluginType
 
 	// Upsert

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -36,7 +36,7 @@ type RunnerAgentCommand struct {
 	// generates an random.
 	flagId string
 
-	// This indicates that the runner is an ondemand runner. This information
+	// This indicates that the runner is an on-demand runner. This information
 	// is made available to the plugins so they can alter their behavior for
 	// this unique context.
 	flagODR bool
@@ -85,7 +85,7 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 	})
 	c.ui.Output("Runner logs:", terminal.WithHeaderStyle())
 	if c.flagODR {
-		c.ui.Output("Operating as an Ondemand Runner")
+		c.ui.Output("Operating as an On-demand Runner")
 	} else {
 		c.ui.Output("Operating as a static Runner")
 	}
@@ -270,7 +270,7 @@ func (c *RunnerAgentCommand) Flags() *flag.Sets {
 		f.BoolVar(&flag.BoolVar{
 			Name:   "odr",
 			Target: &c.flagODR,
-			Usage:  "Indicates to the runner it's operating as an ondemand runner.",
+			Usage:  "Indicates to the runner it's operating as an on-demand runner.",
 		})
 	})
 }

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -30,6 +30,6 @@ Run a runner for executing remote operations.
 - `-enable-dynamic-config` - Allow dynamic config to be created when an exec plugin is used.
 - `-liveness-tcp-addr=<string>` - If this is set, the runner will open a TCP listener on this address when it is running. This can be used as a liveness probe endpoint. The TCP server serves no other purpose.
 - `-id=<string>` - If this is set, the runner will use the specified id.
-- `-odr` - Indicates to the runner it's operating as an ondemand runner.
+- `-odr` - Indicates to the runner it's operating as an on-demand runner.
 
 @include "commands/runner-agent_more.mdx"

--- a/website/content/commands/runner-on-demand-set.mdx
+++ b/website/content/commands/runner-on-demand-set.mdx
@@ -2,14 +2,14 @@
 layout: commands
 page_title: 'Commands: Runner on-demand set'
 sidebar_title: 'runner on-demand set'
-description: 'Create or update an ondemand runner configuration.'
+description: 'Create or update an on-demand runner configuration.'
 ---
 
 # Waypoint Runner on-demand set
 
 Command: `waypoint runner on-demand set`
 
-Create or update an ondemand runner configuration.
+Create or update an on-demand runner configuration.
 
 @include "commands/runner-on-demand-set_desc.mdx"
 
@@ -17,13 +17,13 @@ Create or update an ondemand runner configuration.
 
 Usage: `waypoint runner on-demand set [OPTIONS]`
 
-Create or update an ondemand runner configuration.
+Create or update an on-demand runner configuration.
 
-This will register a new ondemand runner config with the given options. If
-a ondemand runner config with the same id already exists, this will update the
+This will register a new on-demand runner config with the given options. If
+a on-demand runner config with the same id already exists, this will update the
 existing runner config using the fields that are set.
 
-Waypoint will use an ondemand runner configuration to spawn containers for
+Waypoint will use an on-demand runner configuration to spawn containers for
 various kinds of work as needed on the platform requested during any given
 lifecycle operation.
 
@@ -35,11 +35,11 @@ lifecycle operation.
 
 #### Command Options
 
-- `-id=<string>` - The id of an existing ondemand runner to update.
-- `-oci-url=<string>` - The url for the OCI image to launch for the ondemand runner.
-- `-env-vars=<string>` - Environment variable to expose to the ondemand runner. Typically used to introduce configuration for the plugins that the runner will execute.
-- `-plugin-type=<string>` - The type of the plugin to launch for the ondemand runner, such as aws-ecs, kubernetes, etc.
-- `-project-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the ondemand runner in.
-- `-default` - Indicates that this ondemand runner should be used by any project that doesn't otherwise specify its own ondemand runner.
+- `-id=<string>` - The id of an existing on-demand runner to update.
+- `-oci-url=<string>` - The url for the OCI image to launch for the on-demand runner.
+- `-env-vars=<string>` - Environment variable to expose to the on-demand runner. Typically used to introduce configuration for the plugins that the runner will execute.
+- `-plugin-type=<string>` - The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.
+- `-project-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
+- `-default` - Indicates that this on-demand runner should be used by any project that doesn't otherwise specify its own on-demand runner.
 
 @include "commands/runner-on-demand-set_more.mdx"


### PR DESCRIPTION
This pull request fixes the panic when a non-existence runner id is requested but not found for setting a runner config. It also fixes up usages of "ondemand" and replaces it with "on-demand", and returns an error about `-plugin-type` not being set prior to the upsert to give a better user-facing message for a missing flag.

Fixes #2176 