### PR TITLE
Correctly parse ODR images when using a registry with a port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/davecgh/go-spew v1.1.1
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.7+incompatible

--- a/internal/serverinstall/serverinstall_test.go
+++ b/internal/serverinstall/serverinstall_test.go
@@ -1,0 +1,55 @@
+package serverinstall
+
+import "testing"
+
+func TestDefaultODRImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverImage string
+		want        string
+		wantErr     bool
+	}{
+		{
+			"Short name (does not add docker.io/library)",
+			"hashicorp/waypoint:latest",
+			"hashicorp/waypoint-odr:latest",
+			false,
+		},
+		{
+			"Alpha",
+			"ghcr.io/hashicorp/waypoint/alpha:latest",
+			"ghcr.io/hashicorp/waypoint/alpha-odr:latest",
+			false,
+		},
+		{
+			"Custom registry with port (doesn't get confused by multiple colons)",
+			"my.registry:5000/hashicorp/waypoint:latest",
+			"my.registry:5000/hashicorp/waypoint-odr:latest",
+			false,
+		},
+		{
+			"Custom registry with port and no tag returns error (doesn't see the port as a tag)",
+			"my.registry:5000/hashicorp/waypoint",
+			"",
+			true,
+		},
+		{
+			"No tag returns an error",
+			"hashicorp/waypoint",
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := defaultODRImage(tt.serverImage)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("defaultODRImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("defaultODRImage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, running `waypoint server install -platform=docker -accept-tos -docker-server-image=my.registry:5000/waypoint` would have parsed `:5000/waypoint` as a tag, and made the ODR image `my.registry-odr:5000/waypoint`.

This is such a narrow rare bug, but I noticed it and now here we are. Probably wasn't worth the 20 minutes to fix.