### PR TITLE
Require refProject to be set for commands that require an app target.

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -319,7 +319,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 			// and the user provided it via the CLI, set it now.
 			// If they didn't provide a value via flag, we default to
 			// the project from initConfig.
-			if (baseCfg.AppOptional || baseCfg.ProjectTargetRequired) &&
+			if (baseCfg.AppOptional || baseCfg.AppTargetRequired || baseCfg.ProjectTargetRequired) &&
 				c.refProject == nil {
 				if c.flagProject != "" {
 					c.refProject = &pb.Ref_Project{Project: c.flagProject}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/2523