### PR TITLE
Minor CLI papercuts

### DIFF
--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -32,7 +32,13 @@ func (c *baseCommand) initConfig(filename string, optional bool) (*configpkg.Con
 			return nil, nil
 		}
 
-		return nil, errors.New("A Waypoint configuration file (waypoint.hcl) is required but wasn't found.")
+		return nil, errors.New(
+			"A Waypoint configuration file (waypoint.hcl) is required but wasn't found.\n" +
+				"The command can use configuration stored on the server by adding project/app\n" +
+				"as a final argument on the command line.\n" +
+				"For instance: `waypoint deployment list webapp/web` for the app 'web' in\n" +
+				"the project 'webapp'",
+		)
 	}
 
 	return c.initConfigLoad(path)

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -467,7 +467,7 @@ func (c *DeploymentListCommand) Synopsis() string {
 
 func (c *DeploymentListCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint deployment list [options]
+Usage: waypoint deployment list [options] [project/app]
 
   Lists the deployments that were created.
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -848,21 +848,16 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 	if c.flagJson {
 		c.outputJsonAppStatus(appTbl, deployTbl, resourcesTbl, releaseTbl, releaseResourcesTbl, project)
 	} else {
-		c.ui.Output("")
 		c.ui.Output("Application Summary", terminal.WithHeaderStyle())
 		c.ui.Table(appTbl, terminal.WithStyle("Simple"))
-		c.ui.Output("")
 		c.ui.Output("Deployment Summary", terminal.WithHeaderStyle())
 		c.ui.Table(deployTbl, terminal.WithStyle("Simple"))
-		c.ui.Output("")
 		c.ui.Output("Deployment Resources Summary", terminal.WithHeaderStyle())
 		c.ui.Table(resourcesTbl, terminal.WithStyle("Simple"))
-		c.ui.Output("")
 
 		if !releaseUnimplemented {
 			c.ui.Output("Release Summary", terminal.WithHeaderStyle())
 			c.ui.Table(releaseTbl, terminal.WithStyle("Simple"))
-			c.ui.Output("")
 			c.ui.Output("Release Resources Summary", terminal.WithHeaderStyle())
 			c.ui.Table(releaseResourcesTbl, terminal.WithStyle("Simple"))
 			c.ui.Output("")
@@ -872,8 +867,6 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 	}
 
 	if appFailures {
-		c.ui.Output("")
-
 		c.ui.Output(wpStatusHealthTriageMsg, projectTarget, terminal.WithWarningStyle())
 	}
 

--- a/website/content/commands/deployment-list.mdx
+++ b/website/content/commands/deployment-list.mdx
@@ -15,7 +15,7 @@ List deployments.
 
 ## Usage
 
-Usage: `waypoint deployment list [options]`
+Usage: `waypoint deployment list [options] [project/app]`
 
 Lists the deployments that were created.
 


### PR DESCRIPTION
1. Provide better output about a missing config when a remote operation could be used.
2. Indicate that a remote operation is possible in the `deployment list` help.
3. Output fewer blank lines in status report output.