### PR TITLE
ui: ensure ember-cli-flash doesn’t clobber pds-flash-messages

### DIFF
--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -30,6 +30,7 @@ module.exports = function (environment) {
       extendedTimeout: 700,
       type: 'info',
       types: ['error', 'success', 'info', 'warning'],
+      injectionFactories: [],
     },
 
     // Ember-toggle addon settings

--- a/ui/tests/unit/services/pds-flash-messages-test.ts
+++ b/ui/tests/unit/services/pds-flash-messages-test.ts
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import FlashMessagesService from 'waypoint/services/pds-flash-messages';
+import PdsFlashMessages from 'waypoint/services/pds-flash-messages';
+
+class TestRoute extends Route {
+  @service('pdsFlashMessages') flashMessages!: FlashMessagesService;
+}
+
+module('Unit | Services | pds-flash-messages', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('ember-cli-flash default injections do not clobber pds-flash-messages', async function (assert) {
+    this.owner.register('route:test', TestRoute);
+    let route = this.owner.factoryFor('route:test').create();
+    let flashMessages = this.owner.lookup('service:pds-flash-messages');
+
+    assert.strictEqual(route.flashMessages, flashMessages, 'this.flashMessages is the correct singleton');
+  });
+});


### PR DESCRIPTION
This is a pretty subtle bug. By default, ember-cli-flash [automatically injects][1] a `flashMessages` service into various types such as routes and controllers. This is a problem for us because it clobbers our custom `PdsFlashMessages` service. As a result, you could inject the service into a route and it would refuse to work for no apparent reason.

It looks like the ember-cli-flash maintainers intended to remove the automatic injections for v2.0.0 but didn’t actually do so.

[1]: https://github.com/poteto/ember-cli-flash/blob/dde3da9d1ee3fae24e910a7353bb9f88d7fb1690/app/initializers/flash-messages.js#L20-L22