### PR TITLE
skip babel for lib files

### DIFF
--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -41,6 +41,16 @@ module.exports = function (defaults) {
       // webpack: {
       //   plugins: [new (require('webpack-bundle-analyzer').BundleAnalyzerPlugin)()],
       // },
+      skipBabel: [
+        {
+          package: 'waypoint-client',
+          semverRange: '*',
+        },
+        {
+          package: 'waypoint-pb',
+          semverRange: '*',
+        }
+      ]
     },
   });
 


### PR DESCRIPTION
Uses `ember-auto-import`'s `skipBabel` feature to avoid transpiling the `lib/waypoint-pb/server_pb.js` file, which was not needed, and memory-intensive. This speeds up our builds and seems to get rid of [the error we were running into in CI](https://github.com/hashicorp/waypoint/issues/2260).