### PR TITLE
website: fix algolia index job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,6 +419,7 @@ jobs:
           name: Push content to Algolia Index
           command: |
             cd website/
+            npm install -g npm@latest
             npm install
             node scripts/index_search_content.js
 


### PR DESCRIPTION
Install the latest npm during algolia indexing to satisfy our engines requirements.