### PR TITLE
ui: generate API bindings for ODR and UI endpoints and messages

### DIFF
--- a/ui/lib/waypoint-client/ServerServiceClientPb.ts
+++ b/ui/lib/waypoint-client/ServerServiceClientPb.ts
@@ -13,8 +13,8 @@
 
 import * as grpcWeb from 'grpc-web';
 
-import * as internal_server_proto_server_pb from 'waypoint-pb';
 import * as google_protobuf_empty_pb from 'google-protobuf/google/protobuf/empty_pb';
+import * as internal_server_proto_server_pb from 'waypoint-pb';
 
 
 export class WaypointClient {
@@ -2352,6 +2352,126 @@ export class WaypointClient {
     this.methodInfoWaypointHclFmt);
   }
 
+  methodInfoUpsertOnDemandRunnerConfig = new grpcWeb.AbstractClientBase.MethodInfo(
+    internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse,
+    (request: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigRequest) => {
+      return request.serializeBinary();
+    },
+    internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse.deserializeBinary
+  );
+
+  upsertOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null): Promise<internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse>;
+
+  upsertOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse) => void): grpcWeb.ClientReadableStream<internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse>;
+
+  upsertOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback?: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UpsertOnDemandRunnerConfigResponse) => void) {
+    if (callback !== undefined) {
+      return this.client_.rpcCall(
+        this.hostname_ +
+          '/hashicorp.waypoint.Waypoint/UpsertOnDemandRunnerConfig',
+        request,
+        metadata || {},
+        this.methodInfoUpsertOnDemandRunnerConfig,
+        callback);
+    }
+    return this.client_.unaryCall(
+    this.hostname_ +
+      '/hashicorp.waypoint.Waypoint/UpsertOnDemandRunnerConfig',
+    request,
+    metadata || {},
+    this.methodInfoUpsertOnDemandRunnerConfig);
+  }
+
+  methodInfoGetOnDemandRunnerConfig = new grpcWeb.AbstractClientBase.MethodInfo(
+    internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse,
+    (request: internal_server_proto_server_pb.GetOnDemandRunnerConfigRequest) => {
+      return request.serializeBinary();
+    },
+    internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse.deserializeBinary
+  );
+
+  getOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.GetOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null): Promise<internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse>;
+
+  getOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.GetOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse) => void): grpcWeb.ClientReadableStream<internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse>;
+
+  getOnDemandRunnerConfig(
+    request: internal_server_proto_server_pb.GetOnDemandRunnerConfigRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback?: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.GetOnDemandRunnerConfigResponse) => void) {
+    if (callback !== undefined) {
+      return this.client_.rpcCall(
+        this.hostname_ +
+          '/hashicorp.waypoint.Waypoint/GetOnDemandRunnerConfig',
+        request,
+        metadata || {},
+        this.methodInfoGetOnDemandRunnerConfig,
+        callback);
+    }
+    return this.client_.unaryCall(
+    this.hostname_ +
+      '/hashicorp.waypoint.Waypoint/GetOnDemandRunnerConfig',
+    request,
+    metadata || {},
+    this.methodInfoGetOnDemandRunnerConfig);
+  }
+
+  methodInfoListOnDemandRunnerConfigs = new grpcWeb.AbstractClientBase.MethodInfo(
+    internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse,
+    (request: google_protobuf_empty_pb.Empty) => {
+      return request.serializeBinary();
+    },
+    internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse.deserializeBinary
+  );
+
+  listOnDemandRunnerConfigs(
+    request: google_protobuf_empty_pb.Empty,
+    metadata: grpcWeb.Metadata | null): Promise<internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse>;
+
+  listOnDemandRunnerConfigs(
+    request: google_protobuf_empty_pb.Empty,
+    metadata: grpcWeb.Metadata | null,
+    callback: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse) => void): grpcWeb.ClientReadableStream<internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse>;
+
+  listOnDemandRunnerConfigs(
+    request: google_protobuf_empty_pb.Empty,
+    metadata: grpcWeb.Metadata | null,
+    callback?: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.ListOnDemandRunnerConfigsResponse) => void) {
+    if (callback !== undefined) {
+      return this.client_.rpcCall(
+        this.hostname_ +
+          '/hashicorp.waypoint.Waypoint/ListOnDemandRunnerConfigs',
+        request,
+        metadata || {},
+        this.methodInfoListOnDemandRunnerConfigs,
+        callback);
+    }
+    return this.client_.unaryCall(
+    this.hostname_ +
+      '/hashicorp.waypoint.Waypoint/ListOnDemandRunnerConfigs',
+    request,
+    metadata || {},
+    this.methodInfoListOnDemandRunnerConfigs);
+  }
+
   methodInfoUpsertBuild = new grpcWeb.AbstractClientBase.MethodInfo(
     internal_server_proto_server_pb.UpsertBuildResponse,
     (request: internal_server_proto_server_pb.UpsertBuildRequest) => {
@@ -2550,6 +2670,86 @@ export class WaypointClient {
     request,
     metadata || {},
     this.methodInfoUpsertStatusReport);
+  }
+
+  methodInfoUI_ListDeployments = new grpcWeb.AbstractClientBase.MethodInfo(
+    internal_server_proto_server_pb.UI.ListDeploymentsResponse,
+    (request: internal_server_proto_server_pb.UI.ListDeploymentsRequest) => {
+      return request.serializeBinary();
+    },
+    internal_server_proto_server_pb.UI.ListDeploymentsResponse.deserializeBinary
+  );
+
+  uI_ListDeployments(
+    request: internal_server_proto_server_pb.UI.ListDeploymentsRequest,
+    metadata: grpcWeb.Metadata | null): Promise<internal_server_proto_server_pb.UI.ListDeploymentsResponse>;
+
+  uI_ListDeployments(
+    request: internal_server_proto_server_pb.UI.ListDeploymentsRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UI.ListDeploymentsResponse) => void): grpcWeb.ClientReadableStream<internal_server_proto_server_pb.UI.ListDeploymentsResponse>;
+
+  uI_ListDeployments(
+    request: internal_server_proto_server_pb.UI.ListDeploymentsRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback?: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UI.ListDeploymentsResponse) => void) {
+    if (callback !== undefined) {
+      return this.client_.rpcCall(
+        this.hostname_ +
+          '/hashicorp.waypoint.Waypoint/UI_ListDeployments',
+        request,
+        metadata || {},
+        this.methodInfoUI_ListDeployments,
+        callback);
+    }
+    return this.client_.unaryCall(
+    this.hostname_ +
+      '/hashicorp.waypoint.Waypoint/UI_ListDeployments',
+    request,
+    metadata || {},
+    this.methodInfoUI_ListDeployments);
+  }
+
+  methodInfoUI_ListReleases = new grpcWeb.AbstractClientBase.MethodInfo(
+    internal_server_proto_server_pb.UI.ListReleasesResponse,
+    (request: internal_server_proto_server_pb.UI.ListReleasesRequest) => {
+      return request.serializeBinary();
+    },
+    internal_server_proto_server_pb.UI.ListReleasesResponse.deserializeBinary
+  );
+
+  uI_ListReleases(
+    request: internal_server_proto_server_pb.UI.ListReleasesRequest,
+    metadata: grpcWeb.Metadata | null): Promise<internal_server_proto_server_pb.UI.ListReleasesResponse>;
+
+  uI_ListReleases(
+    request: internal_server_proto_server_pb.UI.ListReleasesRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UI.ListReleasesResponse) => void): grpcWeb.ClientReadableStream<internal_server_proto_server_pb.UI.ListReleasesResponse>;
+
+  uI_ListReleases(
+    request: internal_server_proto_server_pb.UI.ListReleasesRequest,
+    metadata: grpcWeb.Metadata | null,
+    callback?: (err: grpcWeb.Error,
+               response: internal_server_proto_server_pb.UI.ListReleasesResponse) => void) {
+    if (callback !== undefined) {
+      return this.client_.rpcCall(
+        this.hostname_ +
+          '/hashicorp.waypoint.Waypoint/UI_ListReleases',
+        request,
+        metadata || {},
+        this.methodInfoUI_ListReleases,
+        callback);
+    }
+    return this.client_.unaryCall(
+    this.hostname_ +
+      '/hashicorp.waypoint.Waypoint/UI_ListReleases',
+    request,
+    metadata || {},
+    this.methodInfoUI_ListReleases);
   }
 
 }

--- a/ui/lib/waypoint-pb/server_pb.d.ts
+++ b/ui/lib/waypoint-pb/server_pb.d.ts
@@ -6,6 +6,214 @@ import * as google_protobuf_timestamp_pb from 'google-protobuf/google/protobuf/t
 import * as google_rpc_status_pb from 'api-common-protos/google/rpc/status_pb';
 
 
+export class UI extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UI.AsObject;
+  static toObject(includeInstance: boolean, msg: UI): UI.AsObject;
+  static serializeBinaryToWriter(message: UI, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UI;
+  static deserializeBinaryFromReader(message: UI, reader: jspb.BinaryReader): UI;
+}
+
+export namespace UI {
+  export type AsObject = {
+  }
+
+  export class ListDeploymentsRequest extends jspb.Message {
+    getApplication(): Ref.Application | undefined;
+    setApplication(value?: Ref.Application): ListDeploymentsRequest;
+    hasApplication(): boolean;
+    clearApplication(): ListDeploymentsRequest;
+
+    getWorkspace(): Ref.Workspace | undefined;
+    setWorkspace(value?: Ref.Workspace): ListDeploymentsRequest;
+    hasWorkspace(): boolean;
+    clearWorkspace(): ListDeploymentsRequest;
+
+    getOrder(): OperationOrder | undefined;
+    setOrder(value?: OperationOrder): ListDeploymentsRequest;
+    hasOrder(): boolean;
+    clearOrder(): ListDeploymentsRequest;
+
+    getStatusList(): Array<StatusFilter>;
+    setStatusList(value: Array<StatusFilter>): ListDeploymentsRequest;
+    clearStatusList(): ListDeploymentsRequest;
+    addStatus(value?: StatusFilter, index?: number): StatusFilter;
+
+    getPhysicalState(): Operation.PhysicalState;
+    setPhysicalState(value: Operation.PhysicalState): ListDeploymentsRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ListDeploymentsRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: ListDeploymentsRequest): ListDeploymentsRequest.AsObject;
+    static serializeBinaryToWriter(message: ListDeploymentsRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ListDeploymentsRequest;
+    static deserializeBinaryFromReader(message: ListDeploymentsRequest, reader: jspb.BinaryReader): ListDeploymentsRequest;
+  }
+
+  export namespace ListDeploymentsRequest {
+    export type AsObject = {
+      application?: Ref.Application.AsObject,
+      workspace?: Ref.Workspace.AsObject,
+      order?: OperationOrder.AsObject,
+      statusList: Array<StatusFilter.AsObject>,
+      physicalState: Operation.PhysicalState,
+    }
+  }
+
+
+  export class ListDeploymentsResponse extends jspb.Message {
+    getDeploymentsList(): Array<UI.DeploymentBundle>;
+    setDeploymentsList(value: Array<UI.DeploymentBundle>): ListDeploymentsResponse;
+    clearDeploymentsList(): ListDeploymentsResponse;
+    addDeployments(value?: UI.DeploymentBundle, index?: number): UI.DeploymentBundle;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ListDeploymentsResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: ListDeploymentsResponse): ListDeploymentsResponse.AsObject;
+    static serializeBinaryToWriter(message: ListDeploymentsResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ListDeploymentsResponse;
+    static deserializeBinaryFromReader(message: ListDeploymentsResponse, reader: jspb.BinaryReader): ListDeploymentsResponse;
+  }
+
+  export namespace ListDeploymentsResponse {
+    export type AsObject = {
+      deploymentsList: Array<UI.DeploymentBundle.AsObject>,
+    }
+  }
+
+
+  export class DeploymentBundle extends jspb.Message {
+    getDeployment(): Deployment | undefined;
+    setDeployment(value?: Deployment): DeploymentBundle;
+    hasDeployment(): boolean;
+    clearDeployment(): DeploymentBundle;
+
+    getArtifact(): PushedArtifact | undefined;
+    setArtifact(value?: PushedArtifact): DeploymentBundle;
+    hasArtifact(): boolean;
+    clearArtifact(): DeploymentBundle;
+
+    getBuild(): Build | undefined;
+    setBuild(value?: Build): DeploymentBundle;
+    hasBuild(): boolean;
+    clearBuild(): DeploymentBundle;
+
+    getDeployUrl(): string;
+    setDeployUrl(value: string): DeploymentBundle;
+
+    getJobDataSourceRef(): Job.DataSource.Ref | undefined;
+    setJobDataSourceRef(value?: Job.DataSource.Ref): DeploymentBundle;
+    hasJobDataSourceRef(): boolean;
+    clearJobDataSourceRef(): DeploymentBundle;
+
+    getLatestStatusReport(): StatusReport | undefined;
+    setLatestStatusReport(value?: StatusReport): DeploymentBundle;
+    hasLatestStatusReport(): boolean;
+    clearLatestStatusReport(): DeploymentBundle;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): DeploymentBundle.AsObject;
+    static toObject(includeInstance: boolean, msg: DeploymentBundle): DeploymentBundle.AsObject;
+    static serializeBinaryToWriter(message: DeploymentBundle, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): DeploymentBundle;
+    static deserializeBinaryFromReader(message: DeploymentBundle, reader: jspb.BinaryReader): DeploymentBundle;
+  }
+
+  export namespace DeploymentBundle {
+    export type AsObject = {
+      deployment?: Deployment.AsObject,
+      artifact?: PushedArtifact.AsObject,
+      build?: Build.AsObject,
+      deployUrl: string,
+      jobDataSourceRef?: Job.DataSource.Ref.AsObject,
+      latestStatusReport?: StatusReport.AsObject,
+    }
+  }
+
+
+  export class ListReleasesRequest extends jspb.Message {
+    getApplication(): Ref.Application | undefined;
+    setApplication(value?: Ref.Application): ListReleasesRequest;
+    hasApplication(): boolean;
+    clearApplication(): ListReleasesRequest;
+
+    getWorkspace(): Ref.Workspace | undefined;
+    setWorkspace(value?: Ref.Workspace): ListReleasesRequest;
+    hasWorkspace(): boolean;
+    clearWorkspace(): ListReleasesRequest;
+
+    getOrder(): OperationOrder | undefined;
+    setOrder(value?: OperationOrder): ListReleasesRequest;
+    hasOrder(): boolean;
+    clearOrder(): ListReleasesRequest;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ListReleasesRequest.AsObject;
+    static toObject(includeInstance: boolean, msg: ListReleasesRequest): ListReleasesRequest.AsObject;
+    static serializeBinaryToWriter(message: ListReleasesRequest, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ListReleasesRequest;
+    static deserializeBinaryFromReader(message: ListReleasesRequest, reader: jspb.BinaryReader): ListReleasesRequest;
+  }
+
+  export namespace ListReleasesRequest {
+    export type AsObject = {
+      application?: Ref.Application.AsObject,
+      workspace?: Ref.Workspace.AsObject,
+      order?: OperationOrder.AsObject,
+    }
+  }
+
+
+  export class ListReleasesResponse extends jspb.Message {
+    getReleasesList(): Array<UI.ReleaseBundle>;
+    setReleasesList(value: Array<UI.ReleaseBundle>): ListReleasesResponse;
+    clearReleasesList(): ListReleasesResponse;
+    addReleases(value?: UI.ReleaseBundle, index?: number): UI.ReleaseBundle;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ListReleasesResponse.AsObject;
+    static toObject(includeInstance: boolean, msg: ListReleasesResponse): ListReleasesResponse.AsObject;
+    static serializeBinaryToWriter(message: ListReleasesResponse, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ListReleasesResponse;
+    static deserializeBinaryFromReader(message: ListReleasesResponse, reader: jspb.BinaryReader): ListReleasesResponse;
+  }
+
+  export namespace ListReleasesResponse {
+    export type AsObject = {
+      releasesList: Array<UI.ReleaseBundle.AsObject>,
+    }
+  }
+
+
+  export class ReleaseBundle extends jspb.Message {
+    getRelease(): Release | undefined;
+    setRelease(value?: Release): ReleaseBundle;
+    hasRelease(): boolean;
+    clearRelease(): ReleaseBundle;
+
+    getLatestStatusReport(): StatusReport | undefined;
+    setLatestStatusReport(value?: StatusReport): ReleaseBundle;
+    hasLatestStatusReport(): boolean;
+    clearLatestStatusReport(): ReleaseBundle;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ReleaseBundle.AsObject;
+    static toObject(includeInstance: boolean, msg: ReleaseBundle): ReleaseBundle.AsObject;
+    static serializeBinaryToWriter(message: ReleaseBundle, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ReleaseBundle;
+    static deserializeBinaryFromReader(message: ReleaseBundle, reader: jspb.BinaryReader): ReleaseBundle;
+  }
+
+  export namespace ReleaseBundle {
+    export type AsObject = {
+      release?: Release.AsObject,
+      latestStatusReport?: StatusReport.AsObject,
+    }
+  }
+
+}
+
 export class GetVersionInfoResponse extends jspb.Message {
   getInfo(): VersionInfo | undefined;
   setInfo(value?: VersionInfo): GetVersionInfoResponse;
@@ -343,6 +551,11 @@ export class Project extends jspb.Message {
   hasStatusReportPoll(): boolean;
   clearStatusReportPoll(): Project;
 
+  getOndemandRunner(): Ref.OnDemandRunnerConfig | undefined;
+  setOndemandRunner(value?: Ref.OnDemandRunnerConfig): Project;
+  hasOndemandRunner(): boolean;
+  clearOndemandRunner(): Project;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Project.AsObject;
   static toObject(includeInstance: boolean, msg: Project): Project.AsObject;
@@ -363,6 +576,7 @@ export namespace Project {
     fileChangeSignal: string,
     variablesList: Array<Variable.AsObject>,
     statusReportPoll?: Project.AppStatusPoll.AsObject,
+    ondemandRunner?: Ref.OnDemandRunnerConfig.AsObject,
   }
 
   export class Poll extends jspb.Message {
@@ -938,8 +1152,8 @@ export namespace Ref {
 
 
   export class DeclaredResource extends jspb.Message {
-    getId(): string;
-    setId(value: string): DeclaredResource;
+    getName(): string;
+    setName(value: string): DeclaredResource;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): DeclaredResource.AsObject;
@@ -950,6 +1164,25 @@ export namespace Ref {
   }
 
   export namespace DeclaredResource {
+    export type AsObject = {
+      name: string,
+    }
+  }
+
+
+  export class OnDemandRunnerConfig extends jspb.Message {
+    getId(): string;
+    setId(value: string): OnDemandRunnerConfig;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): OnDemandRunnerConfig.AsObject;
+    static toObject(includeInstance: boolean, msg: OnDemandRunnerConfig): OnDemandRunnerConfig.AsObject;
+    static serializeBinaryToWriter(message: OnDemandRunnerConfig, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): OnDemandRunnerConfig;
+    static deserializeBinaryFromReader(message: OnDemandRunnerConfig, reader: jspb.BinaryReader): OnDemandRunnerConfig;
+  }
+
+  export namespace OnDemandRunnerConfig {
     export type AsObject = {
       id: string,
     }
@@ -1156,11 +1389,11 @@ export namespace Generation {
 }
 
 export class DeclaredResource extends jspb.Message {
-  getId(): string;
-  setId(value: string): DeclaredResource;
-
   getName(): string;
   setName(value: string): DeclaredResource;
+
+  getType(): string;
+  setType(value: string): DeclaredResource;
 
   getPlatform(): string;
   setPlatform(value: string): DeclaredResource;
@@ -1186,8 +1419,8 @@ export class DeclaredResource extends jspb.Message {
 
 export namespace DeclaredResource {
   export type AsObject = {
-    id: string,
     name: string,
+    type: string,
     platform: string,
     state?: google_protobuf_any_pb.Any.AsObject,
     stateJson: string,
@@ -1201,6 +1434,11 @@ export class TaskLaunchInfo extends jspb.Message {
 
   getEnvironmentVariablesMap(): jspb.Map<string, string>;
   clearEnvironmentVariablesMap(): TaskLaunchInfo;
+
+  getEntrypointList(): Array<string>;
+  setEntrypointList(value: Array<string>): TaskLaunchInfo;
+  clearEntrypointList(): TaskLaunchInfo;
+  addEntrypoint(value: string, index?: number): TaskLaunchInfo;
 
   getArgumentsList(): Array<string>;
   setArgumentsList(value: Array<string>): TaskLaunchInfo;
@@ -1219,6 +1457,7 @@ export namespace TaskLaunchInfo {
   export type AsObject = {
     ociUrl: string,
     environmentVariablesMap: Array<[string, string]>,
+    entrypointList: Array<string>,
     argumentsList: Array<string>,
   }
 }
@@ -5158,6 +5397,150 @@ export namespace Artifact {
   }
 }
 
+export class OnDemandRunnerConfig extends jspb.Message {
+  getId(): string;
+  setId(value: string): OnDemandRunnerConfig;
+
+  getOciUrl(): string;
+  setOciUrl(value: string): OnDemandRunnerConfig;
+
+  getEnvironmentVariablesMap(): jspb.Map<string, string>;
+  clearEnvironmentVariablesMap(): OnDemandRunnerConfig;
+
+  getPluginType(): string;
+  setPluginType(value: string): OnDemandRunnerConfig;
+
+  getPluginConfig(): Uint8Array | string;
+  getPluginConfig_asU8(): Uint8Array;
+  getPluginConfig_asB64(): string;
+  setPluginConfig(value: Uint8Array | string): OnDemandRunnerConfig;
+
+  getConfigFormat(): Project.Format;
+  setConfigFormat(value: Project.Format): OnDemandRunnerConfig;
+
+  getDefault(): boolean;
+  setDefault(value: boolean): OnDemandRunnerConfig;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OnDemandRunnerConfig.AsObject;
+  static toObject(includeInstance: boolean, msg: OnDemandRunnerConfig): OnDemandRunnerConfig.AsObject;
+  static serializeBinaryToWriter(message: OnDemandRunnerConfig, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OnDemandRunnerConfig;
+  static deserializeBinaryFromReader(message: OnDemandRunnerConfig, reader: jspb.BinaryReader): OnDemandRunnerConfig;
+}
+
+export namespace OnDemandRunnerConfig {
+  export type AsObject = {
+    id: string,
+    ociUrl: string,
+    environmentVariablesMap: Array<[string, string]>,
+    pluginType: string,
+    pluginConfig: Uint8Array | string,
+    configFormat: Project.Format,
+    pb_default: boolean,
+  }
+}
+
+export class UpsertOnDemandRunnerConfigRequest extends jspb.Message {
+  getConfig(): OnDemandRunnerConfig | undefined;
+  setConfig(value?: OnDemandRunnerConfig): UpsertOnDemandRunnerConfigRequest;
+  hasConfig(): boolean;
+  clearConfig(): UpsertOnDemandRunnerConfigRequest;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UpsertOnDemandRunnerConfigRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: UpsertOnDemandRunnerConfigRequest): UpsertOnDemandRunnerConfigRequest.AsObject;
+  static serializeBinaryToWriter(message: UpsertOnDemandRunnerConfigRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UpsertOnDemandRunnerConfigRequest;
+  static deserializeBinaryFromReader(message: UpsertOnDemandRunnerConfigRequest, reader: jspb.BinaryReader): UpsertOnDemandRunnerConfigRequest;
+}
+
+export namespace UpsertOnDemandRunnerConfigRequest {
+  export type AsObject = {
+    config?: OnDemandRunnerConfig.AsObject,
+  }
+}
+
+export class UpsertOnDemandRunnerConfigResponse extends jspb.Message {
+  getConfig(): OnDemandRunnerConfig | undefined;
+  setConfig(value?: OnDemandRunnerConfig): UpsertOnDemandRunnerConfigResponse;
+  hasConfig(): boolean;
+  clearConfig(): UpsertOnDemandRunnerConfigResponse;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UpsertOnDemandRunnerConfigResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: UpsertOnDemandRunnerConfigResponse): UpsertOnDemandRunnerConfigResponse.AsObject;
+  static serializeBinaryToWriter(message: UpsertOnDemandRunnerConfigResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UpsertOnDemandRunnerConfigResponse;
+  static deserializeBinaryFromReader(message: UpsertOnDemandRunnerConfigResponse, reader: jspb.BinaryReader): UpsertOnDemandRunnerConfigResponse;
+}
+
+export namespace UpsertOnDemandRunnerConfigResponse {
+  export type AsObject = {
+    config?: OnDemandRunnerConfig.AsObject,
+  }
+}
+
+export class GetOnDemandRunnerConfigRequest extends jspb.Message {
+  getConfig(): Ref.OnDemandRunnerConfig | undefined;
+  setConfig(value?: Ref.OnDemandRunnerConfig): GetOnDemandRunnerConfigRequest;
+  hasConfig(): boolean;
+  clearConfig(): GetOnDemandRunnerConfigRequest;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOnDemandRunnerConfigRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOnDemandRunnerConfigRequest): GetOnDemandRunnerConfigRequest.AsObject;
+  static serializeBinaryToWriter(message: GetOnDemandRunnerConfigRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOnDemandRunnerConfigRequest;
+  static deserializeBinaryFromReader(message: GetOnDemandRunnerConfigRequest, reader: jspb.BinaryReader): GetOnDemandRunnerConfigRequest;
+}
+
+export namespace GetOnDemandRunnerConfigRequest {
+  export type AsObject = {
+    config?: Ref.OnDemandRunnerConfig.AsObject,
+  }
+}
+
+export class GetOnDemandRunnerConfigResponse extends jspb.Message {
+  getConfig(): OnDemandRunnerConfig | undefined;
+  setConfig(value?: OnDemandRunnerConfig): GetOnDemandRunnerConfigResponse;
+  hasConfig(): boolean;
+  clearConfig(): GetOnDemandRunnerConfigResponse;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetOnDemandRunnerConfigResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetOnDemandRunnerConfigResponse): GetOnDemandRunnerConfigResponse.AsObject;
+  static serializeBinaryToWriter(message: GetOnDemandRunnerConfigResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetOnDemandRunnerConfigResponse;
+  static deserializeBinaryFromReader(message: GetOnDemandRunnerConfigResponse, reader: jspb.BinaryReader): GetOnDemandRunnerConfigResponse;
+}
+
+export namespace GetOnDemandRunnerConfigResponse {
+  export type AsObject = {
+    config?: OnDemandRunnerConfig.AsObject,
+  }
+}
+
+export class ListOnDemandRunnerConfigsResponse extends jspb.Message {
+  getConfigsList(): Array<OnDemandRunnerConfig>;
+  setConfigsList(value: Array<OnDemandRunnerConfig>): ListOnDemandRunnerConfigsResponse;
+  clearConfigsList(): ListOnDemandRunnerConfigsResponse;
+  addConfigs(value?: OnDemandRunnerConfig, index?: number): OnDemandRunnerConfig;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListOnDemandRunnerConfigsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListOnDemandRunnerConfigsResponse): ListOnDemandRunnerConfigsResponse.AsObject;
+  static serializeBinaryToWriter(message: ListOnDemandRunnerConfigsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListOnDemandRunnerConfigsResponse;
+  static deserializeBinaryFromReader(message: ListOnDemandRunnerConfigsResponse, reader: jspb.BinaryReader): ListOnDemandRunnerConfigsResponse;
+}
+
+export namespace ListOnDemandRunnerConfigsResponse {
+  export type AsObject = {
+    configsList: Array<OnDemandRunnerConfig.AsObject>,
+  }
+}
+
 export class UpsertPushedArtifactRequest extends jspb.Message {
   getArtifact(): PushedArtifact | undefined;
   setArtifact(value?: PushedArtifact): UpsertPushedArtifactRequest;
@@ -6266,6 +6649,18 @@ export class ListStatusReportsRequest extends jspb.Message {
   hasWorkspace(): boolean;
   clearWorkspace(): ListStatusReportsRequest;
 
+  getDeployment(): Ref.Operation | undefined;
+  setDeployment(value?: Ref.Operation): ListStatusReportsRequest;
+  hasDeployment(): boolean;
+  clearDeployment(): ListStatusReportsRequest;
+
+  getRelease(): Ref.Operation | undefined;
+  setRelease(value?: Ref.Operation): ListStatusReportsRequest;
+  hasRelease(): boolean;
+  clearRelease(): ListStatusReportsRequest;
+
+  getTargetCase(): ListStatusReportsRequest.TargetCase;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ListStatusReportsRequest.AsObject;
   static toObject(includeInstance: boolean, msg: ListStatusReportsRequest): ListStatusReportsRequest.AsObject;
@@ -6280,6 +6675,14 @@ export namespace ListStatusReportsRequest {
     order?: OperationOrder.AsObject,
     application?: Ref.Application.AsObject,
     workspace?: Ref.Workspace.AsObject,
+    deployment?: Ref.Operation.AsObject,
+    release?: Ref.Operation.AsObject,
+  }
+
+  export enum TargetCase { 
+    TARGET_NOT_SET = 0,
+    DEPLOYMENT = 5,
+    RELEASE = 6,
   }
 }
 
@@ -6416,11 +6819,6 @@ export class StatusReport extends jspb.Message {
   hasHealth(): boolean;
   clearHealth(): StatusReport;
 
-  getResourcesHealthList(): Array<StatusReport.Health>;
-  setResourcesHealthList(value: Array<StatusReport.Health>): StatusReport;
-  clearResourcesHealthList(): StatusReport;
-  addResourcesHealth(value?: StatusReport.Health, index?: number): StatusReport.Health;
-
   getGeneratedTime(): google_protobuf_timestamp_pb.Timestamp | undefined;
   setGeneratedTime(value?: google_protobuf_timestamp_pb.Timestamp): StatusReport;
   hasGeneratedTime(): boolean;
@@ -6433,6 +6831,11 @@ export class StatusReport extends jspb.Message {
   setResourcesList(value: Array<StatusReport.Resource>): StatusReport;
   clearResourcesList(): StatusReport;
   addResources(value?: StatusReport.Resource, index?: number): StatusReport.Resource;
+
+  getDeprecatedResourcesHealthList(): Array<StatusReport.Health>;
+  setDeprecatedResourcesHealthList(value: Array<StatusReport.Health>): StatusReport;
+  clearDeprecatedResourcesHealthList(): StatusReport;
+  addDeprecatedResourcesHealth(value?: StatusReport.Health, index?: number): StatusReport.Health;
 
   getTargetIdCase(): StatusReport.TargetIdCase;
 
@@ -6454,10 +6857,10 @@ export namespace StatusReport {
     id: string,
     statusReport?: google_protobuf_any_pb.Any.AsObject,
     health?: StatusReport.Health.AsObject,
-    resourcesHealthList: Array<StatusReport.Health.AsObject>,
     generatedTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
     external: boolean,
     resourcesList: Array<StatusReport.Resource.AsObject>,
+    deprecatedResourcesHealthList: Array<StatusReport.Health.AsObject>,
   }
 
   export class Resource extends jspb.Message {
@@ -6495,13 +6898,16 @@ export namespace StatusReport {
     getStateJson(): string;
     setStateJson(value: string): Resource;
 
-    getHealth(): StatusReport.Health | undefined;
-    setHealth(value?: StatusReport.Health): Resource;
-    hasHealth(): boolean;
-    clearHealth(): Resource;
+    getHealth(): StatusReport.Resource.Health;
+    setHealth(value: StatusReport.Resource.Health): Resource;
 
     getHealthMessage(): string;
     setHealthMessage(value: string): Resource;
+
+    getDeprecatedHealth(): StatusReport.Health | undefined;
+    setDeprecatedHealth(value?: StatusReport.Health): Resource;
+    hasDeprecatedHealth(): boolean;
+    clearDeprecatedHealth(): Resource;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): Resource.AsObject;
@@ -6523,8 +6929,18 @@ export namespace StatusReport {
       categoryDisplayHint: ResourceCategoryDisplayHint,
       createdTime?: google_protobuf_timestamp_pb.Timestamp.AsObject,
       stateJson: string,
-      health?: StatusReport.Health.AsObject,
+      health: StatusReport.Resource.Health,
       healthMessage: string,
+      deprecatedHealth?: StatusReport.Health.AsObject,
+    }
+
+    export enum Health { 
+      UNKNOWN = 0,
+      ALIVE = 1,
+      READY = 2,
+      DOWN = 3,
+      MISSING = 5,
+      PARTIAL = 4,
     }
   }
 
@@ -6536,11 +6952,11 @@ export namespace StatusReport {
     getHealthMessage(): string;
     setHealthMessage(value: string): Health;
 
-    getName(): string;
-    setName(value: string): Health;
+    getDeprecatedName(): string;
+    setDeprecatedName(value: string): Health;
 
-    getId(): string;
-    setId(value: string): Health;
+    getDeprecatedId(): string;
+    setDeprecatedId(value: string): Health;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): Health.AsObject;
@@ -6554,8 +6970,8 @@ export namespace StatusReport {
     export type AsObject = {
       healthStatus: string,
       healthMessage: string,
-      name: string,
-      id: string,
+      deprecatedName: string,
+      deprecatedId: string,
     }
   }
 
@@ -6693,20 +7109,10 @@ export namespace LogBatch {
 }
 
 export class ConfigVar extends jspb.Message {
-  getApplication(): Ref.Application | undefined;
-  setApplication(value?: Ref.Application): ConfigVar;
-  hasApplication(): boolean;
-  clearApplication(): ConfigVar;
-
-  getProject(): Ref.Project | undefined;
-  setProject(value?: Ref.Project): ConfigVar;
-  hasProject(): boolean;
-  clearProject(): ConfigVar;
-
-  getRunner(): Ref.Runner | undefined;
-  setRunner(value?: Ref.Runner): ConfigVar;
-  hasRunner(): boolean;
-  clearRunner(): ConfigVar;
+  getTarget(): ConfigVar.Target | undefined;
+  setTarget(value?: ConfigVar.Target): ConfigVar;
+  hasTarget(): boolean;
+  clearTarget(): ConfigVar;
 
   getName(): string;
   setName(value: string): ConfigVar;
@@ -6730,9 +7136,24 @@ export class ConfigVar extends jspb.Message {
   getNameIsPath(): boolean;
   setNameIsPath(value: boolean): ConfigVar;
 
-  getScopeCase(): ConfigVar.ScopeCase;
+  getApplication(): Ref.Application | undefined;
+  setApplication(value?: Ref.Application): ConfigVar;
+  hasApplication(): boolean;
+  clearApplication(): ConfigVar;
+
+  getProject(): Ref.Project | undefined;
+  setProject(value?: Ref.Project): ConfigVar;
+  hasProject(): boolean;
+  clearProject(): ConfigVar;
+
+  getRunner(): Ref.Runner | undefined;
+  setRunner(value?: Ref.Runner): ConfigVar;
+  hasRunner(): boolean;
+  clearRunner(): ConfigVar;
 
   getValueCase(): ConfigVar.ValueCase;
+
+  getUnusedScopeCase(): ConfigVar.UnusedScopeCase;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ConfigVar.AsObject;
@@ -6744,15 +7165,16 @@ export class ConfigVar extends jspb.Message {
 
 export namespace ConfigVar {
   export type AsObject = {
-    application?: Ref.Application.AsObject,
-    project?: Ref.Project.AsObject,
-    runner?: Ref.Runner.AsObject,
+    target?: ConfigVar.Target.AsObject,
     name: string,
     unset?: google_protobuf_empty_pb.Empty.AsObject,
     pb_static: string,
     dynamic?: ConfigVar.DynamicVal.AsObject,
     internal: boolean,
     nameIsPath: boolean,
+    application?: Ref.Application.AsObject,
+    project?: Ref.Project.AsObject,
+    runner?: Ref.Runner.AsObject,
   }
 
   export class DynamicVal extends jspb.Message {
@@ -6778,18 +7200,76 @@ export namespace ConfigVar {
   }
 
 
-  export enum ScopeCase { 
-    SCOPE_NOT_SET = 0,
-    APPLICATION = 3,
-    PROJECT = 4,
-    RUNNER = 5,
+  export class Target extends jspb.Message {
+    getGlobal(): Ref.Global | undefined;
+    setGlobal(value?: Ref.Global): Target;
+    hasGlobal(): boolean;
+    clearGlobal(): Target;
+
+    getProject(): Ref.Project | undefined;
+    setProject(value?: Ref.Project): Target;
+    hasProject(): boolean;
+    clearProject(): Target;
+
+    getApplication(): Ref.Application | undefined;
+    setApplication(value?: Ref.Application): Target;
+    hasApplication(): boolean;
+    clearApplication(): Target;
+
+    getWorkspace(): Ref.Workspace | undefined;
+    setWorkspace(value?: Ref.Workspace): Target;
+    hasWorkspace(): boolean;
+    clearWorkspace(): Target;
+
+    getLabelSelector(): string;
+    setLabelSelector(value: string): Target;
+
+    getRunner(): Ref.Runner | undefined;
+    setRunner(value?: Ref.Runner): Target;
+    hasRunner(): boolean;
+    clearRunner(): Target;
+
+    getAppScopeCase(): Target.AppScopeCase;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Target.AsObject;
+    static toObject(includeInstance: boolean, msg: Target): Target.AsObject;
+    static serializeBinaryToWriter(message: Target, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Target;
+    static deserializeBinaryFromReader(message: Target, reader: jspb.BinaryReader): Target;
   }
+
+  export namespace Target {
+    export type AsObject = {
+      global?: Ref.Global.AsObject,
+      project?: Ref.Project.AsObject,
+      application?: Ref.Application.AsObject,
+      workspace?: Ref.Workspace.AsObject,
+      labelSelector: string,
+      runner?: Ref.Runner.AsObject,
+    }
+
+    export enum AppScopeCase { 
+      APP_SCOPE_NOT_SET = 0,
+      GLOBAL = 1,
+      PROJECT = 2,
+      APPLICATION = 3,
+    }
+  }
+
 
   export enum ValueCase { 
     VALUE_NOT_SET = 0,
     UNSET = 7,
     STATIC = 2,
     DYNAMIC = 6,
+  }
+
+  export enum UnusedScopeCase { 
+    UNUSED_SCOPE_NOT_SET = 0,
+    APPLICATION = 3,
+    PROJECT = 4,
+    RUNNER = 5,
   }
 }
 
@@ -6843,6 +7323,14 @@ export class ConfigGetRequest extends jspb.Message {
   hasRunner(): boolean;
   clearRunner(): ConfigGetRequest;
 
+  getWorkspace(): Ref.Workspace | undefined;
+  setWorkspace(value?: Ref.Workspace): ConfigGetRequest;
+  hasWorkspace(): boolean;
+  clearWorkspace(): ConfigGetRequest;
+
+  getLabelsMap(): jspb.Map<string, string>;
+  clearLabelsMap(): ConfigGetRequest;
+
   getPrefix(): string;
   setPrefix(value: string): ConfigGetRequest;
 
@@ -6861,6 +7349,8 @@ export namespace ConfigGetRequest {
     application?: Ref.Application.AsObject,
     project?: Ref.Project.AsObject,
     runner?: Ref.RunnerId.AsObject,
+    workspace?: Ref.Workspace.AsObject,
+    labelsMap: Array<[string, string]>,
     prefix: string,
   }
 
@@ -6868,7 +7358,6 @@ export namespace ConfigGetRequest {
     SCOPE_NOT_SET = 0,
     APPLICATION = 2,
     PROJECT = 3,
-    RUNNER = 4,
   }
 }
 

--- a/ui/lib/waypoint-pb/server_pb.js
+++ b/ui/lib/waypoint-pb/server_pb.js
@@ -44,7 +44,9 @@ goog.exportSymbol('proto.hashicorp.waypoint.ConfigSource', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ConfigSource.ScopeCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.DynamicVal', null, global);
-goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.ScopeCase', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.Target', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.Target.AppScopeCase', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.UnusedScopeCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ConfigVar.ValueCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ConvertInviteTokenRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.CreateHostnameRequest', null, global);
@@ -136,6 +138,8 @@ goog.exportSymbol('proto.hashicorp.waypoint.GetLogStreamRequest.Application', nu
 goog.exportSymbol('proto.hashicorp.waypoint.GetLogStreamRequest.ScopeCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.GetOIDCAuthURLRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.GetOIDCAuthURLResponse', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.GetProjectRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.GetProjectResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.GetPushedArtifactRequest', null, global);
@@ -222,12 +226,14 @@ goog.exportSymbol('proto.hashicorp.waypoint.ListInstancesResponse', null, global
 goog.exportSymbol('proto.hashicorp.waypoint.ListJobsRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListJobsResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListOIDCAuthMethodsResponse', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListProjectsResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListPushedArtifactsRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListPushedArtifactsResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListReleasesRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListReleasesResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListStatusReportsRequest', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.ListStatusReportsRequest.TargetCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListStatusReportsResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListUsersResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.ListWorkspacesRequest', null, global);
@@ -240,6 +246,7 @@ goog.exportSymbol('proto.hashicorp.waypoint.LoginTokenRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.NewTokenResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.OIDCAuthMethod', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.OIDCAuthMethod.Kind', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.OnDemandRunnerConfig', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Operation', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Operation.PhysicalState', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.OperationOrder', null, global);
@@ -258,6 +265,7 @@ goog.exportSymbol('proto.hashicorp.waypoint.Ref.AuthMethod', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.Component', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.DeclaredResource', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.Global', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.Operation', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.Operation.TargetCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Ref.OperationSeq', null, global);
@@ -316,6 +324,7 @@ goog.exportSymbol('proto.hashicorp.waypoint.StatusFilter.Filter.FilterCase', nul
 goog.exportSymbol('proto.hashicorp.waypoint.StatusReport', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.StatusReport.Health', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.StatusReport.Resource', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.StatusReport.Resource.Health', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.StatusReport.TargetIdCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.TaskLaunchInfo', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Token', null, global);
@@ -325,6 +334,13 @@ goog.exportSymbol('proto.hashicorp.waypoint.Token.Invite.Signup', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Token.KindCase', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Token.Login', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.TokenTransport', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.DeploymentBundle', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.ListDeploymentsRequest', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.ListDeploymentsResponse', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.ListReleasesRequest', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.ListReleasesResponse', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UI.ReleaseBundle', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpdateUserRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpdateUserResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertApplicationRequest', null, global);
@@ -336,6 +352,8 @@ goog.exportSymbol('proto.hashicorp.waypoint.UpsertBuildResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertDeploymentRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertDeploymentRequest.Tristate', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertDeploymentResponse', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest', null, global);
+goog.exportSymbol('proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertProjectRequest', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertProjectResponse', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.UpsertPushedArtifactRequest', null, global);
@@ -364,6 +382,153 @@ goog.exportSymbol('proto.hashicorp.waypoint.WaypointHclFmtResponse', null, globa
 goog.exportSymbol('proto.hashicorp.waypoint.Workspace', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Workspace.Application', null, global);
 goog.exportSymbol('proto.hashicorp.waypoint.Workspace.Project', null, global);
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.displayName = 'proto.hashicorp.waypoint.UI';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.UI.ListDeploymentsRequest.repeatedFields_, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.ListDeploymentsRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.ListDeploymentsRequest.displayName = 'proto.hashicorp.waypoint.UI.ListDeploymentsRequest';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.UI.ListDeploymentsResponse.repeatedFields_, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.ListDeploymentsResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.ListDeploymentsResponse.displayName = 'proto.hashicorp.waypoint.UI.ListDeploymentsResponse';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.DeploymentBundle, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.DeploymentBundle.displayName = 'proto.hashicorp.waypoint.UI.DeploymentBundle';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.ListReleasesRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.ListReleasesRequest.displayName = 'proto.hashicorp.waypoint.UI.ListReleasesRequest';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.UI.ListReleasesResponse.repeatedFields_, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.ListReleasesResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.ListReleasesResponse.displayName = 'proto.hashicorp.waypoint.UI.ListReleasesResponse';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UI.ReleaseBundle, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UI.ReleaseBundle.displayName = 'proto.hashicorp.waypoint.UI.ReleaseBundle';
+}
 /**
  * Generated by JsPbCodeGenerator.
  * @param {Array=} opt_data Optional initial data array, typically from a
@@ -1077,6 +1242,27 @@ if (goog.DEBUG && !COMPILED) {
    * @override
    */
   proto.hashicorp.waypoint.Ref.DeclaredResource.displayName = 'proto.hashicorp.waypoint.Ref.DeclaredResource';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.displayName = 'proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig';
 }
 /**
  * Generated by JsPbCodeGenerator.
@@ -4301,6 +4487,132 @@ if (goog.DEBUG && !COMPILED) {
  * @extends {jspb.Message}
  * @constructor
  */
+proto.hashicorp.waypoint.OnDemandRunnerConfig = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.OnDemandRunnerConfig, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.OnDemandRunnerConfig.displayName = 'proto.hashicorp.waypoint.OnDemandRunnerConfig';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.displayName = 'proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.displayName = 'proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.displayName = 'proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.displayName = 'proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.repeatedFields_, null);
+};
+goog.inherits(proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.displayName = 'proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
 proto.hashicorp.waypoint.UpsertPushedArtifactRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
@@ -4974,7 +5286,7 @@ if (goog.DEBUG && !COMPILED) {
  * @constructor
  */
 proto.hashicorp.waypoint.ListStatusReportsRequest = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.ListStatusReportsRequest.repeatedFields_, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hashicorp.waypoint.ListStatusReportsRequest.repeatedFields_, proto.hashicorp.waypoint.ListStatusReportsRequest.oneofGroups_);
 };
 goog.inherits(proto.hashicorp.waypoint.ListStatusReportsRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
@@ -5256,6 +5568,27 @@ if (goog.DEBUG && !COMPILED) {
    * @override
    */
   proto.hashicorp.waypoint.ConfigVar.DynamicVal.displayName = 'proto.hashicorp.waypoint.ConfigVar.DynamicVal';
+}
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.hashicorp.waypoint.ConfigVar.Target = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_);
+};
+goog.inherits(proto.hashicorp.waypoint.ConfigVar.Target, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  /**
+   * @public
+   * @override
+   */
+  proto.hashicorp.waypoint.ConfigVar.Target.displayName = 'proto.hashicorp.waypoint.ConfigVar.Target';
 }
 /**
  * Generated by JsPbCodeGenerator.
@@ -6370,6 +6703,1610 @@ if (goog.DEBUG && !COMPILED) {
    */
   proto.hashicorp.waypoint.WaypointHclFmtResponse.displayName = 'proto.hashicorp.waypoint.WaypointHclFmtResponse';
 }
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI}
+ */
+proto.hashicorp.waypoint.UI.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI;
+  return proto.hashicorp.waypoint.UI.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI}
+ */
+proto.hashicorp.waypoint.UI.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.repeatedFields_ = [4];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.ListDeploymentsRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
+    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f),
+    order: (f = msg.getOrder()) && proto.hashicorp.waypoint.OperationOrder.toObject(includeInstance, f),
+    statusList: jspb.Message.toObjectList(msg.getStatusList(),
+    proto.hashicorp.waypoint.StatusFilter.toObject, includeInstance),
+    physicalState: jspb.Message.getFieldWithDefault(msg, 5, 0)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.ListDeploymentsRequest;
+  return proto.hashicorp.waypoint.UI.ListDeploymentsRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Ref.Application;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Application.deserializeBinaryFromReader);
+      msg.setApplication(value);
+      break;
+    case 2:
+      var value = new proto.hashicorp.waypoint.Ref.Workspace;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Workspace.deserializeBinaryFromReader);
+      msg.setWorkspace(value);
+      break;
+    case 3:
+      var value = new proto.hashicorp.waypoint.OperationOrder;
+      reader.readMessage(value,proto.hashicorp.waypoint.OperationOrder.deserializeBinaryFromReader);
+      msg.setOrder(value);
+      break;
+    case 4:
+      var value = new proto.hashicorp.waypoint.StatusFilter;
+      reader.readMessage(value,proto.hashicorp.waypoint.StatusFilter.deserializeBinaryFromReader);
+      msg.addStatus(value);
+      break;
+    case 5:
+      var value = /** @type {!proto.hashicorp.waypoint.Operation.PhysicalState} */ (reader.readEnum());
+      msg.setPhysicalState(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.ListDeploymentsRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getApplication();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Ref.Application.serializeBinaryToWriter
+    );
+  }
+  f = message.getWorkspace();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.hashicorp.waypoint.Ref.Workspace.serializeBinaryToWriter
+    );
+  }
+  f = message.getOrder();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      proto.hashicorp.waypoint.OperationOrder.serializeBinaryToWriter
+    );
+  }
+  f = message.getStatusList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      4,
+      f,
+      proto.hashicorp.waypoint.StatusFilter.serializeBinaryToWriter
+    );
+  }
+  f = message.getPhysicalState();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      5,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional Ref.Application application = 1;
+ * @return {?proto.hashicorp.waypoint.Ref.Application}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.getApplication = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Application} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Application, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Application|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.setApplication = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.clearApplication = function() {
+  return this.setApplication(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.hasApplication = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional Ref.Workspace workspace = 2;
+ * @return {?proto.hashicorp.waypoint.Ref.Workspace}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.getWorkspace = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Workspace} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Workspace, 2));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Workspace|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.setWorkspace = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.clearWorkspace = function() {
+  return this.setWorkspace(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.hasWorkspace = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional OperationOrder order = 3;
+ * @return {?proto.hashicorp.waypoint.OperationOrder}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.getOrder = function() {
+  return /** @type{?proto.hashicorp.waypoint.OperationOrder} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.OperationOrder, 3));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.OperationOrder|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.setOrder = function(value) {
+  return jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.clearOrder = function() {
+  return this.setOrder(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.hasOrder = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * repeated StatusFilter status = 4;
+ * @return {!Array<!proto.hashicorp.waypoint.StatusFilter>}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.getStatusList = function() {
+  return /** @type{!Array<!proto.hashicorp.waypoint.StatusFilter>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.StatusFilter, 4));
+};
+
+
+/**
+ * @param {!Array<!proto.hashicorp.waypoint.StatusFilter>} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.setStatusList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 4, value);
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.StatusFilter=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.StatusFilter}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.addStatus = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.hashicorp.waypoint.StatusFilter, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.clearStatusList = function() {
+  return this.setStatusList([]);
+};
+
+
+/**
+ * optional Operation.PhysicalState physical_state = 5;
+ * @return {!proto.hashicorp.waypoint.Operation.PhysicalState}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.getPhysicalState = function() {
+  return /** @type {!proto.hashicorp.waypoint.Operation.PhysicalState} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.Operation.PhysicalState} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsRequest.prototype.setPhysicalState = function(value) {
+  return jspb.Message.setProto3EnumField(this, 5, value);
+};
+
+
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.ListDeploymentsResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    deploymentsList: jspb.Message.toObjectList(msg.getDeploymentsList(),
+    proto.hashicorp.waypoint.UI.DeploymentBundle.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.ListDeploymentsResponse;
+  return proto.hashicorp.waypoint.UI.ListDeploymentsResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.UI.DeploymentBundle;
+      reader.readMessage(value,proto.hashicorp.waypoint.UI.DeploymentBundle.deserializeBinaryFromReader);
+      msg.addDeployments(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.ListDeploymentsResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getDeploymentsList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.UI.DeploymentBundle.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated DeploymentBundle deployments = 1;
+ * @return {!Array<!proto.hashicorp.waypoint.UI.DeploymentBundle>}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.getDeploymentsList = function() {
+  return /** @type{!Array<!proto.hashicorp.waypoint.UI.DeploymentBundle>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.UI.DeploymentBundle, 1));
+};
+
+
+/**
+ * @param {!Array<!proto.hashicorp.waypoint.UI.DeploymentBundle>} value
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse} returns this
+*/
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.setDeploymentsList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.UI.DeploymentBundle=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle}
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.addDeployments = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.hashicorp.waypoint.UI.DeploymentBundle, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.UI.ListDeploymentsResponse} returns this
+ */
+proto.hashicorp.waypoint.UI.ListDeploymentsResponse.prototype.clearDeploymentsList = function() {
+  return this.setDeploymentsList([]);
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.DeploymentBundle.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.DeploymentBundle} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    deployment: (f = msg.getDeployment()) && proto.hashicorp.waypoint.Deployment.toObject(includeInstance, f),
+    artifact: (f = msg.getArtifact()) && proto.hashicorp.waypoint.PushedArtifact.toObject(includeInstance, f),
+    build: (f = msg.getBuild()) && proto.hashicorp.waypoint.Build.toObject(includeInstance, f),
+    deployUrl: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    jobDataSourceRef: (f = msg.getJobDataSourceRef()) && proto.hashicorp.waypoint.Job.DataSource.Ref.toObject(includeInstance, f),
+    latestStatusReport: (f = msg.getLatestStatusReport()) && proto.hashicorp.waypoint.StatusReport.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.DeploymentBundle;
+  return proto.hashicorp.waypoint.UI.DeploymentBundle.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.DeploymentBundle} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Deployment;
+      reader.readMessage(value,proto.hashicorp.waypoint.Deployment.deserializeBinaryFromReader);
+      msg.setDeployment(value);
+      break;
+    case 3:
+      var value = new proto.hashicorp.waypoint.PushedArtifact;
+      reader.readMessage(value,proto.hashicorp.waypoint.PushedArtifact.deserializeBinaryFromReader);
+      msg.setArtifact(value);
+      break;
+    case 4:
+      var value = new proto.hashicorp.waypoint.Build;
+      reader.readMessage(value,proto.hashicorp.waypoint.Build.deserializeBinaryFromReader);
+      msg.setBuild(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setDeployUrl(value);
+      break;
+    case 6:
+      var value = new proto.hashicorp.waypoint.Job.DataSource.Ref;
+      reader.readMessage(value,proto.hashicorp.waypoint.Job.DataSource.Ref.deserializeBinaryFromReader);
+      msg.setJobDataSourceRef(value);
+      break;
+    case 2:
+      var value = new proto.hashicorp.waypoint.StatusReport;
+      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.deserializeBinaryFromReader);
+      msg.setLatestStatusReport(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.DeploymentBundle.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.DeploymentBundle} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getDeployment();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Deployment.serializeBinaryToWriter
+    );
+  }
+  f = message.getArtifact();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      proto.hashicorp.waypoint.PushedArtifact.serializeBinaryToWriter
+    );
+  }
+  f = message.getBuild();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      proto.hashicorp.waypoint.Build.serializeBinaryToWriter
+    );
+  }
+  f = message.getDeployUrl();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
+      f
+    );
+  }
+  f = message.getJobDataSourceRef();
+  if (f != null) {
+    writer.writeMessage(
+      6,
+      f,
+      proto.hashicorp.waypoint.Job.DataSource.Ref.serializeBinaryToWriter
+    );
+  }
+  f = message.getLatestStatusReport();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.hashicorp.waypoint.StatusReport.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional Deployment deployment = 1;
+ * @return {?proto.hashicorp.waypoint.Deployment}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getDeployment = function() {
+  return /** @type{?proto.hashicorp.waypoint.Deployment} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Deployment, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Deployment|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setDeployment = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.clearDeployment = function() {
+  return this.setDeployment(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.hasDeployment = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional PushedArtifact artifact = 3;
+ * @return {?proto.hashicorp.waypoint.PushedArtifact}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getArtifact = function() {
+  return /** @type{?proto.hashicorp.waypoint.PushedArtifact} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.PushedArtifact, 3));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.PushedArtifact|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setArtifact = function(value) {
+  return jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.clearArtifact = function() {
+  return this.setArtifact(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.hasArtifact = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional Build build = 4;
+ * @return {?proto.hashicorp.waypoint.Build}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getBuild = function() {
+  return /** @type{?proto.hashicorp.waypoint.Build} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Build, 4));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Build|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setBuild = function(value) {
+  return jspb.Message.setWrapperField(this, 4, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.clearBuild = function() {
+  return this.setBuild(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.hasBuild = function() {
+  return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional string deploy_url = 5;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getDeployUrl = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setDeployUrl = function(value) {
+  return jspb.Message.setProto3StringField(this, 5, value);
+};
+
+
+/**
+ * optional Job.DataSource.Ref job_data_source_ref = 6;
+ * @return {?proto.hashicorp.waypoint.Job.DataSource.Ref}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getJobDataSourceRef = function() {
+  return /** @type{?proto.hashicorp.waypoint.Job.DataSource.Ref} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Job.DataSource.Ref, 6));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Job.DataSource.Ref|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setJobDataSourceRef = function(value) {
+  return jspb.Message.setWrapperField(this, 6, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.clearJobDataSourceRef = function() {
+  return this.setJobDataSourceRef(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.hasJobDataSourceRef = function() {
+  return jspb.Message.getField(this, 6) != null;
+};
+
+
+/**
+ * optional StatusReport latest_status_report = 2;
+ * @return {?proto.hashicorp.waypoint.StatusReport}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.getLatestStatusReport = function() {
+  return /** @type{?proto.hashicorp.waypoint.StatusReport} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.StatusReport, 2));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.StatusReport|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.setLatestStatusReport = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.DeploymentBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.clearLatestStatusReport = function() {
+  return this.setLatestStatusReport(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.DeploymentBundle.prototype.hasLatestStatusReport = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.ListReleasesRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
+    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f),
+    order: (f = msg.getOrder()) && proto.hashicorp.waypoint.OperationOrder.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.ListReleasesRequest;
+  return proto.hashicorp.waypoint.UI.ListReleasesRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Ref.Application;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Application.deserializeBinaryFromReader);
+      msg.setApplication(value);
+      break;
+    case 2:
+      var value = new proto.hashicorp.waypoint.Ref.Workspace;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Workspace.deserializeBinaryFromReader);
+      msg.setWorkspace(value);
+      break;
+    case 3:
+      var value = new proto.hashicorp.waypoint.OperationOrder;
+      reader.readMessage(value,proto.hashicorp.waypoint.OperationOrder.deserializeBinaryFromReader);
+      msg.setOrder(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.ListReleasesRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getApplication();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Ref.Application.serializeBinaryToWriter
+    );
+  }
+  f = message.getWorkspace();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.hashicorp.waypoint.Ref.Workspace.serializeBinaryToWriter
+    );
+  }
+  f = message.getOrder();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      proto.hashicorp.waypoint.OperationOrder.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional Ref.Application application = 1;
+ * @return {?proto.hashicorp.waypoint.Ref.Application}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.getApplication = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Application} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Application, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Application|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.setApplication = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.clearApplication = function() {
+  return this.setApplication(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.hasApplication = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional Ref.Workspace workspace = 2;
+ * @return {?proto.hashicorp.waypoint.Ref.Workspace}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.getWorkspace = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Workspace} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Workspace, 2));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Workspace|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.setWorkspace = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.clearWorkspace = function() {
+  return this.setWorkspace(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.hasWorkspace = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional OperationOrder order = 3;
+ * @return {?proto.hashicorp.waypoint.OperationOrder}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.getOrder = function() {
+  return /** @type{?proto.hashicorp.waypoint.OperationOrder} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.OperationOrder, 3));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.OperationOrder|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+*/
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.setOrder = function(value) {
+  return jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesRequest} returns this
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.clearOrder = function() {
+  return this.setOrder(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesRequest.prototype.hasOrder = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.ListReleasesResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    releasesList: jspb.Message.toObjectList(msg.getReleasesList(),
+    proto.hashicorp.waypoint.UI.ReleaseBundle.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesResponse}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.ListReleasesResponse;
+  return proto.hashicorp.waypoint.UI.ListReleasesResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesResponse}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.UI.ReleaseBundle;
+      reader.readMessage(value,proto.hashicorp.waypoint.UI.ReleaseBundle.deserializeBinaryFromReader);
+      msg.addReleases(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.ListReleasesResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.ListReleasesResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getReleasesList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.UI.ReleaseBundle.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated ReleaseBundle releases = 1;
+ * @return {!Array<!proto.hashicorp.waypoint.UI.ReleaseBundle>}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.getReleasesList = function() {
+  return /** @type{!Array<!proto.hashicorp.waypoint.UI.ReleaseBundle>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.UI.ReleaseBundle, 1));
+};
+
+
+/**
+ * @param {!Array<!proto.hashicorp.waypoint.UI.ReleaseBundle>} value
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesResponse} returns this
+*/
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.setReleasesList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.UI.ReleaseBundle=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle}
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.addReleases = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.hashicorp.waypoint.UI.ReleaseBundle, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.UI.ListReleasesResponse} returns this
+ */
+proto.hashicorp.waypoint.UI.ListReleasesResponse.prototype.clearReleasesList = function() {
+  return this.setReleasesList([]);
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UI.ReleaseBundle.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UI.ReleaseBundle} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    release: (f = msg.getRelease()) && proto.hashicorp.waypoint.Release.toObject(includeInstance, f),
+    latestStatusReport: (f = msg.getLatestStatusReport()) && proto.hashicorp.waypoint.StatusReport.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UI.ReleaseBundle;
+  return proto.hashicorp.waypoint.UI.ReleaseBundle.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UI.ReleaseBundle} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Release;
+      reader.readMessage(value,proto.hashicorp.waypoint.Release.deserializeBinaryFromReader);
+      msg.setRelease(value);
+      break;
+    case 2:
+      var value = new proto.hashicorp.waypoint.StatusReport;
+      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.deserializeBinaryFromReader);
+      msg.setLatestStatusReport(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UI.ReleaseBundle.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UI.ReleaseBundle} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getRelease();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Release.serializeBinaryToWriter
+    );
+  }
+  f = message.getLatestStatusReport();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.hashicorp.waypoint.StatusReport.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional Release release = 1;
+ * @return {?proto.hashicorp.waypoint.Release}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.getRelease = function() {
+  return /** @type{?proto.hashicorp.waypoint.Release} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Release, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Release|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.setRelease = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.clearRelease = function() {
+  return this.setRelease(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.hasRelease = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional StatusReport latest_status_report = 2;
+ * @return {?proto.hashicorp.waypoint.StatusReport}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.getLatestStatusReport = function() {
+  return /** @type{?proto.hashicorp.waypoint.StatusReport} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.StatusReport, 2));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.StatusReport|undefined} value
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle} returns this
+*/
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.setLatestStatusReport = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UI.ReleaseBundle} returns this
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.clearLatestStatusReport = function() {
+  return this.setLatestStatusReport(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UI.ReleaseBundle.prototype.hasLatestStatusReport = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
 
 
 
@@ -8582,7 +10519,8 @@ proto.hashicorp.waypoint.Project.toObject = function(includeInstance, msg) {
     fileChangeSignal: jspb.Message.getFieldWithDefault(msg, 8, ""),
     variablesList: jspb.Message.toObjectList(msg.getVariablesList(),
     proto.hashicorp.waypoint.Variable.toObject, includeInstance),
-    statusReportPoll: (f = msg.getStatusReportPoll()) && proto.hashicorp.waypoint.Project.AppStatusPoll.toObject(includeInstance, f)
+    statusReportPoll: (f = msg.getStatusReportPoll()) && proto.hashicorp.waypoint.Project.AppStatusPoll.toObject(includeInstance, f),
+    ondemandRunner: (f = msg.getOndemandRunner()) && proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -8663,6 +10601,11 @@ proto.hashicorp.waypoint.Project.deserializeBinaryFromReader = function(msg, rea
       var value = new proto.hashicorp.waypoint.Project.AppStatusPoll;
       reader.readMessage(value,proto.hashicorp.waypoint.Project.AppStatusPoll.deserializeBinaryFromReader);
       msg.setStatusReportPoll(value);
+      break;
+    case 11:
+      var value = new proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.setOndemandRunner(value);
       break;
     default:
       reader.skipField();
@@ -8766,6 +10709,14 @@ proto.hashicorp.waypoint.Project.serializeBinaryToWriter = function(message, wri
       10,
       f,
       proto.hashicorp.waypoint.Project.AppStatusPoll.serializeBinaryToWriter
+    );
+  }
+  f = message.getOndemandRunner();
+  if (f != null) {
+    writer.writeMessage(
+      11,
+      f,
+      proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.serializeBinaryToWriter
     );
   }
 };
@@ -9397,6 +11348,43 @@ proto.hashicorp.waypoint.Project.prototype.clearStatusReportPoll = function() {
  */
 proto.hashicorp.waypoint.Project.prototype.hasStatusReportPoll = function() {
   return jspb.Message.getField(this, 10) != null;
+};
+
+
+/**
+ * optional Ref.OnDemandRunnerConfig ondemand_runner = 11;
+ * @return {?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.Project.prototype.getOndemandRunner = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig, 11));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig|undefined} value
+ * @return {!proto.hashicorp.waypoint.Project} returns this
+*/
+proto.hashicorp.waypoint.Project.prototype.setOndemandRunner = function(value) {
+  return jspb.Message.setWrapperField(this, 11, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.Project} returns this
+ */
+proto.hashicorp.waypoint.Project.prototype.clearOndemandRunner = function() {
+  return this.setOndemandRunner(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.Project.prototype.hasOndemandRunner = function() {
+  return jspb.Message.getField(this, 11) != null;
 };
 
 
@@ -13120,7 +15108,7 @@ proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.toObject = function(opt_
  */
 proto.hashicorp.waypoint.Ref.DeclaredResource.toObject = function(includeInstance, msg) {
   var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 1, "")
+    name: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
 
   if (includeInstance) {
@@ -13159,7 +15147,7 @@ proto.hashicorp.waypoint.Ref.DeclaredResource.deserializeBinaryFromReader = func
     switch (field) {
     case 1:
       var value = /** @type {string} */ (reader.readString());
-      msg.setId(value);
+      msg.setName(value);
       break;
     default:
       reader.skipField();
@@ -13190,6 +15178,136 @@ proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.serializeBinary = functi
  */
 proto.hashicorp.waypoint.Ref.DeclaredResource.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getName();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string name = 1;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.getName = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.Ref.DeclaredResource} returns this
+ */
+proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.setName = function(value) {
+  return jspb.Message.setProto3StringField(this, 1, value);
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    id: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig;
+  return proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
   f = message.getId();
   if (f.length > 0) {
     writer.writeString(
@@ -13204,16 +15322,16 @@ proto.hashicorp.waypoint.Ref.DeclaredResource.serializeBinaryToWriter = function
  * optional string id = 1;
  * @return {string}
  */
-proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.getId = function() {
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.prototype.getId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /**
  * @param {string} value
- * @return {!proto.hashicorp.waypoint.Ref.DeclaredResource} returns this
+ * @return {!proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} returns this
  */
-proto.hashicorp.waypoint.Ref.DeclaredResource.prototype.setId = function(value) {
+proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.prototype.setId = function(value) {
   return jspb.Message.setProto3StringField(this, 1, value);
 };
 
@@ -14547,8 +16665,8 @@ proto.hashicorp.waypoint.DeclaredResource.prototype.toObject = function(opt_incl
  */
 proto.hashicorp.waypoint.DeclaredResource.toObject = function(includeInstance, msg) {
   var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 6, ""),
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    type: jspb.Message.getFieldWithDefault(msg, 6, ""),
     platform: jspb.Message.getFieldWithDefault(msg, 2, ""),
     state: (f = msg.getState()) && google_protobuf_any_pb.Any.toObject(includeInstance, f),
     stateJson: jspb.Message.getFieldWithDefault(msg, 4, ""),
@@ -14589,13 +16707,13 @@ proto.hashicorp.waypoint.DeclaredResource.deserializeBinaryFromReader = function
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 6:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setId(value);
-      break;
     case 1:
       var value = /** @type {string} */ (reader.readString());
       msg.setName(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setType(value);
       break;
     case 2:
       var value = /** @type {string} */ (reader.readString());
@@ -14643,17 +16761,17 @@ proto.hashicorp.waypoint.DeclaredResource.prototype.serializeBinary = function()
  */
 proto.hashicorp.waypoint.DeclaredResource.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getId();
-  if (f.length > 0) {
-    writer.writeString(
-      6,
-      f
-    );
-  }
   f = message.getName();
   if (f.length > 0) {
     writer.writeString(
       1,
+      f
+    );
+  }
+  f = message.getType();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
       f
     );
   }
@@ -14690,24 +16808,6 @@ proto.hashicorp.waypoint.DeclaredResource.serializeBinaryToWriter = function(mes
 
 
 /**
- * optional string id = 6;
- * @return {string}
- */
-proto.hashicorp.waypoint.DeclaredResource.prototype.getId = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.hashicorp.waypoint.DeclaredResource} returns this
- */
-proto.hashicorp.waypoint.DeclaredResource.prototype.setId = function(value) {
-  return jspb.Message.setProto3StringField(this, 6, value);
-};
-
-
-/**
  * optional string name = 1;
  * @return {string}
  */
@@ -14722,6 +16822,24 @@ proto.hashicorp.waypoint.DeclaredResource.prototype.getName = function() {
  */
 proto.hashicorp.waypoint.DeclaredResource.prototype.setName = function(value) {
   return jspb.Message.setProto3StringField(this, 1, value);
+};
+
+
+/**
+ * optional string type = 6;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.DeclaredResource.prototype.getType = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.DeclaredResource} returns this
+ */
+proto.hashicorp.waypoint.DeclaredResource.prototype.setType = function(value) {
+  return jspb.Message.setProto3StringField(this, 6, value);
 };
 
 
@@ -14822,7 +16940,7 @@ proto.hashicorp.waypoint.DeclaredResource.prototype.setCategoryDisplayHint = fun
  * @private {!Array<number>}
  * @const
  */
-proto.hashicorp.waypoint.TaskLaunchInfo.repeatedFields_ = [3];
+proto.hashicorp.waypoint.TaskLaunchInfo.repeatedFields_ = [4,3];
 
 
 
@@ -14857,6 +16975,7 @@ proto.hashicorp.waypoint.TaskLaunchInfo.toObject = function(includeInstance, msg
   var f, obj = {
     ociUrl: jspb.Message.getFieldWithDefault(msg, 1, ""),
     environmentVariablesMap: (f = msg.getEnvironmentVariablesMap()) ? f.toObject(includeInstance, undefined) : [],
+    entrypointList: (f = jspb.Message.getRepeatedField(msg, 4)) == null ? undefined : f,
     argumentsList: (f = jspb.Message.getRepeatedField(msg, 3)) == null ? undefined : f
   };
 
@@ -14904,6 +17023,10 @@ proto.hashicorp.waypoint.TaskLaunchInfo.deserializeBinaryFromReader = function(m
         jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "", "");
          });
       break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addEntrypoint(value);
+      break;
     case 3:
       var value = /** @type {string} */ (reader.readString());
       msg.addArguments(value);
@@ -14947,6 +17070,13 @@ proto.hashicorp.waypoint.TaskLaunchInfo.serializeBinaryToWriter = function(messa
   f = message.getEnvironmentVariablesMap(true);
   if (f && f.getLength() > 0) {
     f.serializeBinary(2, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
+  }
+  f = message.getEntrypointList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      4,
+      f
+    );
   }
   f = message.getArgumentsList();
   if (f.length > 0) {
@@ -14996,6 +17126,43 @@ proto.hashicorp.waypoint.TaskLaunchInfo.prototype.getEnvironmentVariablesMap = f
 proto.hashicorp.waypoint.TaskLaunchInfo.prototype.clearEnvironmentVariablesMap = function() {
   this.getEnvironmentVariablesMap().clear();
   return this;};
+
+
+/**
+ * repeated string entrypoint = 4;
+ * @return {!Array<string>}
+ */
+proto.hashicorp.waypoint.TaskLaunchInfo.prototype.getEntrypointList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 4));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.hashicorp.waypoint.TaskLaunchInfo} returns this
+ */
+proto.hashicorp.waypoint.TaskLaunchInfo.prototype.setEntrypointList = function(value) {
+  return jspb.Message.setField(this, 4, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.TaskLaunchInfo} returns this
+ */
+proto.hashicorp.waypoint.TaskLaunchInfo.prototype.addEntrypoint = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 4, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.TaskLaunchInfo} returns this
+ */
+proto.hashicorp.waypoint.TaskLaunchInfo.prototype.clearEntrypointList = function() {
+  return this.setEntrypointList([]);
+};
 
 
 /**
@@ -43970,6 +46137,1107 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     http://goto/soy-param-migration
  * @return {!Object}
  */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.OnDemandRunnerConfig} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    id: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    ociUrl: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    environmentVariablesMap: (f = msg.getEnvironmentVariablesMap()) ? f.toObject(includeInstance, undefined) : [],
+    pluginType: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    pluginConfig: msg.getPluginConfig_asB64(),
+    configFormat: jspb.Message.getFieldWithDefault(msg, 6, 0),
+    pb_default: jspb.Message.getBooleanFieldWithDefault(msg, 7, false)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.OnDemandRunnerConfig;
+  return proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.OnDemandRunnerConfig} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOciUrl(value);
+      break;
+    case 3:
+      var value = msg.getEnvironmentVariablesMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "", "");
+         });
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setPluginType(value);
+      break;
+    case 5:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setPluginConfig(value);
+      break;
+    case 6:
+      var value = /** @type {!proto.hashicorp.waypoint.Project.Format} */ (reader.readEnum());
+      msg.setConfigFormat(value);
+      break;
+    case 7:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setDefault(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.OnDemandRunnerConfig} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getOciUrl();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getEnvironmentVariablesMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(3, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
+  }
+  f = message.getPluginType();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
+  f = message.getPluginConfig_asU8();
+  if (f.length > 0) {
+    writer.writeBytes(
+      5,
+      f
+    );
+  }
+  f = message.getConfigFormat();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      6,
+      f
+    );
+  }
+  f = message.getDefault();
+  if (f) {
+    writer.writeBool(
+      7,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string id = 1;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setId = function(value) {
+  return jspb.Message.setProto3StringField(this, 1, value);
+};
+
+
+/**
+ * optional string oci_url = 2;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getOciUrl = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setOciUrl = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * map<string, string> environment_variables = 3;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getEnvironmentVariablesMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 3, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.clearEnvironmentVariablesMap = function() {
+  this.getEnvironmentVariablesMap().clear();
+  return this;};
+
+
+/**
+ * optional string plugin_type = 4;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getPluginType = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setPluginType = function(value) {
+  return jspb.Message.setProto3StringField(this, 4, value);
+};
+
+
+/**
+ * optional bytes plugin_config = 5;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getPluginConfig = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/**
+ * optional bytes plugin_config = 5;
+ * This is a type-conversion wrapper around `getPluginConfig()`
+ * @return {string}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getPluginConfig_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getPluginConfig()));
+};
+
+
+/**
+ * optional bytes plugin_config = 5;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getPluginConfig()`
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getPluginConfig_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getPluginConfig()));
+};
+
+
+/**
+ * @param {!(string|Uint8Array)} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setPluginConfig = function(value) {
+  return jspb.Message.setProto3BytesField(this, 5, value);
+};
+
+
+/**
+ * optional Project.Format config_format = 6;
+ * @return {!proto.hashicorp.waypoint.Project.Format}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getConfigFormat = function() {
+  return /** @type {!proto.hashicorp.waypoint.Project.Format} */ (jspb.Message.getFieldWithDefault(this, 6, 0));
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.Project.Format} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setConfigFormat = function(value) {
+  return jspb.Message.setProto3EnumField(this, 6, value);
+};
+
+
+/**
+ * optional bool default = 7;
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.getDefault = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 7, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig} returns this
+ */
+proto.hashicorp.waypoint.OnDemandRunnerConfig.prototype.setDefault = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 7, value);
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    config: (f = msg.getConfig()) && proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest;
+  return proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.setConfig(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getConfig();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional OnDemandRunnerConfig config = 1;
+ * @return {?proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.getConfig = function() {
+  return /** @type{?proto.hashicorp.waypoint.OnDemandRunnerConfig} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.OnDemandRunnerConfig, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.OnDemandRunnerConfig|undefined} value
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest} returns this
+*/
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.setConfig = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest} returns this
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.clearConfig = function() {
+  return this.setConfig(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigRequest.prototype.hasConfig = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    config: (f = msg.getConfig()) && proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse;
+  return proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.setConfig(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getConfig();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional OnDemandRunnerConfig config = 1;
+ * @return {?proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.getConfig = function() {
+  return /** @type{?proto.hashicorp.waypoint.OnDemandRunnerConfig} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.OnDemandRunnerConfig, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.OnDemandRunnerConfig|undefined} value
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse} returns this
+*/
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.setConfig = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse} returns this
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.clearConfig = function() {
+  return this.setConfig(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.UpsertOnDemandRunnerConfigResponse.prototype.hasConfig = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    config: (f = msg.getConfig()) && proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest;
+  return proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.setConfig(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getConfig();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional Ref.OnDemandRunnerConfig config = 1;
+ * @return {?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.getConfig = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.OnDemandRunnerConfig|undefined} value
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest} returns this
+*/
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.setConfig = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest} returns this
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.clearConfig = function() {
+  return this.setConfig(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigRequest.prototype.hasConfig = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    config: (f = msg.getConfig()) && proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse;
+  return proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.setConfig(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getConfig();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional OnDemandRunnerConfig config = 1;
+ * @return {?proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.getConfig = function() {
+  return /** @type{?proto.hashicorp.waypoint.OnDemandRunnerConfig} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.OnDemandRunnerConfig, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.OnDemandRunnerConfig|undefined} value
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse} returns this
+*/
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.setConfig = function(value) {
+  return jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse} returns this
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.clearConfig = function() {
+  return this.setConfig(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.GetOnDemandRunnerConfigResponse.prototype.hasConfig = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    configsList: jspb.Message.toObjectList(msg.getConfigsList(),
+    proto.hashicorp.waypoint.OnDemandRunnerConfig.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse;
+  return proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.OnDemandRunnerConfig;
+      reader.readMessage(value,proto.hashicorp.waypoint.OnDemandRunnerConfig.deserializeBinaryFromReader);
+      msg.addConfigs(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getConfigsList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.OnDemandRunnerConfig.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated OnDemandRunnerConfig configs = 1;
+ * @return {!Array<!proto.hashicorp.waypoint.OnDemandRunnerConfig>}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.getConfigsList = function() {
+  return /** @type{!Array<!proto.hashicorp.waypoint.OnDemandRunnerConfig>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.OnDemandRunnerConfig, 1));
+};
+
+
+/**
+ * @param {!Array<!proto.hashicorp.waypoint.OnDemandRunnerConfig>} value
+ * @return {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse} returns this
+*/
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.setConfigsList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.OnDemandRunnerConfig=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.OnDemandRunnerConfig}
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.addConfigs = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.hashicorp.waypoint.OnDemandRunnerConfig, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse} returns this
+ */
+proto.hashicorp.waypoint.ListOnDemandRunnerConfigsResponse.prototype.clearConfigsList = function() {
+  return this.setConfigsList([]);
+};
+
+
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
 proto.hashicorp.waypoint.UpsertPushedArtifactRequest.prototype.toObject = function(opt_includeInstance) {
   return proto.hashicorp.waypoint.UpsertPushedArtifactRequest.toObject(opt_includeInstance, this);
 };
@@ -52307,6 +55575,32 @@ proto.hashicorp.waypoint.GetLatestStatusReportRequest.prototype.hasWorkspace = f
  */
 proto.hashicorp.waypoint.ListStatusReportsRequest.repeatedFields_ = [1];
 
+/**
+ * Oneof group definitions for this message. Each group defines the field
+ * numbers belonging to that group. When of these fields' value is set, all
+ * other fields in the group are cleared. During deserialization, if multiple
+ * fields are encountered for a group, only the last value seen will be kept.
+ * @private {!Array<!Array<number>>}
+ * @const
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.oneofGroups_ = [[5,6]];
+
+/**
+ * @enum {number}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.TargetCase = {
+  TARGET_NOT_SET: 0,
+  DEPLOYMENT: 5,
+  RELEASE: 6
+};
+
+/**
+ * @return {proto.hashicorp.waypoint.ListStatusReportsRequest.TargetCase}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.getTargetCase = function() {
+  return /** @type {proto.hashicorp.waypoint.ListStatusReportsRequest.TargetCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ListStatusReportsRequest.oneofGroups_[0]));
+};
+
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -52342,7 +55636,9 @@ proto.hashicorp.waypoint.ListStatusReportsRequest.toObject = function(includeIns
     proto.hashicorp.waypoint.StatusFilter.toObject, includeInstance),
     order: (f = msg.getOrder()) && proto.hashicorp.waypoint.OperationOrder.toObject(includeInstance, f),
     application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
-    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f)
+    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f),
+    deployment: (f = msg.getDeployment()) && proto.hashicorp.waypoint.Ref.Operation.toObject(includeInstance, f),
+    release: (f = msg.getRelease()) && proto.hashicorp.waypoint.Ref.Operation.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -52398,6 +55694,16 @@ proto.hashicorp.waypoint.ListStatusReportsRequest.deserializeBinaryFromReader = 
       var value = new proto.hashicorp.waypoint.Ref.Workspace;
       reader.readMessage(value,proto.hashicorp.waypoint.Ref.Workspace.deserializeBinaryFromReader);
       msg.setWorkspace(value);
+      break;
+    case 5:
+      var value = new proto.hashicorp.waypoint.Ref.Operation;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Operation.deserializeBinaryFromReader);
+      msg.setDeployment(value);
+      break;
+    case 6:
+      var value = new proto.hashicorp.waypoint.Ref.Operation;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Operation.deserializeBinaryFromReader);
+      msg.setRelease(value);
       break;
     default:
       reader.skipField();
@@ -52458,6 +55764,22 @@ proto.hashicorp.waypoint.ListStatusReportsRequest.serializeBinaryToWriter = func
       4,
       f,
       proto.hashicorp.waypoint.Ref.Workspace.serializeBinaryToWriter
+    );
+  }
+  f = message.getDeployment();
+  if (f != null) {
+    writer.writeMessage(
+      5,
+      f,
+      proto.hashicorp.waypoint.Ref.Operation.serializeBinaryToWriter
+    );
+  }
+  f = message.getRelease();
+  if (f != null) {
+    writer.writeMessage(
+      6,
+      f,
+      proto.hashicorp.waypoint.Ref.Operation.serializeBinaryToWriter
     );
   }
 };
@@ -52609,6 +55931,80 @@ proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.clearWorkspace = fun
  */
 proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.hasWorkspace = function() {
   return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional Ref.Operation deployment = 5;
+ * @return {?proto.hashicorp.waypoint.Ref.Operation}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.getDeployment = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Operation} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Operation, 5));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Operation|undefined} value
+ * @return {!proto.hashicorp.waypoint.ListStatusReportsRequest} returns this
+*/
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.setDeployment = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 5, proto.hashicorp.waypoint.ListStatusReportsRequest.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ListStatusReportsRequest} returns this
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.clearDeployment = function() {
+  return this.setDeployment(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.hasDeployment = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional Ref.Operation release = 6;
+ * @return {?proto.hashicorp.waypoint.Ref.Operation}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.getRelease = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Operation} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Operation, 6));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Operation|undefined} value
+ * @return {!proto.hashicorp.waypoint.ListStatusReportsRequest} returns this
+*/
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.setRelease = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 6, proto.hashicorp.waypoint.ListStatusReportsRequest.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ListStatusReportsRequest} returns this
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.clearRelease = function() {
+  return this.setRelease(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ListStatusReportsRequest.prototype.hasRelease = function() {
+  return jspb.Message.getField(this, 6) != null;
 };
 
 
@@ -53338,7 +56734,7 @@ proto.hashicorp.waypoint.ExpediteStatusReportResponse.prototype.setJobId = funct
  * @private {!Array<number>}
  * @const
  */
-proto.hashicorp.waypoint.StatusReport.repeatedFields_ = [9,12];
+proto.hashicorp.waypoint.StatusReport.repeatedFields_ = [12,9];
 
 /**
  * Oneof group definitions for this message. Each group defines the field
@@ -53405,12 +56801,12 @@ proto.hashicorp.waypoint.StatusReport.toObject = function(includeInstance, msg) 
     id: jspb.Message.getFieldWithDefault(msg, 6, ""),
     statusReport: (f = msg.getStatusReport()) && google_protobuf_any_pb.Any.toObject(includeInstance, f),
     health: (f = msg.getHealth()) && proto.hashicorp.waypoint.StatusReport.Health.toObject(includeInstance, f),
-    resourcesHealthList: jspb.Message.toObjectList(msg.getResourcesHealthList(),
-    proto.hashicorp.waypoint.StatusReport.Health.toObject, includeInstance),
     generatedTime: (f = msg.getGeneratedTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
     external: jspb.Message.getBooleanFieldWithDefault(msg, 11, false),
     resourcesList: jspb.Message.toObjectList(msg.getResourcesList(),
-    proto.hashicorp.waypoint.StatusReport.Resource.toObject, includeInstance)
+    proto.hashicorp.waypoint.StatusReport.Resource.toObject, includeInstance),
+    deprecatedResourcesHealthList: jspb.Message.toObjectList(msg.getDeprecatedResourcesHealthList(),
+    proto.hashicorp.waypoint.StatusReport.Health.toObject, includeInstance)
   };
 
   if (includeInstance) {
@@ -53484,11 +56880,6 @@ proto.hashicorp.waypoint.StatusReport.deserializeBinaryFromReader = function(msg
       reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader);
       msg.setHealth(value);
       break;
-    case 9:
-      var value = new proto.hashicorp.waypoint.StatusReport.Health;
-      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader);
-      msg.addResourcesHealth(value);
-      break;
     case 10:
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
@@ -53502,6 +56893,11 @@ proto.hashicorp.waypoint.StatusReport.deserializeBinaryFromReader = function(msg
       var value = new proto.hashicorp.waypoint.StatusReport.Resource;
       reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Resource.deserializeBinaryFromReader);
       msg.addResources(value);
+      break;
+    case 9:
+      var value = new proto.hashicorp.waypoint.StatusReport.Health;
+      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader);
+      msg.addDeprecatedResourcesHealth(value);
       break;
     default:
       reader.skipField();
@@ -53593,14 +56989,6 @@ proto.hashicorp.waypoint.StatusReport.serializeBinaryToWriter = function(message
       proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter
     );
   }
-  f = message.getResourcesHealthList();
-  if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      9,
-      f,
-      proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter
-    );
-  }
   f = message.getGeneratedTime();
   if (f != null) {
     writer.writeMessage(
@@ -53622,6 +57010,14 @@ proto.hashicorp.waypoint.StatusReport.serializeBinaryToWriter = function(message
       12,
       f,
       proto.hashicorp.waypoint.StatusReport.Resource.serializeBinaryToWriter
+    );
+  }
+  f = message.getDeprecatedResourcesHealthList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      9,
+      f,
+      proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter
     );
   }
 };
@@ -53669,8 +57065,9 @@ proto.hashicorp.waypoint.StatusReport.Resource.toObject = function(includeInstan
     categoryDisplayHint: jspb.Message.getFieldWithDefault(msg, 8, 0),
     createdTime: (f = msg.getCreatedTime()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
     stateJson: jspb.Message.getFieldWithDefault(msg, 10, ""),
-    health: (f = msg.getHealth()) && proto.hashicorp.waypoint.StatusReport.Health.toObject(includeInstance, f),
-    healthMessage: jspb.Message.getFieldWithDefault(msg, 12, "")
+    health: jspb.Message.getFieldWithDefault(msg, 13, 0),
+    healthMessage: jspb.Message.getFieldWithDefault(msg, 12, ""),
+    deprecatedHealth: (f = msg.getDeprecatedHealth()) && proto.hashicorp.waypoint.StatusReport.Health.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -53749,14 +57146,18 @@ proto.hashicorp.waypoint.StatusReport.Resource.deserializeBinaryFromReader = fun
       var value = /** @type {string} */ (reader.readString());
       msg.setStateJson(value);
       break;
-    case 11:
-      var value = new proto.hashicorp.waypoint.StatusReport.Health;
-      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader);
+    case 13:
+      var value = /** @type {!proto.hashicorp.waypoint.StatusReport.Resource.Health} */ (reader.readEnum());
       msg.setHealth(value);
       break;
     case 12:
       var value = /** @type {string} */ (reader.readString());
       msg.setHealthMessage(value);
+      break;
+    case 11:
+      var value = new proto.hashicorp.waypoint.StatusReport.Health;
+      reader.readMessage(value,proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader);
+      msg.setDeprecatedHealth(value);
       break;
     default:
       reader.skipField();
@@ -53860,11 +57261,10 @@ proto.hashicorp.waypoint.StatusReport.Resource.serializeBinaryToWriter = functio
     );
   }
   f = message.getHealth();
-  if (f != null) {
-    writer.writeMessage(
-      11,
-      f,
-      proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter
+  if (f !== 0.0) {
+    writer.writeEnum(
+      13,
+      f
     );
   }
   f = message.getHealthMessage();
@@ -53874,8 +57274,28 @@ proto.hashicorp.waypoint.StatusReport.Resource.serializeBinaryToWriter = functio
       f
     );
   }
+  f = message.getDeprecatedHealth();
+  if (f != null) {
+    writer.writeMessage(
+      11,
+      f,
+      proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter
+    );
+  }
 };
 
+
+/**
+ * @enum {number}
+ */
+proto.hashicorp.waypoint.StatusReport.Resource.Health = {
+  UNKNOWN: 0,
+  ALIVE: 1,
+  READY: 2,
+  DOWN: 3,
+  MISSING: 5,
+  PARTIAL: 4
+};
 
 /**
  * optional string id = 1;
@@ -54096,39 +57516,20 @@ proto.hashicorp.waypoint.StatusReport.Resource.prototype.setStateJson = function
 
 
 /**
- * optional Health health = 11;
- * @return {?proto.hashicorp.waypoint.StatusReport.Health}
+ * optional Health health = 13;
+ * @return {!proto.hashicorp.waypoint.StatusReport.Resource.Health}
  */
 proto.hashicorp.waypoint.StatusReport.Resource.prototype.getHealth = function() {
-  return /** @type{?proto.hashicorp.waypoint.StatusReport.Health} */ (
-    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.StatusReport.Health, 11));
+  return /** @type {!proto.hashicorp.waypoint.StatusReport.Resource.Health} */ (jspb.Message.getFieldWithDefault(this, 13, 0));
 };
 
 
 /**
- * @param {?proto.hashicorp.waypoint.StatusReport.Health|undefined} value
+ * @param {!proto.hashicorp.waypoint.StatusReport.Resource.Health} value
  * @return {!proto.hashicorp.waypoint.StatusReport.Resource} returns this
-*/
+ */
 proto.hashicorp.waypoint.StatusReport.Resource.prototype.setHealth = function(value) {
-  return jspb.Message.setWrapperField(this, 11, value);
-};
-
-
-/**
- * Clears the message field making it undefined.
- * @return {!proto.hashicorp.waypoint.StatusReport.Resource} returns this
- */
-proto.hashicorp.waypoint.StatusReport.Resource.prototype.clearHealth = function() {
-  return this.setHealth(undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.hashicorp.waypoint.StatusReport.Resource.prototype.hasHealth = function() {
-  return jspb.Message.getField(this, 11) != null;
+  return jspb.Message.setProto3EnumField(this, 13, value);
 };
 
 
@@ -54147,6 +57548,43 @@ proto.hashicorp.waypoint.StatusReport.Resource.prototype.getHealthMessage = func
  */
 proto.hashicorp.waypoint.StatusReport.Resource.prototype.setHealthMessage = function(value) {
   return jspb.Message.setProto3StringField(this, 12, value);
+};
+
+
+/**
+ * optional Health deprecated_health = 11;
+ * @return {?proto.hashicorp.waypoint.StatusReport.Health}
+ */
+proto.hashicorp.waypoint.StatusReport.Resource.prototype.getDeprecatedHealth = function() {
+  return /** @type{?proto.hashicorp.waypoint.StatusReport.Health} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.StatusReport.Health, 11));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.StatusReport.Health|undefined} value
+ * @return {!proto.hashicorp.waypoint.StatusReport.Resource} returns this
+*/
+proto.hashicorp.waypoint.StatusReport.Resource.prototype.setDeprecatedHealth = function(value) {
+  return jspb.Message.setWrapperField(this, 11, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.StatusReport.Resource} returns this
+ */
+proto.hashicorp.waypoint.StatusReport.Resource.prototype.clearDeprecatedHealth = function() {
+  return this.setDeprecatedHealth(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.StatusReport.Resource.prototype.hasDeprecatedHealth = function() {
+  return jspb.Message.getField(this, 11) != null;
 };
 
 
@@ -54184,8 +57622,8 @@ proto.hashicorp.waypoint.StatusReport.Health.toObject = function(includeInstance
   var f, obj = {
     healthStatus: jspb.Message.getFieldWithDefault(msg, 1, ""),
     healthMessage: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    name: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    id: jspb.Message.getFieldWithDefault(msg, 4, "")
+    deprecatedName: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    deprecatedId: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -54232,11 +57670,11 @@ proto.hashicorp.waypoint.StatusReport.Health.deserializeBinaryFromReader = funct
       break;
     case 3:
       var value = /** @type {string} */ (reader.readString());
-      msg.setName(value);
+      msg.setDeprecatedName(value);
       break;
     case 4:
       var value = /** @type {string} */ (reader.readString());
-      msg.setId(value);
+      msg.setDeprecatedId(value);
       break;
     default:
       reader.skipField();
@@ -54281,14 +57719,14 @@ proto.hashicorp.waypoint.StatusReport.Health.serializeBinaryToWriter = function(
       f
     );
   }
-  f = message.getName();
+  f = message.getDeprecatedName();
   if (f.length > 0) {
     writer.writeString(
       3,
       f
     );
   }
-  f = message.getId();
+  f = message.getDeprecatedId();
   if (f.length > 0) {
     writer.writeString(
       4,
@@ -54335,10 +57773,10 @@ proto.hashicorp.waypoint.StatusReport.Health.prototype.setHealthMessage = functi
 
 
 /**
- * optional string name = 3;
+ * optional string deprecated_name = 3;
  * @return {string}
  */
-proto.hashicorp.waypoint.StatusReport.Health.prototype.getName = function() {
+proto.hashicorp.waypoint.StatusReport.Health.prototype.getDeprecatedName = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
 };
 
@@ -54347,16 +57785,16 @@ proto.hashicorp.waypoint.StatusReport.Health.prototype.getName = function() {
  * @param {string} value
  * @return {!proto.hashicorp.waypoint.StatusReport.Health} returns this
  */
-proto.hashicorp.waypoint.StatusReport.Health.prototype.setName = function(value) {
+proto.hashicorp.waypoint.StatusReport.Health.prototype.setDeprecatedName = function(value) {
   return jspb.Message.setProto3StringField(this, 3, value);
 };
 
 
 /**
- * optional string id = 4;
+ * optional string deprecated_id = 4;
  * @return {string}
  */
-proto.hashicorp.waypoint.StatusReport.Health.prototype.getId = function() {
+proto.hashicorp.waypoint.StatusReport.Health.prototype.getDeprecatedId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
 };
 
@@ -54365,7 +57803,7 @@ proto.hashicorp.waypoint.StatusReport.Health.prototype.getId = function() {
  * @param {string} value
  * @return {!proto.hashicorp.waypoint.StatusReport.Health} returns this
  */
-proto.hashicorp.waypoint.StatusReport.Health.prototype.setId = function(value) {
+proto.hashicorp.waypoint.StatusReport.Health.prototype.setDeprecatedId = function(value) {
   return jspb.Message.setProto3StringField(this, 4, value);
 };
 
@@ -54646,44 +58084,6 @@ proto.hashicorp.waypoint.StatusReport.prototype.hasHealth = function() {
 
 
 /**
- * repeated Health resources_health = 9;
- * @return {!Array<!proto.hashicorp.waypoint.StatusReport.Health>}
- */
-proto.hashicorp.waypoint.StatusReport.prototype.getResourcesHealthList = function() {
-  return /** @type{!Array<!proto.hashicorp.waypoint.StatusReport.Health>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.StatusReport.Health, 9));
-};
-
-
-/**
- * @param {!Array<!proto.hashicorp.waypoint.StatusReport.Health>} value
- * @return {!proto.hashicorp.waypoint.StatusReport} returns this
-*/
-proto.hashicorp.waypoint.StatusReport.prototype.setResourcesHealthList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 9, value);
-};
-
-
-/**
- * @param {!proto.hashicorp.waypoint.StatusReport.Health=} opt_value
- * @param {number=} opt_index
- * @return {!proto.hashicorp.waypoint.StatusReport.Health}
- */
-proto.hashicorp.waypoint.StatusReport.prototype.addResourcesHealth = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 9, opt_value, proto.hashicorp.waypoint.StatusReport.Health, opt_index);
-};
-
-
-/**
- * Clears the list making it empty but non-null.
- * @return {!proto.hashicorp.waypoint.StatusReport} returns this
- */
-proto.hashicorp.waypoint.StatusReport.prototype.clearResourcesHealthList = function() {
-  return this.setResourcesHealthList([]);
-};
-
-
-/**
  * optional google.protobuf.Timestamp generated_time = 10;
  * @return {?proto.google.protobuf.Timestamp}
  */
@@ -54773,6 +58173,44 @@ proto.hashicorp.waypoint.StatusReport.prototype.addResources = function(opt_valu
  */
 proto.hashicorp.waypoint.StatusReport.prototype.clearResourcesList = function() {
   return this.setResourcesList([]);
+};
+
+
+/**
+ * repeated Health deprecated_resources_health = 9;
+ * @return {!Array<!proto.hashicorp.waypoint.StatusReport.Health>}
+ */
+proto.hashicorp.waypoint.StatusReport.prototype.getDeprecatedResourcesHealthList = function() {
+  return /** @type{!Array<!proto.hashicorp.waypoint.StatusReport.Health>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.hashicorp.waypoint.StatusReport.Health, 9));
+};
+
+
+/**
+ * @param {!Array<!proto.hashicorp.waypoint.StatusReport.Health>} value
+ * @return {!proto.hashicorp.waypoint.StatusReport} returns this
+*/
+proto.hashicorp.waypoint.StatusReport.prototype.setDeprecatedResourcesHealthList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 9, value);
+};
+
+
+/**
+ * @param {!proto.hashicorp.waypoint.StatusReport.Health=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hashicorp.waypoint.StatusReport.Health}
+ */
+proto.hashicorp.waypoint.StatusReport.prototype.addDeprecatedResourcesHealth = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 9, opt_value, proto.hashicorp.waypoint.StatusReport.Health, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.hashicorp.waypoint.StatusReport} returns this
+ */
+proto.hashicorp.waypoint.StatusReport.prototype.clearDeprecatedResourcesHealthList = function() {
+  return this.setDeprecatedResourcesHealthList([]);
 };
 
 
@@ -55681,24 +59119,7 @@ proto.hashicorp.waypoint.LogBatch.prototype.clearLinesList = function() {
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.hashicorp.waypoint.ConfigVar.oneofGroups_ = [[3,4,5],[7,2,6]];
-
-/**
- * @enum {number}
- */
-proto.hashicorp.waypoint.ConfigVar.ScopeCase = {
-  SCOPE_NOT_SET: 0,
-  APPLICATION: 3,
-  PROJECT: 4,
-  RUNNER: 5
-};
-
-/**
- * @return {proto.hashicorp.waypoint.ConfigVar.ScopeCase}
- */
-proto.hashicorp.waypoint.ConfigVar.prototype.getScopeCase = function() {
-  return /** @type {proto.hashicorp.waypoint.ConfigVar.ScopeCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0]));
-};
+proto.hashicorp.waypoint.ConfigVar.oneofGroups_ = [[7,2,6],[3,4,5]];
 
 /**
  * @enum {number}
@@ -55714,7 +59135,24 @@ proto.hashicorp.waypoint.ConfigVar.ValueCase = {
  * @return {proto.hashicorp.waypoint.ConfigVar.ValueCase}
  */
 proto.hashicorp.waypoint.ConfigVar.prototype.getValueCase = function() {
-  return /** @type {proto.hashicorp.waypoint.ConfigVar.ValueCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1]));
+  return /** @type {proto.hashicorp.waypoint.ConfigVar.ValueCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0]));
+};
+
+/**
+ * @enum {number}
+ */
+proto.hashicorp.waypoint.ConfigVar.UnusedScopeCase = {
+  UNUSED_SCOPE_NOT_SET: 0,
+  APPLICATION: 3,
+  PROJECT: 4,
+  RUNNER: 5
+};
+
+/**
+ * @return {proto.hashicorp.waypoint.ConfigVar.UnusedScopeCase}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.getUnusedScopeCase = function() {
+  return /** @type {proto.hashicorp.waypoint.ConfigVar.UnusedScopeCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1]));
 };
 
 
@@ -55748,15 +59186,16 @@ proto.hashicorp.waypoint.ConfigVar.prototype.toObject = function(opt_includeInst
  */
 proto.hashicorp.waypoint.ConfigVar.toObject = function(includeInstance, msg) {
   var f, obj = {
-    application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
-    project: (f = msg.getProject()) && proto.hashicorp.waypoint.Ref.Project.toObject(includeInstance, f),
-    runner: (f = msg.getRunner()) && proto.hashicorp.waypoint.Ref.Runner.toObject(includeInstance, f),
+    target: (f = msg.getTarget()) && proto.hashicorp.waypoint.ConfigVar.Target.toObject(includeInstance, f),
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
     unset: (f = msg.getUnset()) && google_protobuf_empty_pb.Empty.toObject(includeInstance, f),
     pb_static: jspb.Message.getFieldWithDefault(msg, 2, ""),
     dynamic: (f = msg.getDynamic()) && proto.hashicorp.waypoint.ConfigVar.DynamicVal.toObject(includeInstance, f),
     internal: jspb.Message.getBooleanFieldWithDefault(msg, 8, false),
-    nameIsPath: jspb.Message.getBooleanFieldWithDefault(msg, 9, false)
+    nameIsPath: jspb.Message.getBooleanFieldWithDefault(msg, 9, false),
+    application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
+    project: (f = msg.getProject()) && proto.hashicorp.waypoint.Ref.Project.toObject(includeInstance, f),
+    runner: (f = msg.getRunner()) && proto.hashicorp.waypoint.Ref.Runner.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -55793,20 +59232,10 @@ proto.hashicorp.waypoint.ConfigVar.deserializeBinaryFromReader = function(msg, r
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 3:
-      var value = new proto.hashicorp.waypoint.Ref.Application;
-      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Application.deserializeBinaryFromReader);
-      msg.setApplication(value);
-      break;
-    case 4:
-      var value = new proto.hashicorp.waypoint.Ref.Project;
-      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Project.deserializeBinaryFromReader);
-      msg.setProject(value);
-      break;
-    case 5:
-      var value = new proto.hashicorp.waypoint.Ref.Runner;
-      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Runner.deserializeBinaryFromReader);
-      msg.setRunner(value);
+    case 10:
+      var value = new proto.hashicorp.waypoint.ConfigVar.Target;
+      reader.readMessage(value,proto.hashicorp.waypoint.ConfigVar.Target.deserializeBinaryFromReader);
+      msg.setTarget(value);
       break;
     case 1:
       var value = /** @type {string} */ (reader.readString());
@@ -55833,6 +59262,21 @@ proto.hashicorp.waypoint.ConfigVar.deserializeBinaryFromReader = function(msg, r
     case 9:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setNameIsPath(value);
+      break;
+    case 3:
+      var value = new proto.hashicorp.waypoint.Ref.Application;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Application.deserializeBinaryFromReader);
+      msg.setApplication(value);
+      break;
+    case 4:
+      var value = new proto.hashicorp.waypoint.Ref.Project;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Project.deserializeBinaryFromReader);
+      msg.setProject(value);
+      break;
+    case 5:
+      var value = new proto.hashicorp.waypoint.Ref.Runner;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Runner.deserializeBinaryFromReader);
+      msg.setRunner(value);
       break;
     default:
       reader.skipField();
@@ -55863,28 +59307,12 @@ proto.hashicorp.waypoint.ConfigVar.prototype.serializeBinary = function() {
  */
 proto.hashicorp.waypoint.ConfigVar.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getApplication();
+  f = message.getTarget();
   if (f != null) {
     writer.writeMessage(
-      3,
+      10,
       f,
-      proto.hashicorp.waypoint.Ref.Application.serializeBinaryToWriter
-    );
-  }
-  f = message.getProject();
-  if (f != null) {
-    writer.writeMessage(
-      4,
-      f,
-      proto.hashicorp.waypoint.Ref.Project.serializeBinaryToWriter
-    );
-  }
-  f = message.getRunner();
-  if (f != null) {
-    writer.writeMessage(
-      5,
-      f,
-      proto.hashicorp.waypoint.Ref.Runner.serializeBinaryToWriter
+      proto.hashicorp.waypoint.ConfigVar.Target.serializeBinaryToWriter
     );
   }
   f = message.getName();
@@ -55929,6 +59357,30 @@ proto.hashicorp.waypoint.ConfigVar.serializeBinaryToWriter = function(message, w
     writer.writeBool(
       9,
       f
+    );
+  }
+  f = message.getApplication();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      proto.hashicorp.waypoint.Ref.Application.serializeBinaryToWriter
+    );
+  }
+  f = message.getProject();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      proto.hashicorp.waypoint.Ref.Project.serializeBinaryToWriter
+    );
+  }
+  f = message.getRunner();
+  if (f != null) {
+    writer.writeMessage(
+      5,
+      f,
+      proto.hashicorp.waypoint.Ref.Runner.serializeBinaryToWriter
     );
   }
 };
@@ -56097,31 +59549,240 @@ proto.hashicorp.waypoint.ConfigVar.DynamicVal.prototype.clearConfigMap = functio
   return this;};
 
 
+
 /**
- * optional Ref.Application application = 3;
- * @return {?proto.hashicorp.waypoint.Ref.Application}
+ * Oneof group definitions for this message. Each group defines the field
+ * numbers belonging to that group. When of these fields' value is set, all
+ * other fields in the group are cleared. During deserialization, if multiple
+ * fields are encountered for a group, only the last value seen will be kept.
+ * @private {!Array<!Array<number>>}
+ * @const
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.getApplication = function() {
-  return /** @type{?proto.hashicorp.waypoint.Ref.Application} */ (
-    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Application, 3));
+proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_ = [[1,2,3]];
+
+/**
+ * @enum {number}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.AppScopeCase = {
+  APP_SCOPE_NOT_SET: 0,
+  GLOBAL: 1,
+  PROJECT: 2,
+  APPLICATION: 3
+};
+
+/**
+ * @return {proto.hashicorp.waypoint.ConfigVar.Target.AppScopeCase}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getAppScopeCase = function() {
+  return /** @type {proto.hashicorp.waypoint.ConfigVar.Target.AppScopeCase} */(jspb.Message.computeOneofCase(this, proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_[0]));
+};
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * Optional fields that are not set will be set to undefined.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     net/proto2/compiler/js/internal/generator.cc#kKeyword.
+ * @param {boolean=} opt_includeInstance Deprecated. whether to include the
+ *     JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.toObject = function(opt_includeInstance) {
+  return proto.hashicorp.waypoint.ConfigVar.Target.toObject(opt_includeInstance, this);
 };
 
 
 /**
- * @param {?proto.hashicorp.waypoint.Ref.Application|undefined} value
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Deprecated. Whether to include
+ *     the JSPB instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.hashicorp.waypoint.ConfigVar.Target} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    global: (f = msg.getGlobal()) && proto.hashicorp.waypoint.Ref.Global.toObject(includeInstance, f),
+    project: (f = msg.getProject()) && proto.hashicorp.waypoint.Ref.Project.toObject(includeInstance, f),
+    application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
+    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f),
+    labelSelector: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    runner: (f = msg.getRunner()) && proto.hashicorp.waypoint.Ref.Runner.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.hashicorp.waypoint.ConfigVar.Target;
+  return proto.hashicorp.waypoint.ConfigVar.Target.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.hashicorp.waypoint.ConfigVar.Target} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.hashicorp.waypoint.Ref.Global;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Global.deserializeBinaryFromReader);
+      msg.setGlobal(value);
+      break;
+    case 2:
+      var value = new proto.hashicorp.waypoint.Ref.Project;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Project.deserializeBinaryFromReader);
+      msg.setProject(value);
+      break;
+    case 3:
+      var value = new proto.hashicorp.waypoint.Ref.Application;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Application.deserializeBinaryFromReader);
+      msg.setApplication(value);
+      break;
+    case 4:
+      var value = new proto.hashicorp.waypoint.Ref.Workspace;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Workspace.deserializeBinaryFromReader);
+      msg.setWorkspace(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setLabelSelector(value);
+      break;
+    case 6:
+      var value = new proto.hashicorp.waypoint.Ref.Runner;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Runner.deserializeBinaryFromReader);
+      msg.setRunner(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.hashicorp.waypoint.ConfigVar.Target.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.hashicorp.waypoint.ConfigVar.Target} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getGlobal();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.hashicorp.waypoint.Ref.Global.serializeBinaryToWriter
+    );
+  }
+  f = message.getProject();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.hashicorp.waypoint.Ref.Project.serializeBinaryToWriter
+    );
+  }
+  f = message.getApplication();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      proto.hashicorp.waypoint.Ref.Application.serializeBinaryToWriter
+    );
+  }
+  f = message.getWorkspace();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      proto.hashicorp.waypoint.Ref.Workspace.serializeBinaryToWriter
+    );
+  }
+  f = message.getLabelSelector();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
+      f
+    );
+  }
+  f = message.getRunner();
+  if (f != null) {
+    writer.writeMessage(
+      6,
+      f,
+      proto.hashicorp.waypoint.Ref.Runner.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional Ref.Global global = 1;
+ * @return {?proto.hashicorp.waypoint.Ref.Global}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getGlobal = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Global} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Global, 1));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Global|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
 */
-proto.hashicorp.waypoint.ConfigVar.prototype.setApplication = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 3, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setGlobal = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 1, proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_[0], value);
 };
 
 
 /**
  * Clears the message field making it undefined.
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.clearApplication = function() {
-  return this.setApplication(undefined);
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.clearGlobal = function() {
+  return this.setGlobal(undefined);
 };
 
 
@@ -56129,35 +59790,35 @@ proto.hashicorp.waypoint.ConfigVar.prototype.clearApplication = function() {
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.hasApplication = function() {
-  return jspb.Message.getField(this, 3) != null;
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.hasGlobal = function() {
+  return jspb.Message.getField(this, 1) != null;
 };
 
 
 /**
- * optional Ref.Project project = 4;
+ * optional Ref.Project project = 2;
  * @return {?proto.hashicorp.waypoint.Ref.Project}
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.getProject = function() {
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getProject = function() {
   return /** @type{?proto.hashicorp.waypoint.Ref.Project} */ (
-    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Project, 4));
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Project, 2));
 };
 
 
 /**
  * @param {?proto.hashicorp.waypoint.Ref.Project|undefined} value
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
 */
-proto.hashicorp.waypoint.ConfigVar.prototype.setProject = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 4, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setProject = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 2, proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_[0], value);
 };
 
 
 /**
  * Clears the message field making it undefined.
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.clearProject = function() {
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.clearProject = function() {
   return this.setProject(undefined);
 };
 
@@ -56166,35 +59827,127 @@ proto.hashicorp.waypoint.ConfigVar.prototype.clearProject = function() {
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.hasProject = function() {
-  return jspb.Message.getField(this, 4) != null;
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.hasProject = function() {
+  return jspb.Message.getField(this, 2) != null;
 };
 
 
 /**
- * optional Ref.Runner runner = 5;
- * @return {?proto.hashicorp.waypoint.Ref.Runner}
+ * optional Ref.Application application = 3;
+ * @return {?proto.hashicorp.waypoint.Ref.Application}
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.getRunner = function() {
-  return /** @type{?proto.hashicorp.waypoint.Ref.Runner} */ (
-    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Runner, 5));
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getApplication = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Application} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Application, 3));
 };
 
 
 /**
- * @param {?proto.hashicorp.waypoint.Ref.Runner|undefined} value
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * @param {?proto.hashicorp.waypoint.Ref.Application|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
 */
-proto.hashicorp.waypoint.ConfigVar.prototype.setRunner = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 5, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setApplication = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 3, proto.hashicorp.waypoint.ConfigVar.Target.oneofGroups_[0], value);
 };
 
 
 /**
  * Clears the message field making it undefined.
- * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.clearRunner = function() {
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.clearApplication = function() {
+  return this.setApplication(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.hasApplication = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional Ref.Workspace workspace = 4;
+ * @return {?proto.hashicorp.waypoint.Ref.Workspace}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getWorkspace = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Workspace} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Workspace, 4));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Workspace|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setWorkspace = function(value) {
+  return jspb.Message.setWrapperField(this, 4, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.clearWorkspace = function() {
+  return this.setWorkspace(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.hasWorkspace = function() {
+  return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional string label_selector = 5;
+ * @return {string}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getLabelSelector = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setLabelSelector = function(value) {
+  return jspb.Message.setProto3StringField(this, 5, value);
+};
+
+
+/**
+ * optional Ref.Runner runner = 6;
+ * @return {?proto.hashicorp.waypoint.Ref.Runner}
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.getRunner = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Runner} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Runner, 6));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Runner|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.setRunner = function(value) {
+  return jspb.Message.setWrapperField(this, 6, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar.Target} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.clearRunner = function() {
   return this.setRunner(undefined);
 };
 
@@ -56203,8 +59956,45 @@ proto.hashicorp.waypoint.ConfigVar.prototype.clearRunner = function() {
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.hashicorp.waypoint.ConfigVar.prototype.hasRunner = function() {
-  return jspb.Message.getField(this, 5) != null;
+proto.hashicorp.waypoint.ConfigVar.Target.prototype.hasRunner = function() {
+  return jspb.Message.getField(this, 6) != null;
+};
+
+
+/**
+ * optional Target target = 10;
+ * @return {?proto.hashicorp.waypoint.ConfigVar.Target}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.getTarget = function() {
+  return /** @type{?proto.hashicorp.waypoint.ConfigVar.Target} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.ConfigVar.Target, 10));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.ConfigVar.Target|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.prototype.setTarget = function(value) {
+  return jspb.Message.setWrapperField(this, 10, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.clearTarget = function() {
+  return this.setTarget(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.hasTarget = function() {
+  return jspb.Message.getField(this, 10) != null;
 };
 
 
@@ -56241,7 +60031,7 @@ proto.hashicorp.waypoint.ConfigVar.prototype.getUnset = function() {
  * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
 */
 proto.hashicorp.waypoint.ConfigVar.prototype.setUnset = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 7, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+  return jspb.Message.setOneofWrapperField(this, 7, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
 };
 
 
@@ -56277,7 +60067,7 @@ proto.hashicorp.waypoint.ConfigVar.prototype.getStatic = function() {
  * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
  */
 proto.hashicorp.waypoint.ConfigVar.prototype.setStatic = function(value) {
-  return jspb.Message.setOneofField(this, 2, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+  return jspb.Message.setOneofField(this, 2, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
 };
 
 
@@ -56286,7 +60076,7 @@ proto.hashicorp.waypoint.ConfigVar.prototype.setStatic = function(value) {
  * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
  */
 proto.hashicorp.waypoint.ConfigVar.prototype.clearStatic = function() {
-  return jspb.Message.setOneofField(this, 2, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], undefined);
+  return jspb.Message.setOneofField(this, 2, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], undefined);
 };
 
 
@@ -56314,7 +60104,7 @@ proto.hashicorp.waypoint.ConfigVar.prototype.getDynamic = function() {
  * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
 */
 proto.hashicorp.waypoint.ConfigVar.prototype.setDynamic = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 6, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+  return jspb.Message.setOneofWrapperField(this, 6, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[0], value);
 };
 
 
@@ -56369,6 +60159,117 @@ proto.hashicorp.waypoint.ConfigVar.prototype.getNameIsPath = function() {
  */
 proto.hashicorp.waypoint.ConfigVar.prototype.setNameIsPath = function(value) {
   return jspb.Message.setProto3BooleanField(this, 9, value);
+};
+
+
+/**
+ * optional Ref.Application application = 3;
+ * @return {?proto.hashicorp.waypoint.Ref.Application}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.getApplication = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Application} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Application, 3));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Application|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.prototype.setApplication = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 3, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.clearApplication = function() {
+  return this.setApplication(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.hasApplication = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional Ref.Project project = 4;
+ * @return {?proto.hashicorp.waypoint.Ref.Project}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.getProject = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Project} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Project, 4));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Project|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.prototype.setProject = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 4, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.clearProject = function() {
+  return this.setProject(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.hasProject = function() {
+  return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional Ref.Runner runner = 5;
+ * @return {?proto.hashicorp.waypoint.Ref.Runner}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.getRunner = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Runner} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Runner, 5));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Runner|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+*/
+proto.hashicorp.waypoint.ConfigVar.prototype.setRunner = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 5, proto.hashicorp.waypoint.ConfigVar.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigVar} returns this
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.clearRunner = function() {
+  return this.setRunner(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigVar.prototype.hasRunner = function() {
+  return jspb.Message.getField(this, 5) != null;
 };
 
 
@@ -56642,7 +60543,7 @@ proto.hashicorp.waypoint.ConfigSetResponse.serializeBinaryToWriter = function(me
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.hashicorp.waypoint.ConfigGetRequest.oneofGroups_ = [[2,3,4]];
+proto.hashicorp.waypoint.ConfigGetRequest.oneofGroups_ = [[2,3]];
 
 /**
  * @enum {number}
@@ -56650,8 +60551,7 @@ proto.hashicorp.waypoint.ConfigGetRequest.oneofGroups_ = [[2,3,4]];
 proto.hashicorp.waypoint.ConfigGetRequest.ScopeCase = {
   SCOPE_NOT_SET: 0,
   APPLICATION: 2,
-  PROJECT: 3,
-  RUNNER: 4
+  PROJECT: 3
 };
 
 /**
@@ -56695,6 +60595,8 @@ proto.hashicorp.waypoint.ConfigGetRequest.toObject = function(includeInstance, m
     application: (f = msg.getApplication()) && proto.hashicorp.waypoint.Ref.Application.toObject(includeInstance, f),
     project: (f = msg.getProject()) && proto.hashicorp.waypoint.Ref.Project.toObject(includeInstance, f),
     runner: (f = msg.getRunner()) && proto.hashicorp.waypoint.Ref.RunnerId.toObject(includeInstance, f),
+    workspace: (f = msg.getWorkspace()) && proto.hashicorp.waypoint.Ref.Workspace.toObject(includeInstance, f),
+    labelsMap: (f = msg.getLabelsMap()) ? f.toObject(includeInstance, undefined) : [],
     prefix: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
 
@@ -56746,6 +60648,17 @@ proto.hashicorp.waypoint.ConfigGetRequest.deserializeBinaryFromReader = function
       var value = new proto.hashicorp.waypoint.Ref.RunnerId;
       reader.readMessage(value,proto.hashicorp.waypoint.Ref.RunnerId.deserializeBinaryFromReader);
       msg.setRunner(value);
+      break;
+    case 5:
+      var value = new proto.hashicorp.waypoint.Ref.Workspace;
+      reader.readMessage(value,proto.hashicorp.waypoint.Ref.Workspace.deserializeBinaryFromReader);
+      msg.setWorkspace(value);
+      break;
+    case 6:
+      var value = msg.getLabelsMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "", "");
+         });
       break;
     case 1:
       var value = /** @type {string} */ (reader.readString());
@@ -56803,6 +60716,18 @@ proto.hashicorp.waypoint.ConfigGetRequest.serializeBinaryToWriter = function(mes
       f,
       proto.hashicorp.waypoint.Ref.RunnerId.serializeBinaryToWriter
     );
+  }
+  f = message.getWorkspace();
+  if (f != null) {
+    writer.writeMessage(
+      5,
+      f,
+      proto.hashicorp.waypoint.Ref.Workspace.serializeBinaryToWriter
+    );
+  }
+  f = message.getLabelsMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(6, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
   }
   f = message.getPrefix();
   if (f.length > 0) {
@@ -56903,7 +60828,7 @@ proto.hashicorp.waypoint.ConfigGetRequest.prototype.getRunner = function() {
  * @return {!proto.hashicorp.waypoint.ConfigGetRequest} returns this
 */
 proto.hashicorp.waypoint.ConfigGetRequest.prototype.setRunner = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 4, proto.hashicorp.waypoint.ConfigGetRequest.oneofGroups_[0], value);
+  return jspb.Message.setWrapperField(this, 4, value);
 };
 
 
@@ -56923,6 +60848,65 @@ proto.hashicorp.waypoint.ConfigGetRequest.prototype.clearRunner = function() {
 proto.hashicorp.waypoint.ConfigGetRequest.prototype.hasRunner = function() {
   return jspb.Message.getField(this, 4) != null;
 };
+
+
+/**
+ * optional Ref.Workspace workspace = 5;
+ * @return {?proto.hashicorp.waypoint.Ref.Workspace}
+ */
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.getWorkspace = function() {
+  return /** @type{?proto.hashicorp.waypoint.Ref.Workspace} */ (
+    jspb.Message.getWrapperField(this, proto.hashicorp.waypoint.Ref.Workspace, 5));
+};
+
+
+/**
+ * @param {?proto.hashicorp.waypoint.Ref.Workspace|undefined} value
+ * @return {!proto.hashicorp.waypoint.ConfigGetRequest} returns this
+*/
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.setWorkspace = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.hashicorp.waypoint.ConfigGetRequest} returns this
+ */
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.clearWorkspace = function() {
+  return this.setWorkspace(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.hasWorkspace = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * map<string, string> labels = 6;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.getLabelsMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 6, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.hashicorp.waypoint.ConfigGetRequest} returns this
+ */
+proto.hashicorp.waypoint.ConfigGetRequest.prototype.clearLabelsMap = function() {
+  this.getLabelsMap().clear();
+  return this;};
 
 
 /**

--- a/ui/mirage/models/health.ts
+++ b/ui/mirage/models/health.ts
@@ -10,8 +10,6 @@ export default Model.extend({
 
     result.setHealthStatus(this.status);
     result.setHealthMessage(this.message);
-    result.setName(this.name);
-    result.setId(this.id);
 
     return result;
   },

--- a/ui/mirage/models/status-report.ts
+++ b/ui/mirage/models/status-report.ts
@@ -26,7 +26,7 @@ export default Model.extend({
     result.setId(this.id);
     // TODO: result.setStatusReport(value?: google_protobuf_any_pb.Any)
     result.setHealth(this.health?.toProtobuf());
-    result.setResourcesHealthList(this.resourcesHealthList.models.map((h) => h.toProtobuf()));
+    result.setDeprecatedResourcesHealthList(this.resourcesHealthList.models.map((h) => h.toProtobuf()));
 
     return result;
   },

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -36,6 +36,6 @@ export function expediteStatusReport(schema: any, { requestBody }: Request): Res
   // let requestMsg = decode(ExpediteStatusReportRequest, requestBody);
   // let ref = requestMsg.getRef();
   let result = new ExpediteStatusReportResponse();
-  result.setId('JOB_ID');
+  result.setJobId('JOB_ID');
   return this.serialize(result, 'application');
 }


### PR DESCRIPTION
This is not required for any particular bit of work, but will make for cleaner diffs on other PRs.

Tool versions:

| Tool | Version |
| --- | --- |
| libprotoc | [3.17.3](https://github.com/protocolbuffers/protobuf/releases/tag/v3.17.3) |
| ts-protoc-gen | [0.15.0](https://github.com/improbable-eng/ts-protoc-gen/releases/tag/v0.15.0) |

## Not on backporting

I’m deliberately not backporting this one because not all of the new API is on 0.5.x.