### PR TITLE
Set and get new config scopes from the CLI

### DIFF
--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -16,10 +16,12 @@ import (
 type ConfigSetCommand struct {
 	*baseCommand
 
-	flagGlobal  bool
-	flagRunner  bool
-	flagProject string
-	flagScope   string
+	flagGlobal         bool
+	flagRunner         bool
+	flagProject        string
+	flagScope          string
+	flagWorkspaceScope string
+	flagLabelScope     string
 }
 
 func (c *ConfigSetCommand) Run(args []string) int {
@@ -137,6 +139,18 @@ func (c *ConfigSetCommand) Run(args []string) int {
 			}
 		}
 
+		// If we have a workspace flag set, set that.
+		if v := c.flagWorkspaceScope; v != "" {
+			configVar.Target.Workspace = &pb.Ref_Workspace{
+				Workspace: v,
+			}
+		}
+
+		// If we have a label flag set, set that.
+		if v := c.flagLabelScope; v != "" {
+			configVar.Target.LabelSelector = v
+		}
+
 		req.Variables = append(req.Variables, configVar)
 	}
 
@@ -168,6 +182,24 @@ func (c *ConfigSetCommand) Flags() *flag.Sets {
 			Usage: "The name of the project for 'project' or 'app' scopes specified " +
 				"with -scope. This is not required if scope is global or there is " +
 				"a local waypoint.hcl file.",
+			Default: "",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "workspace-scope",
+			Target: &c.flagWorkspaceScope,
+			Usage: "Specify that the configuration is only available within a " +
+				"specific workspace. This configuration will only be set for " +
+				"deployments or operations (if -runner if set) when the workspace " +
+				"matches this.",
+			Default: "",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "label-scope",
+			Target: &c.flagLabelScope,
+			Usage: "If set, configuration will only be set if the deployment " +
+				"or operation (if -runner is set) has a matching label set.",
 			Default: "",
 		})
 

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -171,7 +171,7 @@ func (c *ConfigSetCommand) Flags() *flag.Sets {
 			Name:   "scope",
 			Target: &c.flagScope,
 			Usage: "The scope for this configuration. The configuration will only " +
-				"appear within this scope. This can be one of 'global', 'project', or" +
+				"appear within this scope. This can be one of 'global', 'project', or " +
 				"'app'.",
 			Default: "project",
 		})

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -20,8 +20,25 @@ Usage: `waypoint config get [prefix]`
 Retrieve and print all config variables previously configured that have
 the given prefix. If no prefix is given, all variables are returned.
 
-By specifying the "-app" flag you can look at config variables for
-a specific application rather than the project.
+The output of this command depends on whether an exact application is
+specified or not. If no app is specified with "-app", this will list
+all POSSIBLE config vars that could be set for an application. It is
+the list of "possible" variables because some are dependent on the application
+name, workspace, or labels.
+
+By specifying the "-app" flag you can look at config variables that
+would be resolved for a specific application. This will never show duplicate
+variables and will show the full resolved list of variables that will be
+set for a specific application. This will default to a workspace of "default"
+and empty labels.
+
+To further simulate what config variables an application would receive,
+you may specify the "-workspace" flag or the "-label" flag (repeatedly)
+to set the label context.
+
+The "-runner" flag can be specified to show the list of variables that
+would be set for a runner. All of the above filtering applies to runners,
+as well.
 
 #### Global Options
 
@@ -34,5 +51,7 @@ a specific application rather than the project.
 - `-json` - Output in JSON
 - `-raw` - Output in key=val
 - `-runner` - Show configuration that is set on runners. This will not show any configuration that is set on any applications. This only includes configuration set with the -runner flag.
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-project=<string>` - The name of the project for 'project' or 'app' scopes specified with -scope. This is not required if scope is global or there is a local waypoint.hcl file.
 
 @include "commands/config-get_more.mdx"

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -31,7 +31,7 @@ Specify the "-app" flag to set a config variable for a specific app.
 
 #### Command Options
 
-- `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or'app'.
+- `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or 'app'.
 - `-project=<string>` - The name of the project for 'project' or 'app' scopes specified with -scope. This is not required if scope is global or there is a local waypoint.hcl file.
 - `-workspace-scope=<string>` - Specify that the configuration is only available within a specific workspace. This configuration will only be set for deployments or operations (if -runner if set) when the workspace matches this.
 - `-label-scope=<string>` - If set, configuration will only be set if the deployment or operation (if -runner is set) has a matching label set.

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -31,6 +31,10 @@ Specify the "-app" flag to set a config variable for a specific app.
 
 #### Command Options
 
-- `-runner` - Expose this configuration on runners. This can be used to set things such as credentials to cloud platforms for remote runners. This configuration will not be exposed to deployed applications.
+- `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or'app'.
+- `-project=<string>` - The name of the project for 'project' or 'app' scopes specified with -scope. This is not required if scope is global or there is a local waypoint.hcl file.
+- `-workspace-scope=<string>` - Specify that the configuration is only available within a specific workspace. This configuration will only be set for deployments or operations (if -runner if set) when the workspace matches this.
+- `-label-scope=<string>` - If set, configuration will only be set if the deployment or operation (if -runner is set) has a matching label set.
+- `-runner` - Expose this configuration on runners. This can be used to set things such as credentials to cloud platforms for remote runners. This configuration will not be exposed to deployed applications. If this is specified in the context of a project, this will apply only to runners operating on jobs for the specific project or application.
 
 @include "commands/config-set_more.mdx"


### PR DESCRIPTION
This PR finishes up the coding part of #2169. This modifies the CLI to support all the new scoping options. 

I admit this isn't the cleanest UX possible. I'd love to challenge this a bit more with folks in the future and figure out how we can maybe make the `waypoint config` CLIs a little easier to use perhaps. Right now you gotta balance a bunch of flags.My counter argument is people probably won't use the CLI for more advanced config setting and will prefer to use the config file or UI (tbd). 

In terms of the bigger picture #2169, I need to work up docs still. But this should finish all the main coding parts. 