### PR TITLE
ui: add type declarations for router.refresh

### DIFF
--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -15,3 +15,15 @@ declare module 'ember-a11y-testing/test-support/audit' {
     axeOptions?: Record<string, unknown>
   ): Promise<void>;
 }
+
+declare module '@ember/routing/router-service' {
+  import Route from '@ember/routing/route';
+
+  type Transition = ReturnType<Route['transitionTo']>;
+
+  export default class RouterService {
+    // This method comes from ember-router-service-refresh-polyfill,
+    // which does not provide its own type declarations.
+    refresh(pivotRouteName?: string): Transition;
+  }
+}


### PR DESCRIPTION
## Why the change?

One step closer to running the linters in CI.

## How do I test it?

Loads the branch up in your editor and check that the type error in [`project-input-variables/list.ts:73`](https://github.com/hashicorp/waypoint/blob/573b25edb0af4b3c5f85d77a8e32871c3a0927ad/ui/app/components/project-input-variables/list.ts#L73) is gone.