### PR TITLE
ui: de-lint remaining items in `app` directory

### DIFF
--- a/ui/app/config/environment.d.ts
+++ b/ui/app/config/environment.d.ts
@@ -9,7 +9,7 @@ export default config;
  */
 declare const config: {
   apiAddress: string;
-  environment: any;
+  environment: string;
   modulePrefix: string;
   podModulePrefix: string;
   locationType: string;

--- a/ui/app/controllers/workspace/projects/new.ts
+++ b/ui/app/controllers/workspace/projects/new.ts
@@ -12,7 +12,7 @@ export default class WorkspaceProjectsNew extends Controller {
   @tracked createGit = false;
 
   @action
-  async saveProject(e: Event) {
+  async saveProject(e: Event): Promise<void> {
     e.preventDefault();
     let project = this.model;
     let ref = new Project();

--- a/ui/app/controllers/workspace/projects/project/settings/config-variables.ts
+++ b/ui/app/controllers/workspace/projects/project/settings/config-variables.ts
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { Model as ProjectRouteModel } from 'waypoint/routes/workspace/projects/project';
+
+export default class extends Controller {
+  @tracked project?: ProjectRouteModel;
+}

--- a/ui/app/helpers/current-year.ts
+++ b/ui/app/helpers/current-year.ts
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
 // currentYear
-export function currentYear([]): number {
+export function currentYear(): number {
   return new Date().getFullYear();
 }
 

--- a/ui/app/helpers/enforce-protocol.ts
+++ b/ui/app/helpers/enforce-protocol.ts
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-export function enforceProtocol(params/*, hash*/) {
+export function enforceProtocol(params: [string] /*, hash*/): string {
   let str = params[0];
 
   let isHttps = str.startsWith('https://');

--- a/ui/app/routes/workspace/projects/project/settings/config-variables.ts
+++ b/ui/app/routes/workspace/projects/project/settings/config-variables.ts
@@ -2,7 +2,12 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { ConfigGetRequest, ConfigGetResponse, Ref } from 'waypoint-pb';
-import { Params as ProjectRouteParams } from 'waypoint/routes/workspace/projects/project';
+import {
+  Model as ProjectRouteModel,
+  Params as ProjectRouteParams,
+} from 'waypoint/routes/workspace/projects/project';
+import ConfigVariablesController from 'waypoint/controllers/workspace/projects/project/settings/config-variables';
+
 export default class WorkspaceProjectsProjectSettingsConfigVariables extends Route {
   @service api!: ApiService;
 
@@ -17,9 +22,11 @@ export default class WorkspaceProjectsProjectSettingsConfigVariables extends Rou
     return config?.toObject();
   }
 
-  setupController(controller, model, transition) {
-    super.setupController(controller, model, transition);
-    let project = this.modelFor('workspace.projects.project');
+  setupController(...args: Parameters<Route['setupController']>): void {
+    super.setupController(...args);
+
+    let controller = args[0] as ConfigVariablesController;
+    let project = this.modelFor('workspace.projects.project') as ProjectRouteModel;
 
     controller.project = project;
   }


### PR DESCRIPTION
## Why the change?

One step closer to running linters in CI.

## How do I test this?

The only part of this that isn’t strictly type annotations is the changes to the config-variables route and the addition of the config-variables controller. To test this part, I recommend:

1. Check out the branch
2. Boot the UI against a local waypoint server (`yarn start local`)
3. Try adding, editing, removing config vars
4. Verify everything works correctly

**Why test against a local server?**

Because I wrote a buggy Mirage handler for this and I need to fix it still.