### PR TITLE
internal/cli: Adjust spacing in help text

### DIFF
--- a/internal/cli/k8s_bootstrap.go
+++ b/internal/cli/k8s_bootstrap.go
@@ -326,11 +326,11 @@ Usage: waypoint k8s bootstrap [options]
 
   This command will do a number of things:
 
-    1. Equivalent of "waypoint server bootstrap"
-    2. Write a bootstrap token to the given Kubernetes secret
-    3. Create a token for a static runner and write it to the configured
-       Kubernetes secret.
-    4. Configure Kubernetes on-demand runners.
+  1. Equivalent of "waypoint server bootstrap"
+  2. Write a bootstrap token to the given Kubernetes secret
+  3. Create a token for a static runner and write it to the configured
+     Kubernetes secret.
+  4. Configure Kubernetes on-demand runners.
 
   This command will only run if the server hasn't already been bootstrapped.
   If the server is bootstrapped, this will not run again. This doesn't handle

--- a/website/content/commands/k8s-bootstrap.mdx
+++ b/website/content/commands/k8s-bootstrap.mdx
@@ -24,11 +24,11 @@ will not work with out-of-cluster kubectl configuration.
 
 This command will do a number of things:
 
-    1. Equivalent of "waypoint server bootstrap"
-    2. Write a bootstrap token to the given Kubernetes secret
-    3. Create a token for a static runner and write it to the configured
-       Kubernetes secret.
-    4. Configure Kubernetes on-demand runners.
+1. Equivalent of "waypoint server bootstrap"
+2. Write a bootstrap token to the given Kubernetes secret
+3. Create a token for a static runner and write it to the configured
+   Kubernetes secret.
+4. Configure Kubernetes on-demand runners.
 
 This command will only run if the server hasn't already been bootstrapped.
 If the server is bootstrapped, this will not run again. This doesn't handle


### PR DESCRIPTION
This commit fixes up the spacing in the k8s bootstrap helptext so that
the ordered list doesn't render as a codeblock

Before:

![Screenshot from 2021-09-21 08-58-30](https://user-images.githubusercontent.com/810277/134205393-3336619a-1c09-409d-b70e-cd82ca8aee86.png)

With this fix:

![Screenshot from 2021-09-21 08-58-41](https://user-images.githubusercontent.com/810277/134205415-b77333e9-cf5f-46aa-a597-3de15de5bbf7.png)
