### PR TITLE
use preserveSymlinks to fix /lib imports

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "allowJs": true,
     "moduleResolution": "node",
+    "preserveSymlinks": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": false,
     "noImplicitThis": true,


### PR DESCRIPTION
fixes an issue where vscode would use the local path when auto-completing imports after we merged https://github.com/hashicorp/waypoint/pull/2439