### PR TITLE
Remove console.log from operation logs component

### DIFF
--- a/ui/app/components/operation-logs/index.ts
+++ b/ui/app/components/operation-logs/index.ts
@@ -1,11 +1,11 @@
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { Status } from 'grpc-web';
+import { GetJobStreamRequest, GetJobStreamResponse } from 'waypoint-pb';
 
 import ApiService from 'waypoint/services/api';
+import Component from '@glimmer/component';
+import { Status } from 'grpc-web';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { GetJobStreamRequest, GetJobStreamResponse } from 'waypoint-pb';
+import { tracked } from '@glimmer/tracking';
 
 interface OperationLogsArgs {
   jobId: string;
@@ -92,12 +92,10 @@ export default class OperationLogs extends Component<OperationLogsArgs> {
             let step = event.getStep();
 
             if (line && line.getMsg()) {
-              console.log(line);
               this.addLogLine(this.typeLine, line.toObject());
             }
 
             if (step && step.getOutput()) {
-              console.log(step);
               let newStep = step.toObject();
 
               if (step.getOutput_asU8().length > 0) {

--- a/ui/app/routes/application.ts
+++ b/ui/app/routes/application.ts
@@ -1,8 +1,8 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 import SessionService from 'waypoint/services/session';
 import Transition from '@ember/routing/-private/transition';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 const ErrInvalidToken = 'invalid authentication token';
 

--- a/ui/app/services/poll-model.ts
+++ b/ui/app/services/poll-model.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import Service from '@ember/service';
 import Route from '@ember/routing/route';
+import Service from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
 import { timeout } from 'ember-concurrency';


### PR DESCRIPTION
The console.log calls were slowing down dev tools quite a lot in my experience 