### PR TITLE
internal/server: Add many validations to authenticated endpoints

### DIFF
--- a/.changelog/2273.txt
+++ b/.changelog/2273.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+server: Adds API validation to ensure server doesn't panic when given an empty
+request body
+```

--- a/internal/server/ptypes/application.go
+++ b/internal/server/ptypes/application.go
@@ -1,10 +1,12 @@
 package ptypes
 
 import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
@@ -25,4 +27,12 @@ func TestApplication(t testing.T, src *pb.Application) *pb.Application {
 	}))
 
 	return src
+}
+
+// ValidateUpsertApplicationRequest
+func ValidateUpsertApplicationRequest(v *pb.UpsertApplicationRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Project, validation.Required),
+		validation.Field(&v.Name, validation.Required),
+	))
 }

--- a/internal/server/ptypes/artifact.go
+++ b/internal/server/ptypes/artifact.go
@@ -10,31 +10,33 @@ import (
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-// TestBuild returns a valid user for tests.
-func TestBuild(t testing.T, src *pb.Build) *pb.Build {
+// TestArtifact returns a valid user for tests.
+func TestArtifact(t testing.T, src *pb.PushedArtifact) *pb.PushedArtifact {
 	t.Helper()
 
 	if src == nil {
-		src = &pb.Build{}
+		src = &pb.PushedArtifact{}
 	}
 
-	require.NoError(t, mergo.Merge(src, &pb.Build{
+	require.NoError(t, mergo.Merge(src, &pb.PushedArtifact{
 		Id: "test",
 	}))
 
 	return src
 }
 
-// ValidateBuild validates the user structure.
-func ValidateBuild(v *pb.Build) error {
+// ValidatePushedArtifact validates the user structure.
+func ValidatePushedArtifact(v *pb.PushedArtifact) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		ValidateBuildRules(v)...,
+		ValidatePushedArtifactRules(v)...,
 	))
 }
 
-// ValidateBuildRules
-func ValidateBuildRules(v *pb.Build) []*validation.FieldRules {
+// ValidatePushedArtifactRules
+func ValidatePushedArtifactRules(v *pb.PushedArtifact) []*validation.FieldRules {
 	return []*validation.FieldRules{
+		validation.Field(&v.Artifact, validation.Required),
+
 		validationext.StructField(&v.Application, func() []*validation.FieldRules {
 			return []*validation.FieldRules{
 				validation.Field(&v.Application.Application, validation.Required),
@@ -50,18 +52,15 @@ func ValidateBuildRules(v *pb.Build) []*validation.FieldRules {
 	}
 }
 
-// ValidateGetBuildRequest
-func ValidateGetBuildRequest(v *pb.GetBuildRequest) error {
+// ValidateUpsertArtifactRequest
+func ValidateUpsertPushedArtifactRequest(v *pb.UpsertPushedArtifactRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validation.Field(&v.Ref, validation.Required),
-		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
-			return ValidateRefOperationRules(v.Ref)
-		}),
+		validation.Field(&v.Artifact, validation.Required),
 	))
 }
 
-// ValidateListBuildsRequest
-func ValidateListBuildsRequest(v *pb.ListBuildsRequest) error {
+// ValidateListPushedArtifactsRequest
+func ValidateListPushedArtifactsRequest(v *pb.ListPushedArtifactsRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
 		validationext.StructField(&v.Application, func() []*validation.FieldRules {
 			return []*validation.FieldRules{
@@ -71,19 +70,19 @@ func ValidateListBuildsRequest(v *pb.ListBuildsRequest) error {
 		})))
 }
 
-// ValidateGetLatestBuildRequest
-func ValidateGetLatestBuildRequest(v *pb.GetLatestBuildRequest) error {
+// ValidateGetLatestPushedArtifactRequest
+func ValidateGetLatestPushedArtifactRequest(v *pb.GetLatestPushedArtifactRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
 		validation.Field(&v.Application, validation.Required),
 	))
 }
 
-// ValidateUpsertBuildRequest
-func ValidateUpsertBuildRequest(v *pb.UpsertBuildRequest) error {
+// ValidateGetPushedArtifactRequest
+func ValidateGetPushedArtifactRequest(v *pb.GetPushedArtifactRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validation.Field(&v.Build, validation.Required),
-		validationext.StructField(&v.Build, func() []*validation.FieldRules {
-			return ValidateBuildRules(v.Build)
+		validation.Field(&v.Ref, validation.Required),
+		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
+			return ValidateRefOperationRules(v.Ref)
 		}),
 	))
 }

--- a/internal/server/ptypes/auth_method.go
+++ b/internal/server/ptypes/auth_method.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"go/token"
 
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/hashicorp/go-bexpr"
 	"github.com/imdario/mergo"
@@ -85,6 +85,13 @@ func ValidateUpsertAuthMethodRequest(v *pb.UpsertAuthMethodRequest) error {
 
 // ValidateDeleteAuthMethodRequest
 func ValidateDeleteAuthMethodRequest(v *pb.DeleteAuthMethodRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.AuthMethod, validation.Required),
+	))
+}
+
+// ValidateGetAuthMethodRequest
+func ValidateGetAuthMethodRequest(v *pb.GetAuthMethodRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
 		validation.Field(&v.AuthMethod, validation.Required),
 	))

--- a/internal/server/ptypes/build.go
+++ b/internal/server/ptypes/build.go
@@ -35,10 +35,6 @@ func ValidateBuild(v *pb.Build) error {
 // ValidateBuildRules
 func ValidateBuildRules(v *pb.Build) []*validation.FieldRules {
 	return []*validation.FieldRules{
-		validation.Field(&v.Id, validation.Required),
-
-		validation.Field(&v.Sequence, validation.When(v.Id == "", validation.Required).Else(validation.Nil)),
-
 		validationext.StructField(&v.Application, func() []*validation.FieldRules {
 			return []*validation.FieldRules{
 				validation.Field(&v.Application.Application, validation.Required),
@@ -89,6 +85,16 @@ func ValidateGetLatestBuildRequest(v *pb.GetLatestBuildRequest) error {
 			return []*validation.FieldRules{
 				validation.Field(&v.Workspace.Workspace, validation.Required),
 			}
+		}),
+	))
+}
+
+// ValidateUpsertBuildRequest
+func ValidateUpsertBuildRequest(v *pb.UpsertBuildRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Build, validation.Required),
+		validationext.StructField(&v.Build, func() []*validation.FieldRules {
+			return ValidateBuildRules(v.Build)
 		}),
 	))
 }

--- a/internal/server/ptypes/build.go
+++ b/internal/server/ptypes/build.go
@@ -1,0 +1,94 @@
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// TestBuild returns a valid user for tests.
+func TestBuild(t testing.T, src *pb.Build) *pb.Build {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.Build{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.Build{
+		Id: "test",
+	}))
+
+	return src
+}
+
+// ValidateBuild validates the user structure.
+func ValidateBuild(v *pb.Build) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		ValidateBuildRules(v)...,
+	))
+}
+
+// ValidateBuildRules
+func ValidateBuildRules(v *pb.Build) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Id, validation.Required),
+
+		validation.Field(&v.Sequence, validation.When(v.Id == "", validation.Required).Else(validation.Nil)),
+
+		validationext.StructField(&v.Application, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Application.Application, validation.Required),
+				validation.Field(&v.Application.Project, validation.Required),
+			}
+		}),
+
+		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Workspace.Workspace, validation.Required),
+			}
+		}),
+	}
+}
+
+// ValidateGetBuildRequest
+func ValidateGetBuildRequest(v *pb.GetBuildRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Ref, validation.Required),
+		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
+			return ValidateRefOperationRules(v.Ref)
+		}),
+	))
+}
+
+// ValidateListBuildsRequest
+func ValidateListBuildsRequest(v *pb.ListBuildsRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validationext.StructField(&v.Application, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Application.Application, validation.Required),
+				validation.Field(&v.Application.Project, validation.Required),
+			}
+		})))
+}
+
+// ValidateGetLatestBuildRequest
+func ValidateGetLatestBuildRequest(v *pb.GetLatestBuildRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validationext.StructField(&v.Application, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Application.Application, validation.Required),
+				validation.Field(&v.Application.Project, validation.Required),
+			}
+		}),
+
+		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Workspace.Workspace, validation.Required),
+			}
+		}),
+	))
+}

--- a/internal/server/ptypes/build.go
+++ b/internal/server/ptypes/build.go
@@ -74,18 +74,8 @@ func ValidateListBuildsRequest(v *pb.ListBuildsRequest) error {
 // ValidateGetLatestBuildRequest
 func ValidateGetLatestBuildRequest(v *pb.GetLatestBuildRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validationext.StructField(&v.Application, func() []*validation.FieldRules {
-			return []*validation.FieldRules{
-				validation.Field(&v.Application.Application, validation.Required),
-				validation.Field(&v.Application.Project, validation.Required),
-			}
-		}),
-
-		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
-			return []*validation.FieldRules{
-				validation.Field(&v.Workspace.Workspace, validation.Required),
-			}
-		}),
+		validation.Field(&v.Application, validation.Required),
+		validation.Field(&v.Workspace, validation.Required),
 	))
 }
 

--- a/internal/server/ptypes/config.go
+++ b/internal/server/ptypes/config.go
@@ -1,0 +1,28 @@
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// ValidateSetConfigSourceRequest
+func ValidateSetConfigSourceRequest(v *pb.SetConfigSourceRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.ConfigSource, validation.Required),
+	))
+}
+
+// ValidateGetConfigRequest
+func ValidateGetConfigRequest(v *pb.ConfigGetRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Scope, validation.Required),
+	))
+}
+
+// ValidateGetConfigRequest
+func ValidateGetConfigSourceRequest(v *pb.GetConfigSourceRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Scope, validation.Required),
+	))
+}

--- a/internal/server/ptypes/deployment.go
+++ b/internal/server/ptypes/deployment.go
@@ -6,7 +6,25 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
 )
+
+// TestDeployment returns a valid project for tests.
+func TestDeployment(t testing.T, src *pb.Deployment) *pb.Deployment {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.Deployment{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.Deployment{
+		Id: "test",
+	}))
+
+	return src
+}
 
 // Type wrapper around the proto type so that we can add some methods.
 type Deployment struct{ *pb.Deployment }
@@ -23,6 +41,31 @@ func (v *Deployment) URLFragment() string {
 	}
 
 	return "v" + strconv.FormatUint(seq, 10)
+}
+
+// ValidateDeployment validates the project structure.
+func ValidateDeployment(v *pb.Deployment) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		ValidateDeploymentRules(v)...,
+	))
+}
+
+// ValidateDeploymentRules
+func ValidateDeploymentRules(v *pb.Deployment) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Application, validation.Required),
+		validation.Field(&v.Workspace, validation.Required),
+	}
+}
+
+// ValidateUpsertDeploymentRequest
+func ValidateUpsertDeploymentRequest(v *pb.UpsertDeploymentRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Deployment, validation.Required),
+		validationext.StructField(&v.Deployment, func() []*validation.FieldRules {
+			return ValidateDeploymentRules(v.Deployment)
+		}),
+	))
 }
 
 // ValidateGetDeploymentRequest

--- a/internal/server/ptypes/hostname.go
+++ b/internal/server/ptypes/hostname.go
@@ -1,0 +1,15 @@
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// ValidateCreateHostnameRequest
+func ValidateCreateHostnameRequest(v *pb.CreateHostnameRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Hostname, validation.Required),
+		validation.Field(&v.Target, validation.Required),
+	))
+}

--- a/internal/server/ptypes/hostname.go
+++ b/internal/server/ptypes/hostname.go
@@ -9,7 +9,6 @@ import (
 // ValidateCreateHostnameRequest
 func ValidateCreateHostnameRequest(v *pb.CreateHostnameRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validation.Field(&v.Hostname, validation.Required),
 		validation.Field(&v.Target, validation.Required),
 	))
 }

--- a/internal/server/ptypes/job.go
+++ b/internal/server/ptypes/job.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -50,6 +50,7 @@ func TestJobNew(t testing.T, src *pb.Job) *pb.Job {
 }
 
 // ValidateJob validates the job structure.
+// TODO: This still fails if the job passed in to be validated is nil
 func ValidateJob(job *pb.Job) error {
 	return validationext.Error(validation.ValidateStruct(job,
 		validation.Field(&job.Id, validation.By(isEmpty)),

--- a/internal/server/ptypes/ondemand_runner.go
+++ b/internal/server/ptypes/ondemand_runner.go
@@ -61,6 +61,13 @@ func ValidateUpsertOnDemandRunnerConfigRequest(v *pb.UpsertOnDemandRunnerConfigR
 	))
 }
 
+// ValidateGetOnDemandRunnerConfigRequest
+func ValidateGetOnDemandRunnerConfigRequest(v *pb.GetOnDemandRunnerConfigRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Config, validation.Required),
+	))
+}
+
 func isPluginHcl(p *pb.OnDemandRunnerConfig) validation.Rule {
 	return validation.By(func(_ interface{}) error {
 		if len(p.PluginConfig) == 0 {

--- a/internal/server/ptypes/project.go
+++ b/internal/server/ptypes/project.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
@@ -78,6 +78,13 @@ func ValidateUpsertProjectRequest(v *pb.UpsertProjectRequest) error {
 		validationext.StructField(&v.Project, func() []*validation.FieldRules {
 			return ValidateProjectRules(v.Project)
 		}),
+	))
+}
+
+// ValidateGetProjectRequest
+func ValidateGetProjectRequest(v *pb.GetProjectRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Project, validation.Required),
 	))
 }
 

--- a/internal/server/ptypes/project.go
+++ b/internal/server/ptypes/project.go
@@ -88,6 +88,13 @@ func ValidateGetProjectRequest(v *pb.GetProjectRequest) error {
 	))
 }
 
+// ValidateGetProjectRequest
+func ValidateUIGetProjectRequest(v *pb.UI_GetProjectRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Project, validation.Required),
+	))
+}
+
 func isWaypointHcl(p *pb.Project) validation.Rule {
 	return validation.By(func(_ interface{}) error {
 		if len(p.WaypointHcl) == 0 {

--- a/internal/server/ptypes/project.go
+++ b/internal/server/ptypes/project.go
@@ -88,7 +88,7 @@ func ValidateGetProjectRequest(v *pb.GetProjectRequest) error {
 	))
 }
 
-// ValidateGetProjectRequest
+// ValidateUIGetProjectRequest
 func ValidateUIGetProjectRequest(v *pb.UI_GetProjectRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
 		validation.Field(&v.Project, validation.Required),

--- a/internal/server/ptypes/release.go
+++ b/internal/server/ptypes/release.go
@@ -1,0 +1,31 @@
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// ValidateGetReleaseRequest
+func ValidateGetReleaseRequest(v *pb.GetReleaseRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Ref, validation.Required),
+		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
+			return ValidateRefOperationRules(v.Ref)
+		}),
+	))
+}
+
+// ValidateGetLatestReleaseRequest
+func ValidateGetLatestReleaseRequest(v *pb.GetLatestReleaseRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Application, validation.Required),
+	))
+}
+
+// ValidateUpsertArtifactRequest
+func ValidateUpsertReleaseRequest(v *pb.UpsertReleaseRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Release, validation.Required),
+	))
+}

--- a/internal/server/ptypes/server_config.go
+++ b/internal/server/ptypes/server_config.go
@@ -1,7 +1,7 @@
 package ptypes
 
 import (
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -28,6 +28,7 @@ func TestServerConfig(t testing.T, src *pb.ServerConfig) *pb.ServerConfig {
 }
 
 // ValidateServerConfig validates the server config structure.
+// TODO: This still panics if the server config is nil
 func ValidateServerConfig(c *pb.ServerConfig) error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.AdvertiseAddrs, validation.Required, validation.Length(1, 1)),

--- a/internal/server/ptypes/status_report.go
+++ b/internal/server/ptypes/status_report.go
@@ -1,0 +1,90 @@
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+)
+
+// TestStatusReport returns a valid user for tests.
+func TestStatusReport(t testing.T, src *pb.StatusReport) *pb.StatusReport {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.StatusReport{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.StatusReport{
+		Id: "test",
+	}))
+
+	return src
+}
+
+// ValidateStatusReport validates the user structure.
+func ValidateStatusReport(v *pb.StatusReport) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		ValidateStatusReportRules(v)...,
+	))
+}
+
+// ValidateStatusReportRules
+func ValidateStatusReportRules(v *pb.StatusReport) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.TargetId, validation.Required),
+		validation.Field(&v.Health, validation.Required),
+
+		validationext.StructField(&v.Application, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Application.Application, validation.Required),
+				validation.Field(&v.Application.Project, validation.Required),
+			}
+		}),
+
+		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Workspace.Workspace, validation.Required),
+			}
+		}),
+	}
+}
+
+// ValidateUpsertArtifactRequest
+func ValidateUpsertStatusReportRequest(v *pb.UpsertStatusReportRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.StatusReport, validation.Required),
+	))
+}
+
+// ValidateListStatusReportsRequest
+func ValidateListStatusReportsRequest(v *pb.ListStatusReportsRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Target, validation.Required),
+		validationext.StructField(&v.Application, func() []*validation.FieldRules {
+			return []*validation.FieldRules{
+				validation.Field(&v.Application.Application, validation.Required),
+				validation.Field(&v.Application.Project, validation.Required),
+			}
+		})))
+}
+
+// ValidateGetLatestStatusReportRequest
+func ValidateGetLatestStatusReportRequest(v *pb.GetLatestStatusReportRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Application, validation.Required),
+	))
+}
+
+// ValidateGetStatusReportRequest
+func ValidateGetStatusReportRequest(v *pb.GetStatusReportRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Ref, validation.Required),
+		validationext.StructField(&v.Ref, func() []*validation.FieldRules {
+			return ValidateRefOperationRules(v.Ref)
+		}),
+	))
+}

--- a/internal/server/ptypes/status_report.go
+++ b/internal/server/ptypes/status_report.go
@@ -63,7 +63,6 @@ func ValidateUpsertStatusReportRequest(v *pb.UpsertStatusReportRequest) error {
 // ValidateListStatusReportsRequest
 func ValidateListStatusReportsRequest(v *pb.ListStatusReportsRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validation.Field(&v.Target, validation.Required),
 		validationext.StructField(&v.Application, func() []*validation.FieldRules {
 			return []*validation.FieldRules{
 				validation.Field(&v.Application.Application, validation.Required),

--- a/internal/server/singleprocess/service_artifact.go
+++ b/internal/server/singleprocess/service_artifact.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -15,6 +16,10 @@ func (s *service) UpsertPushedArtifact(
 	ctx context.Context,
 	req *pb.UpsertPushedArtifactRequest,
 ) (*pb.UpsertPushedArtifactResponse, error) {
+	if err := serverptypes.ValidateUpsertPushedArtifactRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.Artifact
 
 	// If we have no ID, then we're inserting and need to generate an ID.
@@ -41,6 +46,10 @@ func (s *service) ListPushedArtifacts(
 	ctx context.Context,
 	req *pb.ListPushedArtifactsRequest,
 ) (*pb.ListPushedArtifactsResponse, error) {
+	if err := serverptypes.ValidateListPushedArtifactsRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.ArtifactList(req.Application,
 		state.ListWithStatusFilter(req.Status...),
 		state.ListWithOrder(req.Order),
@@ -74,6 +83,10 @@ func (s *service) GetLatestPushedArtifact(
 	ctx context.Context,
 	req *pb.GetLatestPushedArtifactRequest,
 ) (*pb.PushedArtifact, error) {
+	if err := serverptypes.ValidateGetLatestPushedArtifactRequest(req); err != nil {
+		return nil, err
+	}
+
 	return s.state.ArtifactLatest(req.Application, req.Workspace)
 }
 
@@ -82,5 +95,9 @@ func (s *service) GetPushedArtifact(
 	ctx context.Context,
 	req *pb.GetPushedArtifactRequest,
 ) (*pb.PushedArtifact, error) {
+	if err := serverptypes.ValidateGetPushedArtifactRequest(req); err != nil {
+		return nil, err
+	}
+
 	return s.state.ArtifactGet(req.Ref)
 }

--- a/internal/server/singleprocess/service_auth_method.go
+++ b/internal/server/singleprocess/service_auth_method.go
@@ -13,6 +13,10 @@ func (s *service) GetAuthMethod(
 	ctx context.Context,
 	req *pb.GetAuthMethodRequest,
 ) (*pb.GetAuthMethodResponse, error) {
+	if err := serverptypes.ValidateGetAuthMethodRequest(req); err != nil {
+		return nil, err
+	}
+
 	value, err := s.state.AuthMethodGet(req.AuthMethod)
 	if err != nil {
 		return nil, err

--- a/internal/server/singleprocess/service_build.go
+++ b/internal/server/singleprocess/service_build.go
@@ -16,6 +16,10 @@ func (s *service) UpsertBuild(
 	ctx context.Context,
 	req *pb.UpsertBuildRequest,
 ) (*pb.UpsertBuildResponse, error) {
+	if err := serverptypes.ValidateUpsertBuildRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.Build
 
 	// If we have no ID, then we're inserting and need to generate an ID.

--- a/internal/server/singleprocess/service_build.go
+++ b/internal/server/singleprocess/service_build.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -41,6 +42,10 @@ func (s *service) ListBuilds(
 	ctx context.Context,
 	req *pb.ListBuildsRequest,
 ) (*pb.ListBuildsResponse, error) {
+	if err := serverptypes.ValidateListBuildsRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.BuildList(req.Application,
 		state.ListWithWorkspace(req.Workspace),
 		state.ListWithOrder(req.Order),
@@ -56,6 +61,10 @@ func (s *service) GetLatestBuild(
 	ctx context.Context,
 	req *pb.GetLatestBuildRequest,
 ) (*pb.Build, error) {
+	if err := serverptypes.ValidateGetLatestBuildRequest(req); err != nil {
+		return nil, err
+	}
+
 	return s.state.BuildLatest(req.Application, req.Workspace)
 }
 
@@ -64,5 +73,9 @@ func (s *service) GetBuild(
 	ctx context.Context,
 	req *pb.GetBuildRequest,
 ) (*pb.Build, error) {
+	if err := serverptypes.ValidateGetBuildRequest(req); err != nil {
+		return nil, err
+	}
+
 	return s.state.BuildGet(req.Ref)
 }

--- a/internal/server/singleprocess/service_config.go
+++ b/internal/server/singleprocess/service_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/ptypes"
 )
 
 func (s *service) SetConfig(
@@ -23,6 +24,10 @@ func (s *service) GetConfig(
 	ctx context.Context,
 	req *pb.ConfigGetRequest,
 ) (*pb.ConfigGetResponse, error) {
+	if err := ptypes.ValidateGetConfigRequest(req); err != nil {
+		return nil, err
+	}
+
 	vars, err := s.state.ConfigGet(req)
 	if err != nil {
 		return nil, err
@@ -35,6 +40,10 @@ func (s *service) SetConfigSource(
 	ctx context.Context,
 	req *pb.SetConfigSourceRequest,
 ) (*empty.Empty, error) {
+	if err := ptypes.ValidateSetConfigSourceRequest(req); err != nil {
+		return nil, err
+	}
+
 	if err := s.state.ConfigSourceSet(req.ConfigSource); err != nil {
 		return nil, err
 	}
@@ -46,6 +55,10 @@ func (s *service) GetConfigSource(
 	ctx context.Context,
 	req *pb.GetConfigSourceRequest,
 ) (*pb.GetConfigSourceResponse, error) {
+	if err := ptypes.ValidateGetConfigSourceRequest(req); err != nil {
+		return nil, err
+	}
+
 	vars, err := s.state.ConfigSourceGet(req)
 	if err != nil {
 		return nil, err

--- a/internal/server/singleprocess/service_deploy.go
+++ b/internal/server/singleprocess/service_deploy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/server/ptypes"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -20,6 +21,10 @@ func (s *service) UpsertDeployment(
 	ctx context.Context,
 	req *pb.UpsertDeploymentRequest,
 ) (*pb.UpsertDeploymentResponse, error) {
+	if err := serverptypes.ValidateUpsertDeploymentRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.Deployment
 
 	// If we have no ID, then we're inserting and need to generate an ID.

--- a/internal/server/singleprocess/service_hostname.go
+++ b/internal/server/singleprocess/service_hostname.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/ptypes"
 )
 
 const (
@@ -24,6 +25,10 @@ func (s *service) CreateHostname(
 	ctx context.Context,
 	req *pb.CreateHostnameRequest,
 ) (*pb.CreateHostnameResponse, error) {
+	if err := ptypes.ValidateCreateHostnameRequest(req); err != nil {
+		return nil, err
+	}
+
 	urlClient := s.urlClient()
 	if urlClient == nil {
 		return nil, status.Errorf(codes.FailedPrecondition,

--- a/internal/server/singleprocess/service_ondemand_runner.go
+++ b/internal/server/singleprocess/service_ondemand_runner.go
@@ -9,7 +9,6 @@ import (
 	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 )
 
-// TODO: test
 func (s *service) UpsertOnDemandRunnerConfig(
 	ctx context.Context,
 	req *pb.UpsertOnDemandRunnerConfigRequest,
@@ -26,11 +25,14 @@ func (s *service) UpsertOnDemandRunnerConfig(
 	return &pb.UpsertOnDemandRunnerConfigResponse{Config: result}, nil
 }
 
-// TODO: test
 func (s *service) GetOnDemandRunnerConfig(
 	ctx context.Context,
 	req *pb.GetOnDemandRunnerConfigRequest,
 ) (*pb.GetOnDemandRunnerConfigResponse, error) {
+	if err := serverptypes.ValidateGetOnDemandRunnerConfigRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.OnDemandRunnerConfigGet(req.Config)
 	if err != nil {
 		return nil, err
@@ -41,7 +43,6 @@ func (s *service) GetOnDemandRunnerConfig(
 	}, nil
 }
 
-// TODO: test
 func (s *service) ListOnDemandRunnerConfigs(
 	ctx context.Context,
 	req *empty.Empty,

--- a/internal/server/singleprocess/service_project.go
+++ b/internal/server/singleprocess/service_project.go
@@ -48,6 +48,10 @@ func (s *service) GetProject(
 	ctx context.Context,
 	req *pb.GetProjectRequest,
 ) (*pb.GetProjectResponse, error) {
+	if err := serverptypes.ValidateGetProjectRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.ProjectGet(req.Project)
 	if err != nil {
 		return nil, err
@@ -83,6 +87,10 @@ func (s *service) UpsertApplication(
 	ctx context.Context,
 	req *pb.UpsertApplicationRequest,
 ) (*pb.UpsertApplicationResponse, error) {
+	if err := serverptypes.ValidateUpsertApplicationRequest(req); err != nil {
+		return nil, err
+	}
+
 	// Get the project
 	praw, err := s.state.ProjectGet(req.Project)
 	if err != nil {

--- a/internal/server/singleprocess/service_release.go
+++ b/internal/server/singleprocess/service_release.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -15,6 +16,10 @@ func (s *service) UpsertRelease(
 	ctx context.Context,
 	req *pb.UpsertReleaseRequest,
 ) (*pb.UpsertReleaseResponse, error) {
+	if err := ptypes.ValidateUpsertReleaseRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.Release
 
 	// If we have no ID, then we're inserting and need to generate an ID.
@@ -66,6 +71,10 @@ func (s *service) GetLatestRelease(
 	ctx context.Context,
 	req *pb.GetLatestReleaseRequest,
 ) (*pb.Release, error) {
+	if err := ptypes.ValidateGetLatestReleaseRequest(req); err != nil {
+		return nil, err
+	}
+
 	r, err := s.state.ReleaseLatest(req.Application, req.Workspace)
 	if err != nil {
 		return nil, err
@@ -83,6 +92,10 @@ func (s *service) GetRelease(
 	ctx context.Context,
 	req *pb.GetReleaseRequest,
 ) (*pb.Release, error) {
+	if err := ptypes.ValidateGetReleaseRequest(req); err != nil {
+		return nil, err
+	}
+
 	r, err := s.state.ReleaseGet(req.Ref)
 	if err != nil {
 		return nil, err

--- a/internal/server/singleprocess/service_status_report.go
+++ b/internal/server/singleprocess/service_status_report.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/waypoint/internal/server"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	"github.com/hashicorp/waypoint/internal/server/singleprocess/state"
 )
 
@@ -16,6 +17,10 @@ func (s *service) UpsertStatusReport(
 	ctx context.Context,
 	req *pb.UpsertStatusReportRequest,
 ) (*pb.UpsertStatusReportResponse, error) {
+	if err := serverptypes.ValidateUpsertStatusReportRequest(req); err != nil {
+		return nil, err
+	}
+
 	result := req.StatusReport
 
 	// If we have no ID, then we're inserting and need to generate an ID.
@@ -42,6 +47,10 @@ func (s *service) ListStatusReports(
 	ctx context.Context,
 	req *pb.ListStatusReportsRequest,
 ) (*pb.ListStatusReportsResponse, error) {
+	if err := serverptypes.ValidateListStatusReportsRequest(req); err != nil {
+		return nil, err
+	}
+
 	result, err := s.state.StatusReportList(req.Application,
 		state.ListWithStatusFilter(req.Status...),
 		state.ListWithOrder(req.Order),
@@ -83,6 +92,10 @@ func (s *service) GetLatestStatusReport(
 	ctx context.Context,
 	req *pb.GetLatestStatusReportRequest,
 ) (*pb.StatusReport, error) {
+	if err := serverptypes.ValidateGetLatestStatusReportRequest(req); err != nil {
+		return nil, err
+	}
+
 	r, err := s.state.StatusReportLatest(req.Application, req.Workspace)
 	if err != nil {
 		return nil, err
@@ -96,6 +109,10 @@ func (s *service) GetStatusReport(
 	ctx context.Context,
 	req *pb.GetStatusReportRequest,
 ) (*pb.StatusReport, error) {
+	if err := serverptypes.ValidateGetStatusReportRequest(req); err != nil {
+		return nil, err
+	}
+
 	r, err := s.state.StatusReportGet(req.Ref)
 	if err != nil {
 		return nil, err

--- a/internal/server/singleprocess/service_ui_project.go
+++ b/internal/server/singleprocess/service_ui_project.go
@@ -5,12 +5,17 @@ import (
 	"sort"
 
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 )
 
 func (s *service) UI_GetProject(
 	ctx context.Context,
 	req *pb.UI_GetProjectRequest,
 ) (*pb.UI_GetProjectResponse, error) {
+	if err := serverptypes.ValidateUIGetProjectRequest(req); err != nil {
+		return nil, err
+	}
+
 	project, err := s.state.ProjectGet(req.Project)
 
 	if err != nil {


### PR DESCRIPTION
This pull request adds many validations to various authenticated endpoints that would panic if given an empty request body.

Fixes https://github.com/hashicorp/waypoint/issues/2270