### PR TITLE
waypoint login -from-kubernetes

### DIFF
--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -89,6 +89,7 @@ func (c *baseCommand) initClient(
 		serverclient.FromContext(c.contextStorage, ""),
 		serverclient.FromEnv(),
 		serverclient.FromContextConfig(flagConnection),
+		serverclient.Logger(c.Log.Named("serverclient")),
 	}, connectOpts...)
 	c.clientContext, err = serverclient.ContextConfig(connectOpts...)
 	if err != nil {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -510,7 +510,7 @@ for one of two reasons. First, the Waypoint server may not be bootstrapped.
 After installing Waypoint on Kubernetes, it takes a few minutes for Waypoint
 to bootstrap itself.
 
-If Waypoint is already bootstrapped, its possible the server administrator
+If Waypoint is already bootstrapped, it's possible the server administrator
 already deleted the secret. Future users should not use this authentication
 method and should instead ask another Waypoint user to generate an invite token
 for them.

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,24 +12,33 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/cap/util"
 	"github.com/posener/complete"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	wpoidc "github.com/hashicorp/waypoint/internal/auth/oidc"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/pkg/k8sauth"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 	"github.com/hashicorp/waypoint/internal/serverclient"
+	"github.com/hashicorp/waypoint/internal/serverconfig"
 )
 
 type LoginCommand struct {
 	*baseCommand
 
-	flagAuthMethod string
-	flagToken      string
+	flagAuthMethod     string
+	flagToken          string
+	flagK8S            bool
+	flagK8SService     string
+	flagK8STokenSecret string
 }
 
 func (c *LoginCommand) Run(args []string) int {
+	ctx := c.Ctx
+
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
 		WithArgs(args),
@@ -35,6 +46,11 @@ func (c *LoginCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithNoAutoServer(), // no need to login for local mode
 		WithConnectionArg(),
+
+		// Don't initialize the client automatically because if we have
+		// -from-kubernetes set we may want to do more logic to detect the
+		// server URL.
+		WithClient(false),
 	); err != nil {
 		// This error specifically comes if we attempt to run this without
 		// a server address configured.
@@ -58,9 +74,42 @@ func (c *LoginCommand) Run(args []string) int {
 		return 1
 	}
 
+	// If we are using K8S and we don't have an address set, then
+	// look it up using the service.
+	if c.flagK8S && c.flagConnection.Server.Address == "" {
+		addr, err := c.k8sServerAddr(ctx)
+		if err != nil {
+			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+			return 1
+		}
+
+		c.flagConnection.Server.Address = addr
+
+		// TLS is always skip verify for the current version of the helm
+		// chart. We will add a way to detect TLS settings later.
+		c.flagConnection.Server.Tls = true
+		c.flagConnection.Server.TlsSkipVerify = true
+	}
+
+	// Manually initialize our client. We have to do this because we have
+	// WithClient(false) set above in case we populate the server addr with
+	// Kubernetes info.
+	c.project, err = c.initClient(ctx)
+	if err != nil {
+		c.ui.Output(
+			"Error reconnecting with token: %s",
+			clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return 1
+	}
+
 	// Determine our auth func, which by default is OIDC
-	var authFunc func() (string, int)
+	var authFunc func(context.Context) (string, int)
 	switch {
+	case c.flagK8S:
+		authFunc = c.loginK8S
+
 	case c.flagToken != "":
 		authFunc = c.loginToken
 
@@ -69,7 +118,7 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	// Log in
-	token, exitCode := authFunc()
+	token, exitCode := authFunc(ctx)
 	if exitCode > 0 {
 		return exitCode
 	}
@@ -110,10 +159,10 @@ func (c *LoginCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *LoginCommand) loginToken() (string, int) {
+func (c *LoginCommand) loginToken(ctx context.Context) (string, int) {
 	// First we decode the token to ensure it is valid and also to figure
 	// out if we have a login or invite token.
-	decodeResp, err := c.project.Client().DecodeToken(c.Ctx, &pb.DecodeTokenRequest{
+	decodeResp, err := c.project.Client().DecodeToken(ctx, &pb.DecodeTokenRequest{
 		Token: c.flagToken,
 	})
 	if err != nil {
@@ -134,7 +183,7 @@ func (c *LoginCommand) loginToken() (string, int) {
 	}
 
 	// Convert it
-	convertResp, err := c.project.Client().ConvertInviteToken(c.Ctx, &pb.ConvertInviteTokenRequest{
+	convertResp, err := c.project.Client().ConvertInviteToken(ctx, &pb.ConvertInviteTokenRequest{
 		Token: c.flagToken,
 	})
 	if err != nil {
@@ -145,9 +194,9 @@ func (c *LoginCommand) loginToken() (string, int) {
 	return convertResp.Token, 0
 }
 
-func (c *LoginCommand) loginOIDC() (string, int) {
+func (c *LoginCommand) loginOIDC(ctx context.Context) (string, int) {
 	// Get our OIDC auth methods
-	respList, err := c.project.Client().ListOIDCAuthMethods(c.Ctx, &empty.Empty{})
+	respList, err := c.project.Client().ListOIDCAuthMethods(ctx, &empty.Empty{})
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return "", 1
@@ -187,7 +236,7 @@ func (c *LoginCommand) loginOIDC() (string, int) {
 	}
 
 	// Get the auth URL
-	respURL, err := c.project.Client().GetOIDCAuthURL(c.Ctx, &pb.GetOIDCAuthURLRequest{
+	respURL, err := c.project.Client().GetOIDCAuthURL(ctx, &pb.GetOIDCAuthURLRequest{
 		AuthMethod:  refAM,
 		RedirectUri: callbackSrv.RedirectUri(),
 		Nonce:       callbackSrv.Nonce(),
@@ -208,7 +257,7 @@ func (c *LoginCommand) loginOIDC() (string, int) {
 	// Wait
 	var req *pb.CompleteOIDCAuthRequest
 	select {
-	case <-c.Ctx.Done():
+	case <-ctx.Done():
 		// User cancelled
 		return "", 1
 
@@ -222,7 +271,7 @@ func (c *LoginCommand) loginOIDC() (string, int) {
 
 	// Complete the auth
 	req.AuthMethod = refAM
-	respToken, err := c.project.Client().CompleteOIDCAuth(c.Ctx, req)
+	respToken, err := c.project.Client().CompleteOIDCAuth(ctx, req)
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return "", 1
@@ -237,6 +286,87 @@ func (c *LoginCommand) loginOIDC() (string, int) {
 	)
 
 	return respToken.Token, 0
+}
+
+func (c *LoginCommand) loginK8S(ctx context.Context) (string, int) {
+	// Get our Kubernetes client
+	clientset, ns, _, err := k8sauth.Clientset("", "")
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return "", 1
+	}
+	secretClient := clientset.CoreV1().Secrets(ns)
+
+	// Get the secret
+	secret, err := secretClient.Get(ctx, c.flagK8STokenSecret, metav1.GetOptions{})
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return "", 1
+	}
+
+	// Get our token
+	tokenB64 := secret.Data["token"]
+	if len(tokenB64) == 0 {
+		c.ui.Output(strings.TrimSpace(errK8STokenEmpty), terminal.WithErrorStyle())
+		return "", 1
+	}
+
+	token, err := base64.StdEncoding.DecodeString(string(tokenB64))
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return "", 1
+	}
+
+	return string(token), 0
+}
+
+func (c *LoginCommand) k8sServerAddr(ctx context.Context) (string, error) {
+	// Get our Kubernetes client
+	clientset, ns, _, err := k8sauth.Clientset("", "")
+	if err != nil {
+		return "", err
+	}
+	serviceClient := clientset.CoreV1().Services(ns)
+
+	// Get the service
+	var advertiseAddr string
+	waitOut := false
+	err = wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
+		service, err := serviceClient.Get(ctx, c.flagK8SService, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if service.Spec.Type == "LoadBalancer" {
+			if ig := service.Status.LoadBalancer.Ingress; len(ig) > 0 {
+				advertiseAddr = ig[0].IP
+				return true, nil
+			}
+		} else {
+			if ip := service.Spec.ClusterIP; ip != "" {
+				advertiseAddr = ip
+				return true, nil
+			}
+		}
+
+		// Only show this once.
+		if !waitOut {
+			c.ui.Output("Waiting for the Waypoint service to become ready...")
+			waitOut = true
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// The advertise addr always needs the gRPC port. For our Helm chart
+	// this isn't configurable so this is always correct.
+	advertiseAddr += ":" + serverconfig.DefaultGRPCPort
+
+	c.ui.Output("Waypoint server URL: %s", advertiseAddr)
+	return advertiseAddr, nil
 }
 
 func (c *LoginCommand) Flags() *flag.Sets {
@@ -254,6 +384,32 @@ func (c *LoginCommand) Flags() *flag.Sets {
 			Target: &c.flagToken,
 			Usage: "Auth with a token. This will force auth-method to 'token'. " +
 				"This works with both login and invite tokens.",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:   "from-kubernetes",
+			Target: &c.flagK8S,
+			Usage: "Perform the initial authentication after Waypoint is installed " +
+				"to Kubernetes. This requires kubectl to be configured with access to the " +
+				"Kubernetes cluster. The primary use case of this is to get the first " +
+				"token from a Waypoint installation. After that, future users should use " +
+				"a configured auth method or request a token from an administrator.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "-from-kubernetes-service",
+			Target: &c.flagK8SService,
+			Usage: "The name of the Kubernetes service to get the server address from " +
+				"when using the -from-kubernetes flag.",
+			Default: "waypoint-ui",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "-from-kubernetes-secret",
+			Target: &c.flagK8STokenSecret,
+			Usage: "The name of the Kubernetes secret that has the Waypoint token " +
+				"when using the -from-kubernetes flag.",
+			Default: "waypoint-server-token",
 		})
 	})
 }
@@ -319,6 +475,18 @@ waypoint login https://example.com
 	errTokenInvalid = `
 The specified token is not a valid login or invite token. Please
 double-check the token and try again.
+`
+
+	errK8STokenEmpty = `
+The Waypoint token in the Kubernetes secret is empty. This is usually
+for one of two reasons. First, the Waypoint server may not be bootstrapped.
+After installing Waypoint on Kubernetes, it takes a few minutes for Waypoint
+to bootstrap itself.
+
+If Waypoint is already bootstrapped, its possible the server administrator
+already deleted the secret. Future users should not use this authentication
+method and should instead ask another Waypoint user to generate an invite token
+for them.
 `
 
 	outVisitURL = `

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"sort"
@@ -151,6 +150,8 @@ func (c *LoginCommand) Run(args []string) int {
 		"address", newContext.Server.Address,
 		"tls", newContext.Server.Tls,
 		"tls_skip_verify", newContext.Server.TlsSkipVerify,
+		"token", newContext.Server.AuthToken,
+		"require_auth", newContext.Server.RequireAuth,
 	)
 
 	// Validate the connection
@@ -338,13 +339,7 @@ func (c *LoginCommand) loginK8S(ctx context.Context) (string, int) {
 		return "", 1
 	}
 
-	token, err := base64.StdEncoding.DecodeString(string(tokenB64))
-	if err != nil {
-		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
-		return "", 1
-	}
-
-	return string(token), 0
+	return string(tokenB64), 0
 }
 
 func (c *LoginCommand) k8sServerAddr(ctx context.Context) (string, error) {

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -465,6 +465,11 @@ Usage: waypoint login [server address]
   other forms such as OIDC. You can use "-token" to specify a login or
   invite token and configure the CLI to access the server.
 
+  The "-from-kubernetes" flag can be used after a fresh Waypoint installation
+  on Kubernetes to log in using the bootstrap token. This requires local
+  Kubernetes connection configuration via a KUBECONFIG environment variable
+  or file.
+
 ` + c.Flags().Help())
 }
 

--- a/internal/pkg/k8sauth/doc.go
+++ b/internal/pkg/k8sauth/doc.go
@@ -1,0 +1,4 @@
+// Package k8sauth has helpers for authenticating to Kubernetes. This
+// makes it easy to get a clientset, namespace information, etc. for both
+// in-cluster and out-of-cluster auth.
+package k8sauth

--- a/internal/pkg/k8sauth/k8sauth.go
+++ b/internal/pkg/k8sauth/k8sauth.go
@@ -1,0 +1,95 @@
+package k8sauth
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Clientset returns a K8S clientset and configured namespace. This will
+// attempt to use in-cluster auth if available if kubeconfig is not explicitly
+// specified. Otherwise, this will fall back to out of cluster auth.
+func Clientset(kubeconfig, context string) (*kubernetes.Clientset, string, *rest.Config, error) {
+	if kubeconfig == "" {
+		cs, ns, c, err := ClientsetInCluster()
+		if err == nil {
+			return cs, ns, c, nil
+		}
+
+		// If we got an error about not being in the cluster, that's okay
+		// and fall back to out of cluster auth. If we got any other error
+		// though then report an error.
+		if err != rest.ErrNotInCluster {
+			return nil, "", nil, err
+		}
+	}
+
+	return ClientsetOutOfCluster(kubeconfig, context)
+}
+
+// ClientsetOutOfCluster loads a Kubernetes clientset using only a kubeconfig.
+func ClientsetOutOfCluster(kubeconfig, context string) (*kubernetes.Clientset, string, *rest.Config, error) {
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	// Path to the kube config file
+	if kubeconfig != "" {
+		loader.ExplicitPath = kubeconfig
+	}
+
+	// Build our config and client
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loader,
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		},
+	)
+
+	// Get our configured namespace
+	ns, _, err := config.Namespace()
+	if err != nil {
+		return nil, "", nil, status.Errorf(codes.Aborted,
+			"failed to initialize K8S client configuration: %s", err)
+	}
+
+	clientconfig, err := config.ClientConfig()
+	if err != nil {
+		return nil, "", nil, status.Errorf(codes.Aborted,
+			"failed to initialize K8S client configuration: %s", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(clientconfig)
+	if err != nil {
+		return nil, "", nil, status.Errorf(codes.Aborted,
+			"failed to initialize K8S client: %s", err)
+	}
+
+	return clientset, ns, clientconfig, nil
+}
+
+// ClientsetInCluster returns a K8S clientset and configured namespace for
+// in-cluster usage.
+func ClientsetInCluster() (*kubernetes.Clientset, string, *rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	ns := "default"
+	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if v := strings.TrimSpace(string(data)); len(v) > 0 {
+			ns = v
+		}
+	}
+
+	return clientset, ns, config, nil
+}

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -46,5 +46,8 @@ invite token and configure the CLI to access the server.
 
 - `-auth-method=<string>` - Auth method to use for login. This will default to the only available auth method if only one exists.
 - `-token=<string>` - Auth with a token. This will force auth-method to 'token'. This works with both login and invite tokens.
+- `-from-kubernetes` - Perform the initial authentication after Waypoint is installed to Kubernetes. This requires kubectl to be configured with access to the Kubernetes cluster. The primary use case of this is to get the first token from a Waypoint installation. After that, future users should use a configured auth method or request a token from an administrator.
+- `--from-kubernetes-service=<string>` - The name of the Kubernetes service to get the server address from when using the -from-kubernetes flag.
+- `--from-kubernetes-secret=<string>` - The name of the Kubernetes secret that has the Waypoint token when using the -from-kubernetes flag.
 
 @include "commands/login_more.mdx"

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -30,6 +30,11 @@ This command can be used for token-based authentication as well as
 other forms such as OIDC. You can use "-token" to specify a login or
 invite token and configure the CLI to access the server.
 
+The "-from-kubernetes" flag can be used after a fresh Waypoint installation
+on Kubernetes to log in using the bootstrap token. This requires local
+Kubernetes connection configuration via a KUBECONFIG environment variable
+or file.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.


### PR DESCRIPTION
This introduces `waypoint login -from-kubernetes` that performs automatic authentication after a Helm-based install. This looks up the Waypoint service, gets the token from the Kubernetes secret, and completes the login.