### PR TITLE
ui: Release Resources

### DIFF
--- a/.changelog/2386.txt
+++ b/.changelog/2386.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Release resources
+```

--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -26,8 +26,8 @@
         <tr>
           <th scope="row">
             <LinkTo
-              @route="workspace.projects.project.app.deployment.resource"
-              @model={{resource.id}}
+              @route={{@route}}
+              @models={{append (or @models (array)) resource.id}}
             >
               {{resource.name}}
             </LinkTo>

--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -1,6 +1,9 @@
 <div
   data-test-resources-table
-  class="resources-table"
+  class="
+    resources-table
+    {{if @withMargin "resources-table--with-margin"}}
+  "
 >
   <table>
     <caption>{{yield to="caption"}}</caption>

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -48,7 +48,9 @@ Router.map(function () {
           });
           this.route('releases');
           this.route('release-id', { path: '/release/:release_id' });
-          this.route('release', { path: '/release/seq/:sequence' });
+          this.route('release', { path: '/release/seq/:sequence' }, function () {
+            this.route('resource', { path: 'resources/:resource_id' });
+          });
           this.route('logs');
           this.route('exec');
         });

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -6,7 +6,7 @@ import { Model as AppRouteModel } from '../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
 type Params = { sequence: string };
-type Model = Release.AsObject & WithStatusReport;
+export type Model = Release.AsObject & WithStatusReport;
 
 interface WithStatusReport {
   statusReport?: StatusReport.AsObject;

--- a/ui/app/routes/workspace/projects/project/app/release/resource.ts
+++ b/ui/app/routes/workspace/projects/project/app/release/resource.ts
@@ -1,0 +1,37 @@
+import Route from '@ember/routing/route';
+import { StatusReport } from 'waypoint-pb';
+import { Model as ReleaseRouteModel } from '../release';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
+import { action } from '@ember/object';
+
+interface Params {
+  resource_id: string;
+}
+
+type Model = StatusReport.Resource.AsObject;
+
+export default class extends Route {
+  @action
+  breadcrumbs(): Breadcrumb[] {
+    let release = this.modelFor('workspace.projects.project.app.release') as ReleaseRouteModel;
+    return [
+      {
+        label: `v${release.sequence}`,
+        route: 'workspace.projects.project.app.release',
+        icon: 'public-default',
+      },
+    ];
+  }
+
+  model({ resource_id }: Params): Model {
+    let release = this.modelFor('workspace.projects.project.app.release') as ReleaseRouteModel;
+    let resources = release.statusReport?.resourcesList ?? [];
+    let resource = resources.find((r) => r.id === resource_id);
+
+    if (!resource) {
+      throw new Error(`Resource ${resource_id} not found`);
+    }
+
+    return resource;
+  }
+}

--- a/ui/app/styles/components/resources-table.scss
+++ b/ui/app/styles/components/resources-table.scss
@@ -6,6 +6,10 @@
   line-height: 17px;
   color: rgb(var(--text-muted));
 
+  &--with-margin {
+    margin-bottom: scale.$sm--1;
+  }
+
   table {
     background: rgb(var(--background));
     border-radius: 5px;

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -5,6 +5,7 @@
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.release')
   (not (includes this.target.currentRouteName 'workspace.projects.project.app.deployment.'))
+  (not (includes this.target.currentRouteName 'workspace.projects.project.app.release.'))
 )}}
 <PageHeader @iconName="git-repository">
   <div class="title">

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -34,7 +34,10 @@
     <Section>
       <:heading>{{t "page.deployment.resources.heading"}}</:heading>
       <:body>
-        <ResourcesTable @resources={{@model.statusReport.resourcesList}}>
+        <ResourcesTable
+          @resources={{@model.statusReport.resourcesList}}
+          @route="workspace.projects.project.app.deployment.resource"
+        >
           <:caption>
             {{t "page.deployment.resources.table-caption" htmlSafe=true}}
           </:caption>

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -30,21 +30,49 @@
 
   <StatusReportBar @model={{@model}} @artifactType="Deployment"/>
 
-  {{#if @model.statusReport.resourcesList.length}}
-    <Section>
-      <:heading>{{t "page.deployment.resources.heading"}}</:heading>
-      <:body>
-        <ResourcesTable
-          @resources={{@model.statusReport.resourcesList}}
-          @route="workspace.projects.project.app.deployment.resource"
-        >
-          <:caption>
-            {{t "page.deployment.resources.table-caption" htmlSafe=true}}
-          </:caption>
-        </ResourcesTable>
-      </:body>
-    </Section>
-  {{/if}}
+  {{#let
+    @model.statusReport.resourcesList
+    @model.release.statusReport.resourcesList
+    as |deploymentResources releaseResources|
+  }}
+    {{#if (or deploymentResources.length releaseResources.length)}}
+      <Section>
+        <:heading>{{t "page.deployment.resources.heading"}}</:heading>
+        <:body>
+          {{#if deploymentResources.length}}
+            <ResourcesTable
+              @resources={{deploymentResources}}
+              @route="workspace.projects.project.app.deployment.resource"
+              @models={{array @model.sequence}}
+              @withMargin={{true}}
+            >
+              <:caption>
+                {{t "page.deployment.resources.deployment-table-caption" htmlSafe=true}}
+              </:caption>
+            </ResourcesTable>
+          {{/if}}
+
+          {{#if releaseResources.length}}
+            <ResourcesTable
+              @resources={{releaseResources}}
+              @route="workspace.projects.project.app.release.resource"
+              @models={{array @model.release.sequence}}
+            >
+              <:caption>
+                {{t "page.deployment.resources.release-table-caption-prefix" htmlSafe=true}}
+                <LinkTo
+                  @route="workspace.projects.project.app.release"
+                  @model={{@model.release.sequence}}
+                >
+                  <b class="badge badge--info badge--version">v{{@model.release.sequence}}</b>
+                </LinkTo>
+              </:caption>
+            </ResourcesTable>
+          {{/if}}
+        </:body>
+      </Section>
+    {{/if}}
+  {{/let}}
 
   <Section>
     <:heading>{{t "page.deployment.logs.heading"}}</:heading>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -1,43 +1,68 @@
 {{page-title (concat "Release" " v" @model.sequence)}}
 
-<PageHeader @iconName="public-default">
-  <div class="title">
-    {{! TODO(jgwhite): Make this a real <h1> }}
-    <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b></h2>
-    <small>
-      <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
-      <span>Released on <b>{{component-name @model.component.name}}</b>
-        {{date-format-distance-to-now @model.status.startTime.seconds }}</span>
-    </small>
-    {{#if @model.preload.jobDataSourceRef.git.commit}}
+{{#if (not-eq this.target.currentRouteName "workspace.projects.project.app.release.resource")}}
+  <PageHeader @iconName="public-default">
+    <div class="title">
+      {{! TODO(jgwhite): Make this a real <h1> }}
+      <h2 aria-level="1"><b class="badge badge--version">v{{@model.sequence}}</b></h2>
       <small>
-        <GitCommit @commit={{@model.preload.jobDataSourceRef.git.commit}}/>
+        <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
+        <span>Released on <b>{{component-name @model.component.name}}</b>
+          {{date-format-distance-to-now @model.status.startTime.seconds }}</span>
       </small>
-    {{/if}}
-  </div>
-  <div class="actions">
-    {{#if @isLatest}}
-    <button class="button button--primary" type="button">
-      <span>{{@model.release.url}}</span>
-      <Pds::Icon @type="exit" class="icon" />
-    </button>
-    {{/if}}
-  </div>
-</PageHeader>
-
-<StatusReportBar @model={{@model}} @artifactType="Release">
-  {{!-- todo(pearkes): API doesn't return this object but just a string of it, so wait for that to be fixed --}}
-  {{#if @model.deployment }}
-    <div class="item">
-      <small>
-        Released deployment <LinkTo @route="workspace.projects.project.app.deployment"
-          @models={{array @model.deployment.id}}>
-          <b class="badge badge--version">v{{@model.deployment.sequence}}</b>
-          <code>{{@model.deployment.id}}</code>
-        </LinkTo>
-      </small>
+      {{#if @model.preload.jobDataSourceRef.git.commit}}
+        <small>
+          <GitCommit @commit={{@model.preload.jobDataSourceRef.git.commit}}/>
+        </small>
+      {{/if}}
     </div>
-  {{/if}}
-</StatusReportBar>
+    <div class="actions">
+      {{#if @isLatest}}
+      <button class="button button--primary" type="button">
+        <span>{{@model.release.url}}</span>
+        <Pds::Icon @type="exit" class="icon" />
+      </button>
+      {{/if}}
+    </div>
+  </PageHeader>
 
-<OperationLogs @jobId={{@model.jobId}} />
+  <StatusReportBar @model={{@model}} @artifactType="Release">
+    {{!-- todo(pearkes): API doesn't return this object but just a string of it, so wait for that to be fixed --}}
+    {{#if @model.deployment }}
+      <div class="item">
+        <small>
+          Released deployment <LinkTo @route="workspace.projects.project.app.deployment"
+            @models={{array @model.deployment.id}}>
+            <b class="badge badge--version">v{{@model.deployment.sequence}}</b>
+            <code>{{@model.deployment.id}}</code>
+          </LinkTo>
+        </small>
+      </div>
+    {{/if}}
+  </StatusReportBar>
+
+  {{#if @model.statusReport.resourcesList.length}}
+    <Section>
+      <:heading>{{t "page.release.resources.heading"}}</:heading>
+      <:body>
+        <ResourcesTable
+          @resources={{@model.statusReport.resourcesList}}
+          @route="workspace.projects.project.app.release.resource"
+        >
+          <:caption>
+            {{t "page.release.resources.table-caption" htmlSafe=true}}
+          </:caption>
+        </ResourcesTable>
+      </:body>
+    </Section>
+  {{/if}}
+
+  <Section>
+    <:heading>{{t "page.release.logs.heading"}}</:heading>
+    <:body>
+      <OperationLogs @jobId={{@model.jobId}} />
+    </:body>
+  </Section>
+{{/if}}
+
+{{outlet}}

--- a/ui/app/templates/workspace/projects/project/app/release/resource.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release/resource.hbs
@@ -1,0 +1,14 @@
+{{page-title (concat @model.name " | Resources")}}
+
+<PageHeader @iconName={{icon-for-component @model.platform}}>
+  <div class="title">
+    <h1>{{@model.name}}</h1>
+    <small>
+      <span>{{@model.type}}</span>
+    </small>
+  </div>
+  <div class="actions">
+  </div>
+</PageHeader>
+
+<ResourceDetail @resource={{@model}} />

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -68,8 +68,8 @@ export default Factory.extend({
       server.create('release', 'random', 'minutes-old-success', {
         sequence: 3,
         application,
-        deployment: deployments[2],
-        statusReport: server.create('status-report', 'ready', { application }),
+        deployment: deployments[0],
+        statusReport: server.create('status-report', 'ready', 'with-release-resources', { application }),
       });
       server.create('release', 'random', 'hours-old-success', {
         sequence: 2,
@@ -79,7 +79,7 @@ export default Factory.extend({
       server.create('release', 'random', 'days-old-success', {
         sequence: 1,
         application,
-        deployment: deployments[0],
+        deployment: deployments[2],
       });
     },
   }),

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -41,25 +41,27 @@ export default Factory.extend({
           sequence: 4,
           application,
           build: builds[0],
-          statusReport: server.create('status-report', 'alive', 'with-resources', { application }),
+          statusReport: server.create('status-report', 'alive', 'with-deployment-resources', { application }),
         }),
         server.create('deployment', 'random', 'minutes-old-success', {
           sequence: 3,
           application,
           build: builds[1],
-          statusReport: server.create('status-report', 'ready', 'with-resources', { application }),
+          statusReport: server.create('status-report', 'ready', 'with-deployment-resources', { application }),
         }),
         server.create('deployment', 'random', 'hours-old-success', {
           sequence: 2,
           application,
           build: builds[2],
-          statusReport: server.create('status-report', 'partial', 'with-resources', { application }),
+          statusReport: server.create('status-report', 'partial', 'with-deployment-resources', {
+            application,
+          }),
         }),
         server.create('deployment', 'random', 'days-old-success', {
           sequence: 1,
           application,
           build: builds[3],
-          statusReport: server.create('status-report', 'down', 'with-resources', { application }),
+          statusReport: server.create('status-report', 'down', 'with-deployment-resources', { application }),
         }),
       ];
 

--- a/ui/mirage/factories/resource.ts
+++ b/ui/mirage/factories/resource.ts
@@ -62,4 +62,39 @@ export default Factory.extend({
       },
     }),
   }),
+
+  'random-service': trait({
+    id: () => fakeId(),
+    name: 'web',
+    platform: 'kubernetes',
+    type: 'service',
+    categoryDisplayHint: 'ROUTER',
+    createdTime: () => new Date(),
+    state: () => ({
+      ipAddress: '10.104.177.149',
+      service: {
+        metadata: {
+          name: 'web',
+          namespace: 'default',
+          uid: '267ef8f3-2b41-4e3e-88b4-b28799dc87a0',
+          resourceVersion: '405154',
+        },
+        spec: {
+          ports: [{ protocol: 'TCP', port: 80, targetPort: 'http' }],
+          selector: {
+            name: 'web-v2',
+            'waypoint.hashicorp.com/id': '01FGW6JS8XWG4G66YD8RH75BNM',
+          },
+          clusterIP: '10.104.177.149',
+          clusterIPs: ['10.104.177.149'],
+          type: 'ClusterIP',
+          sessionAffinity: 'None',
+          ipFamilies: ['IPv4'],
+          ipFamilyPolicy: 'SingleStack',
+        },
+      },
+    }),
+    health: 'READY',
+    healthMessage: 'Available: Deployment has minimum availability.',
+  }),
 });

--- a/ui/mirage/factories/status-report.ts
+++ b/ui/mirage/factories/status-report.ts
@@ -46,4 +46,10 @@ export default Factory.extend({
       server.create('resource', 'random-deployment', { statusReport });
     },
   }),
+
+  'with-release-resources': trait({
+    afterCreate(statusReport, server) {
+      server.create('resource', 'random-service', { statusReport });
+    },
+  }),
 });

--- a/ui/mirage/factories/status-report.ts
+++ b/ui/mirage/factories/status-report.ts
@@ -41,7 +41,7 @@ export default Factory.extend({
     },
   }),
 
-  'with-resources': trait({
+  'with-deployment-resources': trait({
     afterCreate(statusReport, server) {
       server.create('resource', 'random-deployment', { statusReport });
     },

--- a/ui/tests/acceptance/deployment-resource-list-test.ts
+++ b/ui/tests/acceptance/deployment-resource-list-test.ts
@@ -14,11 +14,16 @@ module('Acceptance | deployment resource list', function (hooks) {
     let application = this.server.create('application', { project, name: 'my-app' });
     let deployment = this.server.create('deployment', 'random', { application, sequence: 1 });
     let statusReport = this.server.create('status-report', 'ready', { application, target: deployment });
-    this.server.create('resource', { statusReport, name: 'example-pod' });
+    let resource = this.server.create('resource', { statusReport, name: 'example-pod' });
 
     await visit(`/default/${project.name}/app/${application.name}/deployment/seq/${deployment.sequence}`);
 
     assert.dom('[data-test-resources-table]').containsText('example-pod');
+    assert
+      .dom(
+        `[href="/default/${project.name}/app/${application.name}/deployment/seq/${deployment.sequence}/resources/${resource.id}"`
+      )
+      .exists();
   });
 
   test('empty state', async function (assert) {

--- a/ui/tests/acceptance/release-resource-detail-test.ts
+++ b/ui/tests/acceptance/release-resource-detail-test.ts
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import login from 'waypoint/tests/helpers/login';
+
+module('Acceptance | release resource detail', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  login();
+
+  test('happy path', async function (assert) {
+    let project = this.server.create('project', { name: 'my-project' });
+    let application = this.server.create('application', { project, name: 'my-app' });
+    let release = this.server.create('release', 'random', { application, sequence: 1 });
+    let statusReport = this.server.create('status-report', 'ready', { application, target: release });
+    let resource = this.server.create('resource', {
+      statusReport,
+      name: 'example-service',
+      state: { example: 'OK' },
+    });
+
+    await visit(
+      `/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}`
+    );
+
+    assert.dom('h1').containsText('example-service');
+    assert.dom('[data-test-json-viewer]').containsText('"example": "OK"');
+  });
+
+  test('error state', async function (assert) {
+    let project = this.server.create('project', { name: 'my-project' });
+    let application = this.server.create('application', { project, name: 'my-app' });
+    let release = this.server.create('release', 'random', { application, sequence: 1 });
+
+    await visit(
+      `/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/nope`
+    );
+
+    assert.dom('main').containsText('Resource nope not found');
+  });
+});

--- a/ui/tests/acceptance/release-resource-list-test.ts
+++ b/ui/tests/acceptance/release-resource-list-test.ts
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import login from 'waypoint/tests/helpers/login';
+
+module('Acceptance | release resource list', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  login();
+
+  test('happy path', async function (assert) {
+    let project = this.server.create('project', { name: 'my-project' });
+    let application = this.server.create('application', { project, name: 'my-app' });
+    let release = this.server.create('release', 'random', { application, sequence: 1 });
+    let statusReport = this.server.create('status-report', 'ready', { application, target: release });
+    let resource = this.server.create('resource', { statusReport, name: 'example-pod' });
+
+    await visit(`/default/${project.name}/app/${application.name}/release/seq/${release.sequence}`);
+
+    assert.dom('[data-test-resources-table]').containsText('example-pod');
+    assert
+      .dom(
+        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"`
+      )
+      .exists();
+  });
+
+  test('happy path on the deployment detail page', async function (assert) {
+    let project = this.server.create('project', { name: 'my-project' });
+    let application = this.server.create('application', { project, name: 'my-app' });
+    let deployment = this.server.create('deployment', 'random', { application, sequence: 1 });
+    let release = this.server.create('release', 'random', { application, deployment, sequence: 1 });
+    let statusReport = this.server.create('status-report', 'ready', { application, target: release });
+    let resource = this.server.create('resource', { statusReport, name: 'example-service' });
+
+    await visit(`/default/${project.name}/app/${application.name}/deployment/seq/${deployment.sequence}`);
+
+    assert.dom('[data-test-resources-table]').containsText('example-service');
+    assert
+      .dom(
+        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"`
+      )
+      .exists();
+  });
+
+  test('empty state', async function (assert) {
+    let project = this.server.create('project', { name: 'my-project' });
+    let application = this.server.create('application', { project, name: 'my-app' });
+    let release = this.server.create('release', 'random', { application, sequence: 1 });
+    this.server.create('status-report', 'ready', { application, target: release });
+
+    await visit(`/default/${project.name}/app/${application.name}/release/seq/${release.sequence}`);
+
+    assert.dom('[data-test-resources-table]').doesNotExist();
+  });
+});

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -33,11 +33,18 @@ page:
   deployment:
     resources:
       heading: Resources
-      table-caption: Resources created by <b>this deployment</b>
+      deployment-table-caption: Resources created by <b>this deployment</b>
+      release-table-caption-prefix: Resources created by <b>Release</b>
     logs:
       heading: Deployment Logs
   releases:
     title: 'Releases'
+  release:
+    resources:
+      heading: Resources
+      table-caption: Resources created by <b>this release</b>
+    logs:
+      heading: Release Logs
 
 form:
   project_new:


### PR DESCRIPTION
## Why the change?

Closes #2386 

## What’s the plan?

- [x] Add resource list to release detail page
- [x] Add release resource detail page
- [x] Add release resources to deployment detail page
- [x] Add suitable demo data to default mirage scenario

## What does it look like?

https://user-images.githubusercontent.com/34030/135536405-8b8d87c7-2281-4a6e-a561-335f636c7576.mp4

## How do I test it?

### Using Mirage

1. Check out the branch:
   ```sh
   git checkout ui/release-resources
   ```
2. Boot the dev server
   ```sh
   cd ui && ember serve
   ```
3. [Visit the app](http://localhost:4200)
4. Browse different releases and deployments
5. Verify that when resources are available they render correctly
6. Verify that when resources aren’t available the empty state makes sense

### For realsies

1. Check out the branch:
   ```sh
   git checkout ui/release-resources
   ```
2. Build the ember app
   ```sh
   (cd ui && make)
   ```
3. Bundle the static assets
   ```sh
   make static-assets
   ```
4. Build the dev server
   ```sh
   make docker/server
   ```
5. Build the CLI
   ```sh
   make bin
   ```
6. Install waypoint on your platform of choice, i.e.
   ```sh
   ./waypoint install -platform=kubernetes -accept-tos -k8s-server-image=waypoint:dev -k8s-odr-image=waypoint-odr:dev
   ```
7. Open the UI
   ```
   ./waypoint ui -authenticate
   ```
8. Try out an example app of your choice (i.e. [kubernetes/nodejs](https://github.com/hashicorp/waypoint-examples/tree/main/kubernetes/nodejs))
9. Browse different releases and deployments
10. Verify that when resources are available they render correctly
11. Verify that when resources aren’t available the empty state makes sense
