### PR TITLE
init: disable plugin check for now

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -151,7 +151,13 @@ func (c *InitCommand) Run(args []string) int {
 		c.validateConfig,
 		c.validateServer,
 		c.validateProject,
-		c.validatePlugins,
+		// NOTE(mitchellh): this is disabled as of 0.6 since we can't load
+		// plugins in the CLI safely due to the usage of input variables +
+		// remote runners. This will be fixed in the future by migrating the
+		// init task to the InitOp remote operation. We're keeping this code
+		// around so we can migrate it then.
+		// c.validatePlugins,
+
 		// NOTE(mitchellh): this is disabled as of 0.2 since we can't load
 		// config anymore. We're keeping the code around so that we can migrate
 		// it in the future.


### PR DESCRIPTION
With the introduction of input variables, it is possible to use input
variables in a way that `waypoint init` cannot actually load the
configuration. This is because we don't actually render input variables
in the CLI (because we may not have all values).

The solution is to move this into a runner operation. We've already
started this process with the work we did in 0.6 around InitOp, but we
don't yet call this from the CLI.

For now, for 0.6, we just disable this init check. This was a safety
check anyways and has no practical implications so we can turn it off.
We'll turn it back on once we switch to remote operations.