### PR TITLE
Close the local runner on exit.

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -126,8 +126,13 @@ type baseCommand struct {
 }
 
 // Close cleans up any resources that the command created. This should be
-// defered by any CLI command that embeds baseCommand in the Run command.
+// deferred by any CLI command that embeds baseCommand in the Run command.
 func (c *baseCommand) Close() error {
+	// Close the project client, which gracefully shuts down the local runner
+	if c.project != nil {
+		c.project.Close()
+	}
+
 	// Close our UI if it implements it. The glint-based UI does for example
 	// to finish up all the CLI output.
 	if closer, ok := c.ui.(io.Closer); ok && closer != nil {


### PR DESCRIPTION
Closes https://github.com/hashicorp/waypoint/issues/1484

Calling `Close` on the project also closes the internal runner. Without this, the runner races against the main goroutine to shut down, but often loses and isn't able to send the JobComplete message back to the server.