### PR TITLE
internal/pkg/epinject: support SSH DOCKER_HOST

### DIFF
--- a/.changelog/2277.txt
+++ b/.changelog/2277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/docker: support SSH hosts for entrypoint injection
+```


### PR DESCRIPTION
This makes it so that our entrypoint injection supports Docker hosts over SSH. We did this for `builtin/docker` but not for `internal/pkg/epinject`. I copy and pasted the function so we don't have to cross package boundaries (in case we ever extract our plugins).