### PR TITLE
builtin/k8s: Set hostname on release URL if requested in Waypoint

### DIFF
--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -554,10 +554,17 @@ func (r *Releaser) resourceIngressCreate(
 		if r.config.IngressConfig.TlsConfig != nil {
 			protocol = "https://"
 		}
-		lbIngress := ingress.Status.LoadBalancer.Ingress[0]
-		result.Url = protocol + lbIngress.IP
-		if lbIngress.Hostname != "" {
-			result.Url = protocol + lbIngress.Hostname
+
+		if r.config.IngressConfig.Host != "" {
+			// We set the requested hostname from the waypoint.hcl if defined
+			result.Url = protocol + r.config.IngressConfig.Host
+		} else {
+			// set the hostname based on the load balancer configured in k8s
+			lbIngress := ingress.Status.LoadBalancer.Ingress[0]
+			result.Url = protocol + lbIngress.IP
+			if lbIngress.Hostname != "" {
+				result.Url = protocol + lbIngress.Hostname
+			}
 		}
 
 		if serviceBackend.Spec.Ports[0].Port != 80 {


### PR DESCRIPTION
Prior to this commit, the Ingress resource create func would only set
the release URL based on the configured load balancer from k8s. This
commit changes that by first looking to see if the user requested a Host
to be set and use that instead, otherwise try to get the URL from the
configured load balancer.

Fixes #2475