### PR TITLE
ui: de-lint `<LogStream>`

### DIFF
--- a/ui/app/components/log-stream/index.hbs
+++ b/ui/app/components/log-stream/index.hbs
@@ -20,7 +20,7 @@
             onEnter=(fn (mut this.isFollowingLogs) true)
             onExit=(fn (mut this.isFollowingLogs) false)
           }}
-          {{did-update this.updateScroll this.logLines.length}}
+          {{did-update this.updateScroll this.lines.length}}
         ></div>
       </div>
     </div>


### PR DESCRIPTION
## Why the change?

Another step closer to running eslint in CI.

These are mostly fixes to add type annotations or satisfy TypeScript, with the exception of the template change which genuinely fixes a bug.

## How do I test it?

1. Check out the branch
2. Point the dev server at a local waypoint server (`yarn ember serve local`)
3. Watch the logs for a running deployment
4. Verify the scroll-following works correctly