### PR TITLE
internal/server/state: fix flaky AppOperation test

### DIFF
--- a/internal/server/singleprocess/state/app_operation_test.go
+++ b/internal/server/singleprocess/state/app_operation_test.go
@@ -144,6 +144,13 @@ func TestAppOperation(t *testing.T) {
 		// to test our index is really doing the right thing.
 		rand.Shuffle(len(times), func(i, j int) { times[i], times[j] = times[j], times[i] })
 
+		// Since we search by latest sequence later, we don't want our latest
+		// to be sequence #1. This fixes a flaky test that would happen in
+		// that case cause we'd search for sequence 0 which doesn't exist.
+		if times[0] == latest {
+			times[0], times[1] = times[1], times[0]
+		}
+
 		// Create a build for each time
 		for _, timeVal := range times {
 			pt, err := ptypes.TimestampProto(timeVal)


### PR DESCRIPTION
This test could fail if it ordered the times in such a way that the
latest time was at index 0, because then the latest would have sequence
1 and later in the test we search for the operation with sequence
"latest - 1" and sequence 0 doesn't exist. This ensures that latest is
never index 0.

Fixes flake: https://app.circleci.com/pipelines/github/hashicorp/waypoint/11383/workflows/1dfd3099-49d1-4ad3-bf55-0d9e7bd3d19d/jobs/108114