### PR TITLE
Return instead of panic in code that is only used in dev

### DIFF
--- a/.changelog/2533.txt
+++ b/.changelog/2533.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serverinstall/ecs: Fix potential panic in some ECS On-Demand Runner releases
+```

--- a/internal/assets/dev.go
+++ b/internal/assets/dev.go
@@ -1,5 +1,8 @@
 //go:generate go-bindata -dev -pkg assets -o dev_assets.go -tags !assetsembedded ceb
 
+//go:build !assetsembedded
+// +build !assetsembedded
+
 package assets
 
 import (
@@ -10,8 +13,13 @@ import (
 var rootDir string
 
 func init() {
+	// Set a reasonable default in the event we somehow fail to find the root
+	// directory
+	rootDir = "./internal/assets"
 	dir, err := os.Getwd()
 	if err != nil {
+		// There is some strange circumstance that would cause this to panic,
+		// but would only happen in a dev environment anyway.
 		panic(err)
 	}
 
@@ -29,7 +37,4 @@ func init() {
 
 		dir = nextDir
 	}
-
-	// Uuuuhhh...
-	rootDir = "./internal/assets"
 }


### PR DESCRIPTION
This bit of code causes an issue in at least AWS ECS server installs using on-demand runners, where a release will fail:

```
! Unrecognized remote plugin message:
  This usually means that the plugin is either invalid or simply
  needs to be recompiled to support the latest protocol.
```

The underlying issue is a panic during the init phase caused by something that's only used in development, so here we change that to simply return. 

**UPDATE:** refactored/rebased to completely exclude `internal/assets/dev.go` from builds with the `assetsembedded` tag (see [the Makefile](https://github.com/hashicorp/waypoint/blob/c9393cf4be0a5b88147bfa9464d0864f7d24be41/Makefile) for reference). The `dev.go` file was generating `dev_assets.go` which was _not_ included in builds, however the `dev.go` file itself still was, and it's `init()` method could cause troubles