### PR TITLE
Fix a panic in `waypoint runner profile inspect`

### DIFF
--- a/internal/cli/runner_profile_inspect.go
+++ b/internal/cli/runner_profile_inspect.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -30,7 +32,7 @@ func (c *RunnerProfileInspectCommand) Run(args []string) int {
 	}
 
 	if len(c.args) == 0 {
-		c.ui.Output("Runner profile ID required.", terminal.WithErrorStyle())
+		c.ui.Output("Runner profile name required.", terminal.WithErrorStyle())
 		return 1
 	}
 	name := c.args[0]
@@ -40,7 +42,7 @@ func (c *RunnerProfileInspectCommand) Run(args []string) int {
 			Name: name,
 		},
 	})
-	if err != nil {
+	if err != nil && status.Code(err) != codes.NotFound {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
@@ -52,6 +54,11 @@ func (c *RunnerProfileInspectCommand) Run(args []string) int {
 				Id: name,
 			},
 		})
+
+		if status.Code(err) == codes.NotFound {
+			c.ui.Output("runner profile not found", terminal.WithErrorStyle())
+			return 1
+		}
 
 		if err != nil {
 			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())

--- a/internal/server/singleprocess/state/ondemand_runner.go
+++ b/internal/server/singleprocess/state/ondemand_runner.go
@@ -183,7 +183,7 @@ func (s *State) onDemandRunnerGet(
 		next := iter.Next()
 		if next == nil {
 			// Indicates that there isn't one of the given name.
-			return nil, nil
+			return nil, status.Errorf(codes.NotFound, "ondemand runner config not found")
 		}
 
 		idx := next.(*onDemandRunnerIndexRecord)

--- a/internal/server/singleprocess/state/ondemand_runner_test.go
+++ b/internal/server/singleprocess/state/ondemand_runner_test.go
@@ -59,6 +59,15 @@ func TestOnDemandRunnerConfig(t *testing.T) {
 			require.NotNil(resp)
 		}
 
+		// Get missing (returns not found error)
+		{
+			_, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{
+				Id: strings.ToUpper("unknown"),
+			})
+			require.Error(err)
+			require.Equal(status.Code(err), codes.NotFound)
+		}
+
 		// List
 		{
 			resp, err := s.OnDemandRunnerConfigList()


### PR DESCRIPTION
Merge after https://github.com/hashicorp/waypoint/pull/2403

Previously, `waypoint runner profile inspect foo` would panic if no profile with a name or ID of foo existed. Panic:

```
» Runner profile:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x723e9ac]

goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.(*RunnerProfileInspectCommand).Run(0xc000406fe0, 0xc0004356c0, 0x1, 0x4, 0xc000406c30)
	/Users/izaak/dev/waypoint/internal/cli/runner_profile_inspect.go:79 +0x62c
github.com/mitchellh/cli.(*CLI).Run(0xc0009c8000, 0xc000d3fee8, 0x86a8f18, 0xc000435700)
	/Users/izaak/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x41a
github.com/hashicorp/waypoint/internal/cli.Main(0xc000435680, 0x5, 0x8, 0x0)
	/Users/izaak/dev/waypoint/internal/cli/main.go:126 +0x57a
main.main()
	/Users/izaak/dev/waypoint/cmd/waypoint/main.go:14 +0xa5
```

This fixes that panic by having the server return a "not found" error on OnDemandRunnerGet. It looks like it was intentional that it returned "nil" previously if not found, but this makes the behavior consistent with other API responses like `user inspect`.

Also some incidental typo fixes.