### PR TITLE
ui: fix remaining linting errors and enable linting in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,6 +443,22 @@ jobs:
       - store_test_results:
           path: ui/test-results
 
+  # run frontend linters
+  frontend-lint:
+    docker:
+      - image: *EMBER_IMAGE
+    environment:
+      <<: *ENVIRONMENT
+    steps:
+      - checkout
+      - md5uilib
+      - restore_cache:
+          key: *YARN_CACHE_KEY
+      - run:
+          working_directory: ui
+          command: yarn lint
+      - notify_main_failure
+
 workflows:
   version: 2
   go-tests:
@@ -528,9 +544,11 @@ workflows:
   frontend:
     jobs:
       - frontend-cache
+      - frontend-lint
       - ember-build-tests:
           requires:
             - frontend-cache
+            - frontend-lint
       - ember-test:
           requires:
             - ember-build-tests

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -49,8 +49,8 @@ module.exports = function (defaults) {
         {
           package: 'waypoint-pb',
           semverRange: '*',
-        }
-      ]
+        },
+      ],
     },
   });
 

--- a/ui/mirage/factories/config-variable.ts
+++ b/ui/mirage/factories/config-variable.ts
@@ -11,7 +11,10 @@ export default Factory.extend({
     name: () => faker.hacker.noun(),
     dynamic: {
       from: () => 'kubernetes',
-      configMap: () => [['name', 'my-config-map'], ['key', 'port']],
-    }
+      configMap: () => [
+        ['name', 'my-config-map'],
+        ['key', 'port'],
+      ],
+    },
   }),
 });

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'miragejs';
 import {
   ListStatusReportsRequest,
   ListStatusReportsResponse,
-  ExpediteStatusReportRequest,
   ExpediteStatusReportResponse,
 } from 'waypoint-pb';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
@@ -30,7 +29,7 @@ export function getLatest(): Response {
   return this.serialize(new Empty(), 'application');
 }
 
-export function expediteStatusReport(schema: any, { requestBody }: Request): Response {
+export function expediteStatusReport(): Response {
   // while this is not being used in the current implementation to generate the mocked job id response
   // i'm leaving this here in case we want to update this to handle specific requests
   // let requestMsg = decode(ExpediteStatusReportRequest, requestBody);


### PR DESCRIPTION
## Why the change?

I believe running the JS, TS, and HBS linters in CI will help us catch bugs before they hit main. I’m not so concerned with code consistency, though that is a nice side-effect too I guess.

## How do I test this?

Good question. I think this might be worth discussing as a team during horde time.