### PR TITLE
ui: fix `flashMessages.error` regression

### DIFF
--- a/ui/app/services/flash-messages.ts
+++ b/ui/app/services/flash-messages.ts
@@ -7,18 +7,19 @@ type FlashFunction = (
   message: FlashFunctionParams[0],
   // This allows the “throw any property you like on the flash object”
   // behavior of ember-cli-flash to type check.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  options?: FlashFunctionParams[1] & Record<string, any>
+  options?: FlashFunctionParams[1] & Record<string, unknown>
 ) => ReturnType<BaseFlashFunction>;
 
 class PdsFlashMessages extends FlashMessages {
   // This is the one custom convenience method we register in
   // config/environment.js.
   //
-  // The superclass will dynamically initialize this method when the
-  // service is created (thus the extra exclamation to reassure
-  // TypeScript).
-  error!: FlashFunction;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  error(..._args: Parameters<FlashFunction>): FlashMessages {
+    // This is a stub implementation. The superclass will dynamically add the
+    // real implementation at runtime.
+    return this;
+  }
 }
 
 export default PdsFlashMessages;


### PR DESCRIPTION
## Why the change?

Fixes a bug introduced by #2174 

## How do I test it?

1. Check out the branch
2. Boot the dev server
3. [Visit `http://localhost:4200/default/marketing-public/settings/variables`](http://localhost:4200/default/marketing-public/settings/variables)
4. Try to add an empty input variable
5. Verify you see an error notification in the lower left