### PR TITLE
ui/mirage: add support for data source and polling

### DIFF
--- a/ui/app/components/app-form/project-repository-settings.ts
+++ b/ui/app/components/app-form/project-repository-settings.ts
@@ -122,7 +122,7 @@ export default class AppFormProjectRepositorySettings extends Component<ProjectS
     // If ssh force users to use a git: url
     if (this.authSSH) {
       if (gitUrl.protocol !== 'ssh') {
-        this.flashMessages.error('Git url needs to use "git:" protocol');
+        this.flashMessages.error('Git url needs to use "ssh:" protocol');
         return false;
       }
     }

--- a/ui/mirage/factories/job-data-source.ts
+++ b/ui/mirage/factories/job-data-source.ts
@@ -1,0 +1,7 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  'marketing-public': trait({
+    git: association('waypoint-ssh'),
+  }),
+});

--- a/ui/mirage/factories/job-git-basic.ts
+++ b/ui/mirage/factories/job-git-basic.ts
@@ -1,0 +1,8 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  example: trait({
+    username: 'example',
+    password: 'example',
+  }),
+});

--- a/ui/mirage/factories/job-git-ssh.ts
+++ b/ui/mirage/factories/job-git-ssh.ts
@@ -1,0 +1,9 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  example: trait({
+    user: 'example',
+    password: 'example',
+    privateKeyPem: btoa('example'),
+  }),
+});

--- a/ui/mirage/factories/job-git.ts
+++ b/ui/mirage/factories/job-git.ts
@@ -1,0 +1,10 @@
+import { Factory, trait, association } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  'waypoint-ssh': trait({
+    url: 'git@github.com:hashicorp/waypoint.git',
+    ref: 'main',
+    path: 'website',
+    ssh: association('example'),
+  }),
+});

--- a/ui/mirage/factories/project-poll.ts
+++ b/ui/mirage/factories/project-poll.ts
@@ -1,0 +1,8 @@
+import { Factory, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  'every-2-minutes': trait({
+    enabled: true,
+    interval: '2m',
+  }),
+});

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait, association } from 'ember-cli-mirage';
 import faker from '../faker';
 
 export default Factory.extend({
@@ -26,6 +26,10 @@ export default Factory.extend({
   // This is our primary demo trait for development mode
   'marketing-public': trait({
     name: 'marketing-public',
+
+    dataSource: association('marketing-public'),
+    dataSourcePoll: association('every-2-minutes'),
+
     afterCreate(project, server) {
       let application = server.create('application', 'with-random-name', { project });
 

--- a/ui/mirage/models/job-data-source.ts
+++ b/ui/mirage/models/job-data-source.ts
@@ -1,0 +1,19 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Job } from 'waypoint-pb';
+
+export default Model.extend({
+  project: belongsTo({ inverse: 'dataSource' }),
+  git: belongsTo('job-git', { inverse: 'dataSource' }),
+
+  toProtobuf(): Job.DataSource {
+    let result = new Job.DataSource();
+
+    if (this.git) {
+      result.setGit(this.git.toProtobuf());
+    } else {
+      result.setLocal(new Job.Local());
+    }
+
+    return result;
+  },
+});

--- a/ui/mirage/models/job-git-basic.ts
+++ b/ui/mirage/models/job-git-basic.ts
@@ -1,0 +1,15 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Job } from 'waypoint-pb';
+
+export default Model.extend({
+  parent: belongsTo('job-git', { inverse: 'basic' }),
+
+  toProtobuf(): Job.Git.Basic {
+    let result = new Job.Git.Basic();
+
+    result.setUsername(this.username);
+    result.setPassword(this.password);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/job-git-ssh.ts
+++ b/ui/mirage/models/job-git-ssh.ts
@@ -1,0 +1,16 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Job } from 'waypoint-pb';
+
+export default Model.extend({
+  parent: belongsTo('job-git', { inverse: 'ssh' }),
+
+  toProtobuf(): Job.Git.SSH {
+    let result = new Job.Git.SSH();
+
+    result.setUser(this.user);
+    result.setPassword(this.password);
+    result.setPrivateKeyPem(this.privateKeyPem);
+
+    return result;
+  },
+});

--- a/ui/mirage/models/job-git.ts
+++ b/ui/mirage/models/job-git.ts
@@ -1,0 +1,21 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Job } from 'waypoint-pb';
+
+export default Model.extend({
+  dataSource: belongsTo('job-data-source', { inverse: 'git' }),
+  basic: belongsTo('job-git-basic', { inverse: 'parent' }),
+  ssh: belongsTo('job-git-ssh', { inverse: 'parent' }),
+
+  toProtobuf(): Job.Git {
+    let result = new Job.Git();
+
+    result.setUrl(this.url);
+    result.setRef(this.ref);
+    result.setPath(this.path);
+    result.setIgnoreChangesOutsidePath(this.ignoreChangesOutsidePath ?? true);
+    result.setBasic(this.basic?.toProtobuf());
+    result.setSsh(this.ssh?.toProtobuf());
+
+    return result;
+  },
+});

--- a/ui/mirage/models/project-poll.ts
+++ b/ui/mirage/models/project-poll.ts
@@ -1,0 +1,15 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+import { Project } from 'waypoint-pb';
+
+export default Model.extend({
+  project: belongsTo({ inverse: 'dataSourcePoll' }),
+
+  toProtobuf(): Project.Poll {
+    let result = new Project.Poll();
+
+    result.setEnabled(this.enabled ?? false);
+    result.setInterval(this.interval ?? '2m');
+
+    return result;
+  },
+});

--- a/ui/mirage/models/project.ts
+++ b/ui/mirage/models/project.ts
@@ -1,15 +1,18 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 import { Project, Ref } from 'waypoint-pb';
 
 export default Model.extend({
   applications: hasMany(),
   variables: hasMany(),
+  dataSource: belongsTo('job-data-source'),
+  dataSourcePoll: belongsTo('project-poll'),
+
   toProtobuf(): Project {
     let result = new Project();
 
     result.setApplicationsList(this.applications.models.map((a) => a.toProtobuf()));
-    // TODO: result.setDataSource(...)
-    // TODO: result.setDataSourcePoll(...)
+    result.setDataSource(this.dataSource?.toProtobuf());
+    result.setDataSourcePoll(this.dataSourcePoll?.toProtobuf());
     result.setFileChangeSignal(this.fileChangeSignal);
     result.setName(this.name);
     result.setRemoteEnabled(this.remoteEnabled);


### PR DESCRIPTION
## Why the change?

Closes #1940 

## What’s the plan?

- [x] Add data source to default scenario
- [x] Add the models
- [x] Add the factories
- [x] Add the handler

## What does it look like?

https://user-images.githubusercontent.com/34030/137494811-b5d162de-fc6b-458e-8556-bee3eb962dd7.mp4

## How do I test it?

1. Check out this branch (`git checkout ui/mirage-data-source`)
2. Boot the dev server (`cd ui && yarn start`)
3. Visit [localhost:4200](http://localhost:4200)
4. Try editing project data source and polling settings
5. Verify settings appear to be stored and retrieved correctly