### PR TITLE
ui: add memory usage ouput to `ember-build-tests` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,11 @@ jobs:
           key: *YARN_CACHE_KEY
       - run: cd ui && yarn build:test
 
+      # Emits the maximum memory usage by the container up to this point
+      - run:
+          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          when: always
+
       # saves the build to a workspace to be passed to a downstream job
       - persist_to_workspace:
           root: ui


### PR DESCRIPTION
## Why the change?

This comes from the investigation of #2260, is based on @izaaklauer’s sage suggestion to record memory usage from our troublesome CI job so we can track it over time.

## What does it look like?

Take a look at the CI run for this PR. Something like this:

<img width="552" alt="133150120-df3a6716-db8e-460b-a173-d9a835e62f2b" src="https://user-images.githubusercontent.com/34030/133151500-19f08dcb-b302-4dc6-a7a6-6f47cf1b5e41.png">

## Any downsides?

I don’t *think* so. It’s a negligible amount of extra work for the CI environment, makes our CI config only marginally more complicated, and gives us some valuable information.