### PR TITLE
internal/server: config resolution needs to account for workspaces

### DIFF
--- a/internal/server/gen/server.pb.go
+++ b/internal/server/gen/server.pb.go
@@ -10237,11 +10237,14 @@ func (x *LogBatch) GetLines() []*LogBatch_Entry {
 // both the project and app scope), the following rules are applied to determine
 // which variable value is used:
 //
-//   1. The most specific "scope" is used: app over project over global.
+//   1. If a workspace is set one one but not the other, the variable
+//      with the workspace sorts higher than no workspace.
 //
-//   2. If scopes match, the variable with a label selector set is used.
+//   2. The most specific "scope" is used: app over project over global.
 //
-//   3. If both have label selectors, the config variable with the longer
+//   3. If scopes match, the variable with a label selector set is used.
+//
+//   4. If both have label selectors, the config variable with the longer
 //      label selector by string length is used. This is arbitrary but makes
 //      the process deterministic.
 //

--- a/internal/server/proto/server.proto
+++ b/internal/server/proto/server.proto
@@ -3378,11 +3378,14 @@ message LogBatch {
 // both the project and app scope), the following rules are applied to determine
 // which variable value is used:
 //
-//   1. The most specific "scope" is used: app over project over global.
+//   1. If a workspace is set one one but not the other, the variable
+//      with the workspace sorts higher than no workspace.
 //
-//   2. If scopes match, the variable with a label selector set is used.
+//   2. The most specific "scope" is used: app over project over global.
 //
-//   3. If both have label selectors, the config variable with the longer
+//   3. If scopes match, the variable with a label selector set is used.
+//
+//   4. If both have label selectors, the config variable with the longer
 //      label selector by string length is used. This is arbitrary but makes
 //      the process deterministic.
 //


### PR DESCRIPTION
The config resolution rules omitted workspace targeting. This ended up
in behavior that worked as "intended" in this broken case: sometimes
you'd get workspace-scoped prioritizing over non-workspace-scoped and
vice versa. It was undefined!

This clarifies the resolution to note that a variable with a workspace
set takes higher priority over one without a variable set, and encodes
this rule into the sort logic. This also adds tests for this.