### PR TITLE
Papercuts in kubernetes server install

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -185,17 +185,11 @@ func (p *Platform) resourceDeploymentStatus(
 			}
 		}
 
-		var deployHealth sdk.StatusReport_Health
-		switch mostRecentCondition.Type {
-		case v1.DeploymentAvailable:
-			deployHealth = sdk.StatusReport_READY
-		case v1.DeploymentProgressing:
-			deployHealth = sdk.StatusReport_ALIVE
-		case v1.DeploymentReplicaFailure:
-			deployHealth = sdk.StatusReport_DOWN
-		default:
-			deployHealth = sdk.StatusReport_UNKNOWN
-		}
+		// The most recently updated condition isn't always the most pertinent - a healthy deployment
+		// can have a "Progressing" most recently updated condition at steady-state.
+		// If the deployment exists, we'll mark it as "Ready", and rely on our pod status checks
+		// to give more detailed status.
+		deployHealth := sdk.StatusReport_READY
 
 		// Redact env vars from containers - they can contain secrets
 		for i := 0; i < len(deployResp.Spec.Template.Spec.Containers); i++ {

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -125,7 +125,7 @@ task {
 	return doc, nil
 }
 
-// TaskLauncher implements Configurable
+// Config implements Configurable
 func (p *TaskLauncher) Config() (interface{}, error) {
 	return &p.config, nil
 }

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -42,7 +42,7 @@ type RunnerAgentCommand struct {
 	flagODR bool
 }
 
-// This is how long a runner in ODR mode will wait for it's job assignment before
+// This is how long a runner in ODR mode will wait for its job assignment before
 // timing out.
 var defaultRunnerODRAcceptTimeout = 60 * time.Second
 


### PR DESCRIPTION
- Fixes a problem where deployments would be marked as "Degraded", but were actually fine
- Adds a new clusterrole and clusterrolebinding to the install flow to allow the runner to get and list nodes, which it needs to discover the IP of nodeport type services.
- If for some reason the nodeport ip discovery fails, don't fail the whole release (per @evanphx 's suggestion)