### PR TITLE
ui: fix frontend-lint config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,10 +544,11 @@ workflows:
   frontend:
     jobs:
       - frontend-cache
-      - frontend-lint
-      - ember-build-tests:
+      - frontend-lint:
           requires:
             - frontend-cache
+      - ember-build-tests:
+          requires:
             - frontend-lint
       - ember-test:
           requires:


### PR DESCRIPTION
I forgot to declare `frontend-cache` as a dependency of `frontend-lint`.