### PR TITLE
builtin/k8s: Do not preserve old annotations

### DIFF
--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -462,12 +462,7 @@ func (r *Releaser) resourceIngressCreate(
 
 	// Apply any annotations to the ingress resource
 	if r.config.IngressConfig.Annotations != nil {
-		if ingressResource.ObjectMeta.Annotations == nil {
-			ingressResource.ObjectMeta.Annotations = map[string]string{}
-		}
-		for k, v := range r.config.IngressConfig.Annotations {
-			ingressResource.ObjectMeta.Annotations[k] = v
-		}
+		ingressResource.ObjectMeta.Annotations = r.config.IngressConfig.Annotations
 	}
 
 	// Define the ingress resources backend service it should route traffic to


### PR DESCRIPTION
The previous fix for ingress annotations would accidentally preserve any
old annotations that might of been set in a waypoint.hcl. So if a user
decided to update and remove some old values, they would continue to be
present in the next release. This commit fixes that by setting the
ingress resource annotations to whats exactly set in a waypoint.hcl.