### PR TITLE
internal/server: log kubeprobe http requests at trace level

### DIFF
--- a/.changelog/2348.txt
+++ b/.changelog/2348.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: HTTP requests from Kubernetes probes are logged at a trace level rather than info
+```


### PR DESCRIPTION
The "kube-probe" user agent is sent for Kubernetes health checks. If the
user agent matches this, we still log but we do so at a lower level so
that our logs don't get flooded.