### PR TITLE
ui: fix resources-table border-color bug

### DIFF
--- a/ui/app/styles/components/resources-table.scss
+++ b/ui/app/styles/components/resources-table.scss
@@ -10,7 +10,10 @@
     background: rgb(var(--background));
     border-radius: 5px;
     border-spacing: 0;
-    border: 1px solid rgb(var(--border));
+    border: 1px solid;
+    // border-color must be separated out to work around a bug in clean-css
+    // https://github.com/hashicorp/waypoint/issues/2376
+    border-color: rgb(var(--border));
     overflow: hidden;
     table-layout: fixed;
     width: 100%;


### PR DESCRIPTION
## Why the change?

Closes #2376

## What does it look like?

### Before

![image](https://user-images.githubusercontent.com/34030/135254018-70f73385-cf28-423c-999a-f24cfee27064.png)

### After

![image](https://user-images.githubusercontent.com/34030/135254067-2d4dcb32-989e-49c7-b7cb-3e6e74c6c473.png)

## How do I test it?

1. Check out the branch:
   ```sh
   git checkout ui/fix-resource-table-border
   ```
2. Enable CSS minification in `ui/ember-cli-build.js`:
   ```js
   minifyCSS: { enabled: true }
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit a deployment detail page](http://localhost:4200/default/marketing-public/app/wp-matrix/deployment/seq/4)
4. Verify the table border is the correct color

### How do we protect against future regressions?

Still investigating. Unfortunately upgrading clean-css doesn’t seem to be feasible. We may be able to disable clean-css entirely, if the filesize savings are sufficiently small.