### PR TITLE
docs: add details about remote runners on server upgrade

### DIFF
--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -115,7 +115,7 @@ in the future.
 2. Check the help text from running `waypoint server upgrade -help`.
 
 3. Ensure you are in the right server context before upgrading. This can be
-   verified through `waypoint context`.
+   verified through `waypoint context verify`.
 
 4. When ready, run the upgrade command for your given platform. For example:
 
@@ -125,6 +125,8 @@ waypoint server upgrade -platform=kubernetes -auto-approve
 
 This will automatically save a snapshot of the server in your current directory
 prior to upgrading.
+
+If the server was installed with a remote runner, Waypoint will uninstall the existing runner and install a new one with the new version.
 
 ### Client Upgrade
 

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -114,8 +114,10 @@ in the future.
 
 2. Check the help text from running `waypoint server upgrade -help`.
 
-3. Ensure you are in the right server context before upgrading. This can be
-   verified through `waypoint context verify`.
+3. Ensure you are in the right server context before upgrading.
+   Check current context with `waypoint context inspect`. If this is not the intended context to upgrade,
+   run `waypoint context list` and choose the right one with `waypoint context use <name>`.
+   The upgrade automatically runs `waypoint context verify`.
 
 4. When ready, run the upgrade command for your given platform. For example:
 


### PR DESCRIPTION
As the title suggests :)

Though in the process of investigating this, we uncovered that the `-runner` flag is mentioned in the documentation, but missing from the flag list. Another PR coming to fix that.

Follow-up to https://github.com/hashicorp/waypoint/issues/2113