### PR TITLE
internal/server/state: peek should return blocked jobs

### DIFF
--- a/internal/server/singleprocess/state/job_test.go
+++ b/internal/server/singleprocess/state/job_test.go
@@ -363,6 +363,14 @@ func TestJobAssign(t *testing.T) {
 			require.Equal("A", job.Id)
 		}
 
+		// Peeking still returns blocked jobs. We do this because otherwise
+		// its possible for peek to return empty when there is an eligible job,
+		// its just waiting.
+		job, err := s.JobPeekForRunner(context.Background(), &pb.Runner{Id: "R_A"})
+		require.NoError(err)
+		require.NotNil(job)
+		require.Equal("B", job.Id)
+
 		// Get the next value in a goroutine
 		{
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
We use Peek to check if there is any potential candidate jobs for a
runner, not a guarantee that it will immediately be assigned that job.
In the scenario where a job is blocked (defined below), peek would
return nil which broke the on-demand runner use case that used peek to
verify a job exists for a runner.

A job is "blocked" when another job is already assigned for the same
`(app, project, workspace)` tuple. This serializes operations for that
tuple to prevent concurrency issues but still allow concurrency across
projects/apps/workspaces.