### PR TITLE
docker: Support multi-target builds under kaniko/ODR

### DIFF
--- a/builtin/docker/kaniko.go
+++ b/builtin/docker/kaniko.go
@@ -126,6 +126,10 @@ func (b *Builder) buildWithKaniko(
 		"-d", localRef,
 	}
 
+	if b.config.Target != "" {
+		args = append(args, "--target", b.config.Target)
+	}
+
 	// If we have build args we append each
 	for k, v := range buildArgs {
 		// v should always not be nil but guard just in case to avoid a panic


### PR DESCRIPTION
Follow up on #1969, adds the same targeting support when building under Kaniko.