### PR TITLE
Website: move context and context inspect lower in CLI navigation

### DIFF
--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -8,14 +8,6 @@
     "path": "deploy"
   },
   {
-    "title": "context",
-    "path": "context"
-  },
-  {
-    "title": "context-inspect",
-    "path": "context-inspect"
-  },
-  {
     "title": "destroy",
     "path": "destroy"
   },
@@ -111,6 +103,10 @@
     "path": "config-sync"
   },
   {
+    "title": "context",
+    "path": "context"
+  },
+  {
     "title": "context clear",
     "path": "context-clear"
   },
@@ -121,6 +117,10 @@
   {
     "title": "context delete",
     "path": "context-delete"
+  },
+  {
+    "title": "context inspect",
+    "path": "context-inspect"
   },
   {
     "title": "context list",

--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -32,10 +32,6 @@
     "path": "logs"
   },
   {
-    "title": "project apply",
-    "path": "project-apply"
-  },
-  {
     "title": "release",
     "path": "release"
   },
@@ -173,6 +169,10 @@
   {
     "title": "plugin",
     "path": "plugin"
+  },
+  {
+    "title": "project apply",
+    "path": "project-apply"
   },
   {
     "title": "project inspect",


### PR DESCRIPTION
I believe the current `context` and `context-inspect` are misplaced in the CLI nav. I've moved them lower with the other `context` commands, and also removed the `-` from `context-inspect`. Attached are before/after screen grabs.

**Before:**
<img width="252" alt="Screen Shot 2021-09-29 at 16 37 04" src="https://user-images.githubusercontent.com/61721/135352329-5a6c294f-4f74-44cc-8e8b-9d268866015b.png">

**After:**
<img width="262" alt="Screen Shot 2021-09-29 at 16 37 37" src="https://user-images.githubusercontent.com/61721/135352356-0691ee28-2775-486e-a137-4218ec5c3986.png">


