### PR TITLE
fix text overflow in flash notifications with long words

### DIFF
--- a/.changelog/2411.txt
+++ b/.changelog/2411.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: notification messages display nicely when containing long words such as URLs
+```

--- a/ui/app/styles/components/notifications.scss
+++ b/ui/app/styles/components/notifications.scss
@@ -42,5 +42,10 @@
         opacity: 0;
       }
     }
+    // Overrides for the flash-messages content
+    .pds-popup__header {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
   }
 }


### PR DESCRIPTION
Fixes: #2265 

before: 

<img width="1001" alt="Screen Shot 2021-10-04 at 17 51 17" src="https://user-images.githubusercontent.com/1416421/135883404-10204ba1-a1f2-453c-9872-e70367bc5d7e.png">

after: 
<img width="828" alt="Screen Shot 2021-10-04 at 17 51 10" src="https://user-images.githubusercontent.com/1416421/135883431-c2c7c98d-a1b4-40e0-b64f-a26882ef6b8a.png">

