### PR TITLE
Ignore node_modules directory

### DIFF
--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   extends: 'recommended',
+  ignore: ['node_modules/**'],
 };


### PR DESCRIPTION
This could have been a VSCode issue too, but I started getting `template-lint` errors for addons from the `node_modules` dir. This explicitly ignore the directory.
<img width="1516" alt="Screen Shot 2021-09-06 at 16 51 02" src="https://user-images.githubusercontent.com/1416421/132234866-be195a7d-e143-48fd-adac-0e5fd7e52e4e.png">
