### PR TITLE
ui: upgrade typescript to 4.4.2

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -110,7 +110,7 @@
     "qunit": "^2.13.0",
     "qunit-dom": "^1.6.0",
     "sass": "^1.26.10",
-    "typescript": "^3.9.6",
+    "typescript": "^4.4.2",
     "ua-parser-js": "^0.7.24",
     "webpack-bundle-analyzer": "^3.8.0"
   },

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -16388,10 +16388,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 ua-parser-js@^0.7.24:
   version "0.7.24"


### PR DESCRIPTION
## Why the change?

This is a speculative fix for #2260. See investigation notes on that issue for more details.

## It’s a major version bump? Is that scary?

[The breaking changes in 4.0](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#breaking-changes) are not so bad, so I think this is a safe upgrade.

## How do I test it?

Check out the repo and try building, running, testing the repo. Verify nothing breaks and no new weird compiler warnings appear. CI should give a pretty good indication of this but the interaction between VS Code and TypeScript might cause new interesting stuff to happen.