### PR TITLE
ui: Use enhanced OCI image lookup on resource detail page

### DIFF
--- a/ui/app/components/container-image-tag/index.hbs
+++ b/ui/app/components/container-image-tag/index.hbs
@@ -1,14 +1,5 @@
 {{#each this.imageRefs as |imageRef|}}
-  <span data-test-container-info class="container-badge" title="Image">
-    {{imageRef.label}}
-    <span class="container-badge-tag">
-      {{#if (eq imageRef.label "sha256")}}
-        {{truncate-commit imageRef.tag}}
-      {{else}}
-        {{imageRef.tag}}
-      {{/if}}
-    </span>
-  </span> 
+  <ImageRef @imageRef={{imageRef}} />
 {{else}}
   n/a
 {{/each}}

--- a/ui/app/components/container-image-tag/index.ts
+++ b/ui/app/components/container-image-tag/index.ts
@@ -2,29 +2,10 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
 import { StatusReport } from 'waypoint-pb';
+import { ImageRef, findImageRefs } from 'waypoint/utils/image-refs';
 
 interface Args {
   statusReport: StatusReport.AsObject;
-}
-
-class ImageRef {
-  ref: string;
-
-  constructor(ref: string) {
-    this.ref = ref;
-  }
-
-  get label(): string {
-    return this.split[0];
-  }
-
-  get tag(): string {
-    return this.split[1];
-  }
-
-  private get split(): string[] {
-    return this.ref.split(':');
-  }
 }
 
 export default class extends Component<Args> {
@@ -39,26 +20,4 @@ export default class extends Component<Args> {
   get imageRefs(): ImageRef[] {
     return findImageRefs(this.states);
   }
-}
-
-function findImageRefs(obj: unknown, result: ImageRef[] = []): ImageRef[] {
-  if (typeof obj !== 'object') {
-    return result;
-  }
-
-  if (obj === null) {
-    return result;
-  }
-
-  for (let [key, value] of Object.entries(obj)) {
-    if (key.toLowerCase() === 'image' && typeof value === 'string') {
-      if (!result.some((image) => image.ref === value)) {
-        result.push(new ImageRef(value));
-      }
-    } else {
-      findImageRefs(value, result);
-    }
-  }
-
-  return result;
 }

--- a/ui/app/components/image-ref.hbs
+++ b/ui/app/components/image-ref.hbs
@@ -1,0 +1,12 @@
+<span data-test-image-ref class="image-ref" title="Image">
+  <span class="image-ref__label">
+    {{@imageRef.label}}
+  </span>
+  <span class="image-ref__tag">
+    {{#if (eq @imageRef.label "sha256")}}
+      {{truncate-commit @imageRef.tag}}
+    {{else}}
+      {{@imageRef.tag}}
+    {{/if}}
+  </span>
+</span> 

--- a/ui/app/components/resource-detail.hbs
+++ b/ui/app/components/resource-detail.hbs
@@ -28,10 +28,14 @@
               </td>
             </tr>
           {{/if}}
-          {{#if this.image}}
+          {{#if this.imageRefs.length}}
             <tr>
               <th scope="row">{{t "resource-detail.overview.image"}}</th>
-              <td><code>{{this.image}}</code></td>
+              <td>
+                {{#each this.imageRefs as |imageRef|}}
+                  <ImageRef @imageRef={{imageRef}} />
+                {{/each}}
+              </td>
             </tr>
           {{/if}}
         </tbody>

--- a/ui/app/components/resource-detail.ts
+++ b/ui/app/components/resource-detail.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
 import { StatusReport } from 'waypoint-pb';
+import { ImageRef, findImageRefs } from 'waypoint/utils/image-refs';
 
 interface Args {
   resource?: StatusReport.Resource.AsObject;
@@ -36,8 +37,8 @@ export default class extends Component<Args> {
     return this.state?.pod?.metadata?.labels;
   }
 
-  get image(): string | undefined {
-    return this.state?.pod?.spec?.containers?.[0]?.image;
+  get imageRefs(): ImageRef[] {
+    return findImageRefs(this.state);
   }
 
   get hasLabels(): boolean {

--- a/ui/app/styles/components/_index.scss
+++ b/ui/app/styles/components/_index.scss
@@ -7,11 +7,11 @@
 @import 'cli-hint';
 @import 'code-editor-field.scss';
 @import 'copyable-code';
-@import 'container-image-tag';
 @import 'empty-state';
 @import 'flash';
 @import 'git-commit';
 @import 'icon-tile';
+@import 'image-ref';
 @import 'input';
 @import 'json-viewer';
 @import 'label-list';

--- a/ui/app/styles/components/image-ref.scss
+++ b/ui/app/styles/components/image-ref.scss
@@ -1,8 +1,8 @@
-.container-badge {
+.image-ref {
   display: flex;
   align-items: center;
 
-  &-tag {
+  &__tag {
     background: rgb(var(--tag-background));
     color: rgb(var(--text-muted));
     border-radius: 2px;

--- a/ui/app/utils/image-refs.ts
+++ b/ui/app/utils/image-refs.ts
@@ -1,0 +1,48 @@
+export class ImageRef {
+  ref: string;
+
+  constructor(ref: string) {
+    this.ref = ref;
+  }
+
+  get label(): string {
+    return this.split[0];
+  }
+
+  get tag(): string {
+    return this.split[1];
+  }
+
+  private get split(): string[] {
+    return this.ref.split(':');
+  }
+}
+
+/**
+ * Returns a flat map of values for `image` properties within the given object.
+ *
+ * @param {object|array} obj search space
+ * @param {ImageRef[]} [result=[]] starting result array (used internally, usually no need to pass this)
+ * @returns {ImageRef[]} an array of found ImageRefs
+ */
+export function findImageRefs(obj: unknown, result: ImageRef[] = []): ImageRef[] {
+  if (typeof obj !== 'object') {
+    return result;
+  }
+
+  if (obj === null) {
+    return result;
+  }
+
+  for (let [key, value] of Object.entries(obj)) {
+    if (key.toLowerCase() === 'image' && typeof value === 'string') {
+      if (!result.some((image) => image.ref === value)) {
+        result.push(new ImageRef(value));
+      }
+    } else {
+      findImageRefs(value, result);
+    }
+  }
+
+  return result;
+}

--- a/ui/tests/acceptance/deployment-resource-detail-test.ts
+++ b/ui/tests/acceptance/deployment-resource-detail-test.ts
@@ -17,7 +17,10 @@ module('Acceptance | deployment resource detail', function (hooks) {
     let resource = this.server.create('resource', {
       statusReport,
       name: 'example-pod',
-      state: { example: 'OK' },
+      state: {
+        example: 'OK',
+        image: 'example:1',
+      },
     });
 
     await visit(
@@ -25,6 +28,7 @@ module('Acceptance | deployment resource detail', function (hooks) {
     );
 
     assert.dom('h1').containsText('example-pod');
+    assert.dom('[data-test-resource-detail]').containsText('example 1');
     assert.dom('[data-test-json-viewer]').containsText('"example": "OK"');
   });
 

--- a/ui/tests/integration/components/container-image-tag-test.ts
+++ b/ui/tests/integration/components/container-image-tag-test.ts
@@ -37,6 +37,6 @@ module('Integration | Component | container-image-tag', function (hooks) {
     });
 
     await render(hbs`<ContainerImageTag @statusReport={{this.multiStatus}}/>`);
-    assert.dom('[data-test-container-info]').exists({ count: 2 });
+    assert.dom('[data-test-image-ref]').exists({ count: 2 });
   });
 });

--- a/ui/tests/integration/components/status-report-meta-table-test.ts
+++ b/ui/tests/integration/components/status-report-meta-table-test.ts
@@ -35,7 +35,7 @@ module('Integration | Component | meta-table', function (hooks) {
     `);
 
     assert.ok(this.element.textContent?.includes('Image'));
-    assert.dom('[data-test-container-info]').exists();
+    assert.dom('[data-test-image-ref]').exists();
     assert.ok(this.element.textContent?.includes('Health Check'));
     assert.dom('[data-test-status-report-indicator]').exists();
   });


### PR DESCRIPTION
## Why the change?

Closes #2418 

## What’s the plan?

- [x] Extract `findImageRefs` from `<ContainerImageTag>`
- [x] Extract styling and markup for an individual image ref from `<ContainerImageTag>`
- [x] Use enhanced OCI image lookup on resource detail page

## What does it look like?

### Before

<img width="653" alt="CleanShot 2021-10-06 at 14 00 39@2x" src="https://user-images.githubusercontent.com/34030/136198241-a2df9c84-ea70-4469-b280-9ceabce8520c.png">

### After

<img width="661" alt="CleanShot 2021-10-06 at 14 01 12@2x" src="https://user-images.githubusercontent.com/34030/136198269-679173d5-929e-45fe-bc5c-f2adaeff61eb.png">

## How do I test this?

1. Pull this branch down `ui/resource-detail-improve-image`
2. [Run with a local Waypoint server](https://github.com/hashicorp/waypoint/blob/main/ui/README.md#running-with-a-local-waypoint-server)
3. Visit a few different resource detail pages
5. Verify image refs show up correctly