### PR TITLE
cli/login: Set platform to kubernetes if flag is used

### DIFF
--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -146,6 +146,9 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 	newContext.Server.AuthToken = token
 	newContext.Server.RequireAuth = true
+	if c.flagK8S {
+		newContext.Server.Platform = "kubernetes"
+	}
 	log.Debug("final login connection info",
 		"address", newContext.Server.Address,
 		"tls", newContext.Server.Tls,


### PR DESCRIPTION
Prior to this commit, the context created from logging in using a
Kubernetes secret would leave the server context platform field empty.
This commit fixes that by ensuring it is set if the flag was requested
when logging in from a Waypoint server installed in Kubernetes.