### PR TITLE
Enabling dynamic config files

### DIFF
--- a/.changelog/2416.txt
+++ b/.changelog/2416.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+config: Fix dynamic config vars targeting files.
+```
+

--- a/builtin/vault/config_sourcer.go
+++ b/builtin/vault/config_sourcer.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -148,9 +149,15 @@ func (cs *ConfigSourcer) read(
 			secret, err := client.Logical().Read(vaultReq.Path)
 			if err != nil {
 				result.Result = &pb.ConfigSource_Value_Error{
-					Error: status.New(codes.Aborted, err.Error()).Proto(),
+					Error: status.New(codes.Aborted, fmt.Sprintf("Failed to read from vault. Path: %q, err: %q", vaultReq.Path, err)).Proto(),
 				}
 
+				continue
+			}
+			if secret == nil {
+				result.Result = &pb.ConfigSource_Value_Error{
+					Error: status.New(codes.Aborted, fmt.Sprintf("path %q is missing", vaultReq.Path)).Proto(),
+				}
 				continue
 			}
 			cachedSecretVal = &cachedSecret{Secret: secret}


### PR DESCRIPTION
Prior to this, it appears that dynamic config targeting files did not work - our logic was treating all dynamic config as env vars, and not respecting [`name_is_path` ](https://github.com/hashicorp/waypoint/blob/33fa916c8fa2e295e8913efba91de7e086760cd6/internal/server/proto/server.proto#L3433).

This enables stanzas like this to work:

```
 config {
   file = {
    "/shared-config/nginx.conf" = configdynamic("vault", {
    path = "secret/data/apps/sample-app"
     key = "data/nginx.conf"
    })
   }
 }
```

I can't claim to have deeply understood all of the surrounding logic, so if there's a better place or way to do this, I'm open to feedback.

This also incidentally adds some better error messages to the vault config-sourcer plugin.