### PR TITLE
ui/deployments: fix header

### DIFF
--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -2,8 +2,9 @@
 
 {{#if (and
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.build')
-  (not (includes this.target.currentRouteName 'workspace.projects.project.app.deployment'))
+  (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.release')
+  (not (includes this.target.currentRouteName 'workspace.projects.project.app.deployment.'))
 )}}
 <PageHeader @iconName="git-repository">
   <div class="title">


### PR DESCRIPTION
## Why the change?

I introduced this bug in #2317.

Fixes #2377

## What does it look like?

### Before

![image](https://user-images.githubusercontent.com/34030/135248628-079b1e19-5127-4eb4-89a8-30a842c761b9.png)

### After

![image](https://user-images.githubusercontent.com/34030/135248579-f4fae5f4-344f-4625-a45b-20e412330b97.png)

## How do I test it?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/fix-app-deployments-header
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the deployments list page](http://localhost:4200/default/marketing-public/app/wp-matrix/deployments)
4. Verify you see the app header with breadcrumbs, latest boxes etc.
5. [Visit the deployment detail page](http://localhost:4200/default/marketing-public/app/wp-matrix/deployment/seq/4)
6. Verify you no longer see the app header
7. [Visit the resource detail page](http://localhost:4200/default/marketing-public/app/wp-matrix/deployment/seq/4/resources/TKJ66SLM110F1OEXK0VZSD9Z)
8. Verify you no longer see the app header