### PR TITLE
UI: Add Edge to supported browsers

### DIFF
--- a/ui/config/targets.js
+++ b/ui/config/targets.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions',
+  'last 1 Edge versions',
+];
 
 module.exports = {
   browsers,


### PR DESCRIPTION
Adding Edge to the list of supported browsers, which probably reflects our intentions more closely. 

(This is a follow up to a discussion that happened in our team Slack last week after some Safari shenanigans)

We could also support the last 2 versions of each browsers for those times where big javascript support changes happen, [as seen in terraform cloud](https://github.com/hashicorp/atlas/blob/1de48b35ebc8ac1d7fd2cf00b4c44831edc32806/frontend/atlas/config/targets.js#L4-L7). Any thoughts on that, team?