### PR TITLE
builtin/k8s: Move port warning to log

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -621,9 +621,18 @@ func (p *Platform) resourceDeploymentCreate(
 
 	// App container must have some kind of port
 	if len(appContainerSpec.Ports) == 0 {
-		log.Debug("No ports defined - defaulting to http on port %d", DefaultServicePort)
+		log.Warn("No ports defined in waypoint.hcl - defaulting to http on port %d", DefaultServicePort)
 		appContainerSpec.Ports = append(appContainerSpec.Ports, &Port{Port: DefaultServicePort, Name: "http"})
 	}
+
+	portStep := sg.Add("")
+	defer func() { portStep.Abort() }()
+	// we dont use %q to save us convering a uint Port to a string and handling the error
+	portStep.Update("Expected %q port \"%d\" for app %q",
+		appContainerSpec.Ports[0].Name,
+		appContainerSpec.Ports[0].Port,
+		result.Name)
+	portStep.Done()
 
 	envVars := make(map[string]string)
 	// Add deploy config environment to container env vars


### PR DESCRIPTION
We shouldn't warn for when Waypoint picks a default value unless it's a
requirement that the user pick that value. This commit moves the warning
message about a default port to a debug message rather than printing a
warning to the terminal.