### PR TITLE
Support specifying custom environment variables for input variable default values

### DIFF
--- a/.changelog/2362.txt
+++ b/.changelog/2362.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+config: input variables (`variable`) can now use an `env` key to specify
+alternate environment variable names to source variable values from
+```

--- a/internal/config/variables/testdata/valid.hcl
+++ b/internal/config/variables/testdata/valid.hcl
@@ -17,3 +17,9 @@ variable "whatdoesittaketobenumber" {
   default = 1
   type = number
 }
+
+variable "envs" {
+  default = 1
+  type = number
+  env = ["foo", "bar"]
+}

--- a/internal/config/variables/variables_test.go
+++ b/internal/config/variables/variables_test.go
@@ -63,7 +63,7 @@ func TestVariables_DecodeVariableBlock(t *testing.T) {
 			}
 
 			if tt.err == "" {
-				require.False(diags.HasErrors())
+				require.False(diags.HasErrors(), diags.Error())
 				return
 			}
 

--- a/internal/config/variables/variables_test.go
+++ b/internal/config/variables/variables_test.go
@@ -1,6 +1,7 @@
 package variables
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -403,6 +404,96 @@ func TestVariables_SetJobInputVariables(t *testing.T) {
 			for _, v := range tt.expected {
 				require.Contains(vars, v)
 			}
+		})
+	}
+}
+
+func TestLoadEnvValues(t *testing.T) {
+	cases := []struct {
+		name     string
+		vars     map[string]*Variable
+		env      map[string]string
+		expected map[string]string
+	}{
+		{
+			"WP_VAR_ always wins",
+			map[string]*Variable{
+				"foo": {
+					Name: "foo",
+					Env:  []string{"one", "two"},
+				},
+			},
+			map[string]string{"WP_VAR_foo": "x", "one": "1", "two": "2"},
+			map[string]string{"foo": "x"},
+		},
+
+		{
+			"first match takes priority",
+			map[string]*Variable{
+				"foo": {
+					Name: "foo",
+					Env:  []string{"one", "two"},
+				},
+			},
+			map[string]string{"one": "1", "two": "2"},
+			map[string]string{"foo": "1"},
+		},
+
+		{
+			"first match takes priority (second set)",
+			map[string]*Variable{
+				"foo": {
+					Name: "foo",
+					Env:  []string{"one", "two"},
+				},
+			},
+			map[string]string{"two": "2"},
+			map[string]string{"foo": "2"},
+		},
+
+		{
+			"none set",
+			map[string]*Variable{
+				"foo": {
+					Name: "foo",
+					Env:  []string{"one", "two"},
+				},
+			},
+			map[string]string{},
+			map[string]string{},
+		},
+
+		{
+			"env key not set",
+			map[string]*Variable{
+				"foo": {
+					Name: "foo",
+				},
+			},
+			map[string]string{"one": "1", "two": "2"},
+			map[string]string{},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Set our env vars
+			for k, v := range tt.env {
+				defer os.Setenv(k, os.Getenv(k))
+				require.NoError(os.Setenv(k, v))
+			}
+
+			actual, diags := LoadEnvValues(tt.vars)
+			require.False(diags.HasErrors(), diags.Error())
+
+			actualMap := map[string]string{}
+			for _, v := range actual {
+				actualMap[v.Name] = v.Value.(*pb.Variable_Str).Str
+			}
+
+			require.Equal(tt.expected, actualMap)
 		})
 	}
 }

--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -149,6 +149,12 @@ func (r *Runner) executeJob(
 		return nil, err
 	}
 
+	// Load variable values from the environment.
+	envVars, diags := variables.LoadEnvValues(cfg.InputVariables)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
 	// Here we'll load our values from auto vars files and the server/UI, and
 	// combine them with any values set on the job
 	// The order values are added to our final pbVars slice is the order
@@ -159,6 +165,7 @@ func (r *Runner) executeJob(
 	}
 
 	pbVars := resp.Project.GetVariables()
+	pbVars = append(pbVars, envVars...)
 	pbVars = append(pbVars, vcsVars...)
 	pbVars = append(pbVars, job.Variables...)
 

--- a/website/content/docs/waypoint-hcl/variable.mdx
+++ b/website/content/docs/waypoint-hcl/variable.mdx
@@ -35,6 +35,7 @@ variable "tag" {
 Supply a value to a specified `variable` with one of the following methods:
 
 - the [`default`][inpage-default] value in the definition block
+- an environment variable on the runner specified by `env` in the definition block
 - the parameter `-var key=value`
 - the parameter `-var-file=filename`, where `filename` is the name of a file
   with variable values
@@ -56,5 +57,9 @@ Supply a value to a specified `variable` with one of the following methods:
 
 - `description` `(string: "")` - A short summary documenting what the variable
   is and its purpose.
+
+- `env` `(list of string: [])` - Sets a set of environment variables to source
+  a default value from if a value is not set. The environment variables are read
+  only on the runner. See [environment variables](/docs/waypoint-hcl/variables/input#environment-variables) for more information.
 
 [expression]: /docs/waypoint-hcl/syntax/expressions#types-and-values 'Expressions: Types and Values'

--- a/website/content/docs/waypoint-hcl/variables/input.mdx
+++ b/website/content/docs/waypoint-hcl/variables/input.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Input Variables - Variables - waypoint.hcl
 description: |-
-  Input variables allow you to customize Waypoint configuration according to 
+  Input variables allow you to customize Waypoint configuration according to
   set parameters. This section documents input variable syntax, including how to
   define, reference, and use input variables.
 ---
@@ -29,6 +29,7 @@ blocks include:
 variable "port" {
   type    = number
   default = 8080
+  env     = ["PORT"]
 }
 
 variable "image_name" {
@@ -62,6 +63,7 @@ Waypoint CLI defines the following optional arguments for variable declarations:
 - [`default`][inpage-default] - A default value.
 - [`type`][inpage-type] - This specifies what value types are accepted for the variable.
 - [`description`][inpage-description] - This specifies the input variable's documentation.
+- [`env`][inpage-env] - Default value sourced from an environment variable.
 
 ### Default values
 
@@ -273,9 +275,26 @@ the root object properties corresponding to variable names:
 
 ### Environment Variables
 
-As a fallback for the other ways of defining variables, Waypoint searches
-the environment of its own process for environment variables named `WP_VAR_`
-followed by the name of a declared variable.
+[inpage-env]: #environment-variables
+
+If a variable specifies a value for the `env` field, environment variables
+of those names are searched to provide a value for the variable. The variables
+are searched in order, and the first non-empty environment variable is
+used. The special environment variable named `WP_VAR_<name>` (where `<name>`
+is the name of the variable) always works regardless of if `env` is set or not.
+
+For example, given the following variable:
+
+```hcl
+variable "port" {
+  type    = number
+  default = 8080
+  env     = ["PORT"]
+}
+```
+
+Waypoint will search for a value in `WP_VAR_port` followed by `PORT`.
+If neither are set, the default `8080` is used as specified in the stanza.
 
 This can be useful when running Waypoint in automation, or when running a
 sequence of Waypoint commands in succession with the same variables.
@@ -291,6 +310,11 @@ On operating systems where environment variable names are case-sensitive,
 Waypoint matches the variable name exactly as given in configuration, and
 so the required environment variable name will usually have a mix of upper
 and lower case letters as in the above example.
+
+-> **Note:** Environment variables specified with `env` are only loaded
+as default values on the Waypoint [runner](/docs/runner). For local operations
+this is the same machine as the CLI but for production use cases this might
+be a remote machine.
 
 ### Variables in the UI
 


### PR DESCRIPTION
This lets input variables specify any named environment variable as a source for a default value. Example: 

```
variable "region" {
  type    = string
  env     = ["REGION"]
}
```

If the `REGION` env var is set, it will populate the default value of this variable (Note: `WP_VAR_region` takes priority always). If multiple env vars are specified, the first matching takes priority. If none of the defined env vars are set, the `default` value (if set) is used. If no default is specified, it is an error since the variable is required and unset.

The env vars specified here are loaded _only at the runner (config evaluation time)_ currently. I'm unsure if we want to expand this to load at CLI time but I would say no, we only want WP_VAR_ variables there, unless the CLI also happens to be the runner (local mode).

This also fixes a potential bug I found where WP_VAR_ variables weren't loaded at runner-time. This could easily be as intended but I think we want to load those at runner-time too so that runner scoped configs can set variables for builds and so on.

**TODO:** I still have to write docs and validate this a bit more.
