### PR TITLE
Use proper background color for toggle input

### DIFF
--- a/.changelog/2410.txt
+++ b/.changelog/2410.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Toggle checkboxes are nicely styled in dark mode
+```

--- a/ui/app/styles/components/x-toggle.scss
+++ b/ui/app/styles/components/x-toggle.scss
@@ -5,7 +5,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --toggle-color-off: #{dehex(color.$ui-cool-gray-100)};
+    --toggle-color-off: #{dehex(color.$ui-cool-gray-900)};
     --toggle-color-on: #{dehex(color.$blue-500)};
   }
 }


### PR DESCRIPTION
Fixes: #2142 
<img width="581" alt="Screen Shot 2021-10-04 at 16 09 39" src="https://user-images.githubusercontent.com/1416421/135866648-112facc9-7366-403b-9ecd-2d173019b7a6.png">
<img width="580" alt="Screen Shot 2021-10-04 at 16 09 44" src="https://user-images.githubusercontent.com/1416421/135866659-a2867b9a-2733-4ce1-9e69-51beeadce04e.png">


There already were some dark mode variables, but the scheme wasn't very adequate