### PR TITLE
Defaulting odr image to hashicorp/waypoint-odr:latest

### DIFF
--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -216,7 +216,7 @@ func (c *RunnerProfileSetCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "oci-url",
 			Target:  &c.flagOCIUrl,
-			Default: "hashicorp/waypoint-odr:stable",
+			Default: "hashicorp/waypoint-odr:latest",
 			Usage:   "The url for the OCI image to launch for the on-demand runner.",
 		})
 

--- a/internal/server/ptypes/ondemand_runner.go
+++ b/internal/server/ptypes/ondemand_runner.go
@@ -27,7 +27,7 @@ func TestOnDemandRunnerConfig(t testing.T, src *pb.OnDemandRunnerConfig) *pb.OnD
 
 	require.NoError(t, mergo.Merge(src, &pb.OnDemandRunnerConfig{
 		PluginType: "docker",
-		OciUrl:     "hashicorp/waypoint:stable",
+		OciUrl:     "hashicorp/waypoint-odr:latest",
 	}))
 
 	return src


### PR DESCRIPTION
It used to have the `stable` tag, but I don't think that's conventional.