### PR TITLE
fix(website): `start` script reloads app on save

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -55,7 +55,7 @@
     "generate:component": "next-hashicorp generate component",
     "generate:readme": "next-hashicorp markdown-blocks README.md",
     "lint": "next-hashicorp lint",
-    "start": "next-remote-watch ./content/**/*.mdx",
+    "start": "next-remote-watch './content/**/*.mdx'",
     "static": "npm run build && npm run export"
   }
 }


### PR DESCRIPTION
# Description
this fixes the website `start` script to reload the app on save of `./content/**/*.mdx` files

🎟 [task](https://app.asana.com/0/1100423001970639/1200899528748349/f)

## Related
- https://github.com/hashicorp/vault/pull/12476
- https://github.com/hashicorp/nomad/pull/11119
- https://github.com/hashicorp/consul/pull/10973
- https://github.com/hashicorp/vagrant/pull/12507
- https://github.com/hashicorp/packer/pull/11244
- https://github.com/hashicorp/sentinel/pull/437
- https://github.com/hashicorp/terraform-website-next/pull/90
- https://github.com/hashicorp/boundary/pull/1499
- https://github.com/hashicorp/waypoint/pull/2193
