### PR TITLE
internal/server: Add API validation for GetDeployment endpoint

### DIFF
--- a/.changelog/2269.txt
+++ b/.changelog/2269.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+server: Validate GetDeployment request has a valid request body to avoid a server
+panic.
+```

--- a/internal/server/ptypes/deployment.go
+++ b/internal/server/ptypes/deployment.go
@@ -3,6 +3,8 @@ package ptypes
 import (
 	"strconv"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
@@ -21,4 +23,14 @@ func (v *Deployment) URLFragment() string {
 	}
 
 	return "v" + strconv.FormatUint(seq, 10)
+}
+
+// ValidateGetDeploymentRequest
+func ValidateGetDeploymentRequest(v *pb.GetDeploymentRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Ref, validation.Required),
+		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
+			return ValidateRefOperationRules(v.Ref)
+		}),
+	))
 }

--- a/internal/server/ptypes/ref.go
+++ b/internal/server/ptypes/ref.go
@@ -1,8 +1,7 @@
 package ptypes
 
 import (
-	"github.com/go-ozzo/ozzo-validation/v4"
-
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
@@ -10,5 +9,12 @@ import (
 func ValidateRefWorkspaceRules(v *pb.Ref_Workspace) []*validation.FieldRules {
 	return []*validation.FieldRules{
 		validation.Field(&v.Workspace, validation.Required),
+	}
+}
+
+// ValidateRefOperationRules
+func ValidateRefOperationRules(v *pb.Ref_Operation) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Target, validation.Required),
 	}
 }

--- a/internal/server/singleprocess/service_deploy.go
+++ b/internal/server/singleprocess/service_deploy.go
@@ -117,6 +117,10 @@ func (s *service) GetDeployment(
 	ctx context.Context,
 	req *pb.GetDeploymentRequest,
 ) (*pb.Deployment, error) {
+	if err := ptypes.ValidateGetDeploymentRequest(req); err != nil {
+		return nil, err
+	}
+
 	d, err := s.state.DeploymentGet(req.Ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Prior to this commit, if a request left out a request body, the server
would panic and shut down. This commit fixes that by adding a validation
step first to ensure the request is properly formed prior to handling
it.

Fixes #1682

With the new validation:

```
brian@localghost:static λ docker run -it --network host fullstorydev/grpcurl --insecure -H "client-api-protocol: 1,1" -H "Authorization: `waypoint user token`" localhost:9701 hashicorp.waypoint.Waypoint/GetDeployment
ERROR:
  Code: InvalidArgument
  Message: ref: cannot be blank.
  Details:
  1)    {"@type":"type.googleapis.com/google.rpc.BadRequest","fieldViolations":[{"field":"ref","description":"cannot be blank"}]}
```

Before, you would get this and the server would panic and exit:

```
brian@localghost:static λ docker run -it --network host fullstorydev/grpcurl --insecure -H "client-api-protocol: 1,1" -H "Authorization: `waypoint user token`" localhost:9701 hashicorp.waypoint.Waypoint/GetDeployment
ERROR:
  Code: Unavailable
  Message: transport is closing
```