### PR TITLE
internal/cli: plugin-config instead of project-config

### DIFF
--- a/internal/cli/ondemand_runner_apply.go
+++ b/internal/cli/ondemand_runner_apply.go
@@ -231,7 +231,7 @@ func (c *OnDemandRunnerConfigApplyCommand) Flags() *flag.Sets {
 		})
 
 		f.StringVar(&flag.StringVar{
-			Name:    "project-config",
+			Name:    "plugin-config",
 			Target:  &c.flagPluginConfig,
 			Default: "",
 			Usage: "Path to an hcl file that contains the configuration for the plugin. " +
@@ -270,7 +270,7 @@ Usage: waypoint runner on-demand set [OPTIONS]
   This will register a new on-demand runner config with the given options. If
   a on-demand runner config with the same id already exists, this will update the
   existing runner config using the fields that are set.
-  
+
   Waypoint will use an on-demand runner configuration to spawn containers for
   various kinds of work as needed on the platform requested during any given
   lifecycle operation.

--- a/website/content/commands/runner-on-demand-set.mdx
+++ b/website/content/commands/runner-on-demand-set.mdx
@@ -39,7 +39,7 @@ lifecycle operation.
 - `-oci-url=<string>` - The url for the OCI image to launch for the on-demand runner.
 - `-env-vars=<string>` - Environment variable to expose to the on-demand runner. Typically used to introduce configuration for the plugins that the runner will execute.
 - `-plugin-type=<string>` - The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.
-- `-project-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
+- `-plugin-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
 - `-default` - Indicates that this on-demand runner should be used by any project that doesn't otherwise specify its own on-demand runner.
 
 @include "commands/runner-on-demand-set_more.mdx"


### PR DESCRIPTION
A simple typo I just found.