### PR TITLE
ui: upgrade ember-inflector to ^4.0.2

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -80,7 +80,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",
     "ember-in-viewport": "^3.8.0",
-    "ember-inflector": "^3.0.1",
+    "ember-inflector": "^4.0.2",
     "ember-intl": "^5.5.0",
     "ember-load-initializers": "^2.1.2",
     "ember-named-blocks-polyfill": "^0.2.4",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6150,7 +6150,7 @@ ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.2, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.2, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6794,12 +6794,12 @@ ember-in-viewport@^3.8.0:
     intersection-observer-admin "~0.2.12"
     raf-pool "~0.1.4"
 
-"ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0", ember-inflector@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.1.tgz#04be6df4d7e4000f6d6bd70787cdc995f77be4ab"
-  integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==
+"ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0", ember-inflector@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-4.0.2.tgz#4494f1a5f61c1aca7702d59d54024cc92211d8ec"
+  integrity sha512-+oRstEa52mm0jAFzhr51/xtEWpCEykB3SEBr7vUg8YnXUZJ5hKNBppP938q8Zzr9XfJEbzrtDSGjhKwJCJv6FQ==
   dependencies:
-    ember-cli-babel "^6.6.0"
+    ember-cli-babel "^7.26.5"
 
 ember-intl@^5.5.0:
   version "5.5.1"


### PR DESCRIPTION
## Why the change?

One step towards #2393 

## “Always run `yarn-dedupe` you say?”

Per Chris Krycho’s advice, I also ran `npx yarn-dedupe` after `yarn install`. This process is pretty weird and awkward, I find you have to:

1. Tweak deps in `package.json`
2. Run `yarn install` (or simply `yarn`)
3. Run `npx yarn-dedupe`
4. Run `yarn install` again (because reasons?)

## How do I test it?

I smoke tested this against a real Waypoint server and everything appeared to work as normally.