### PR TITLE
ui: fix types for router service

### DIFF
--- a/ui/types/ember/router-service.d.ts
+++ b/ui/types/ember/router-service.d.ts
@@ -1,0 +1,12 @@
+import '@ember/routing/router-service';
+import Route from '@ember/routing/route';
+
+declare module '@ember/routing/router-service' {
+  type Transition = ReturnType<Route['transitionTo']>;
+
+  export default interface RouterService {
+    // This method comes from ember-router-service-refresh-polyfill,
+    // which does not provide its own type declarations.
+    refresh(pivotRouteName?: string): Transition;
+  }
+}

--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -15,15 +15,3 @@ declare module 'ember-a11y-testing/test-support/audit' {
     axeOptions?: Record<string, unknown>
   ): Promise<void>;
 }
-
-declare module '@ember/routing/router-service' {
-  import Route from '@ember/routing/route';
-
-  type Transition = ReturnType<Route['transitionTo']>;
-
-  export default class RouterService {
-    // This method comes from ember-router-service-refresh-polyfill,
-    // which does not provide its own type declarations.
-    refresh(pivotRouteName?: string): Transition;
-  }
-}


### PR DESCRIPTION
## Why the change?

Fixes some type-system breakage I introduced on the first try #2190 

## What does it look like?

<img width="992" alt="CleanShot 2021-09-03 at 22 57 43@2x" src="https://user-images.githubusercontent.com/34030/132064715-7f9de988-f52f-44b9-83b0-b56730a2f890.png">

<img width="949" alt="CleanShot 2021-09-03 at 22 58 00@2x" src="https://user-images.githubusercontent.com/34030/132064718-cefae4e3-940f-4d28-9ed5-21999115a409.png">

## How do I test it?

1. Check out the branch
2. Run the type-checker `cd ui && yarn tsc --noEmit`
3. Verify that there are no type errors related to the router service
4. Open the project in VSCode
5. Open a file such as `project-repository-setting.ts`
6. Verify that calls to `this.router.transitionTo` and `this.router.refresh` both have correct type hints