### PR TITLE
ui: Updating empty state messages for projects page

### DIFF
--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -42,12 +42,7 @@
   </Card>
   {{else}}
   <EmptyState>
-    <p>There are no projects to display yet</p>
-    <p>To create your first project, create a new application by running
-      <CopyableCode @ref="empty-init" @inline="true">
-        <code id="empty-init">waypoint init</code>
-      </CopyableCode>
-      from the CLI</p>
+    <p>There are no projects to display yet. Create your first project <LinkTo @route="workspace.projects.new">here</LinkTo>.</p>
     <p>For more help getting started, refer to the <ExternalLink href="https://waypointproject.io/docs/getting-started">Waypoint documentation</ExternalLink></p>
   </EmptyState>
   {{/each}}

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -42,7 +42,12 @@
   </Card>
   {{else}}
   <EmptyState>
-    <p>There are no projects to display yet. Create your first project <LinkTo @route="workspace.projects.new">here</LinkTo>.</p>
+    <p>There are no projects to display yet. <LinkTo @route="workspace.projects.new">Create your first project here</LinkTo>.</p>
+    <p>Alternatively, you can run
+      <CopyableCode @ref="empty-init" @inline="true">
+        <code id="empty-init">waypoint init</code>
+      </CopyableCode>
+      from the CLI</p>
     <p>For more help getting started, refer to the <ExternalLink href="https://waypointproject.io/docs/getting-started">Waypoint documentation</ExternalLink></p>
   </EmptyState>
   {{/each}}


### PR DESCRIPTION
This pull request is a small edit to the empty state message for the projects page. The new text includes a link to the "New Project" page.

Previously:
<img width="1083" alt="Screen Shot 2021-09-10 at 1 18 00 PM" src="https://user-images.githubusercontent.com/5719113/132903955-b6d39e63-5d7d-4a5c-b790-17992f05b36d.png">

Now:
<img width="1200" alt="Screen Shot 2021-09-10 at 2 21 14 PM" src="https://user-images.githubusercontent.com/5719113/132903988-2028198e-32a2-4de3-b7b7-dccf49ec24b8.png">


Fixes #2279 