### PR TITLE
builtin/docker: if host is docker.io, use index.docker.io for registry

### DIFF
--- a/builtin/docker/kaniko.go
+++ b/builtin/docker/kaniko.go
@@ -71,6 +71,12 @@ func (b *Builder) buildWithKaniko(
 		return nil, status.Errorf(codes.Internal, "unable to parse image name: %s", err)
 	}
 	host := reference.Domain(ref)
+	if host == "docker.io" {
+		// The normalized name parse above will turn short names like "foo/bar"
+		// into "docker.io/foo/bar" but the actual registry host for these
+		// is "index.docker.io".
+		host = "index.docker.io"
+	}
 	log.Trace("auth host", "host", host)
 
 	if ai.Insecure {


### PR DESCRIPTION
The Docker `reference` library doesn't give us the real registry host in
this special case, so we just set it manually.

If we find a better way to do this, we should do it.