### PR TITLE
Turn xterm DOM rendering on in Safari

### DIFF
--- a/ui/app/utils/browser.ts
+++ b/ui/app/utils/browser.ts
@@ -1,0 +1,7 @@
+/* eslint-disable prettier/prettier */
+const userAgent = navigator.userAgent;
+
+export const isFirefox = (userAgent.indexOf('Firefox') >= 0);
+export const isWebKit = (userAgent.indexOf('AppleWebKit') >= 0);
+export const isChrome = (userAgent.indexOf('Chrome') >= 0);
+export const isSafari = (!isChrome && (userAgent.indexOf('Safari') >= 0));

--- a/ui/app/utils/create-terminal.ts
+++ b/ui/app/utils/create-terminal.ts
@@ -1,5 +1,6 @@
 import { ITerminalOptions, Terminal } from 'xterm';
 
+import { isSafari } from 'waypoint/utils/browser';
 import terminalTheme from 'waypoint/utils/terminal-theme';
 
 interface TerminalOptions {
@@ -17,8 +18,9 @@ export function createTerminal(options: TerminalOptions): Terminal {
     theme: terminalTheme.light,
   };
 
-  // This should be used for DOM rendering in tests only
-  if (options.domRendering === true) {
+  // The optional boolean is used for DOM rendering in tests
+  // Because of a bug with Safari and webGL, we turn DOM rendering on in Safari only
+  if (options.domRendering === true || isSafari) {
     terminalOptions.rendererType = 'dom';
   }
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/waypoint/issues/2397 

This adds a `browser` util to do basic UA detection and turn on DOM rendering in xterm.js (instead of canvas & WebGL) only for Safari 

(marking this as `no-changelog` because the bug hasn't shipped in an official release)