### PR TITLE
Do not set a default value for k8s imagePullSecret on server install

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1490,10 +1490,9 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:    "k8s-pull-secret",
-		Target:  &i.config.imagePullSecret,
-		Usage:   "Secret to use to access the Waypoint server image on Kubernetes.",
-		Default: "github",
+		Name:   "k8s-pull-secret",
+		Target: &i.config.imagePullSecret,
+		Usage:  "Secret to use to access the Waypoint server image on Kubernetes.",
 	})
 
 	set.StringVar(&flag.StringVar{


### PR DESCRIPTION
This was likely present for historical reasons. `waypoint server install -platform=kubernetes -accept-tos` still works without this.