### PR TITLE
Update `project` commands to use `runner profiles` instead of `odr configs`

### DIFF
--- a/.changelog/2489.txt
+++ b/.changelog/2489.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix `project apply` to set runner profiles by name
+```

--- a/internal/cli/project_apply.go
+++ b/internal/cli/project_apply.go
@@ -368,7 +368,7 @@ func (c *ProjectApplyCommand) Run(args []string) int {
 
 	if c.flagOndemandRunner != "" {
 		ref := &pb.Ref_OnDemandRunnerConfig{
-			Id: c.flagOndemandRunner,
+			Name: c.flagOndemandRunner,
 		}
 
 		// Validate the ref is validate by looking up the runner.
@@ -539,9 +539,9 @@ func (c *ProjectApplyCommand) Flags() *flag.Sets {
 		})
 
 		f.StringVar(&flag.StringVar{
-			Name:   "ondemand-runner",
+			Name:   "runner-profile",
 			Target: &c.flagOndemandRunner,
-			Usage:  "Assign an ondemand runner to be used for this project",
+			Usage:  "Name of a runner profile to be used for this project",
 		})
 	})
 }

--- a/internal/cli/project_inspect.go
+++ b/internal/cli/project_inspect.go
@@ -130,9 +130,9 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 
 	fileChangeSignal := project.FileChangeSignal
 
-	var odrId string
+	var runnerProfile string
 	if project.OndemandRunner != nil {
-		odrId = project.OndemandRunner.Id
+		runnerProfile = project.OndemandRunner.Name
 	}
 
 	// Show project info in a flat list where each project option is its
@@ -181,7 +181,7 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 			Name: "File Change Signal", Value: fileChangeSignal,
 		},
 		{
-			Name: "On-Demand Runner Config Id", Value: odrId,
+			Name: "Runner Profile Name", Value: runnerProfile,
 		},
 	}, terminal.WithInfoStyle())
 

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -54,6 +54,6 @@ some fields using flags by specifying the -waypoint-hcl flag.
 - `-poll-interval=<string>` - Interval between polling if polling is enabled.
 - `-app-status-poll` - Enable polling to continuously generate status reports for apps. This is only valid if a Git data source is supplied.
 - `-app-status-poll-interval=<string>` - Interval between polling to generate status reports if polling is enabled.
-- `-ondemand-runner=<string>` - Assign an ondemand runner to be used for this project
+- `-runner-profile=<string>` - Name of a runner profile to be used for this project
 
 @include "commands/project-apply_more.mdx"


### PR DESCRIPTION
This also fixes a bug where we could only set a runner profile with an ID that isn't visible in the CLI anymore.