### PR TITLE
ui/mirage: remove `setExtension` TODOs

### DIFF
--- a/ui/mirage/models/application.ts
+++ b/ui/mirage/models/application.ts
@@ -10,7 +10,6 @@ export default Model.extend({
   toProtobuf(): Application {
     let result = new Application();
 
-    // TODO: result.setExtension(...)
     // TODO: result.setFileChangeSignal(...)
     result.setName(this.name);
     result.setProject(this.project.toProtobufRef());
@@ -22,7 +21,6 @@ export default Model.extend({
     let result = new Ref.Application();
 
     result.setApplication(this.name);
-    // TODO: result.setExtension(...)
     result.setProject(this.project?.name);
 
     return result;

--- a/ui/mirage/models/build.ts
+++ b/ui/mirage/models/build.ts
@@ -15,7 +15,6 @@ export default Model.extend({
     result.setApplication(this.application?.toProtobufRef());
     // TODO: result.setArtifact(...)
     result.setComponent(this.component?.toProtobuf());
-    // TODO: result.setExtension(...)
     result.setId(this.id);
     result.setJobId(this.JobId);
     result.setSequence(this.sequence);

--- a/ui/mirage/models/project.ts
+++ b/ui/mirage/models/project.ts
@@ -10,7 +10,6 @@ export default Model.extend({
     result.setApplicationsList(this.applications.models.map((a) => a.toProtobuf()));
     // TODO: result.setDataSource(...)
     // TODO: result.setDataSourcePoll(...)
-    // TODO: result.setExtension(...)
     result.setFileChangeSignal(this.fileChangeSignal);
     result.setName(this.name);
     result.setRemoteEnabled(this.remoteEnabled);
@@ -24,7 +23,6 @@ export default Model.extend({
   toProtobufRef(): Ref.Project {
     let result = new Ref.Project();
 
-    // TODO: result.setExtension(...)
     result.setProject(this.name);
 
     return result;

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -18,7 +18,6 @@ export default Model.extend({
     result.setApplication(this.application?.toProtobufRef());
     result.setComponent(this.component?.toProtobuf());
     result.setDeploymentId(this.deployment?.id);
-    // TODO: result.setExtension
     result.setId(this.id);
     result.setJobId(this.jobId);
     result.setPreload(this.preloadProtobuf());

--- a/ui/mirage/models/workspace.ts
+++ b/ui/mirage/models/workspace.ts
@@ -9,7 +9,6 @@ export default Model.extend({
     let result = new Workspace();
 
     // TODO: result.setActiveTime
-    // TODO: result.setExtension
     result.setName(this.name);
     // TODO: result.setProjectsList
 


### PR DESCRIPTION
## Why the change?

`extension` is a generic protobuf escape-hatch mechanism which I don’t think we’ll use (at least not yet). No need to fret about populating this field on our Mirage protobufs.

## How do I test this?

No manual testing required, this just removes comments.