### PR TITLE
Waypoint server: Support insecure HTTP listener 

### DIFF
--- a/.changelog/2347.txt
+++ b/.changelog/2347.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli: `server run` can now create a non-TLS HTTP listener. This listener
+redirects to HTTPS unless X-Forwarded-Proto is https.
+```

--- a/internal/server/http_tls.go
+++ b/internal/server/http_tls.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 )
 
 // Proto header to read for the forwarded proto
@@ -13,7 +14,7 @@ func forceTLSHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scheme := r.URL.Scheme
 		if v := r.Header.Get(xForwardedProto); v != "" {
-			scheme = v
+			scheme = strings.ToLower(v)
 		}
 
 		if scheme != "https" {

--- a/internal/server/http_tls.go
+++ b/internal/server/http_tls.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"net/http"
+)
+
+// Proto header to read for the forwarded proto
+const xForwardedProto = "X-Forwarded-Proto"
+
+// forceTLSHandler forces TLS on a URL. This allows forwarded TLS connections
+// with an X-Forwarded-Proto header.
+func forceTLSHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme := r.URL.Scheme
+		if v := r.Header.Get(xForwardedProto); v != "" {
+			scheme = v
+		}
+
+		if scheme != "https" {
+			if r.Method != "GET" {
+				w.WriteHeader(400)
+				return
+			}
+
+			url := *r.URL
+			url.Scheme = "https"
+			if url.Host == "" {
+				url.Host = r.Host
+			}
+
+			http.Redirect(w, r, url.String(), http.StatusTemporaryRedirect)
+			return
+		}
+
+		// Call the next handler in the chain.
+		h.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/http_tls_test.go
+++ b/internal/server/http_tls_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var goodHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+})
+
+func TestForceTLS(t *testing.T) {
+	w := httptest.NewRecorder()
+	url := "http://127.0.0.1/foo/bar"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	h := forceTLSHandler(goodHandler)
+	h.ServeHTTP(w, req)
+	if w.Code != 307 {
+		t.Fatalf("bad: %d", w.Code)
+	}
+	if v := w.HeaderMap.Get("Location"); v != "https://127.0.0.1/foo/bar" {
+		t.Fatalf("bad: %s", v)
+	}
+}
+
+func TestForceTLS_valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	url := "https://127.0.0.1/foo/bar"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	h := forceTLSHandler(goodHandler)
+	h.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("bad: %d", w.Code)
+	}
+}
+
+func TestForceTLS_post(t *testing.T) {
+	w := httptest.NewRecorder()
+	url := "http://127.0.0.1/foo/bar"
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	h := forceTLSHandler(goodHandler)
+	h.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("bad: %d", w.Code)
+	}
+}

--- a/internal/serverconfig/config.go
+++ b/internal/serverconfig/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	// HTTP is the listening configuration for the HTTP service for grpc-web.
 	HTTP Listener `hcl:"http,block"`
 
+	// HTTPInsecure sets up a listener for HTTP that never has TLS enabled.
+	// This is generally not recommended but can make sense in certain
+	// environments. For example, within Kubernetes where TLS termination
+	// happens at a higher level you may want an additional insecure listener
+	// in addition to a secure listener.
+	HTTPInsecure Listener `hcl:"http_insecure,block"`
+
 	// URL configures a server to use a URL service.
 	URL *URL `hcl:"url,block"`
 

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -34,6 +34,7 @@ environment.
 - `-db=<string>` - Path to the database file.
 - `-listen-grpc=<string>` - Address to bind to for gRPC connections.
 - `-listen-http=<string>` - Address to bind to for HTTP connections. Required for the UI.
+- `-listen-http-insecure=<string>` - Address to bind to for insecure HTTP connections. This will not have TLS enabled. This will redirect users to the TLS port UNLESS there is an X-Forwarded-Proto header. This makes this port suitable for proxy backends.
 - `-tls-cert-file=<string>` - Path to a PEM-encoded certificate file for TLS. If this isn't set, a self-signed certificate will be generated. This file will be monitored for changes and will automatically reload on change.
 - `-tls-key-file=<string>` - Path to a PEM-encoded private key file for the TLS certificate specified with -tls-cert-file. This is required if -tls-cert-file is set. This file will be monitored for changes and will automatically reload on change
 - `-disable-ui` - Disable the embedded web interface


### PR DESCRIPTION
This adds a `-listen-http-insecure` flag to the Waypoint server to create an insecure (non-TLS) HTTP listener. 

This insecure HTTP listener behaves in two ways:

1. If there is an `X-Forwarded-Proto` of `https`, it routes the traffic.
2. Otherwise, it redirects to https.

The insecure HTTP listener is primarily to help with the Kubernetes use case where resources such as `Ingress` do not typically talk to their backends with TLS. Further, it helps the basic `LoadBalancer Service` case because port 80 will redirect to TLS versus not connecting today. 

This is opt-in functionality. If the flag isn't specified, an insecure listener is not created. 

There is no way to get this today with `waypoint install` (unless you specify a manual flag). The plan is to integrate this into the Waypoint Helm chart directly.