### PR TITLE
internal/core: add project/app to JobInfo

### DIFF
--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -69,12 +69,16 @@ func newApp(
 	p *Project,
 	cfg *config.App,
 ) (*App, error) {
+	// Copy the job info structure, a shallow copy is fine.
+	jobInfo := *p.jobInfo
+	jobInfo.App = cfg.Name
+
 	// Initialize
 	app := &App{
 		project: p,
 		client:  p.client,
 		source:  &component.Source{App: cfg.Name, Path: cfg.Path},
-		jobInfo: p.jobInfo,
+		jobInfo: &jobInfo,
 		logger:  p.logger.Named("app").Named(cfg.Name),
 		ref: &pb.Ref_Application{
 			Application: cfg.Name,

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -124,6 +124,7 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 	p.labels = opts.Config.Labels
 
 	// Set our final job info
+	p.jobInfo.Project = p.name
 	p.jobInfo.Workspace = p.workspace
 
 	// Initialize all the applications and load all their components.


### PR DESCRIPTION
A little PR that builds on top of recent SDK improvements.

This exposes the project and app name in the component.JobInfo structure
that is already passed to all plugin operations. This will allow plugins
to make use of project/app name as necessary for behavior.

I want to use this information for default release names for Helm.