### PR TITLE
plugin/k8s: apply ingress annotations alongside existing metadata

### DIFF
--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -462,10 +462,11 @@ func (r *Releaser) resourceIngressCreate(
 
 	// Apply any annotations to the ingress resource
 	if r.config.IngressConfig.Annotations != nil {
-		ingressResource = &networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: r.config.IngressConfig.Annotations,
-			},
+		if ingressResource.ObjectMeta.Annotations == nil {
+			ingressResource.ObjectMeta.Annotations = map[string]string{}
+		}
+		for k, v := range r.config.IngressConfig.Annotations {
+			ingressResource.ObjectMeta.Annotations[k] = v
 		}
 	}
 


### PR DESCRIPTION
## Why the change?

Closes #2471

## What does it look like?

```sh
❯ kubectl get ingress web -o yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
  creationTimestamp: "2021-10-13T13:46:43Z"
  generation: 1
  name: web
  namespace: default
  resourceVersion: "60052"
  uid: 89c14f34-bbce-4904-b432-09c8c807dda7
spec:
  rules:
  - host: www.smallwins.club
    http:
      paths:
      - backend:
          service:
            name: web
            port:
              number: 80
        path: /
        pathType: Prefix
status:
  loadBalancer:
    ingress:
    - hostname: aae5c44950ab642d9b3dc30f11e1fdfa-91b09e38188a77ad.elb.eu-west-2.amazonaws.com
```

## How do I test it?

1. Create a kubernetes project with ingress annotations ([see example](https://github.com/jgwhite/waypoint-example/blob/73efce2ce9dc66ab781a581a2a6a2a4314bf8bb6/waypoint.hcl#L36-L45))
2. `waypoint up` the project
3. Verify the ingress resource was created with the desired annotations