### PR TITLE
ui: tell vscode to use workspace version of typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
+  "typescript.tsdk": "./ui/node_modules/typescript/lib",
   "workbench.colorCustomizations": {
     "statusBar.foreground": "#000",
     "statusBar.background": "#19C6CB"
-  },
+  }
 }


### PR DESCRIPTION
## Why the change?

This ensures VS Code is using the project’s own version of Typescript, and will display info that jibes with ember-cli-typescript.

## How do I test it?

Load up the branch in VS Code, open some Typescript files, verify they still behave as you’d expect. Try making some deliberate type errors.