### PR TITLE
Fix overwriting default project model

### DIFF
--- a/.changelog/2250.txt
+++ b/.changelog/2250.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix leaky project repository settings being reused when creating a new project
+```

--- a/ui/app/components/app-form/project-repository-settings.ts
+++ b/ui/app/components/app-form/project-repository-settings.ts
@@ -56,10 +56,12 @@ export default class AppFormProjectRepositorySettings extends Component<ProjectS
   @tracked project: Project.AsObject;
   @tracked authCase: number;
   @tracked serverHcl: boolean;
+  defaultProject: Project.AsObject;
 
   constructor(owner: unknown, args: ProjectSettingsArgs) {
     super(owner, args);
-    this.project = JSON.parse(JSON.stringify(DEFAULT_PROJECT_MODEL)) as Project.AsObject; // to ensure we're doing a deep copy
+    this.defaultProject = JSON.parse(JSON.stringify(DEFAULT_PROJECT_MODEL)) as Project.AsObject; // to ensure we're doing a deep copy
+    this.project = this.defaultProject;
     let { project } = this.args;
     this.populateExistingFields(project, this.project);
     this.authCase = 4;
@@ -128,7 +130,7 @@ export default class AppFormProjectRepositorySettings extends Component<ProjectS
   populateExistingFields(projectFromArgs: Project.AsObject, currentModel: Project.AsObject): void {
     for (let [key, value] of Object.entries(projectFromArgs)) {
       if (isEmpty(value)) {
-        currentModel[key] = DEFAULT_PROJECT_MODEL[key];
+        currentModel[key] = this.defaultProject[key];
         continue;
       }
 

--- a/ui/tests/integration/components/app-form/project-repository-settings-test.ts
+++ b/ui/tests/integration/components/app-form/project-repository-settings-test.ts
@@ -2,8 +2,9 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clearRender, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { Project } from 'waypoint-pb';
 
-module('Integration | Component | app-form/project-settings', function (hooks) {
+module('Integration | Component | app-form/project-repository-settings', function (hooks) {
   setupRenderingTest(hooks);
 
   test('second new project does not have previous input', async function (assert) {
@@ -14,7 +15,7 @@ module('Integration | Component | app-form/project-settings', function (hooks) {
     await fillIn('#git-source-password', 'password');
     await clearRender();
 
-    this.set('project2', {});
+    this.set('project2', new Project().toObject());
     await render(hbs`<AppForm::ProjectRepositorySettings @project={{this.project2}} />`);
 
     assert.dom('#git-source-url').hasValue('');


### PR DESCRIPTION
Fixes: #2150

`populateExistingFields` was mutating the `DEFAULT_PROJECT_MODEL` properties, thus causing the values to be retained when the component was reused. 

This PR sets the `defaultProject` on the component as a static property, and then reads keys from that object in `populateExistingFields`.