### PR TITLE
ui/mirage: add remaining `artifact` plumbing

### DIFF
--- a/ui/mirage/models/artifact.ts
+++ b/ui/mirage/models/artifact.ts
@@ -3,6 +3,7 @@ import { Artifact } from 'waypoint-pb';
 
 export default Model.extend({
   build: belongsTo(),
+  pushedArtifact: belongsTo(),
 
   toProtobuf(): Artifact {
     let result = new Artifact();

--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -42,7 +42,7 @@ export default Model.extend({
   preloadProtobuf(): Deployment.Preload {
     let result = new Deployment.Preload();
 
-    // TODO: result.setArtifact
+    result.setArtifact(this.build?.pushedArtifact?.toProtobuf());
     result.setBuild(this.build?.toProtobuf());
     result.setDeployUrl(this.deployUrl);
 

--- a/ui/mirage/models/pushed-artifact.ts
+++ b/ui/mirage/models/pushed-artifact.ts
@@ -7,12 +7,13 @@ export default Model.extend({
   component: belongsTo({ inverse: 'owner' }),
   status: belongsTo({ inverse: 'owner' }),
   workspace: belongsTo(),
+  artifact: belongsTo(),
 
   toProtobuf(): PushedArtifact {
     let result = new PushedArtifact();
 
     result.setApplication(this.application?.toProtobufRef());
-    // TODO: result.setArtifact
+    result.setArtifact(this.artifact?.toProtobuf());
     result.setBuild(this.build?.toProtobuf());
     result.setBuildId(this.build?.id);
     result.setComponent(this.component?.toProtobuf());

--- a/ui/mirage/models/release.ts
+++ b/ui/mirage/models/release.ts
@@ -38,7 +38,7 @@ export default Model.extend({
   preloadProtobuf(): Release.Preload {
     let result = new Release.Preload();
 
-    // TODO: result.setArtifact
+    result.setArtifact(this.deployment?.build?.pushedArtifact?.toProtobuf());
     result.setBuild(this.deployment?.build?.toProtobuf());
     result.setDeployment(this.deployment?.toProtobuf());
 


### PR DESCRIPTION
## Why the change?

Paying down our TODO debt and making it easier to work on stuff like #2443 

## What does it look like?

https://user-images.githubusercontent.com/34030/138275078-0fd1cf77-d466-4144-90c2-e2abf0b6e035.mp4

## How do I test it?

1. Check out the branch
2. Boot the dev server
3. Try out some of the things demonstrated in the video above
