### PR TITLE
ui/mirage: remove TODOs for `any` fields

### DIFF
--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -19,7 +19,6 @@ export default Model.extend({
     result.setApplication(this.application?.toProtobufRef());
     result.setArtifactId(this.artifactId);
     result.setComponent(this.component?.toProtobuf());
-    // TODO: result.setDeployment
     result.setGeneration(this.generation?.toProtobuf());
     result.setHasEntrypointConfig(this.hasEntrypointConfig);
     result.setHasExecPlugin(this.hasExecPlugin);

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -21,7 +21,6 @@ export default Model.extend({
     result.setId(this.id);
     result.setJobId(this.jobId);
     result.setPreload(this.preloadProtobuf());
-    // TODO: result.setRelease
     result.setSequence(this.sequence);
     result.setState(PhysicalState[this.state as StateName]);
     result.setStatus(this.status?.toProtobuf());

--- a/ui/mirage/models/status-report.ts
+++ b/ui/mirage/models/status-report.ts
@@ -25,7 +25,6 @@ export default Model.extend({
     }
     result.setStatus(this.status?.toProtobuf());
     result.setId(this.id);
-    // TODO: result.setStatusReport(value?: google_protobuf_any_pb.Any)
     result.setHealth(this.health?.toProtobuf());
     result.setDeprecatedResourcesHealthList(this.resourcesHealthList.models.map((h) => h.toProtobuf()));
 


### PR DESCRIPTION
## Why the change?

We don’t expect to really use these.

## How do I test it?

No need, this just removes comments.