### PR TITLE
internal/server/state: job creation happens in dependency order

### DIFF
--- a/internal/pkg/graph/dfs.go
+++ b/internal/pkg/graph/dfs.go
@@ -1,0 +1,36 @@
+package graph
+
+type DFSFunc func(Vertex, func() error) error
+
+func (g *Graph) DFS(start Vertex, cb DFSFunc) error {
+	return g.dfs(cb, map[interface{}]struct{}{}, hashcode(start))
+}
+
+func (g *Graph) dfs(cb DFSFunc, visited map[interface{}]struct{}, v interface{}) error {
+	/*
+	   procedure DFS(G, v) is
+	       label v as discovered
+	       for all directed edges from v to w that are in G.adjacentEdges(v) do
+	           if vertex w is not labeled as discovered then
+	               recursively call DFS(G, w)
+	*/
+
+	// Make our map for visited
+	visited[v] = struct{}{}
+
+	// for all directed edges from v to w that are in G.adjacentEdges(v) do
+	for w := range g.adjacencyOut[v] {
+		// if vertex w is not labeled as discovered then
+		if _, ok := visited[w]; !ok {
+			// call our callback
+			if err := cb(g.hash[w], func() error {
+				// recursively call DFS(G, w)
+				return g.dfs(cb, visited, w)
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/graph/dijkstra.go
+++ b/internal/pkg/graph/dijkstra.go
@@ -1,0 +1,121 @@
+package graph
+
+import (
+	"container/heap"
+	"math"
+)
+
+// Dijkstra implements Dijkstra's algorithm for finding single source
+// shortest paths in an edge-weighted graph with non-negative edge weights.
+// The graph may have cycles.
+func (g *Graph) Dijkstra(src Vertex) (distTo map[interface{}]int, edgeTo map[interface{}]Vertex) {
+	srchash := hashcode(src)
+
+	/*
+	   for each vertex V in G
+	       distance[V] <- infinite
+	       previous[V] <- NULL
+	*/
+	queue := make(distQueue, 0, len(g.hash))
+	queueItem := map[interface{}]*distQueueItem{}
+	for k := range g.hash {
+		item := &distQueueItem{
+			v:        k,
+			distance: math.MaxInt32,
+			previous: nil,
+			index:    len(queue),
+		}
+		queueItem[k] = item
+
+		// If V != S, add V to Priority Queue Q
+		queue = append(queue, item)
+	}
+
+	// distance[S] <- 0
+	queueItem[srchash].distance = 0
+
+	// Init the heap so we can use the queue
+	heap.Init(&queue)
+
+	// while Q IS NOT EMPTY
+	visited := map[interface{}]struct{}{}
+	for queue.Len() > 0 {
+		// U <- Extract MIN from Q
+		u := heap.Pop(&queue).(*distQueueItem)
+		visited[u.v] = struct{}{}
+
+		// for each unvisited neighbour V of U
+		for vhash, weight := range g.adjacencyOut[u.v] {
+			if _, ok := visited[vhash]; ok {
+				continue
+			}
+
+			v := queueItem[vhash]
+
+			// tempDistance <- distance[U] + edge_weight(U, V)
+			tempDistance := u.distance + int32(weight)
+
+			// if tempDistance < distance[V]
+			if tempDistance < v.distance {
+				// distance[V] <- tempDistance
+				// previous[V] <- U
+				v.distance = tempDistance
+				v.previous = u.v
+				heap.Fix(&queue, v.index)
+			}
+		}
+	}
+
+	// Return our distance and previous map
+	distTo = make(map[interface{}]int, len(queueItem))
+	edgeTo = make(map[interface{}]Vertex, len(queueItem))
+	for _, item := range queueItem {
+		distTo[item.v] = int(item.distance)
+		edgeTo[item.v] = g.hash[item.previous]
+	}
+
+	return distTo, edgeTo
+}
+
+// distQueue is a priority queue implementation on top of a heap that
+// is used by Dijkstra to keep track of state. heap.Pop on this queue
+// will return the item with the minimal "distance" value.
+type distQueue []*distQueueItem
+
+type distQueueItem struct {
+	v        interface{} // Vertex hashcode
+	distance int32
+	previous interface{} // Previous vertex hashcode
+	index    int
+}
+
+func (pq distQueue) Len() int { return len(pq) }
+
+func (pq distQueue) Less(i, j int) bool {
+	return pq[i].distance < pq[j].distance
+}
+
+func (pq distQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *distQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*distQueueItem)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *distQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+var _ heap.Interface = (*distQueue)(nil)

--- a/internal/pkg/graph/dijkstra_test.go
+++ b/internal/pkg/graph/dijkstra_test.go
@@ -1,0 +1,64 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDijkstra(t *testing.T) {
+	t.Run("typical", func(t *testing.T) {
+		var g Graph
+		g.Add("B")
+		g.Add("C")
+		g.Add("D")
+		g.Add("E")
+		g.Add("S")
+		g.Add("T")
+		g.AddEdgeWeighted("S", "B", 4)
+		g.AddEdgeWeighted("S", "C", 2)
+		g.AddEdgeWeighted("B", "C", 1)
+		g.AddEdgeWeighted("B", "D", 5)
+		g.AddEdgeWeighted("C", "D", 8)
+		g.AddEdgeWeighted("C", "E", 10)
+		g.AddEdgeWeighted("D", "E", 2)
+		g.AddEdgeWeighted("D", "T", 6)
+		g.AddEdgeWeighted("E", "T", 2)
+
+		distTo, edgeTo := g.Dijkstra("S")
+
+		path := []interface{}{"T"}
+		for next := edgeTo[path[0]]; next != nil; next = edgeTo[next] {
+			path = append(path, next)
+		}
+
+		require.Equal(t, 13, distTo["T"])
+		require.Equal(t, []interface{}{"T", "E", "D", "B", "S"}, path)
+	})
+
+	t.Run("cycle", func(t *testing.T) {
+		var g Graph
+		g.Add("A")
+		g.Add("B")
+		g.Add("C")
+		g.Add("D")
+		g.Add("E")
+		g.Add("F")
+		g.AddEdgeWeighted("A", "B", 10)
+		g.AddEdgeWeighted("B", "C", 1)
+		g.AddEdgeWeighted("C", "E", 3)
+		g.AddEdgeWeighted("E", "D", 10)
+		g.AddEdgeWeighted("D", "B", 10)
+		g.AddEdgeWeighted("E", "F", 22)
+
+		distTo, edgeTo := g.Dijkstra("A")
+
+		path := []interface{}{"F"}
+		for next := edgeTo[path[0]]; next != nil; next = edgeTo[next] {
+			path = append(path, next)
+		}
+
+		require.Equal(t, 36, distTo["F"])
+		require.Equal(t, []interface{}{"F", "E", "C", "B", "A"}, path)
+	})
+}

--- a/internal/pkg/graph/graph.go
+++ b/internal/pkg/graph/graph.go
@@ -1,0 +1,233 @@
+package graph
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+// Graph represents a graph structure.
+//
+// Unless otherwise documented, it is unsafe to call any method on Graph concurrently.
+type Graph struct {
+	// adjacency represents graphs using an adjaency list. Vertices are
+	// represented using their hash codes for simpler equaliy checks.
+	adjacencyOut map[interface{}]map[interface{}]int
+	adjacencyIn  map[interface{}]map[interface{}]int
+
+	// hash maintains the mapping of hash codes to the representative Vertex.
+	// It is assumed that two identical hashcodes of v1 and v2 are semantically
+	// the same Vertex even if v1 != v2 in Go.
+	hash map[interface{}]Vertex
+}
+
+// Add adds a vertex to the graph. If a vertex with the same identity exists
+// this will overwrite that vertex.
+func (g *Graph) Add(v Vertex) Vertex {
+	g.init()
+	h := hashcode(v)
+	if _, ok := g.adjacencyOut[h]; !ok {
+		g.adjacencyOut[h] = make(map[interface{}]int)
+		g.adjacencyIn[h] = make(map[interface{}]int)
+		g.hash[h] = v
+	}
+	return v
+}
+
+// AddOverwrite is the same as Add, except that even if the vertex
+// already exists with the same hashcode, the pointed to value is replaced
+// with the given v. This allows two Vertex values with the same hashcode
+// but different values to be replaced.
+func (g *Graph) AddOverwrite(v Vertex) Vertex {
+	g.init()
+	h := hashcode(v)
+	g.hash[h] = v
+	if _, ok := g.adjacencyOut[h]; !ok {
+		g.adjacencyOut[h] = make(map[interface{}]int)
+		g.adjacencyIn[h] = make(map[interface{}]int)
+	}
+	return v
+}
+
+// Remove removes the given vertex from the graph.
+func (g *Graph) Remove(v Vertex) Vertex {
+	// Note we don't need to call init here because delete() operations
+	// are all safe on nil maps.
+	h := hashcode(v)
+
+	// First, delete all our out-edges by deleting both the
+	// main key as well as any of the other nodes that are tracking the
+	// in edge
+	for out := range g.adjacencyOut[h] {
+		delete(g.adjacencyIn[out], h)
+	}
+	delete(g.adjacencyOut, h)
+
+	// Same as above but for in edges
+	for in := range g.adjacencyIn[h] {
+		delete(g.adjacencyOut[in], h)
+	}
+	delete(g.adjacencyIn, h)
+
+	// Forget this node completely
+	delete(g.hash, h)
+	return v
+}
+
+// Vertex returns the vertex by id. This can be done to get the node that
+// is actually in the graph. This will return nil if the given vertex
+// is not in the graph any longer.
+func (g *Graph) Vertex(id interface{}) Vertex {
+	g.init()
+	return g.hash[id]
+}
+
+// Vertices returns the list of all the vertices in this graph.
+func (g *Graph) Vertices() []Vertex {
+	result := make([]Vertex, 0, len(g.hash))
+	for _, v := range g.hash {
+		result = append(result, v)
+	}
+
+	return result
+}
+
+// AddEdge adds a directed edge to the graph from v1 to v2. Both v1 and v2
+// must already be in the Graph via Add or this will do nothing.
+func (g *Graph) AddEdge(v1, v2 Vertex) {
+	g.AddEdgeWeighted(v1, v2, 1)
+}
+
+// AddEdgeWeighted adds a weighted edge. This is the same as AddEdge but
+// with the specified weight. This will overwrite any existing edges.
+func (g *Graph) AddEdgeWeighted(v1, v2 Vertex, weight int) {
+	g.init()
+	h1, h2 := hashcode(v1), hashcode(v2)
+	g.adjacencyOut[h1][h2] = weight
+	g.adjacencyIn[h2][h1] = weight
+}
+
+func (g *Graph) RemoveEdge(v1, v2 Vertex) {
+	g.init()
+	h1, h2 := hashcode(v1), hashcode(v2)
+	delete(g.adjacencyOut[h1], h2)
+	delete(g.adjacencyIn[h2], h1)
+}
+
+func (g *Graph) OutEdges(v Vertex) []Vertex {
+	edges := g.adjacencyOut[hashcode(v)]
+	if len(edges) == 0 {
+		return nil
+	}
+
+	result := make([]Vertex, 0, len(edges))
+	for h := range edges {
+		result = append(result, g.hash[h])
+	}
+
+	return result
+}
+
+func (g *Graph) InEdges(v Vertex) []Vertex {
+	edges := g.adjacencyIn[hashcode(v)]
+	if len(edges) == 0 {
+		return nil
+	}
+
+	result := make([]Vertex, 0, len(edges))
+	for h := range edges {
+		result = append(result, g.hash[h])
+	}
+
+	return result
+}
+
+// Reverse reverses the graph but _does not make a copy_. Any changes to
+// this graph will impact the original Graph. You must call Copy on the
+// result if you want to have a copy.
+func (g *Graph) Reverse() *Graph {
+	return &Graph{
+		adjacencyOut: g.adjacencyIn,
+		adjacencyIn:  g.adjacencyOut,
+		hash:         g.hash,
+	}
+}
+
+// Copy copies the graph. In the copy, any added or removed edges do not
+// affect the original graph. The vertices themselves are not deep copied.
+func (g *Graph) Copy() *Graph {
+	var g2 Graph
+	g2.init()
+
+	for k, set := range g.adjacencyOut {
+		copy := make(map[interface{}]int)
+		for k, v := range set {
+			copy[k] = v
+		}
+		g2.adjacencyOut[k] = copy
+	}
+	for k, set := range g.adjacencyIn {
+		copy := make(map[interface{}]int)
+		for k, v := range set {
+			copy[k] = v
+		}
+		g2.adjacencyIn[k] = copy
+	}
+	for k, v := range g.hash {
+		g2.hash[k] = v
+	}
+
+	return &g2
+}
+
+// String outputs some human-friendly output for the graph structure.
+func (g *Graph) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("\n")
+
+	// Build the list of node names and a mapping so that we can more
+	// easily alphabetize the output to remain deterministic.
+	names := make([]string, 0, len(g.hash))
+	mapping := make(map[string]Vertex, len(g.hash))
+	for _, v := range g.hash {
+		name := VertexName(v)
+		names = append(names, name)
+		mapping[name] = v
+	}
+	sort.Strings(names)
+
+	// Write each node in order...
+	for _, name := range names {
+		v := mapping[name]
+		targets := g.adjacencyOut[hashcode(v)]
+
+		buf.WriteString(fmt.Sprintf("%s\n", name))
+
+		// Alphabetize dependencies
+		deps := make([]string, 0, len(targets))
+		for targetHash, weight := range targets {
+			deps = append(deps, fmt.Sprintf(
+				"%s (%d)", VertexName(g.hash[targetHash]), weight))
+		}
+		sort.Strings(deps)
+
+		// Write dependencies
+		for _, d := range deps {
+			buf.WriteString(fmt.Sprintf("  %s\n", d))
+		}
+	}
+
+	return buf.String()
+}
+
+func (g *Graph) init() {
+	if g.adjacencyOut == nil {
+		g.adjacencyOut = make(map[interface{}]map[interface{}]int)
+	}
+	if g.adjacencyIn == nil {
+		g.adjacencyIn = make(map[interface{}]map[interface{}]int)
+	}
+	if g.hash == nil {
+		g.hash = make(map[interface{}]Vertex)
+	}
+}

--- a/internal/pkg/graph/kahn.go
+++ b/internal/pkg/graph/kahn.go
@@ -1,0 +1,99 @@
+package graph
+
+import "fmt"
+
+// KahnSort will return the topological sort of the graph using Kahn's algorithm.
+// The graph must not have any cycles or this will panic.
+func (g *Graph) KahnSort() TopoOrder {
+	/*
+	   L ← Empty list that will contain the sorted elements
+	   S ← Set of all nodes with no incoming edge
+
+	   while S is non-empty do
+	       remove a node n from S
+	       add n to tail of L
+	       for each node m with an edge e from n to m do
+	           remove edge e from the graph
+	           if m has no other incoming edges then
+	               insert m into S
+
+	   if graph has edges then
+	       return error   (graph has at least one cycle)
+	   else
+	       return L   (a topologically sorted order)
+	*/
+
+	// Copy the graph
+	g = g.Copy()
+
+	// L ← Empty list that will contain the sorted elements
+	L := make([]Vertex, 0, len(g.adjacencyOut))
+
+	// S ← Set of all nodes with no incoming edge
+	S := []interface{}{}
+	for v, list := range g.adjacencyIn {
+		if len(list) == 0 {
+			S = append(S, v)
+		}
+	}
+
+	// while S is non-empty do
+	for len(S) > 0 {
+		// remove a node n from S
+		n := S[len(S)-1]
+		S = S[:len(S)-1]
+
+		// add n to tail of L
+		L = append(L, g.hash[n])
+
+		// for each node m with an edge e from n to m do
+		for m := range g.adjacencyOut[n] {
+			// remove edge e from the graph
+			g.RemoveEdge(n, m)
+
+			// if m has no other incoming edges then
+			if len(g.adjacencyIn[m]) == 0 {
+				// insert m into S
+				S = append(S, m)
+			}
+		}
+	}
+
+	// if graph has edges then
+	//   return error   (graph has at least one cycle)
+	for _, out := range g.adjacencyOut {
+		if len(out) > 0 {
+			// We have cycles, so let's do cycle detection to give a better
+			// error message.
+			cycles := g.Cycles()
+			panic(fmt.Sprintf("graph has cycles: %v", cycles))
+		}
+	}
+
+	return L
+}
+
+// TopoOrder is a topological ordering.
+type TopoOrder []Vertex
+
+// At returns a new TopoOrder that starts at the given vertex.
+// This returns a slice into the ordering so it is not safe to modify.
+func (t TopoOrder) At(v Vertex) TopoOrder {
+	for i := 0; i < len(t); i++ {
+		if t[i] == v {
+			return t[i:]
+		}
+	}
+	return nil
+}
+
+// Until returns a new TopoOrder that ends at (and includes) the given
+// vertex. This returns a slice into the ordering so it is not safe to modify.
+func (t TopoOrder) Until(v Vertex) TopoOrder {
+	for i := 0; i < len(t); i++ {
+		if t[i] == v {
+			return t[:i]
+		}
+	}
+	return nil
+}

--- a/internal/pkg/graph/path.go
+++ b/internal/pkg/graph/path.go
@@ -1,0 +1,64 @@
+package graph
+
+// TopoShortestPath returns the shortest path information given the
+// topological sort of the graph L. L can be retrieved using any topological
+// sort algorithm such as KahnSort.
+//
+// The return value are two maps with the distance to and edge to information,
+// respectively. distTo maps the total distance from source to the given
+// vertex. edgeTo maps the previous edge to get to a vertex from source.
+func (g *Graph) TopoShortestPath(L TopoOrder) (distTo map[interface{}]int, edgeTo map[interface{}]Vertex) {
+	/*
+	   Set the distance to the source to 0;
+	   Set the distances to all other vertices to infinity;
+	   For each vertex u in L
+	      - Walk through all neighbors v of u;
+	      - If dist(v) > dist(u) + w(u, v)
+	         - Set dist(v) <- dist(u) + w(u, v);
+	*/
+
+	// Set the distance to the source to 0;
+	// Set the distances to all other vertices to infinity;
+	// We don't actually set anything to "infinity" here since we can simulate
+	// it by checking for existance in the map.
+	distTo = map[interface{}]int{}
+	edgeTo = map[interface{}]Vertex{}
+
+	// For each vertex u in L
+	for _, u := range L {
+		uh := hashcode(u)
+
+		// Walk through all neighbors v of u;
+		for vh, weight := range g.adjacencyOut[uh] {
+			// x = dist(u) + w(u, v)
+			x := distTo[uh] + weight
+
+			// If dist(v) > dist(u) + w(u, v)
+			if _, ok := distTo[vh]; !ok || distTo[vh] > x {
+				distTo[vh] = x
+				edgeTo[vh] = u
+			}
+		}
+	}
+
+	return distTo, edgeTo
+}
+
+// EdgeToPath turns an "edge to" mapping into a vertex slice of the path
+// from some target.
+func (g *Graph) EdgeToPath(target Vertex, edgeTo map[interface{}]Vertex) []Vertex {
+	var result []Vertex
+
+	current := target
+	for current != nil {
+		result = append(result, current)
+		current = edgeTo[hashcode(current)]
+	}
+
+	// Reverse it, since this puts the path in reverse order
+	for left, right := 0, len(result)-1; left < right; left, right = left+1, right-1 {
+		result[left], result[right] = result[right], result[left]
+	}
+
+	return result
+}

--- a/internal/pkg/graph/path_test.go
+++ b/internal/pkg/graph/path_test.go
@@ -1,0 +1,63 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphTopoShortestPath(t *testing.T) {
+	require := require.New(t)
+
+	// This test is from the coursera page linked below. I chose to copy
+	// something relatively well known and externally solved so I can be 100%
+	// sure I got it right, plus to test cases where paths change multiple times.
+	// https://www.coursera.org/lecture/algorithms-part2/edge-weighted-dags-6rxSt
+	var g Graph
+	g.Add(0)
+	g.Add(1)
+	g.Add(2)
+	g.Add(3)
+	g.Add(4)
+	g.Add(5)
+	g.Add(6)
+	g.Add(7)
+	g.AddEdgeWeighted(0, 1, 5)
+	g.AddEdgeWeighted(0, 7, 8)
+	g.AddEdgeWeighted(0, 4, 9)
+	g.AddEdgeWeighted(1, 7, 4)
+	g.AddEdgeWeighted(1, 3, 15)
+	g.AddEdgeWeighted(1, 2, 12)
+	g.AddEdgeWeighted(7, 2, 7)
+	g.AddEdgeWeighted(7, 5, 6)
+	g.AddEdgeWeighted(4, 7, 5)
+	g.AddEdgeWeighted(4, 5, 4)
+	g.AddEdgeWeighted(4, 6, 20)
+	g.AddEdgeWeighted(5, 2, 1)
+	g.AddEdgeWeighted(5, 6, 13)
+	g.AddEdgeWeighted(2, 3, 3)
+	g.AddEdgeWeighted(2, 6, 11)
+	g.AddEdgeWeighted(3, 6, 9)
+
+	sort := g.KahnSort()
+	t.Logf("sorted: %#v", sort)
+
+	distTo, edgeTo := g.TopoShortestPath(sort)
+	require.Equal(0, distTo[0])
+	require.Equal(5, distTo[1])
+	require.Equal(14, distTo[2])
+	require.Equal(17, distTo[3])
+	require.Equal(9, distTo[4])
+	require.Equal(13, distTo[5])
+	require.Equal(25, distTo[6])
+	require.Equal(8, distTo[7])
+
+	require.Equal(nil, edgeTo[0])
+	require.Equal(0, edgeTo[1])
+	require.Equal(5, edgeTo[2])
+	require.Equal(2, edgeTo[3])
+	require.Equal(0, edgeTo[4])
+	require.Equal(4, edgeTo[5])
+	require.Equal(2, edgeTo[6])
+	require.Equal(0, edgeTo[7])
+}

--- a/internal/pkg/graph/tarjan.go
+++ b/internal/pkg/graph/tarjan.go
@@ -1,0 +1,118 @@
+package graph
+
+// Cycles returns all the detected cycles. This may not be fully exhaustive
+// since we use Tarjan's algoritm for strongly connected components to detect
+// cycles and this isn't guaranteed to find all cycles.
+func (g *Graph) Cycles() [][]Vertex {
+	var cycles [][]Vertex
+	for _, cycle := range g.StronglyConnected() {
+		if len(cycle) > 1 {
+			cycles = append(cycles, cycle)
+		}
+	}
+
+	return cycles
+}
+
+// StronglyConnected returns the list of strongly connected components
+// within the Graph g.
+func (g *Graph) StronglyConnected() [][]Vertex {
+	vs := g.Vertices()
+	acct := sccAcct{
+		NextIndex:   1,
+		VertexIndex: make(map[Vertex]int, len(vs)),
+	}
+	for _, v := range vs {
+		// Recurse on any non-visited nodes
+		if acct.VertexIndex[v] == 0 {
+			stronglyConnected(&acct, g, v)
+		}
+	}
+	return acct.SCC
+}
+
+func stronglyConnected(acct *sccAcct, g *Graph, v Vertex) int {
+	// Initial vertex visit
+	index := acct.visit(v)
+	minIdx := index
+
+	for _, target := range g.OutEdges(v) {
+		targetIdx := acct.VertexIndex[target]
+
+		// Recurse on successor if not yet visited
+		if targetIdx == 0 {
+			minIdx = min(minIdx, stronglyConnected(acct, g, target))
+		} else if acct.inStack(target) {
+			// Check if the vertex is in the stack
+			minIdx = min(minIdx, targetIdx)
+		}
+	}
+
+	// Pop the strongly connected components off the stack if
+	// this is a root vertex
+	if index == minIdx {
+		var scc []Vertex
+		for {
+			v2 := acct.pop()
+			scc = append(scc, v2)
+			if v2 == v {
+				break
+			}
+		}
+
+		acct.SCC = append(acct.SCC, scc)
+	}
+
+	return minIdx
+}
+
+func min(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
+}
+
+// sccAcct is used ot pass around accounting information for
+// the StronglyConnectedComponents algorithm
+type sccAcct struct {
+	NextIndex   int
+	VertexIndex map[Vertex]int
+	Stack       []Vertex
+	SCC         [][]Vertex
+}
+
+// visit assigns an index and pushes a vertex onto the stack
+func (s *sccAcct) visit(v Vertex) int {
+	idx := s.NextIndex
+	s.VertexIndex[v] = idx
+	s.NextIndex++
+	s.push(v)
+	return idx
+}
+
+// push adds a vertex to the stack
+func (s *sccAcct) push(n Vertex) {
+	s.Stack = append(s.Stack, n)
+}
+
+// pop removes a vertex from the stack
+func (s *sccAcct) pop() Vertex {
+	n := len(s.Stack)
+	if n == 0 {
+		return nil
+	}
+	vertex := s.Stack[n-1]
+	s.Stack = s.Stack[:n-1]
+	return vertex
+}
+
+// inStack checks if a vertex is in the stack
+func (s *sccAcct) inStack(needle Vertex) bool {
+	for _, n := range s.Stack {
+		if n == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pkg/graph/vertex.go
+++ b/internal/pkg/graph/vertex.go
@@ -1,0 +1,37 @@
+package graph
+
+import "fmt"
+
+// Vertex can be anything.
+type Vertex interface{}
+
+// VertexHashable is an optional interface that can be implemented to specify
+// an alternate hash code for a Vertex. If this isnt implemented, Go interface
+// equality is used.
+type VertexHashable interface {
+	Hashcode() interface{}
+}
+
+// VertexID returns the unique ID for a vertex.
+func VertexID(v Vertex) interface{} {
+	return hashcode(v)
+}
+
+// VertexName returns the name of a vertex.
+func VertexName(v Vertex) string {
+	switch v := v.(type) {
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// hashcode returns the hashcode for a Vertex.
+func hashcode(v interface{}) interface{} {
+	if h, ok := v.(VertexHashable); ok {
+		return h.Hashcode()
+	}
+
+	return v
+}


### PR DESCRIPTION
This does two things for the job dependency system:

(1) Checks that jobs being created have no cycles between each other. We
only need to check "between each other" because job creation requires
all dependencies already exist. This means that previously created jobs
new jobs might depend on can't possibly cycle. Therefore, we only need
to check for cycles amongst newly created jobs.

(2) Use a topological sort over the dependencies to ensure that we're
creating the jobs in the correct order. This allows `JobCreate(C, B, A)`
to work even if the order of the jobs to run based on deps is `A, B, C`

This brings in the `graph` package from go-argmapper, a graph package
that is fairly proven at this point; there have been no graph bugs since
releasing Waypoint and it has full test coverage.