### PR TITLE
internal/cli: Ensure project target is set for AppOptional CLI option

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -314,7 +314,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 			// and the user provided it via the CLI, set it now.
 			// If they didn't provide a value via flag, we default to
 			// the project from initConfig.
-			if baseCfg.ProjectTargetRequired &&
+			if (baseCfg.AppOptional || baseCfg.ProjectTargetRequired) &&
 				c.refProject == nil {
 				if c.flagProject != "" {
 					c.refProject = &pb.Ref_Project{Project: c.flagProject}


### PR DESCRIPTION
Prior to this commit, the `waypoint status` CLI would set the project
target if it was inside a Waypoint project, using the AppOptional CLI
option for initialization. This commit ensures the project target is set
if its invoked inside a project dir.