### PR TITLE
ui: fix for hcl field not showing up when initial value is undefined

### DIFF
--- a/ui/app/modifiers/code-mirror.ts
+++ b/ui/app/modifiers/code-mirror.ts
@@ -17,7 +17,7 @@ const _PRESET_DEFAULTS: codemirror.EditorConfiguration = {
 interface Args {
   positional: never;
   named: {
-    value: string;
+    value?: string;
     onInput: (value: string) => void;
     options?: Record<string, unknown>;
   };
@@ -42,7 +42,7 @@ export default class CodeMirrorModifier extends Modifier<Args> {
     let editor = codemirror(this.element, {
       ..._PRESET_DEFAULTS,
       ...this.args.named.options,
-      value: this.args.named.value,
+      value: this.args.named.value ? this.args.named.value : '',
     });
 
     editor.on('change', (editor) => {

--- a/ui/app/modifiers/code-mirror.ts
+++ b/ui/app/modifiers/code-mirror.ts
@@ -42,7 +42,7 @@ export default class CodeMirrorModifier extends Modifier<Args> {
     let editor = codemirror(this.element, {
       ..._PRESET_DEFAULTS,
       ...this.args.named.options,
-      value: this.args.named.value ? this.args.named.value : '',
+      value: this.args.named.value ?? '',
     });
 
     editor.on('change', (editor) => {


### PR DESCRIPTION
## Explanation
Upon implementing the new CodeMirror based HCL text field (#2168), a regression was introduced on the project settings page when the project's value for their HCL file was `undefined`. The CodeMirror field would not render at all when given this unexpected value.

## Buggy UI
<img width="954" alt="Screen Shot 2021-09-13 at 3 09 12 PM" src="https://user-images.githubusercontent.com/60155296/133142477-243a6d43-bc64-435f-985b-92034beaffb1.png">

## UI After This PR
<img width="972" alt="Screen Shot 2021-09-13 at 3 09 47 PM" src="https://user-images.githubusercontent.com/60155296/133142558-e0df57ec-9c56-4a37-be76-e508ca282872.png">
