### PR TITLE
disable sourcemaps in non-dev builds

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -1,11 +1,13 @@
 'use strict';
-
+let environment = process.env.EMBER_ENV || 'development';
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
+  // Disable sourceMaps except in dev
+  let sourceMapsEnabled = environment === 'development' ? 'inline' : false;
   let app = new EmberApp(defaults, {
     babel: {
-      sourceMaps: 'inline',
+      sourceMaps: sourceMapsEnabled,
     },
     'ember-cli-favicon': {
       enabled: true,


### PR DESCRIPTION
Enables source maps only for development builds, to speed up the build times. Part of proposed changes in the investigation on CI failures: https://github.com/hashicorp/waypoint/issues/2260 