### PR TITLE
cli: pass raw string of `server run` flags to install command

### DIFF
--- a/.changelog/2328.txt
+++ b/.changelog/2328.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-cli: Allow raw string of `server run` flags to be provided to `install` cmd
+cli: Allow `install` cmd to support pass-through flags to `server run`
 ```

--- a/.changelog/2328.txt
+++ b/.changelog/2328.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: Allow raw string of `server run` flags to be provided to `install` cmd
+```

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -85,8 +85,8 @@ func (c *InstallCommand) Run(args []string) int {
 	}
 
 	result, err := p.Install(ctx, &serverinstall.InstallOpts{
-		Log:         log,
-		UI:          c.ui,
+		Log:            log,
+		UI:             c.ui,
 		ServerRunFlags: c.flagServerRun,
 	})
 	if err != nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -33,7 +33,6 @@ type InstallCommand struct {
 
 	flagAcceptTOS bool
 	flagRunner    bool
-	flagServerRun string
 }
 
 func (c *InstallCommand) Run(args []string) int {
@@ -84,10 +83,19 @@ func (c *InstallCommand) Run(args []string) int {
 		return 1
 	}
 
+	// collect any args after a `--` break to pass forward as secondary flags
+	var secondaryArgs []string
+	for i, f := range args {
+		if f == "--" {
+			secondaryArgs = args[(i + 1):]
+			break
+		}
+	}
+
 	result, err := p.Install(ctx, &serverinstall.InstallOpts{
 		Log:            log,
 		UI:             c.ui,
-		ServerRunFlags: c.flagServerRun,
+		ServerRunFlags: secondaryArgs,
 	})
 	if err != nil {
 		c.ui.Output(
@@ -390,6 +398,14 @@ Alias: waypoint install
   flag. This only applies to the Waypoint URL service. You may disable the
   URL service by manually running the server. If you disable the URL service,
   you do not need to accept any terms.
+
+  To further customize the server installation, you may pass advanced flag options
+  specified in the documentation for the 'server run' command. To set these values,
+  include a '--' after the full argument list for 'install', followed by these
+  advanced flag options. As an example, to set the server log level to trace
+  and disable the UI, the command would be:
+
+    waypoint install -platform=docker -accept-tos -- -vvv -disable-ui
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -343,7 +343,7 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:   "run-flags",
 			Target: &c.flagServerRun,
-			Usage:  "Include flag values for the installer to supply to the server run command.",
+			Usage:  "Flag values for the installer to supply to the server run command.",
 		})
 
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -33,6 +33,7 @@ type InstallCommand struct {
 
 	flagAcceptTOS bool
 	flagRunner    bool
+	flagServerRun string
 }
 
 func (c *InstallCommand) Run(args []string) int {
@@ -84,8 +85,9 @@ func (c *InstallCommand) Run(args []string) int {
 	}
 
 	result, err := p.Install(ctx, &serverinstall.InstallOpts{
-		Log: log,
-		UI:  c.ui,
+		Log:         log,
+		UI:          c.ui,
+		ServerRunFlags: c.flagServerRun,
 	})
 	if err != nil {
 		c.ui.Output(
@@ -333,9 +335,15 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		f.BoolVar(&flag.BoolVar{
 			Name:    "runner",
 			Target:  &c.flagRunner,
-			Usage:   "Install a runner in addition to the server",
+			Usage:   "Install a runner in addition to the server.",
 			Default: true,
 			Hidden:  true,
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "run-flags",
+			Target: &c.flagServerRun,
+			Usage:  "Include flag values for the installer to supply to the server run command.",
 		})
 
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -340,12 +340,6 @@ func (c *InstallCommand) Flags() *flag.Sets {
 			Hidden:  true,
 		})
 
-		f.StringVar(&flag.StringVar{
-			Name:   "run-flags",
-			Target: &c.flagServerRun,
-			Usage:  "Flag values for the installer to supply to the server run command.",
-		})
-
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.
 		i := 0
 		sortedPlatformNames := make([]string, len(serverinstall.Platforms))

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -632,38 +632,34 @@ func logger(args []string) ([]string, hclog.Logger, io.Writer, error) {
 	// Process arguments looking for `-v` flags to control the log level.
 	// This overrides whatever the env var set.
 	var outArgs []string
-	// We use this to track if flags are given after a --, indicating they should
-	// be passed through to a secondary command; currently, this is largely to
-	// ensure that the `-v(vv)` flags are passed through to be parsed later;
-	// otherwise we'd swallow them in the below case statement
-	hasDoubleHypen := false
-	for _, arg := range args {
+	for i, arg := range args {
 		if len(arg) != 0 && arg[0] != '-' {
 			outArgs = append(outArgs, arg)
 			continue
 		}
+
+		// If we hit a break indicating pass-through flags, we add them all to
+		// outArgs and just exit, since we don't want to process any secondary
+		//  `-v` flags at this time.
 		if arg == "--" {
-			hasDoubleHypen = true
+			outArgs = append(outArgs, args[i:]...)
+			break
 		}
 
-		if !hasDoubleHypen {
-			switch arg {
-			case "-v":
-				if level == hclog.NoLevel || level > hclog.Info {
-					level = hclog.Info
-				}
-			case "-vv":
-				if level == hclog.NoLevel || level > hclog.Debug {
-					level = hclog.Debug
-				}
-			case "-vvv":
-				if level == hclog.NoLevel || level > hclog.Trace {
-					level = hclog.Trace
-				}
-			default:
-				outArgs = append(outArgs, arg)
+		switch arg {
+		case "-v":
+			if level == hclog.NoLevel || level > hclog.Info {
+				level = hclog.Info
 			}
-		} else {
+		case "-vv":
+			if level == hclog.NoLevel || level > hclog.Debug {
+				level = hclog.Debug
+			}
+		case "-vvv":
+			if level == hclog.NoLevel || level > hclog.Trace {
+				level = hclog.Trace
+			}
+		default:
 			outArgs = append(outArgs, arg)
 		}
 	}

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -367,21 +367,21 @@ func (c *ServerRunCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "url-api-addr",
 			Target:  &c.config.URL.APIAddress,
-			Usage:   "Address to Waypoint URL service API",
+			Usage:   "Address to Waypoint URL service API.",
 			Default: "api.waypoint.run:443",
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "url-api-insecure",
 			Target:  &c.config.URL.APIInsecure,
-			Usage:   "True if TLS is not enabled for the Waypoint URL service API",
+			Usage:   "True if TLS is not enabled for the Waypoint URL service API.",
 			Default: false,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "url-control-addr",
 			Target:  &c.config.URL.ControlAddress,
-			Usage:   "Address to Waypoint URL service control API",
+			Usage:   "Address to Waypoint URL service control API.",
 			Default: DefaultURLControlAddress,
 		})
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -418,12 +418,6 @@ func (c *ServerUpgradeCommand) Flags() *flag.Sets {
 			Usage:   "Enable or disable taking a snapshot of Waypoint server prior to upgrades.",
 		})
 
-		f.StringVar(&flag.StringVar{
-			Name:   "run-flags",
-			Target: &c.flagServerRun,
-			Usage:  "Flag values for the installer to supply to the server run command.",
-		})
-
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.
 		i := 0
 		sortedPlatformNames := make([]string, len(serverinstall.Platforms))

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -26,11 +26,12 @@ import (
 type ServerUpgradeCommand struct {
 	*baseCommand
 
-	platform     string
-	contextName  string
-	snapshotName string
-	flagSnapshot bool
-	confirm      bool
+	platform      string
+	contextName   string
+	snapshotName  string
+	flagSnapshot  bool
+	confirm       bool
+	flagServerRun string
 }
 
 func (c *ServerUpgradeCommand) Run(args []string) int {
@@ -215,8 +216,9 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 		initServerVersion, terminal.WithInfoStyle())
 
 	installOpts := &serverinstall.InstallOpts{
-		Log: log,
-		UI:  c.ui,
+		Log:            log,
+		UI:             c.ui,
+		ServerRunFlags: c.flagServerRun,
 	}
 
 	// Upgrade in place
@@ -414,6 +416,12 @@ func (c *ServerUpgradeCommand) Flags() *flag.Sets {
 			Target:  &c.flagSnapshot,
 			Default: true,
 			Usage:   "Enable or disable taking a snapshot of Waypoint server prior to upgrades.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "run-flags",
+			Target: &c.flagServerRun,
+			Usage:  "Include flag values for the installer to supply to the server run command.",
 		})
 
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -421,7 +421,7 @@ func (c *ServerUpgradeCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:   "run-flags",
 			Target: &c.flagServerRun,
-			Usage:  "Include flag values for the installer to supply to the server run command.",
+			Usage:  "Flag values for the installer to supply to the server run command.",
 		})
 
 		// Add platforms in alphabetical order. A consistent order is important for repeatable doc generation.

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -26,12 +26,11 @@ import (
 type ServerUpgradeCommand struct {
 	*baseCommand
 
-	platform      string
-	contextName   string
-	snapshotName  string
-	flagSnapshot  bool
-	confirm       bool
-	flagServerRun string
+	platform     string
+	contextName  string
+	snapshotName string
+	flagSnapshot bool
+	confirm      bool
 }
 
 func (c *ServerUpgradeCommand) Run(args []string) int {
@@ -218,7 +217,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 	installOpts := &serverinstall.InstallOpts{
 		Log:            log,
 		UI:             c.ui,
-		ServerRunFlags: c.flagServerRun,
+		ServerRunFlags: c.args,
 	}
 
 	// Upgrade in place

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1384,7 +1384,7 @@ waypoint status -app=APP-NAME %[1]s
 `)
 
 	wpProjectNotFound = strings.TrimSpace(`
-No project name %q was found for the server context %q. To see a list of
+No project named %q was found for the server context %q. To see a list of
 currently configured projects, run “waypoint project list”.
 
 If you want more information for a specific application, use the '-app' flag

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -226,7 +226,7 @@ func (i *DockerInstaller) Install(
 		Image:        i.config.serverImage,
 		ExposedPorts: nat.PortSet{npGRPC: struct{}{}, npHTTP: struct{}{}},
 		Env:          []string{"PORT=" + grpcPort},
-		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
+		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort), opts.ServerRunFlags},
 	}
 
 	bindings := nat.PortMap{}

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -217,6 +217,8 @@ func (i *DockerInstaller) Install(
 
 	s.Update("Installing Waypoint server to docker")
 
+	cmd := []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)}
+	cmd = append(cmd, opts.ServerRunFlags...)
 	cfg := container.Config{
 		AttachStdout: true,
 		AttachStderr: true,
@@ -226,7 +228,7 @@ func (i *DockerInstaller) Install(
 		Image:        i.config.serverImage,
 		ExposedPorts: nat.PortSet{npGRPC: struct{}{}, npHTTP: struct{}{}},
 		Env:          []string{"PORT=" + grpcPort},
-		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort), opts.ServerRunFlags},
+		Cmd:          cmd,
 	}
 
 	bindings := nat.PortMap{}
@@ -425,6 +427,9 @@ func (i *DockerInstaller) Upgrade(
 	if err != nil {
 		return nil, err
 	}
+
+	cmd := []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)}
+	cmd = append(cmd, opts.ServerRunFlags...)
 	cfg := container.Config{
 		AttachStdout: true,
 		AttachStderr: true,
@@ -434,7 +439,7 @@ func (i *DockerInstaller) Upgrade(
 		Image:        i.config.serverImage,
 		ExposedPorts: nat.PortSet{npGRPC: struct{}{}, npHTTP: struct{}{}},
 		Env:          []string{"PORT=" + grpcPort},
-		Cmd:          []string{"server", "run", "-accept-tos", "-vv", "-db=/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", grpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", httpPort)},
+		Cmd:          cmd,
 	}
 
 	bindings := nat.PortMap{}

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -180,7 +180,7 @@ func (i *ECSInstaller) Install(
 		},
 
 		Run: func(ui terminal.UI) error {
-			server, err = i.Launch(ctx, log, ui, sess, efsInfo, netInfo, executionRole, cluster, serverLogGroup)
+			server, err = i.Launch(ctx, log, ui, sess, efsInfo, netInfo, executionRole, cluster, serverLogGroup, opts.ServerRunFlags)
 			return err
 		},
 
@@ -224,7 +224,7 @@ func (i *ECSInstaller) Launch(
 	sess *session.Session,
 	efsInfo *efsInformation,
 	netInfo *networkInformation,
-	executionRoleArn, clusterName, logGroup string,
+	executionRoleArn, clusterName, logGroup string, rawRunFlags string,
 ) (*ecsServer, error) {
 
 	sg := ui.StepGroup()
@@ -265,6 +265,7 @@ func (i *ECSInstaller) Launch(
 		aws.String("-db=/waypoint-data/data.db"),
 		aws.String(fmt.Sprintf("-listen-grpc=0.0.0.0:%d", grpcPort)),
 		aws.String(fmt.Sprintf("-listen-http=0.0.0.0:%d", httpPort)),
+		aws.String(fmt.Sprintf(rawRunFlags)),
 	}
 
 	def := ecs.ContainerDefinition{

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -224,7 +224,7 @@ func (i *ECSInstaller) Launch(
 	sess *session.Session,
 	efsInfo *efsInformation,
 	netInfo *networkInformation,
-	executionRoleArn, clusterName, logGroup string, rawRunFlags string,
+	executionRoleArn, clusterName, logGroup string, rawRunFlags []string,
 ) (*ecsServer, error) {
 
 	sg := ui.StepGroup()
@@ -265,7 +265,9 @@ func (i *ECSInstaller) Launch(
 		aws.String("-db=/waypoint-data/data.db"),
 		aws.String(fmt.Sprintf("-listen-grpc=0.0.0.0:%d", grpcPort)),
 		aws.String(fmt.Sprintf("-listen-http=0.0.0.0:%d", httpPort)),
-		aws.String(fmt.Sprintf(rawRunFlags)),
+	}
+	for _, f := range rawRunFlags {
+		cmd = append(cmd, aws.String(f))
 	}
 
 	def := ecs.ContainerDefinition{

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1181,7 +1181,7 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 
 // newStatefulSet takes in a k8sConfig and creates a new Waypoint Statefulset
 // for deployment in Kubernetes.
-func newStatefulSet(c k8sConfig, rawRunFlags string) (*appsv1.StatefulSet, error) {
+func newStatefulSet(c k8sConfig, rawRunFlags []string) (*appsv1.StatefulSet, error) {
 	cpuRequest, err := resource.ParseQuantity(c.cpuRequest)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse cpu request resource %s: %s", c.cpuRequest, err)
@@ -1222,6 +1222,16 @@ func newStatefulSet(c k8sConfig, rawRunFlags string) (*appsv1.StatefulSet, error
 		volumeClaimTemplates[0].Spec.StorageClassName = &c.storageClassName
 	}
 
+	ras := []string{
+		"server",
+		"run",
+		"-accept-tos",
+		"-vv",
+		"-db=/data/data.db",
+		"-listen-grpc=0.0.0.0:9701",
+		"-listen-http=0.0.0.0:9702",
+	}
+	ras = append(ras, rawRunFlags...)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serverName,
@@ -1263,16 +1273,7 @@ func newStatefulSet(c k8sConfig, rawRunFlags string) (*appsv1.StatefulSet, error
 								},
 							},
 							Command: []string{serviceName},
-							Args: []string{
-								"server",
-								"run",
-								"-accept-tos",
-								"-vv",
-								"-db=/data/data.db",
-								"-listen-grpc=0.0.0.0:9701",
-								"-listen-http=0.0.0.0:9702",
-								rawRunFlags,
-							},
+							Args: ras,
 							Ports: []apiv1.ContainerPort{
 								{
 									Name:          "grpc",

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1273,7 +1273,7 @@ func newStatefulSet(c k8sConfig, rawRunFlags []string) (*appsv1.StatefulSet, err
 								},
 							},
 							Command: []string{serviceName},
-							Args: ras,
+							Args:    ras,
 							Ports: []apiv1.ContainerPort{
 								{
 									Name:          "grpc",

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -160,7 +160,7 @@ func (i *K8sInstaller) Install(
 	}
 
 	// Decode our configuration
-	statefulset, err := newStatefulSet(i.config)
+	statefulset, err := newStatefulSet(i.config, opts.ServerRunFlags)
 	if err != nil {
 		ui.Output(
 			"Error generating statefulset configuration: %s", clierrors.Humanize(err),
@@ -1181,7 +1181,7 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 
 // newStatefulSet takes in a k8sConfig and creates a new Waypoint Statefulset
 // for deployment in Kubernetes.
-func newStatefulSet(c k8sConfig) (*appsv1.StatefulSet, error) {
+func newStatefulSet(c k8sConfig, rawRunFlags string) (*appsv1.StatefulSet, error) {
 	cpuRequest, err := resource.ParseQuantity(c.cpuRequest)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse cpu request resource %s: %s", c.cpuRequest, err)
@@ -1271,6 +1271,7 @@ func newStatefulSet(c k8sConfig) (*appsv1.StatefulSet, error) {
 								"-db=/data/data.db",
 								"-listen-grpc=0.0.0.0:9701",
 								"-listen-http=0.0.0.0:9702",
+								rawRunFlags,
 							},
 							Ports: []apiv1.ContainerPort{
 								{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -615,7 +615,7 @@ EVAL:
 
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the
 // Nomad API
-func waypointNomadJob(c nomadConfig, rawRunFlags string) *api.Job {
+func waypointNomadJob(c nomadConfig, rawRunFlags []string) *api.Job {
 	job := api.NewServiceJob(serverName, serverName, c.region, 50)
 	job.Namespace = &c.namespace
 	job.Datacenters = c.datacenters
@@ -669,11 +669,13 @@ func waypointNomadJob(c nomadConfig, rawRunFlags string) *api.Job {
 	}
 	job.AddTaskGroup(tg)
 
+	ras := []string{"server", "run", "-accept-tos", "-vv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort)}
+	ras = append(ras, rawRunFlags...)
 	task := api.NewTask("server", "docker")
 	task.Config = map[string]interface{}{
 		"image":          c.serverImage,
 		"ports":          []string{"server", "ui"},
-		"args":           []string{"server", "run", "-accept-tos", "-vv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort), rawRunFlags},
+		"args":           ras,
 		"auth_soft_fail": c.authSoftFail,
 	}
 	task.Env = map[string]string{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -134,7 +134,7 @@ func (i *NomadInstaller) Install(
 	}
 
 	s.Update("Installing Waypoint server to Nomad")
-	allocID, err := i.runJob(ctx, s, client, waypointNomadJob(i.config))
+	allocID, err := i.runJob(ctx, s, client, waypointNomadJob(i.config, opts.ServerRunFlags))
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (i *NomadInstaller) Upgrade(
 	}
 
 	s = sg.Add("Upgrading Waypoint server on Nomad to %q", i.config.serverImage)
-	job := waypointNomadJob(i.config)
+	job := waypointNomadJob(i.config, opts.ServerRunFlags)
 	jobOpts := &api.RegisterOptions{
 		PolicyOverride: i.config.policyOverride,
 	}
@@ -615,7 +615,7 @@ EVAL:
 
 // waypointNomadJob takes in a nomadConfig and returns a Nomad Job per the
 // Nomad API
-func waypointNomadJob(c nomadConfig) *api.Job {
+func waypointNomadJob(c nomadConfig, rawRunFlags string) *api.Job {
 	job := api.NewServiceJob(serverName, serverName, c.region, 50)
 	job.Namespace = &c.namespace
 	job.Datacenters = c.datacenters
@@ -673,7 +673,7 @@ func waypointNomadJob(c nomadConfig) *api.Job {
 	task.Config = map[string]interface{}{
 		"image":          c.serverImage,
 		"ports":          []string{"server", "ui"},
-		"args":           []string{"server", "run", "-accept-tos", "-vv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort)},
+		"args":           []string{"server", "run", "-accept-tos", "-vv", "-db=/alloc/data/data.db", fmt.Sprintf("-listen-grpc=0.0.0.0:%s", defaultGrpcPort), fmt.Sprintf("-listen-http=0.0.0.0:%s", defaultHttpPort), rawRunFlags},
 		"auth_soft_fail": c.authSoftFail,
 	}
 	task.Env = map[string]string{

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -62,8 +62,9 @@ type Installer interface {
 
 // InstallOpts are the options sent to Installer.Install.
 type InstallOpts struct {
-	Log hclog.Logger
-	UI  terminal.UI
+	Log            hclog.Logger
+	UI             terminal.UI
+	ServerRunFlags string
 }
 
 // InstallResults are the results expected for a successful Installer.Install.

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -64,7 +64,7 @@ type Installer interface {
 type InstallOpts struct {
 	Log            hclog.Logger
 	UI             terminal.UI
-	ServerRunFlags string
+	ServerRunFlags []string
 }
 
 // InstallResults are the results expected for a successful Installer.Install.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -36,6 +36,14 @@ flag. This only applies to the Waypoint URL service. You may disable the
 URL service by manually running the server. If you disable the URL service,
 you do not need to accept any terms.
 
+To further customize the server installation, you may pass advanced flag options
+specified in the documentation for the 'server run' command. To set these values,
+include a '--' after the full argument list for 'install', followed by these
+advanced flag options. As an example, to set the server log level to trace
+and disable the UI, the command would be:
+
+    waypoint install -platform=docker -accept-tos -- -vvv -disable-ui
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -48,7 +48,6 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
-- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -48,7 +48,7 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
-- `-run-flags=<string>` - Include flag values for the installer to supply to the server run command.
+- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -48,6 +48,7 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
+- `-run-flags=<string>` - Include flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -36,6 +36,14 @@ flag. This only applies to the Waypoint URL service. You may disable the
 URL service by manually running the server. If you disable the URL service,
 you do not need to accept any terms.
 
+To further customize the server installation, you may pass advanced flag options
+specified in the documentation for the 'server run' command. To set these values,
+include a '--' after the full argument list for 'install', followed by these
+advanced flag options. As an example, to set the server log level to trace
+and disable the UI, the command would be:
+
+    waypoint install -platform=docker -accept-tos -- -vvv -disable-ui
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -48,7 +48,6 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
-- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -48,7 +48,7 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
-- `-run-flags=<string>` - Include flag values for the installer to supply to the server run command.
+- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -48,6 +48,7 @@ you do not need to accept any terms.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context.
 - `-platform=<string>` - Platform to install the Waypoint server into.
+- `-run-flags=<string>` - Include flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -38,9 +38,9 @@ environment.
 - `-tls-key-file=<string>` - Path to a PEM-encoded private key file for the TLS certificate specified with -tls-cert-file. This is required if -tls-cert-file is set.
 - `-disable-ui` - Disable the embedded web interface
 - `-url-enabled` - Enable the URL service.
-- `-url-api-addr=<string>` - Address to Waypoint URL service API
-- `-url-api-insecure` - True if TLS is not enabled for the Waypoint URL service API
-- `-url-control-addr=<string>` - Address to Waypoint URL service control API
+- `-url-api-addr=<string>` - Address to Waypoint URL service API.
+- `-url-api-insecure` - True if TLS is not enabled for the Waypoint URL service API.
+- `-url-control-addr=<string>` - Address to Waypoint URL service control API.
 - `-url-control-token=<string>` - Token for the Waypoint URL server control API.
 - `-url-auto-app-hostname` - Whether apps automatically get a hostname on deploy.
 - `-advertise-addr=<string>` - Address to advertise for the server. This is used by the entrypoints

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -39,6 +39,7 @@ manually installed runners will not be automatically upgraded.
 - `-platform=<string>` - Platform to upgrade the Waypoint server from, defaults to the platform stored in the context.
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
+- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -39,7 +39,6 @@ manually installed runners will not be automatically upgraded.
 - `-platform=<string>` - Platform to upgrade the Waypoint server from, defaults to the platform stored in the context.
 - `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
 - `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
-- `-run-flags=<string>` - Flag values for the installer to supply to the server run command.
 
 #### docker Options
 

--- a/website/content/docs/server/run/index.mdx
+++ b/website/content/docs/server/run/index.mdx
@@ -17,12 +17,16 @@ You can also run and configure the server manually using the
 [`waypoint server run`](/commands/server-run) command. This is meant for more advanced
 users who want to run Waypoint in a platform that the `install` command doesn't support.
 
-It is possible to fine-tune the configuration of the server when using the `waypoint install` command. The `-run-flags` flag on the `install` command accepts a raw
-string of `server run` flags to set on the server. No validation is done on
-these flags, so you must be sure the flag and value are valid per the
-[`waypoint server run`](/commands/server-run) command documentation. For example,
-if you wanted to set the log level to `trace` on a server install, you could
-use the command `waypoint install -platform=docker -accept-tos -run-flags="-vvv"`.
+It is possible to fine-tune the configuration of the server when using the `waypoint install` command.
+To further customize the server installation, you may pass advanced flag options
+specified in the documentation for the [`waypoint server run`](/commands/server-run)
+command. To set these values, include a `--` after the full argument list for
+`install`, followed by these advanced flag options. As an example, to set the
+server log level to trace and disable the UI, you can use the below command.
+
+```shell-session
+  waypoint install -platform=docker -accept-tos -- -vvv -disable-ui
+```
 
 -> **Note:** Only _one_ Waypoint server needs to be installed and run
 for any group of people using Waypoint together. If you are a day-to-day

--- a/website/content/docs/server/run/index.mdx
+++ b/website/content/docs/server/run/index.mdx
@@ -15,8 +15,14 @@ It is a single command to get up and running with Waypoint.
 
 You can also run and configure the server manually using the
 [`waypoint server run`](/commands/server-run) command. This is meant for more advanced
-users who want to run Waypoint in a platform that the `install` command doesn't support
-or to fine-tune the configuration of the server.
+users who want to run Waypoint in a platform that the `install` command doesn't support.
+
+It is possible to fine-tune the configuration of the server when using the `waypoint install` command. The `-run-flags` flag on the `install` command accepts a raw
+string of `server run` flags to set on the server. No validation is done on
+these flags, so you must be sure the flag and value are valid per the
+[`waypoint server run`](/commands/server-run) command documentation. For example,
+if you wanted to set the log level to `trace` on a server install, you could
+use the command `waypoint install -platform=docker -accept-tos -run-flags="-vvv"`.
 
 -> **Note:** Only _one_ Waypoint server needs to be installed and run
 for any group of people using Waypoint together. If you are a day-to-day

--- a/website/content/docs/server/run/maintenance.mdx
+++ b/website/content/docs/server/run/maintenance.mdx
@@ -30,6 +30,7 @@ The Waypoint server stores data into a single `data.db` file.
 For `waypoint install`-based servers:
 
 - **Docker** - `/data/data.db`
+- **ECS** - `/waypoint-data/data.db`
 - **Kubernetes** - `/data/data.db`
 - **Nomad** - `/alloc/data.db`
 

--- a/website/content/plugins/aws-ec2.mdx
+++ b/website/content/plugins/aws-ec2.mdx
@@ -1,7 +1,7 @@
 ---
 layout: plugins
 page_title: 'Plugin: AWS EC2'
-description: 'Build, Deploy, and Release on Kubernetes'
+description: 'Build, Deploy, and Release on AWS EC2'
 ---
 
 # AWS EC2


### PR DESCRIPTION
This allows users to pass flags "through" the `install` command to the `server run` command that all server install platforms use. Included in `upgrade` as well for Nomad and Docker.
There are a couple typos and doc updates for various items as well that I saw while moving around the install/run docs.

Fixes #1514
Fixes #1491 
Augments #2325 by allowing the user to set their server log levels on an install.

**To test:**
Base case:
- On `main`, run `make`, then use the built binary to install the Waypoint server on docker. Check out the logs (`docker logs waypoint-server`) and observe that there are `INFO` and `DEBUG` logs only.

Test case:
- On this branch, run `make`, then use the built binary to install the Waypoint server on docker as follows: `waypoint install -platform=docker -accept-tos -- -vvv`. Check out the logs again, and observe there are now `TRACE` logs as well.