### PR TITLE
website: starting Kuberenetes-focused docs section

### DIFF
--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -15,7 +15,7 @@ artifact that Kubernetes uses.
 Often one of the first challenges when setting up a new application is answering
 two questions: how do I build my application? and how do I get the result of my
 build plumbed into my deployment configuration? Waypoint solves both of these
-by incoporating configuration for both build and deploys into the
+by incorporating configuration for both build and deploys into the
 [waypoint.hcl file](/docs/waypoint-hcl).
 
 -> **The built-in build functionality is optional.** If you have an external

--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -1,0 +1,206 @@
+---
+layout: docs
+page_title: Kubernetes - Building Container Images
+description: |-
+  This page describes how you can configure Waypoint to access Git repositories during the build process.
+---
+
+# Building Container Images
+
+Waypoint incorporates a first-class [build](/docs/lifecycle/build) step that
+can be used to build your container images and other artifacts. This page will
+focus on container (or Docker) images, since these are the primary deployment
+artifact that Kubernetes uses.
+
+Often one of the first challenges when setting up a new application is answering
+two questions: how do I build my application? and how do I get the result of my
+build plumbed into my deployment configuration? Waypoint solves both of these
+by incoporating configuration for both build and deploys into the
+[waypoint.hcl file](/docs/waypoint-hcl).
+
+-> **The built-in build functionality is optional.** If you have an external
+process already setup to build your images, you can
+[use externally-built images](/docs/kubernetes/external-build). Waypoint
+just needs to know about some sort of artifact, whether it is responsible
+for building it or not.
+
+This page will focus on Dockerfile-based builds because these are the most
+popular and also take into account applications that you may have witten
+prior to Waypoint. However, Waypoint supports many more methods of building
+container images. Documentation on other methods along with examples can be
+found on the [build lifecycle page](/docs/lifecycle/build).
+
+## Docker Builder (Dockerfile)
+
+The most popular way to build container images today is using a manually
+written `Dockerfile`. Waypoint can also build images from Dockerfiles
+using the [`docker` builder](/plugins/docker#docker-builder). This also is
+the easiest way to get started with Waypoint with existing applications, since
+most existing applications for Kubernetes have Dockerfiles.
+
+-> **If you don't know Docker, or don't want to write a Dockerfile,**
+take a look at the [`pack` builder](/docs/lifecycle/build#cloud-native-buildpacks).
+This uses buildpacks to autodetect your app language and build a container
+image.
+
+The example below uses the Docker builder:
+
+```hcl
+app "my-app" {
+  build {
+    use "docker" {}
+  }
+}
+```
+
+This will use a `Dockerfile` in the same directory as your `waypoint.hcl`
+file. You can test this using the Waypoint CLI by running `waypoint build`. This
+command will perform the build only, so it can be used for testing. The
+`waypoint build` command should be run in the same directory as your project
+(with the `waypoint.hcl`). If you want to force a
+[remote run](#local-vs-remote-builds), use the `-remote` flag.
+
+```shell-session
+$ waypoint build
+...
+
+# or, to run it remotely in your Kubernetes cluster
+$ waypoint build -remote
+...
+```
+
+### Docker Secrets
+
+A common requirement within Dockerfiles is to be able to access private
+information, whether that be via SSH, some API token, or any other mechanism.
+Because Waypoint image builds happen remotely, they don't have access to your
+local machine's secrets. The recommended approach to ensure secrets can be
+accessed everywhere (locally and remote) is to use Waypoint
+[input variables](/docs/waypoint-hcl/variables/input) paired with
+Docker build arguments.
+
+-> **Why not [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/)?**
+Unfortunately, Docker Secrets aren't supported because [Kaniko](https://github.com/GoogleContainerTools/kaniko)
+does not support them. We use Kaniko as the underlying technology to perform
+Docker builds within your Kubernetes cluster.
+
+The example below shows how we can access a private GitHub repository
+using a [GitHub Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). We show both
+the `waypoint.hcl` and the `Dockerfile` used to build a Go application, as
+an example.
+
+```hcl
+variable "github_token" {
+  type = string
+  env  = ["GITHUB_TOKEN"]
+}
+
+app "my-app" {
+  build {
+    use "docker" {
+      disable_entrypoint = true
+      build_args = {
+        GITHUB_TOKEN = var.github_token
+      }
+    }
+  }
+}
+```
+
+```dockerfile
+FROM golang:1.17-alpine AS builder
+
+# Configure Git
+ARG GITHUB_TOKEN
+RUN apk add --no-cache git
+RUN git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
+# Build Go app
+RUN mkdir -p /src
+WORKDIR /src
+COPY . .
+RUN go mod download
+RUN go build -o /app .
+
+FROM scratch
+
+COPY --from=builder /app /app
+
+ENTRYPOINT ["/app"]
+```
+
+To invoke this, you can set the `github_token` input variable
+[many different ways](docs/waypoint-hcl/variables/input#assigning-values-to-custom-input-variables). For long term use, the recommended location to set the variable
+is via the web UI. However, for testing, you can use the CLI:
+
+```shell-session
+$ waypoint build -var github_token=$MYTOKEN <project>/<app>
+```
+
+## Container Registry
+
+After getting builds working, the next step is usually to push that container
+image to a container registry. Waypoint supports a
+[`registry` stanza](/docs/waypoint-hcl/registry) for specifying a
+container registry for your image. To specify a Docker registry compatiable
+registry, use the `docker` registry:
+
+```hcl
+app "my-app" {
+  build {
+    use "docker" {}
+
+    registry {
+      use "docker" {
+        image = "docker.io/my-org/my-app"
+        tag   = gitrefpretty()
+        username = "myusername"
+        password = "mytoken"
+      }
+    }
+  }
+}
+```
+
+This example would push the built container image to
+[Docker Hub](https://hub.docker.com/), but any compatible registry
+such as Quay, AWS ECR, etc. would work. For now, hardcode your credentials
+as we've done in the example above and run `waypoint build` to verify it works.
+This should push your image now.
+
+### Hiding Credentials
+
+In a real production use-case, you should not put your container registry
+credentials directly in the `waypoint.hcl` file. Instead, you should use
+[input variables](/docs/waypoint-hcl/variables/input) to parameterize them.
+Input variables can be configured to read from environment variables so you
+can use well known environment variables (such as `AWS_ACCESS_KEY`), too.
+
+For remote runners, they can get access to input variables either by
+setting the variables in the web UI, or by setting
+[runner configuration](/docs/runner/config).
+
+## Local vs. Remote Builds
+
+Waypoint can run builds locally where you run the `waypoint` CLI, or
+remotely in your Kubernetes cluster in pods that are launched on demand.
+Builds triggered by Git polling or the UI happen remotely.
+
+To build Docker images within Kubernetes, Waypoint uses
+[Kaniko](https://github.com/GoogleContainerTools/kaniko). Waypoint
+sets up and invokes Kaniko for you, so you don't need to be familiar with it.
+All you need to know is that Kaniko supports almost all modern `Dockerfile`
+syntax, and it lets you do container image builds without any special
+privileges in your Kubernetes cluster.
+
+Remote builds are recommended. To use a remote build, ensure your
+project is [configured for remote operations](/docs/projects/remote),
+then use the `<project>/<app>` syntax to invoke a build:
+
+```shell-session
+$ waypoint build <project>/<app>
+```
+
+-> Note that this will clone your project source, so any local changes won't
+be reflected until you push them to your repository. This is a common source
+of errors!

--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Kubernetes - Building Container Images
 description: |-
-  This page describes how you can configure Waypoint to access Git repositories during the build process.
+  Waypoint incorporates a first-class build step that can be used to build your container images and other artifacts. This page will focus on container (or Docker) images, since these are the primary deployment artifact that Kubernetes uses.
 ---
 
 # Building Container Images

--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -25,7 +25,7 @@ just needs to know about some sort of artifact, whether it is responsible
 for building it or not.
 
 This page will focus on Dockerfile-based builds because these are the most
-popular and also take into account applications that you may have witten
+popular and also take into account applications that you may have written
 prior to Waypoint. However, Waypoint supports many more methods of building
 container images. Documentation on other methods along with examples can be
 found on the [build lifecycle page](/docs/lifecycle/build).

--- a/website/content/docs/kubernetes/external-build.mdx
+++ b/website/content/docs/kubernetes/external-build.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Kubernetes - Project Setup
+page_title: Kubernetes - Using Externally Built Images
 description: |-
   The Waypoint workflow includes the ability to perform the build step directly, but users may also use Waypoint with externally built artifacts such as from CI pipelines.
 ---

--- a/website/content/docs/kubernetes/external-build.mdx
+++ b/website/content/docs/kubernetes/external-build.mdx
@@ -77,7 +77,7 @@ $ waypoint build -var image_tag=$TAG my-project/my-app
 
 -> **Note:** The `<project>/<app>` syntax with `waypoint` CLI operations forces
 a [remote operation](/docs/projects/remote). This can be invoked anywhere;
-`waypoint` does not need the project source available, only credentials to
+`waypoint` does not need the project source to be available in the local filesystem, only credentials to
 access the Waypoint server.
 
 ### Git Functions to Specify the Image Tag

--- a/website/content/docs/kubernetes/external-build.mdx
+++ b/website/content/docs/kubernetes/external-build.mdx
@@ -1,0 +1,136 @@
+---
+layout: docs
+page_title: Kubernetes - Project Setup
+description: |-
+  The Waypoint workflow includes the ability to perform the build step directly, but users may also use Waypoint with externally built artifacts such as from CI pipelines.
+---
+
+# Externally Built Images
+
+The Waypoint workflow includes the ability to perform the
+[build](/docs/lifecycle/build) step directly, but users may also use Waypoint with
+externally built artifacts such as from CI pipelines. This is particularly
+common if you're adopting Waypoint for existing applications (versus
+net new use cases).
+
+## Configuring Waypoint to Use an Existing Image
+
+The [docker-pull builder](/plugins/docker#docker-pull-builder) was designed
+so that Waypoint can use pre-built Docker images. These images can be built
+anyway you want: manually, CI pipelines, 3rd party sources, etc.
+
+The example below shows how we can use an image that was already built.
+In this case, Waypoint does nothing: it just notes that this is the image
+you want to use. It doesn't verify that it can access this image and
+doesn't modify the image in any way. This enables the `deploy` plugin in
+the next step to use this pre-existing image.
+
+```hcl
+build {
+  use "docker-pull" {
+    image = "gcr.io/my-project/my-image"
+    tag   = "abcd1234"
+    disable_entrypoint = true
+  }
+}
+```
+
+A more realistic example would likely use
+[input variables](/docs/waypoint-hcl/variables/input)
+or [functions](/docs/waypoint-hcl/functions/all) to dynamically specify
+the correct image.
+
+### Input Variables to Specify the Image Tag
+
+[Input variables](/docs/waypoint-hcl/variables/input) can be used
+to specify parameters for configuring the image to use, as shown below.
+This is a more realistic example because this allows a step in a system
+such as a CI to specify to Waypoint what the desired image tag is for deployment.
+
+```hcl
+variable "image_tag" {
+  type = string
+}
+
+app "my-app" {
+  build {
+    use "docker-pull" {
+      image = "gcr.io/my-project/my-image"
+      tag   = var.image_tag
+      disable_entrypoint = true
+    }
+  }
+}
+```
+
+This variable can then be used in [many ways](/docs/waypoint-hcl/variables/input#assigning-values-to-custom-input-variables).
+If a CI is executing Waypoint, the most likely way is via a flag:
+
+```shell-session
+$ waypoint build -var image_tag=$TAG my-project/my-app
+```
+
+-> **Note:** The `<project>/<app>` syntax with `waypoint` CLI operations forces
+a [remote operation](/docs/projects/remote). This can be invoked anywhere;
+`waypoint` does not need the project source available, only credentials to
+access the Waypoint server.
+
+### Git Functions to Specify the Image Tag
+
+Another approach to specifying the image tag, particularly in a GitOps-oriented
+workflow, would be to use [Git functions](/docs/waypoint-hcl/functions/all#gitrefhash).
+
+The example below specifies that the tag should always match the current
+Git commit hash. This assumes your external system is building an image for
+every commit. You can also use functions such as `gitreftag` to get the
+current tag.
+
+```hcl
+app "my-app" {
+  build {
+    use "docker-pull" {
+      image = "gcr.io/my-project/my-image"
+      tag   = gitrefhash()
+      disable_entrypoint = true
+    }
+  }
+}
+```
+
+## Invoking Waypoint when Using External Images
+
+When using externally built images, Waypoint should be invoked after the
+image is already created. The approach to do this depends on how your build
+system is configured and how (or if) your team uses Git.
+
+### Invoking from CI
+
+The first approach is to _not use_ [repository polling](/docs/projects/git#polling)
+with Waypoint, because Waypoint may run before your CI system builds the image.
+Instead, the CI system can manually invoke the Waypoint operation once the
+image is built.
+
+To do this, the CI must be configured with
+[connection environment variables](/docs/automating-execution#environment-variables):
+`WAYPOINT_SERVER_ADDR`, `WAYPOINT_SERVER_TOKEN`, etc. Then, after the
+image is built, trigger a deploy:
+
+```shell-session
+$ waypoint up <project>/<app>
+```
+
+You may specify variables and other flags to the `up` command. The `<project>/<app>`
+syntax will force a [remote operation](/docs/projects/remote) so the up will
+happen remotely. This will block while the operation is happening.
+
+### Invoking from Git
+
+Another approach is to continue using Git to trigger deploys. In this
+approach, your [project Git settings](/docs/projects/git) should be configured
+to watch a specific branch that is only merged to when you're ready to deploy.
+
+For example, you can have a `production` branch (or it may just be your main
+branch) that you only merge to _after_ your CI system ran tests and built
+the resulting image.
+
+This requires a different style of Git discipline and may not fit all teams.

--- a/website/content/docs/kubernetes/external-build.mdx
+++ b/website/content/docs/kubernetes/external-build.mdx
@@ -40,6 +40,11 @@ A more realistic example would likely use
 or [functions](/docs/waypoint-hcl/functions/all) to dynamically specify
 the correct image.
 
+-> **Why `disable_entrypoint`?** Waypoint doesn't currently support
+entrypoint injection for the `docker-pull` builder on Kubernetes runners.
+See the [entrypoint injection](#waypoint-entrypoint-with-external-image-builds)
+section on this page for how you can manually inject the entrypoint.
+
 ### Input Variables to Specify the Image Tag
 
 [Input variables](/docs/waypoint-hcl/variables/input) can be used
@@ -134,3 +139,34 @@ branch) that you only merge to _after_ your CI system ran tests and built
 the resulting image.
 
 This requires a different style of Git discipline and may not fit all teams.
+
+## Waypoint Entrypoint with External Image Builds
+
+The [Waypoint Entrypoint](/docs/entrypoint) is an optional component that enables
+features such as `waypoint exec`, log streaming, instance tracking, and more.
+When using externally built Docker images, you must also manually inject
+the entrypoint.
+This is **optional**! Waypoint does not require the entrypoint to perform
+deploys.
+
+To setup the entrypoint, the simplest approach is to use
+[Docker multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/):
+
+```dockerfile
+FROM hashicorp/waypoint:latest AS waypoint
+
+# Your main build:
+FROM yourbaseimage
+
+COPY --from=waypoint /usr/bin/waypoint-entrypoint /waypoint-entrypoint
+
+# Replace "<EXISTING>" with your existing entrypoint (if any)
+ENTRYPOINT ["/waypoint-entrypoint", <EXISTING>]
+```
+
+Note that injecting the entrypoint is safe _even if you don't use Waypoint_.
+If the entrypoint doesn't have the proper environment variables set
+(by Waypoint itself, not as part of the build), then the entrypoints acts
+as if it doesn't exist: it executes its child process and does nothing.
+This lets you start injecting the entrypoint even if you're still only
+experimenting with Waypoint.

--- a/website/content/docs/kubernetes/helm-deploy.mdx
+++ b/website/content/docs/kubernetes/helm-deploy.mdx
@@ -1,0 +1,118 @@
+---
+layout: docs
+page_title: Kubernetes - Deploy with Helm
+description: |-
+  Waypoint can deploy your applications onto Kubernetes using Helm. Waypoint then tracks and shows you the health of all the resources that the Helm chart created.
+---
+
+# Deploying Applications with Helm
+
+Waypoint can deploy your applications onto Kubernetes using [Helm](https://helm.sh/).
+Waypoint then tracks and shows you the health of all the resources that
+the Helm chart created.
+
+If you're already using Helm, this lets you adopt Waypoint with very little
+friction since you can reuse your existing Helm charts for your applications.
+Another benefit of using Helm with Waypoint is that you can set chart values
+more dynamically, such as setting different settings per environment,
+referencing the most recently built artifacts, etc.
+
+-> **Not a Helm user? No problem!** Waypoint supports many other mechanisms
+for deploying to Kubernetes. You can use the [`kubernetes`](/plugins/kubernetes#kubernetes-platform) plugin for highly opinionated, no YAML deployments. Or you can use
+[`kubernetes-apply`)(/plugins/kubernetes#kubernetes-apply-platform) with
+a directory of YAML files.
+
+<!-- Note: will update the block above to point to higher level docs
+once they are written -->
+
+## Why Helm?
+
+The Helm deployment plugin for Waypoint is aimed primarily at people
+who either already use Helm or need to use a tool that lets them specify
+any custom Kubernetes resources. If you don't know Helm and are just trying
+to deploy a typical web service, you can use the YAML-less
+[`kubernetes`](/plugins/helm#values) plugin. And you can always switch
+deployment plugins later, so you don't need to be worried about making a
+"wrong" decision.
+
+For people who are familiar with Helm or would prefer to use Helm,
+you might still ask: but why would I use Helm with Waypoint? Why not use
+Helm directly? There are many reasons:
+
+1. **Dynamic Chart values.** Waypoint makes it easy to set chart values
+  based on dynamic information such as metadata about the most recent
+  artifact build, Git commit information, or just computed or templated
+  information using [HCL functions](/docs/waypoint-hcl/functions/all).
+
+2. **Environments.** Waypoint handles the higher level multi-environment
+  abstraction for you, so you can deploy your chart to multiple environments
+  but manage and see them all using the same tool and UI.
+
+3. **Single Workflow Configuration.** While you still have to write Helm charts,
+  you can invoke Helm using the same tool you're using to invoke builds,
+  release management, etc.
+
+4. **Other Waypoint features.** You can take advantage of other Waypoint
+  features such as [remote operations](/docs/waypoint-hcl/functions/all),
+  [logs](/docs/logs), [exec](/docs/exec), [input variables](/docs/waypoint-hcl/variables/input), and more.
+
+## Using Helm with Waypoint
+
+The example below shows a `waypoint.hcl` configuration that uses a
+Helm chart in the "helm" directory. We set two Chart values `image.repository`
+and `image.tag` to point to the artifact we just built. Notice that with the
+`set` Chart values, we could use any Waypoint variables, HCL functions, etc.
+to dynamically set chart configuration.
+
+```hcl
+app "my-app" {
+  build {
+    use "docker" {}
+
+    registry {
+      use "docker" {
+        image = "docker.io/myorg/myapp"
+        tag   = gitrefpretty()
+      }
+    }
+  }
+
+  deploy {
+    use "helm" {
+      name  = "my-app"
+      chart = "${path.app}/helm"
+
+      set {
+        name  = "image.repository"
+        value = artifact.image
+      }
+
+      set {
+        name  = "image.tag"
+        value = artifact.tag
+      }
+    }
+  }
+}
+```
+
+With this set, you can run `waypoint deploy` (if you have an artifact
+built already) and Waypoint will use Helm to deploy your application.
+
+-> **Note:** The `set` syntax is the same as the `--set` flag used
+with the `helm` CLI. This is documented on the Helm website [here](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set). You can also specify
+[values YAML files](/plugins/helm#values).
+
+### Chart Repositories
+
+The chart doesn't have to be local. You can also use a chart from a
+Helm chart repository:
+
+```hcl
+deploy {
+  use "helm" {
+    chart      = "waypoint"
+    repository = "https://helm.releases.hashicorp.com"
+  }
+}
+```

--- a/website/content/docs/kubernetes/helm-deploy.mdx
+++ b/website/content/docs/kubernetes/helm-deploy.mdx
@@ -40,21 +40,21 @@ you might still ask: but why would I use Helm with Waypoint? Why not use
 Helm directly? There are many reasons:
 
 1. **Dynamic Chart values.** Waypoint makes it easy to set chart values
-  based on dynamic information such as metadata about the most recent
-  artifact build, Git commit information, or just computed or templated
-  information using [HCL functions](/docs/waypoint-hcl/functions/all).
+   based on dynamic information such as metadata about the most recent
+   artifact build, Git commit information, or just computed or templated
+   information using [HCL functions](/docs/waypoint-hcl/functions/all).
 
 2. **Environments.** Waypoint handles the higher level multi-environment
-  abstraction for you, so you can deploy your chart to multiple environments
-  but manage and see them all using the same tool and UI.
+   abstraction for you, so you can deploy your chart to multiple environments
+   but manage and see them all using the same tool and UI.
 
 3. **Single Workflow Configuration.** While you still have to write Helm charts,
-  you can invoke Helm using the same tool you're using to invoke builds,
-  release management, etc.
+   you can invoke Helm using the same tool you're using to invoke builds,
+   release management, etc.
 
 4. **Other Waypoint features.** You can take advantage of other Waypoint
-  features such as [remote operations](/docs/waypoint-hcl/functions/all),
-  [logs](/docs/logs), [exec](/docs/exec), [input variables](/docs/waypoint-hcl/variables/input), and more.
+   features such as [remote operations](/docs/waypoint-hcl/functions/all),
+   [logs](/docs/logs), [exec](/docs/exec), [input variables](/docs/waypoint-hcl/variables/input), and more.
 
 ## Using Helm with Waypoint
 

--- a/website/content/docs/kubernetes/helm-deploy.mdx
+++ b/website/content/docs/kubernetes/helm-deploy.mdx
@@ -60,7 +60,8 @@ Helm directly? There are many reasons:
 
 The example below shows a `waypoint.hcl` configuration that uses a
 Helm chart in the "helm" directory. We set two Chart values `image.repository`
-and `image.tag` to point to the artifact we just built. Notice that with the
+and `image.tag` to point to the artifact we just built (see
+[here for more information on artifact variables](/docs/waypoint-hcl/variables/artifact)). Notice that with the
 `set` Chart values, we could use any Waypoint variables, HCL functions, etc.
 to dynamically set chart configuration.
 

--- a/website/content/docs/kubernetes/install.mdx
+++ b/website/content/docs/kubernetes/install.mdx
@@ -90,19 +90,19 @@ understanding what the above actually does beneath the covers.
 The following is an overview of what happened between the `helm install`
 and `waypoint login` commands:
 
-* A Waypoint server was started on Kubernetes. The Waypoint server must
+- A Waypoint server was started on Kubernetes. The Waypoint server must
   store data, so a persistent volume claim is used to store this state.
 
-* A Waypoint runner profile was configured so that operations such as
+- A Waypoint runner profile was configured so that operations such as
   builds, deploys, etc. launch within Kubernetes pods.
 
-* The Waypoint server was [bootstrapped](/docs/server/run#bootstrap-the-server)
+- The Waypoint server was [bootstrapped](/docs/server/run#bootstrap-the-server)
   which creates the first user. The authentication token for this first
   user was stored in a Kubernetes Secret.
 
-* A `LoadBalancer` service was created to access the Waypoint service.
+- A `LoadBalancer` service was created to access the Waypoint service.
 
-* The `waypoint login` command used your local Kubernetes configuration
+- The `waypoint login` command used your local Kubernetes configuration
   to look up the Waypoint service and connect to it using the bootstrapped
   authentication token present in the Kubernetes secret.
 

--- a/website/content/docs/kubernetes/install.mdx
+++ b/website/content/docs/kubernetes/install.mdx
@@ -1,0 +1,111 @@
+---
+layout: docs
+page_title: Kubernetes - Install
+description: |-
+  The first step in using Waypoint with Kubernetes is installing Waypoint both on your local machine and within the Kubernetes cluster. Waypoint provides a Helm chart to setup a fully production ready Waypoint server cluster on Kubernetes.
+---
+
+# Installing Waypoint for Kubernetes
+
+The first step in using Waypoint with Kubernetes is installing Waypoint
+both on your local machine and within the Kubernetes cluster. Waypoint
+provides a Helm chart to setup a fully production ready Waypoint server cluster
+on Kubernetes.
+
+-> **Why a server?** Waypoint requires a serverside component to enable
+features such as [GitOps](/docs/projects/git), history tracking,
+resource health checking, collaboration with teammates, etc. You can also
+run Waypoint in a purely local mode for quick tasks where the previously
+mentioned features aren't important.
+
+## Installing the Waypoint CLI
+
+If you're setting up a Waypoint server cluster for the first time or you're
+a person who prefers to work with a command-line interface (CLI), you'll need
+the `waypoint` CLI installed on your local machine. The `waypoint` CLI is
+used to run Waypoint operations such as builds and deploys as well as to
+configure the server.
+
+If you have an _existing_ Waypoint server cluster already created and you're
+just trying to _use_ Waypoint, you may be able to just use the web interface
+instead. Ask another team member with Waypoint setup for the URL to your
+interface and credentials to log in.
+
+To install the Waypoint client, go to the [Downloads](/downloads) page
+and follow the instructions. We provide raw binaries as well as full system
+packages depending on your operating system.
+
+To verify Waypoint is setup, run `waypoint` in your terminal. The output
+should start with something that looks like:
+
+```shell-session
+$ waypoint
+Welcome to Waypoint
+Docs: https://waypointproject.io
+Version: vX.Y.Z
+```
+
+~> **Not working?** Ensure the `waypoint` binary is on your
+[`PATH`](https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them). This may require restarting your
+terminal program.
+
+## Installing the Waypoint Server with Helm
+
+The recommended process for installing Waypoint on Kubernetes is with
+[Helm](https://helm.sh/) using the
+[official Waypoint Helm chart](https://github.com/hashicorp/waypoint-helm).
+This documentation assumes you have `helm` installed and that your `kubectl`
+is already configured to talk to a Kubernetes cluster.
+
+You can install Waypoint using the following commands:
+
+```shell-session
+$ helm repo add hashicorp https://helm.releases.hashicorp.com
+"hashicorp" has been added to your repositories
+
+$ helm install waypoint hashicorp/waypoint
+```
+
+The Helm chart has many
+[configurable values](https://github.com/hashicorp/waypoint-helm/blob/main/values.yaml)
+but is designed to work out of the box with reasonable defaults.
+
+Once you run `helm install`, it may take Waypoint up to 10 minutes to
+bootstrap itself. During this time, you may retry running the command below
+to log in to your Waypoint cluster. Once the command succeeds, Waypoint is
+ready for usage! If the command below fails, wait a few moments and try again;
+the Waypoint cluster is probably still bootstrapping.
+
+```shell-session
+$ waypoint login -from-kubernetes
+```
+
+At this point, Waypoint is configured and ready for use!
+
+### What Just Happened?
+
+If you're just starting to get a feel with Waypoint, you can skip this section.
+As you plan to move Waypoint into real production usage, it is probably worth
+understanding what the above actually does beneath the covers.
+The following is an overview of what happened between the `helm install`
+and `waypoint login` commands:
+
+* A Waypoint server was started on Kubernetes. The Waypoint server must
+  store data, so a persistent volume claim is used to store this state.
+
+* A Waypoint runner profile was configured so that operations such as
+  builds, deploys, etc. launch within Kubernetes pods.
+
+* The Waypoint server was [bootstrapped](/docs/server/run#bootstrap-the-server)
+  which creates the first user. The authentication token for this first
+  user was stored in a Kubernetes Secret.
+
+* A `LoadBalancer` service was created to access the Waypoint service.
+
+* The `waypoint login` command used your local Kubernetes configuration
+  to look up the Waypoint service and connect to it using the bootstrapped
+  authentication token present in the Kubernetes secret.
+
+All of these steps _could be_ run manually if you wanted, but the official
+recommendation on Kubernetes is to use the Helm chart. Still, it is important
+to know that there isn't any magic happening behind the scenes.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -84,6 +84,10 @@
       {
         "title": "Building Container Images",
         "path": "kubernetes/container-build"
+      },
+      {
+        "title": "Helm Deployment",
+        "path": "kubernetes/helm-deploy"
       }
     ]
   },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -71,6 +71,22 @@
     "divider": true
   },
   {
+    "title": "Kubernetes",
+    "routes": [
+      {
+        "title": "Install",
+        "path": "kubernetes/install"
+      },
+      {
+        "title": "Externally Built Images",
+        "path": "kubernetes/external-build"
+      }
+    ]
+  },
+  {
+    "divider": true
+  },
+  {
     "title": "Projects",
     "routes": [
       {

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -80,6 +80,10 @@
       {
         "title": "Externally Built Images",
         "path": "kubernetes/external-build"
+      },
+      {
+        "title": "Building Container Images",
+        "path": "kubernetes/container-build"
       }
     ]
   },


### PR DESCRIPTION
This starts the Kubernetes focused docs section.

The goal is to focus more on Kubernetes use cases and being opinionated more towards K8S users needs and challenges.

Note this is missing real runnable example projects. My plan is to fill in various sections with waypoint-examples links where it makes sense, but I wanted to get some content down first.