### PR TITLE
builtin/k8s - Use sequence # in k8s deploy name instead of ID

### DIFF
--- a/.changelog/2296.txt
+++ b/.changelog/2296.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/k8s: Use sequence number in k8s deployment name for improved traceability to waypoint deployments.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ data.db
 # .vscode - We intentionally commit .vscode in order to share project-specific settings
 
 
+.idea

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -757,8 +757,10 @@ func (p *Platform) Deploy(
 	if err != nil {
 		return nil, err
 	}
+
+	seq := deployConfig.Sequence
 	result.Id = id
-	result.Name = strings.ToLower(fmt.Sprintf("%s-%s", src.App, id))
+	result.Name = strings.ToLower(fmt.Sprintf("%s-v%d", src.App, seq))
 
 	// We'll update the user in real time
 	sg := ui.StepGroup()

--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,6 @@ require (
 
 // v0.3.11 panics for some reason on our tests
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.9
+
+// temporary until PR is merged
+replace github.com/hashicorp/waypoint-plugin-sdk => github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210901131310-99045552ce97
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/jinzhu/now v1.1.1 // indirect
@@ -134,6 +134,3 @@ require (
 
 // v0.3.11 panics for some reason on our tests
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.9
-
-// temporary until PR is merged
-replace github.com/hashicorp/waypoint-plugin-sdk => github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210915200021-0edd5b52eb64
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/jinzhu/now v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1429,6 +1429,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058 h1:4nh3l4a32uLyqa7Vf4xnXtoHVuyx4d5drVuQ5TVYbss=
+github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
 github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
 github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -912,10 +912,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef h1:YKouRHFf
 github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210901131310-99045552ce97 h1:LEQUPfA54OnVh2TDIA2J+5QFps8GlRYI+Q3v1kr3IW8=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210901131310-99045552ce97/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058 h1:HTlLR4ZXTKhQINXaZYWWSbWIH3DZU10+j2xZAbxdMZo=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210915200021-0edd5b52eb64 h1:jzuVRGXqtbyysIBe2FjUzujg8QAL4ZJaYFaUxS4Skbo=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210915200021-0edd5b52eb64/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -1431,8 +1429,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
-github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058 h1:4nh3l4a32uLyqa7Vf4xnXtoHVuyx4d5drVuQ5TVYbss=
-github.com/sl1pm4t/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
 github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
 github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -914,6 +914,8 @@ github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2S
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
 github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210901131310-99045552ce97 h1:LEQUPfA54OnVh2TDIA2J+5QFps8GlRYI+Q3v1kr3IW8=
 github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210901131310-99045552ce97/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058 h1:HTlLR4ZXTKhQINXaZYWWSbWIH3DZU10+j2xZAbxdMZo=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210914072340-bd8e2aac4058/go.mod h1:pJSjBDgumtkMumNuLh4wDYiRk/acWo5tzyUEFCC4ugQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -144,11 +144,15 @@ type deployOperation struct {
 	// id is populated with the deployment id on Upsert
 	id string
 
+	// sequence is the monotonically incrementing version number of
+	// the deployment
+	sequence uint64
+
 	// cebToken is the token to set for the deployment to auth
 	cebToken string
 
 	// result is either a component.Deployment or component.DeploymentWithUrl
-	result interface{}
+	result   interface{}
 }
 
 func (op *deployOperation) Close() error {
@@ -272,6 +276,7 @@ func (op *deployOperation) Upsert(
 	if op.id == "" {
 		// Set our internal ID for the Do step
 		op.id = resp.Deployment.Id
+		op.sequence = resp.Deployment.Sequence
 
 		// We need to get our token that we'll give this deployment
 		resp, err := client.GenerateInviteToken(ctx, &pb.InviteTokenRequest{
@@ -297,6 +302,7 @@ func (op *deployOperation) Upsert(
 	// Set the new values on our deployment config
 	dconfig := *op.DeploymentConfig
 	dconfig.Id = op.id
+	dconfig.Sequence = op.sequence
 	dconfig.EntrypointInviteToken = op.cebToken
 	op.DeploymentConfig = &dconfig
 

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -152,7 +152,7 @@ type deployOperation struct {
 	cebToken string
 
 	// result is either a component.Deployment or component.DeploymentWithUrl
-	result   interface{}
+	result interface{}
 }
 
 func (op *deployOperation) Close() error {


### PR DESCRIPTION
This PR adds support in waypoint core to pass the deployment sequence number to plugins, and also modifies the k8s plugin to use sequence number in k8s deployment resource names instead of the ID. 

I opted to entirely replace the Waypoint ID with Sequence # in the k8s deployment name because k8s already assigns several random strings to pods derived from deployments so having the Waypoint ID is noise in my opinion. After this change, deployment names become:
```
NAME              READY   UP-TO-DATE   AVAILABLE   AGE
httpbin-v1        1/1     1            1           34m
httpbin-v2        1/1     1            1           7m1s
```
Where `httpbin` is the waypoint app name.
Pods therefore become:
```
NAME                          READY   STATUS    RESTARTS   AGE
httpbin-v1-7c6bb9f655-n4f6j   1/1     Running   0          36m
httpbin-v2-6fb5898b7d-drvct   1/1     Running   0          9m2s
```

This PR depends on a [change to the waypoint-plugin-sdk](https://github.com/hashicorp/waypoint-plugin-sdk/pull/58).


Closes #2060 

