### PR TITLE
Refactor flake and overlay

### DIFF
--- a/nix/go-changelog.nix
+++ b/nix/go-changelog.nix
@@ -1,0 +1,17 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-changelog";
+  version = "56335215ce3a8676ba7153be7c444daadcb132c7";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "go-changelog";
+    rev = "56335215ce3a8676ba7153be7c444daadcb132c7";
+    sha256 = "0z6ysz4x1rim09g9knbc5x5mrasfk6mzsi0h7jn8q4i035y1gg2j";
+  };
+
+  vendorSha256 = "1pahh64ayr885kv9rd5i4vh4a6hi1w583wch9n1ncvnckznzsdbg";
+
+  subPackages = [ "cmd/changelog-build" ];
+}

--- a/nix/go-mockery.nix
+++ b/nix/go-mockery.nix
@@ -1,0 +1,23 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-mockery";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "vektra";
+    repo = "mockery";
+    rev = "v${version}";
+    sha256 = "16yqhr92n5s0svk31yy3k42764fas694mnqqcny633yi0wqb876a";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=
+    -s -w -X github.com/vektra/mockery/mockery.SemVer=${version}
+  '';
+
+  modSha256 = "0wyzfmhk7plazadbi26rzq3w9cmvqz2dd5jsl6kamw53ps5yh536";
+  vendorSha256 = "0fai4hs3q822dg36a2zrxb191f71xdpafapn6ymi1w9dx68navcb";
+
+  subPackages = [ "cmd/mockery" ];
+}

--- a/nix/go-protobuf-json.nix
+++ b/nix/go-protobuf-json.nix
@@ -1,0 +1,16 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-protobuf-json";
+  version = "069933b8c8344593ed8905d46d59c6647c886f47";
+
+  src = fetchFromGitHub {
+    owner = "mitchellh";
+    repo = "protoc-gen-go-json";
+    rev = "069933b8c8344593ed8905d46d59c6647c886f47";
+    sha256 = "1q5s2pfdxxzvdqghmbw3y2w5nl7wa4x15ngahfarjhahwqsbfsx4";
+  };
+
+  modSha256 = "01wrk2qhrh74nkv6davfifdz7jq6fcl3snn4w2g7vr8p0incdlcf";
+  vendorSha256 = "1hx31gr3l2f0nc8316c9ipmk1xx435g732msr5b344rcfcfrlaxh";
+}

--- a/nix/go-protobuf.nix
+++ b/nix/go-protobuf.nix
@@ -1,0 +1,18 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-protobuf";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "protobuf";
+    rev = "v${version}";
+    sha256 = "1mh5fyim42dn821nsd3afnmgscrzzhn3h8rag635d2jnr23r1zhk";
+  };
+
+  modSha256 = "0lnk2zpl6y9vnq6h3l42ssghq6iqvmixd86g2drpa4z8xxk116wf";
+  vendorSha256 = "1qbndn7k0qqwxqk4ynkjrih7f7h56z1jq2yd62clhj95rca67hh9";
+
+  subPackages = [ "protoc-gen-go" ];
+}

--- a/nix/go-tools.nix
+++ b/nix/go-tools.nix
@@ -1,0 +1,22 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-tools";
+  version = "35839b7038afa36a6c000733552daa1f5ce1e838";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "tools";
+    rev = "35839b7038afa36a6c000733552daa1f5ce1e838";
+    sha256 = "1gnqf62s7arqk807gadp4rd2diz1g0v2khwv9wsb50y8k9k4dfqs";
+  };
+
+  modSha256 = "1pijbkp7a9n2naicg21ydii6xc0g4jm5bw42lljwaks7211ag8k9";
+  vendorSha256 = "0i2fhaj2fd8ii4av1qx87wjkngip9vih8v3i9yr3h28hkq68zkm5";
+
+  subPackages = [ "cmd/stringer" ];
+
+  # This has to be enabled because the stringer tests recompile itself
+  # so it needs a valid reference to `go`
+  allowGoReference = true;
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,100 +1,16 @@
-nixpkgs: final: prev: {
+final: prev: {
   # This is the pinned protoc version we have for this project.
-  protobufPin = prev.callPackage (
-    nixpkgs + "/pkgs/development/libraries/protobuf/generic-v3.nix"
-  ) {
-    version = "3.15.8";
-    sha256 = "1q3k8axhq6g8fqczmd6kbgzpdplrrgygppym4x1l99lzhplx9rqv";
-  };
+  protobufPin = prev.protobuf3_15;
 
-  go-protobuf = prev.buildGoModule rec {
-    pname = "go-protobuf";
-    version = "v1.5.2";
+  devShell = final.callPackage ./waypoint.nix { };
 
-    src = prev.fetchFromGitHub {
-      owner = "golang";
-      repo = "protobuf";
-      rev = "v1.5.2";
-      sha256 = "1mh5fyim42dn821nsd3afnmgscrzzhn3h8rag635d2jnr23r1zhk";
-    };
+  go-protobuf = prev.callPackage ./go-protobuf.nix { };
 
-    modSha256 = "0lnk2zpl6y9vnq6h3l42ssghq6iqvmixd86g2drpa4z8xxk116wf";
-    vendorSha256 = "1qbndn7k0qqwxqk4ynkjrih7f7h56z1jq2yd62clhj95rca67hh9";
+  go-protobuf-json = prev.callPackage ./go-protobuf-json.nix { };
 
-    subPackages = [ "protoc-gen-go" ];
-  };
+  go-tools = prev.callPackage ./go-tools.nix { };
 
-  go-protobuf-json = prev.buildGoModule rec {
-    pname = "go-protobuf-json";
-    version = "069933b8c8344593ed8905d46d59c6647c886f47";
+  go-mockery = prev.callPackage ./go-mockery.nix { };
 
-    src = prev.fetchFromGitHub {
-      owner = "mitchellh";
-      repo = "protoc-gen-go-json";
-      rev = "069933b8c8344593ed8905d46d59c6647c886f47";
-      sha256 = "1q5s2pfdxxzvdqghmbw3y2w5nl7wa4x15ngahfarjhahwqsbfsx4";
-    };
-
-    modSha256 = "01wrk2qhrh74nkv6davfifdz7jq6fcl3snn4w2g7vr8p0incdlcf";
-    vendorSha256 = "1hx31gr3l2f0nc8316c9ipmk1xx435g732msr5b344rcfcfrlaxh";
-  };
-
-  go-tools = prev.buildGoModule rec {
-    pname = "go-tools";
-    version = "35839b7038afa36a6c000733552daa1f5ce1e838";
-
-    src = prev.fetchFromGitHub {
-      owner = "golang";
-      repo = "tools";
-      rev = "35839b7038afa36a6c000733552daa1f5ce1e838";
-      sha256 = "1gnqf62s7arqk807gadp4rd2diz1g0v2khwv9wsb50y8k9k4dfqs";
-    };
-
-    modSha256 = "1pijbkp7a9n2naicg21ydii6xc0g4jm5bw42lljwaks7211ag8k9";
-    vendorSha256 = "0i2fhaj2fd8ii4av1qx87wjkngip9vih8v3i9yr3h28hkq68zkm5";
-
-    subPackages = [ "cmd/stringer" ];
-
-    # This has to be enabled because the stringer tests recompile itself
-    # so it needs a valid reference to `go`
-    allowGoReference = true;
-  };
-
-  go-mockery = prev.buildGoModule rec {
-    pname = "go-mockery";
-    version = "1.1.2";
-
-    src = prev.fetchFromGitHub {
-      owner = "vektra";
-      repo = "mockery";
-      rev = "v${version}";
-      sha256 = "16yqhr92n5s0svk31yy3k42764fas694mnqqcny633yi0wqb876a";
-    };
-
-    buildFlagsArray = ''
-      -ldflags=
-      -s -w -X github.com/vektra/mockery/mockery.SemVer=${version}
-    '';
-
-    modSha256 = "0wyzfmhk7plazadbi26rzq3w9cmvqz2dd5jsl6kamw53ps5yh536";
-    vendorSha256 = "0fai4hs3q822dg36a2zrxb191f71xdpafapn6ymi1w9dx68navcb";
-
-    subPackages = [ "cmd/mockery" ];
-  };
-
-  go-changelog = prev.buildGoModule rec {
-    pname = "go-changelog";
-    version = "56335215ce3a8676ba7153be7c444daadcb132c7";
-
-    src = prev.fetchFromGitHub {
-      owner = "hashicorp";
-      repo = "go-changelog";
-      rev = "56335215ce3a8676ba7153be7c444daadcb132c7";
-      sha256 = "0z6ysz4x1rim09g9knbc5x5mrasfk6mzsi0h7jn8q4i035y1gg2j";
-    };
-
-    vendorSha256 = "1pahh64ayr885kv9rd5i4vh4a6hi1w583wch9n1ncvnckznzsdbg";
-
-    subPackages = [ "cmd/changelog-build" ];
-  };
+  go-changelog = prev.callPackage ./go-changelog.nix { };
 }

--- a/nix/waypoint.nix
+++ b/nix/waypoint.nix
@@ -1,47 +1,81 @@
-{ pkgs }: {
-  shell = pkgs.mkShell rec {
-    name = "waypoint";
+{ lib
+, stdenv
+, autoconf
+, autogen
+, automake
+, docker-compose
+, doctl
+, go
+, go-bindata
+, go-changelog
+, go-mockery
+, go-protobuf
+, go-protobuf-json
+, go-tools
+, grpcurl
+, kubectl
+, libpng
+, libtool
+, minikube
+, mkShell
+, nasm
+, nodejs-16_x
+, pkg-config
+, postgresql_12
+, protobufPin
+, protoc-gen-doc
+, zlib
+}:
 
-    buildInputs = [
-      pkgs.docker-compose
-      pkgs.go
-      pkgs.go-bindata
-      pkgs.grpcurl
-      pkgs.nodejs-16_x
-      pkgs.postgresql_12
-      pkgs.protoc-gen-doc
+mkShell rec {
+  name = "waypoint";
 
-      # Custom packages
-      pkgs.protobufPin
-      pkgs.go-protobuf
-      pkgs.go-protobuf-json
-      pkgs.go-tools
-      pkgs.go-mockery
-      pkgs.go-changelog
+  packages = [
+    docker-compose
+    go
+    go-bindata
+    grpcurl
+    nodejs-16_x
+    postgresql_12
+    protoc-gen-doc
 
-      # For testing
-      pkgs.doctl
-      pkgs.kubectl
-    ] ++ (with pkgs; [
-      # Needed for website/
-      pkgconfig autoconf automake libtool nasm autogen zlib libpng
-    ]) ++ (if pkgs.stdenv.isLinux then [
-      # On Linux we use minikube as the primary k8s testing platform
-      pkgs.minikube
-    ] else []);
+    # Custom packages, added to overlay
+    protobufPin
+    go-protobuf
+    go-protobuf-json
+    go-tools
+    go-mockery
+    go-changelog
 
-    # workaround for npm/gulp dep compilation
-    # https://github.com/imagemin/optipng-bin/issues/108
-    shellHook = ''
-      LD=$CC
-    '';
+    # For testing
+    doctl
+    kubectl
 
-    # Extra env vars
-    PGHOST = "localhost";
-    PGPORT = "5432";
-    PGDATABASE = "noop";
-    PGUSER = "postgres";
-    PGPASSWORD = "postgres";
-    DATABASE_URL = "postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=disable";
-  };
+    # Needed for website/
+    autoconf
+    autogen
+    automake
+    libpng
+    libtool
+    nasm
+    pkg-config
+    zlib
+  ] ++ lib.optionals stdenv.isLinux [
+    # On Linux we use minikube as the primary k8s testing platform
+    minikube
+  ];
+
+  # workaround for npm/gulp dep compilation
+  # https://github.com/imagemin/optipng-bin/issues/108
+  shellHook = ''
+    LD=$CC
+  '';
+
+  # Extra env vars
+  PGHOST = "localhost";
+  PGPORT = "5432";
+  PGDATABASE = "noop";
+  PGUSER = "postgres";
+  PGPASSWORD = "postgres";
+  DATABASE_URL = "postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=disable";
 }


### PR DESCRIPTION
Thought it was awesome that you guys using nix, so I thought I would help with some minor improvements:
- Move added packages into their own files
- Expose legacyPackages, overlay, and overlays attr in flake output
- Use protobuf3_15 instead of override
- Add devShell to overlay

Some non-obvious changes:
Using `packages` (or nativeBuildInputs) instead of `buildInputs` for mkShell allows for `XDG_DATA_DIR` to be set with the shell-completion files of the added packages, so you should get tab completion if you use bash completion (IIRC, fish and zsh don't respect XDG_DATA_DIR) [related nixpkgs PR](https://github.com/NixOS/nixpkgs/pull/104225#issuecomment-777725471)

Otherwise, not much has changed from a nix perspective. Just two renames:
```
jon@jon-desktop /home/jon/projects/waypoint (main)
$ nix eval .#devShell.x86_64-linux.drvPath
"/nix/store/yr303a78g6gh4q7g9cbf96ls6f0bal0x-waypoint.drv"

jon@jon-desktop /home/jon/projects/waypoint (refactor-nix)
$ nix eval .#devShell.x86_64-linux.drvPath
"/nix/store/f3ix16p436x3wci8cn1drhs93hg8gq64-waypoint.drv"

jon@jon-desktop /home/jon/projects/waypoint (refactor-nix)
$ nix run nixpkgs#nix-diff /nix/store/yr303a78g6gh4q7g9cbf96ls6f0bal0x-waypoint.drv /nix/store/f3ix16p436x3wci8cn1drhs93hg8gq64-waypoint.drv
- /nix/store/yr303a78g6gh4q7g9cbf96ls6f0bal0x-waypoint.drv:{out}
+ /nix/store/f3ix16p436x3wci8cn1drhs93hg8gq64-waypoint.drv:{out}
• The set of input derivation names do not match:
    - go-protobuf-v1.5.2
    + go-protobuf-1.5.2
• The environments do not match:
    buildInputs=''
    /nix/store/2y8p2cx4xabvf1hf810s9zb6cb0bx9mc-docker-compose-1.29.2 /nix/store/sppqwgfpqhjl1lk90gxfdyx2jqxbbfwk-go-1.16.7 /nix/store/hlpk5jjw7f2skknlwh7z2gc0c9qnckl7-go-bindata-3.22.0 /nix/store/gz46hwrdjx9i8gxgkia20ayb2nhyf5vy-grpcurl-1.8.2 /nix/store/dih2gzb715q5k8hw7qjmq0n35ba30pb0-nodejs-16.6.1 /nix/store/g1yan04fzg018134jyz5g36439jd4b3d-postgresql-12.7 /nix/store/zgagnpjcpi2zvimmswrv6pf91svjfjf0-protoc-gen-doc-unstable-2019-04-22 /nix/store/s4lqvzb04xvcdijwq2cancpwvi1807bn-protobuf-3.15.8 /nix/store/bly9bmpxhmick415qrasgfvjdj4y5rn3-go-protobuf-v1.5.2 /nix/store/ccd1xjg0p9r23k1i9cpxx9zf7rr36r17-go-protobuf-json-069933b8c8344593ed8905d46d59c6647c886f47 /nix/store/m8n43fdmfnl24d8yh90r9l0xa1w3zvlz-go-tools-35839b7038afa36a6c000733552daa1f5ce1e838 /nix/store/ln0f156f6qcdf15j6gy2mjw263s2clwg-go-mockery-1.1.2 /nix/store/vjx713gmz1qqzllvppnl02f4zpza5gl8-go-changelog-56335215ce3a8676ba7153be7c444daadcb132c7 /nix/store/4mqvyh5q93ja860656bi0q9sg5sqhqs4-doctl-1.63.1 /nix/store/cx42syr9krm4f7hip1za88lr0gmw7y9q-kubectl-1.22.0 /nix/store/3d8z7x0p3fzhjkxdfr3cg6vfkfmqadnd-pkg-config-wrapper-0.29.2 /nix/store/2racw0r4a6f1ya6hv7a47w544cgarcjf-autoconf-2.71 /nix/store/9wgw1bxavq7d4hj3igw8mm4l68vrp5bh-automake-1.16.3 /nix/store/kxi9r99hgdq1bi7ma135pbn7p3jqlmdk-libtool-2.4.6 /nix/store/gr6hd0mba0217fp8msgmj8sp6a2wn6bh-nasm-2.15.05 /nix/store/jklgf34m49dl7fq5xy3b55szy5zjpq2f-autogen-5.18.16-dev /nix/store/mzpfnpbax7i5b8ipsgf27i7nlmnhpvn3-zlib-1.2.11-dev /nix/store/xmdhdglf79q6f5hg9yqbdbzfbrfl9k5v-libpng-apng-1.6.37-dev /nix/store/dbcd4ivx25dqdiq2p95z8q0ysxq6jvzy-minikube-1.22.0
''
    nativeBuildInputs=''
    /nix/store/2y8p2cx4xabvf1hf810s9zb6cb0bx9mc-docker-compose-1.29.2 /nix/store/sppqwgfpqhjl1lk90gxfdyx2jqxbbfwk-go-1.16.7 /nix/store/hlpk5jjw7f2skknlwh7z2gc0c9qnckl7-go-bindata-3.22.0 /nix/store/gz46hwrdjx9i8gxgkia20ayb2nhyf5vy-grpcurl-1.8.2 /nix/store/dih2gzb715q5k8hw7qjmq0n35ba30pb0-nodejs-16.6.1 /nix/store/g1yan04fzg018134jyz5g36439jd4b3d-postgresql-12.7 /nix/store/zgagnpjcpi2zvimmswrv6pf91svjfjf0-protoc-gen-doc-unstable-2019-04-22 /nix/store/s4lqvzb04xvcdijwq2cancpwvi1807bn-protobuf-3.15.8 /nix/store/svqa4qiz30ddabkfjwx0z69a16h4i14g-go-protobuf-1.5.2 /nix/store/ccd1xjg0p9r23k1i9cpxx9zf7rr36r17-go-protobuf-json-069933b8c8344593ed8905d46d59c6647c886f47 /nix/store/m8n43fdmfnl24d8yh90r9l0xa1w3zvlz-go-tools-35839b7038afa36a6c000733552daa1f5ce1e838 /nix/store/ln0f156f6qcdf15j6gy2mjw263s2clwg-go-mockery-1.1.2 /nix/store/vjx713gmz1qqzllvppnl02f4zpza5gl8-go-changelog-56335215ce3a8676ba7153be7c444daadcb132c7 /nix/store/4mqvyh5q93ja860656bi0q9sg5sqhqs4-doctl-1.63.1 /nix/store/cx42syr9krm4f7hip1za88lr0gmw7y9q-kubectl-1.22.0 /nix/store/2racw0r4a6f1ya6hv7a47w544cgarcjf-autoconf-2.71 /nix/store/jklgf34m49dl7fq5xy3b55szy5zjpq2f-autogen-5.18.16-dev /nix/store/9wgw1bxavq7d4hj3igw8mm4l68vrp5bh-automake-1.16.3 /nix/store/xmdhdglf79q6f5hg9yqbdbzfbrfl9k5v-libpng-apng-1.6.37-dev /nix/store/kxi9r99hgdq1bi7ma135pbn7p3jqlmdk-libtool-2.4.6 /nix/store/gr6hd0mba0217fp8msgmj8sp6a2wn6bh-nasm-2.15.05 /nix/store/3d8z7x0p3fzhjkxdfr3cg6vfkfmqadnd-pkg-config-wrapper-0.29.2 /nix/store/mzpfnpbax7i5b8ipsgf27i7nlmnhpvn3-zlib-1.2.11-dev /nix/store/dbcd4ivx25dqdiq2p95z8q0ysxq6jvzy-minikube-1.22.0
''
```