### PR TITLE
ui: use `link:` for vendored/generated libs

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -88,12 +88,6 @@ if you've made API changes in `/internal/server` and want to use those on the fr
 - `go generate ./internal/server`
 - `make gen/ts`
 
-You'll need to re-install the new files to your `node_modules` directory by running:
-
-```
-yarn add ./lib/waypoint-client ./lib/waypoint-pb
-```
-
 ### Code Generators
 
 Make use of the many generators for code, try `ember help generate` for more details

--- a/ui/package.json
+++ b/ui/package.json
@@ -125,12 +125,12 @@
   },
   "dependencies": {
     "@types/google-protobuf": "^3.7.2",
-    "api-common-protos": "./lib/api-common-protos",
+    "api-common-protos": "link:./lib/api-common-protos",
     "ember-cli-typescript-blueprints": "^3.0.0",
     "google-protobuf": "^3.12.2",
-    "grpc-web": "./lib/grpc-web",
-    "waypoint-client": "./lib/waypoint-client",
-    "waypoint-pb": "./lib/waypoint-pb"
+    "grpc-web": "link:./lib/grpc-web",
+    "waypoint-client": "link:./lib/waypoint-client",
+    "waypoint-pb": "link:./lib/waypoint-pb"
   },
   "ember-addon": {}
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2803,8 +2803,9 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-api-common-protos@./lib/api-common-protos:
-  version "1.0.0"
+"api-common-protos@link:./lib/api-common-protos":
+  version "0.0.0"
+  uid ""
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -8544,8 +8545,9 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-grpc-web@./lib/grpc-web:
-  version "1.2.1"
+"grpc-web@link:./lib/grpc-web":
+  version "0.0.0"
+  uid ""
 
 gzip-size@^5.0.0:
   version "5.1.1"
@@ -14128,11 +14130,13 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-waypoint-client@./lib/waypoint-client:
-  version "1.0.0"
+"waypoint-client@link:./lib/waypoint-client":
+  version "0.0.0"
+  uid ""
 
-waypoint-pb@./lib/waypoint-pb:
-  version "1.0.0"
+"waypoint-pb@link:./lib/waypoint-pb":
+  version "0.0.0"
+  uid ""
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Why the change?

Closes #1860

## Any other notes?

I read into the available dependency specifier types and discovered that `link:` does the thing we want: it creates a symlink to a local filepath.

[Check out the Yarn RFC](https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-link-dependency-type.md)

In the video below I claim that this is exclusive to Yarn, but [apparently it works in NPM >= 5.0.0 now too](https://github.com/npm/npm/pull/15900#issuecomment-370948665), though appears to be undocumented.

## What does it look like?

https://user-images.githubusercontent.com/34030/136375067-235a740c-d0d5-4bdf-872a-f53a1656064a.mp4

## How do I test it?

1. `git checkout ui/yarn-link-vendored-libs`
2. `cd ui && yarn install`
2. Try making changes to `server.proto` and then running `make gen/ts`
3. Verify those changes are reflected in TS files that consume the protos