### PR TITLE
core/app_build: Fix panic where Waypoint plugin missing AccessInfoFunc

### DIFF
--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -297,3 +297,5 @@ registry {
 }
 
 var _ component.Documented = (*Registry)(nil)
+var _ component.Registry = (*Registry)(nil)
+var _ component.RegistryAccess = (*Registry)(nil)

--- a/builtin/docker/registry.go
+++ b/builtin/docker/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"google.golang.org/grpc/codes"
@@ -226,3 +227,6 @@ build {
 
 	return doc, nil
 }
+
+var _ component.Registry = (*Registry)(nil)
+var _ component.RegistryAccess = (*Registry)(nil)

--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -155,7 +155,7 @@ func (op *buildOperation) Do(ctx context.Context, log hclog.Logger, app *App, _ 
 
 	// If there is a registry defined and it implements RegistryAccess...
 	if op.Registry != nil {
-		if ra, ok := op.Registry.Value.(component.RegistryAccess); ok {
+		if ra, ok := op.Registry.Value.(component.RegistryAccess); ok && ra.AccessInfoFunc() != nil {
 			raw, err := app.callDynamicFunc(ctx, log, nil, op.Component, ra.AccessInfoFunc())
 			if err == nil {
 				args = append(args, argmapper.Typed(raw))
@@ -175,6 +175,15 @@ func (op *buildOperation) Do(ctx context.Context, log hclog.Logger, app *App, _ 
 			} else {
 				log.Error("error calling dynamic func", "error", err)
 				return nil, err
+			}
+		} else {
+			if ra.AccessInfoFunc() == nil {
+				return nil, status.Error(codes.Internal, "The plugin requested does not "+
+					"define an AccessInfoFunc() in its Registry plugin. This is an internal "+
+					"error and should be reported to the author of the plugin.")
+			} else {
+				return nil, status.Error(codes.Internal, "The given build operation value "+
+					"is not a component.RegistryAccess type.")
 			}
 		}
 	}


### PR DESCRIPTION
This pull request fixes an issue where a compiled Waypoint plugin fails to
register an AccessInfoFunc(). Instead of directly passing nil, causing a
panic during build, we look to see if the function is defined first. If
not, return the proper errors.