### PR TITLE
docker: support for registry auth in deploy

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -718,6 +718,10 @@ func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.U
 
 	ipo := types.ImagePullOptions{}
 
+	if p.config.EncodedAuth != "" {
+		ipo.RegistryAuth = p.config.EncodedAuth
+	}
+	
 	// if the username and password is not null make an authenticated
 	// image pull
 	/*
@@ -812,6 +816,9 @@ type PlatformConfig struct {
 	// TODO Evaluate if this should remain as a default 3000, should be a required field,
 	// or default to another port.
 	ServicePort uint `hcl:"service_port,optional"`
+
+	// Same as encoded_auth for registry config
+	EncodedAuth string `hcl:"encoded_auth,optional"`
 }
 
 type ClientConfig struct {
@@ -948,6 +955,15 @@ deploy {
 			"`DOCKER_API_VERSION` to set the version of the API to reach, leave empty for latest.",
 			"`DOCKER_CERT_PATH` to load the TLS certificates from.",
 			"`DOCKER_TLS_VERIFY` to enable or disable TLS verification, off by default.",
+		),
+	)
+
+	doc.SetField(
+		"encoded_auth",
+		"authentication information for pulling images",
+		docs.Summary(
+			"Similar to `encoded_auth` field for registry -",
+			"base64-encoded JSON with fields `username` and `password`.",
 		),
 	)
 


### PR DESCRIPTION
Hi! This pull request adds encoded_auth setting for docker deploy.

Usage:
```hcl
  deploy {
    use "docker" {
      encoded_auth = base64encode(
        jsonencode({"username": var.dockeruser, "password" : var.dockerpassword})
      )
    }
  }
```

closes #2243