### PR TITLE
internal/clicontext: default to gRPC port for login addr

### DIFF
--- a/.changelog/2320.txt
+++ b/.changelog/2320.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: login subcommand defaults server port to 9701 if it isn't set
+```

--- a/internal/clicontext/config.go
+++ b/internal/clicontext/config.go
@@ -62,6 +62,12 @@ func (c *Config) FromURL(v string) error {
 	// Override
 	if u.Host != "" {
 		c.Server.Address = u.Host
+
+		// If no port is specified, default to port 9701 which is our default
+		// gRPC port for Waypoint installations.
+		if idx := strings.IndexByte(u.Host, ':'); idx < 0 {
+			c.Server.Address += ":9701"
+		}
 	}
 
 	// Specifically http will override TLS

--- a/internal/clicontext/config.go
+++ b/internal/clicontext/config.go
@@ -66,7 +66,7 @@ func (c *Config) FromURL(v string) error {
 		// If no port is specified, default to port 9701 which is our default
 		// gRPC port for Waypoint installations.
 		if idx := strings.IndexByte(u.Host, ':'); idx < 0 {
-			c.Server.Address += ":9701"
+			c.Server.Address += ":" + serverconfig.DefaultGRPCPort
 		}
 	}
 

--- a/internal/clicontext/config_test.go
+++ b/internal/clicontext/config_test.go
@@ -18,7 +18,7 @@ func TestConfigFromURL(t *testing.T) {
 			"foo.com",
 			Config{
 				Server: serverconfig.Client{
-					Address:       "foo.com:9701",
+					Address:       "foo.com:" + serverconfig.DefaultGRPCPort,
 					Tls:           true,
 					TlsSkipVerify: true,
 				},
@@ -42,7 +42,7 @@ func TestConfigFromURL(t *testing.T) {
 			"127.1.2.3",
 			Config{
 				Server: serverconfig.Client{
-					Address:       "127.1.2.3:9701",
+					Address:       "127.1.2.3:" + serverconfig.DefaultGRPCPort,
 					Tls:           true,
 					TlsSkipVerify: true,
 				},

--- a/internal/clicontext/config_test.go
+++ b/internal/clicontext/config_test.go
@@ -18,7 +18,7 @@ func TestConfigFromURL(t *testing.T) {
 			"foo.com",
 			Config{
 				Server: serverconfig.Client{
-					Address:       "foo.com",
+					Address:       "foo.com:9701",
 					Tls:           true,
 					TlsSkipVerify: true,
 				},
@@ -42,7 +42,7 @@ func TestConfigFromURL(t *testing.T) {
 			"127.1.2.3",
 			Config{
 				Server: serverconfig.Client{
-					Address:       "127.1.2.3",
+					Address:       "127.1.2.3:9701",
 					Tls:           true,
 					TlsSkipVerify: true,
 				},

--- a/internal/serverconfig/config.go
+++ b/internal/serverconfig/config.go
@@ -4,6 +4,13 @@ import (
 	"strconv"
 )
 
+const (
+	// Default ports. These are strings because we generally are working with
+	// strings for the ports since they're part of the address string.
+	DefaultGRPCPort = "9701"
+	DefaultHTTPPort = "9702"
+)
+
 // Client configures a client to connect to a server.
 type Client struct {
 	Address string `hcl:"address,attr" json:"address"`

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -125,8 +125,9 @@ const (
 
 // Default server ports to use
 var (
-	defaultGrpcPort = "9701"
-	defaultHttpPort = "9702"
+	// todo: remove these and just use the serverconfig constants.
+	defaultGrpcPort = serverconfig.DefaultGRPCPort
+	defaultHttpPort = serverconfig.DefaultHTTPPort
 )
 
 // defaultODRImage returns the default Waypoint ODR image based on the


### PR DESCRIPTION
Before we would not set a port at all, and I'm not sure what port it was
trying to connect to. Given our installation method on all platforms
defaults our gRPC to port 9701, it makes sense to default to port 9701
if none is specified.

This makes the initial installation login experience smoother cause most
installations can just do:

    $ waypoint login <IP or hostname>

And it'll just work, rather than looking up the port, which is most
likely 9701.