### PR TITLE
ui: de-lint last two components

### DIFF
--- a/ui/app/components/status-report-bar/index.ts
+++ b/ui/app/components/status-report-bar/index.ts
@@ -28,24 +28,24 @@ export default class StatusReportBar extends Component<StatusReportBarArgs> {
   @service('pdsFlashMessages') flashMessages!: FlashMessagesService;
   @tracked isRefreshRunning = false;
 
-  constructor(owner: any, args: any) {
+  constructor(owner: unknown, args: StatusReportBarArgs) {
     super(owner, args);
   }
 
-  get artifactType() {
+  get artifactType(): StatusReportBarArgs['artifactType'] {
     return this.args.artifactType;
   }
 
-  get model() {
+  get model(): StatusReportBarArgs['model'] {
     return this.args.model;
   }
 
-  get statusReport() {
+  get statusReport(): StatusReportBarArgs['model']['statusReport'] {
     return this.model.statusReport;
   }
 
   @action
-  async refreshHealthCheck(e: Event) {
+  async refreshHealthCheck(e: Event): Promise<void> {
     e.preventDefault();
 
     let ref = new Ref.Operation();

--- a/ui/app/components/version-info/index.ts
+++ b/ui/app/components/version-info/index.ts
@@ -5,16 +5,18 @@ import ApiService from 'waypoint/services/api';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { VersionInfo as info } from 'waypoint-pb';
 
-export default class VersionInfo extends Component {
+type Args = Record<string, never>;
+
+export default class VersionInfo extends Component<Args> {
   @service api!: ApiService;
   @tracked versionInfo: info.AsObject | undefined;
 
-  constructor(owner: any, args: any) {
+  constructor(owner: unknown, args: Args) {
     super(owner, args);
     this.getVersionInfo();
   }
 
-  async getVersionInfo() {
+  async getVersionInfo(): Promise<void> {
     let resp = await this.api.client.getVersionInfo(new Empty(), this.api.WithMeta());
     let versionInfo = resp?.getInfo();
 


### PR DESCRIPTION
## Why the change?

One step closer to running linters in CI.

## How do I test it?

These are all local type annotations so should be inherently safe.