### PR TITLE
internal/server: fix flaky test TestServiceGetLogStream_depPlugin

### DIFF
--- a/internal/server/singleprocess/service_entrypoint.go
+++ b/internal/server/singleprocess/service_entrypoint.go
@@ -233,6 +233,7 @@ func (s *service) EntrypointLogStream(
 						return err
 					}
 
+					log.Info("using InstanceLogs record")
 					buf = il.LogBuffer
 				} else {
 					return err

--- a/internal/server/singleprocess/service_logs.go
+++ b/internal/server/singleprocess/service_logs.go
@@ -171,6 +171,7 @@ func (s *service) GetLogStream(
 			log.Debug("deployment supports log plugin. spawning log plugin")
 			inst, jobId, err := s.spawnLogPlugin(srv.Context(), log, deployment)
 			if err != nil {
+				log.Warn("error spawning log plugin", "err", err)
 				return err
 			}
 
@@ -179,7 +180,7 @@ func (s *service) GetLogStream(
 
 			// Because we spawned the writer, we can safely delete the whole thing
 			// when the reader is done.
-			go s.state.InstanceLogsDelete(inst.Id)
+			defer s.state.InstanceLogsDelete(inst.Id)
 
 			log.Debug("log plugin spawned", "job_id", jobId)
 			instanceFunc = func(ws memdb.WatchSet) ([]*streamRec, error) {


### PR DESCRIPTION
The issue here is that we can't force a flush and wait for a recv on the
client/server. Instead of sleeping 100ms and hoping for the best, we use
Eventually with a timeout to accumulate log entries. This should make
this deterministic in even the slowest practical cases.