### PR TITLE
internal/server: peeking a job must close the memdb txn

### DIFF
--- a/internal/server/singleprocess/state/job_test.go
+++ b/internal/server/singleprocess/state/job_test.go
@@ -236,8 +236,13 @@ func TestJobAssign(t *testing.T) {
 			Id: "A",
 		})))
 
+		// Should get a peeked job
+		job, err := s.JobPeekForRunner(context.Background(), &pb.Runner{Id: "R_A"})
+		require.NoError(err)
+		require.NotNil(job)
+
 		// Assign it, we should get this build
-		job, err := s.JobAssignForRunner(context.Background(), &pb.Runner{Id: "R_A"})
+		job, err = s.JobAssignForRunner(context.Background(), &pb.Runner{Id: "R_A"})
 		require.NoError(err)
 		require.NotNil(job)
 		require.Equal("A", job.Id)


### PR DESCRIPTION
This fixes a regression caused in #2186 where ODR would never get assigned a job.