### PR TITLE
cli, server: set default log level to debug on server install

### DIFF
--- a/.changelog/2325.txt
+++ b/.changelog/2325.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Use default log level of debug instead of trace on server install
+```

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -264,7 +264,7 @@ This command will bootstrap the server and setup a CLI context.
 		closer.Close()
 	}
 
-	// Set our log output higher if its not already so that it begins showing.
+	// Set our log output higher if it's not already so that it begins showing.
 	if !log.IsInfo() {
 		log.SetLevel(hclog.Info)
 	}

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -226,7 +226,7 @@ func (i *DockerInstaller) Install(
 		Image:        i.config.serverImage,
 		ExposedPorts: nat.PortSet{npGRPC: struct{}{}, npHTTP: struct{}{}},
 		Env:          []string{"PORT=" + grpcPort},
-		Cmd:          []string{"server", "run", "-accept-tos", "-vvv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
+		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
 	}
 
 	bindings := nat.PortMap{}
@@ -434,7 +434,7 @@ func (i *DockerInstaller) Upgrade(
 		Image:        i.config.serverImage,
 		ExposedPorts: nat.PortSet{npGRPC: struct{}{}, npHTTP: struct{}{}},
 		Env:          []string{"PORT=" + grpcPort},
-		Cmd:          []string{"server", "run", "-accept-tos", "-vvv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
+		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
 	}
 
 	bindings := nat.PortMap{}

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -261,7 +261,7 @@ func (i *ECSInstaller) Launch(
 		aws.String("server"),
 		aws.String("run"),
 		aws.String("-accept-tos"),
-		aws.String("-vvv"),
+		aws.String("-vv"),
 		aws.String("-db=/waypoint-data/data.db"),
 		aws.String(fmt.Sprintf("-listen-grpc=0.0.0.0:%d", grpcPort)),
 		aws.String(fmt.Sprintf("-listen-http=0.0.0.0:%d", httpPort)),
@@ -2300,7 +2300,7 @@ func (i *ECSInstaller) LaunchRunner(
 		Command: []*string{
 			aws.String("runner"),
 			aws.String("agent"),
-			aws.String("-vvv"),
+			aws.String("-vv"),
 			aws.String("-liveness-tcp-addr=:1234"),
 		},
 		Name:  aws.String("waypoint-runner"),

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1155,7 +1155,7 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 							Args: []string{
 								"runner",
 								"agent",
-								"-vvv",
+								"-vv",
 								"-liveness-tcp-addr=:" + strconv.Itoa(livenessPort),
 							},
 							LivenessProbe: &apiv1.Probe{
@@ -1267,7 +1267,7 @@ func newStatefulSet(c k8sConfig) (*appsv1.StatefulSet, error) {
 								"server",
 								"run",
 								"-accept-tos",
-								"-vvv",
+								"-vv",
 								"-db=/data/data.db",
 								"-listen-grpc=0.0.0.0:9701",
 								"-listen-http=0.0.0.0:9702",

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -673,7 +673,7 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	task.Config = map[string]interface{}{
 		"image":          c.serverImage,
 		"ports":          []string{"server", "ui"},
-		"args":           []string{"server", "run", "-accept-tos", "-vvv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort)},
+		"args":           []string{"server", "run", "-accept-tos", "-vv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort)},
 		"auth_soft_fail": c.authSoftFail,
 	}
 	task.Env = map[string]string{
@@ -721,7 +721,7 @@ func waypointRunnerNomadJob(c nomadConfig, opts *InstallRunnerOpts) *api.Job {
 		"args": []string{
 			"runner",
 			"agent",
-			"-vvv",
+			"-vv",
 		},
 		"auth_soft_fail": c.authSoftFail,
 	}


### PR DESCRIPTION
Set default log level to debug rather than trace for the server during an install.
As part of the work for #1514, users will be able to set the log level to trace if desired (for example: `waypoint install -platform=docker -accept-tos -run-flags="-vvv"`)