### PR TITLE
truncate display of long variable values

### DIFF
--- a/ui/app/styles/components/variables-list.scss
+++ b/ui/app/styles/components/variables-list.scss
@@ -19,6 +19,15 @@
   .variables--list-item-value {
     width: 30%;
     margin-right: auto;
+    & > pre {
+      line-height: initial;
+      & > code {
+        max-width: 320px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
   }
   .variables--list-item-name-is-path {
     width: 15%;


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/2191 

<img width="1211" alt="Screen Shot 2021-09-09 at 18 30 37" src="https://user-images.githubusercontent.com/1416421/132725961-468ba528-27e8-40ff-ae4d-8d8c09faf310.png">
