### PR TITLE
ui: add extra options to `api.listPushedArtifacts`

### DIFF
--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -22,6 +22,7 @@ import {
   PushedArtifact,
   Ref,
   Release,
+  StatusFilter,
   StatusReport,
   UpsertProjectRequest,
   Variable,
@@ -94,16 +95,21 @@ export default class ApiService extends Service {
 
   async listPushedArtifacts(
     wsRef: Ref.Workspace,
-    appRef: Ref.Application
+    appRef: Ref.Application,
+    options?: {
+      includeBuild?: boolean;
+      order?: OperationOrder;
+      statusList?: StatusFilter[];
+    }
   ): Promise<PushedArtifact.AsObject[]> {
     let request = new ListPushedArtifactsRequest();
 
     request.setApplication(appRef);
     request.setWorkspace(wsRef);
 
-    // TODO(jgwhite): request.setIncludeBuild
-    // TODO(jgwhite): request.setOrder
-    // TODO(jgwhite): request.setStatusList
+    request.setIncludeBuild(options?.includeBuild ?? false);
+    request.setOrder(options?.order ?? undefined);
+    request.setStatusList(options?.statusList ?? []);
 
     let response = await this.client.listPushedArtifacts(request, this.WithMeta());
     let result = response.getArtifactsList().map((pa) => pa.toObject());


### PR DESCRIPTION
## Why the change?

Pays down some negligible TODO debt.

## How do I test it?

1. Pull this branch down `ui/fix-api-service-todos`
2. Run a local Waypoint server ([see here](https://github.com/hashicorp/waypoint/blob/main/ui/README.md#running-with-a-local-waypoint-server))
3. Create a project
4. `waypoint up`
5. Verify that build information still displays correctly