### PR TITLE
cli: release cmd tuneups

### DIFF
--- a/.changelog/2426.txt
+++ b/.changelog/2426.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+cli: Remove unused arg and use sequence ID for CLI message in `release`
+```
+```release-note:bug
+cli: Fix logic on when a rocket indicator shows in `release list`
+```

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -239,7 +239,7 @@ Usage: waypoint release [options]
   Open a deployment to traffic.
 
   This defaults to the latest deployment. Other deployments can be
-  specified by ID.
+  specified by ID using the '-deployment' flag.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -23,6 +23,7 @@ type ReleaseCreateCommand struct {
 	flagDeployment  string
 	flagPrune       bool
 	flagPruneRetain int
+	flagId          idFormat
 }
 
 func (c *ReleaseCreateCommand) Run(args []string) int {
@@ -114,7 +115,7 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 			} else {
 				c.Log.Warn("deployment already released")
 				app.UI.Output(strings.TrimSpace(releaseUpToDate),
-					deploy.Id,
+					c.flagId.FormatId(deploy.Sequence, deploy.Id),
 					terminal.WithSuccessStyle())
 				return nil
 			}
@@ -233,12 +234,12 @@ func (c *ReleaseCreateCommand) Synopsis() string {
 
 func (c *ReleaseCreateCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint release [options] [id]
+Usage: waypoint release [options]
 
   Open a deployment to traffic.
 
   This defaults to the latest deployment. Other deployments can be
-  specified by sequence number or long ID.
+  specified by ID.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/release_list.go
+++ b/internal/cli/release_list.go
@@ -125,7 +125,7 @@ func (c *ReleaseListCommand) Run(args []string) int {
 					status = "✔"
 					statusColor = terminal.Green
 
-					if resp.Releases[0] != nil {
+					if resp.Releases[0] != nil && resp.Releases[0].Release.Id == b.Id {
 						status = "🚀"
 					}
 

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -15,12 +15,12 @@ Release a deployment
 
 ## Usage
 
-Usage: `waypoint release [options] [id]`
+Usage: `waypoint release [options]`
 
 Open a deployment to traffic.
 
 This defaults to the latest deployment. Other deployments can be
-specified by sequence number or long ID.
+specified by ID.
 
 #### Global Options
 

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -20,7 +20,7 @@ Usage: `waypoint release [options]`
 Open a deployment to traffic.
 
 This defaults to the latest deployment. Other deployments can be
-specified by ID.
+specified by ID using the '-deployment' flag.
 
 #### Global Options
 


### PR DESCRIPTION
Things done:
* removed the `[id]` arg that isn't used
* amend the deployment ID returned in the CLI message to match the type of ID we use in `deployment list`
* fix the logic on whether or not a 🚀 shows in `release list`
