### PR TITLE
ui/test: add api waiter

### DIFF
--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import { DEBUG } from '@glimmer/env';
 import { WaypointClient } from 'waypoint-client';
 import SessionService from 'waypoint/services/session';
 import { inject as service } from '@ember/service';
@@ -61,8 +62,16 @@ export default class ApiService extends Service {
   // If the the apiAddress is not set, this will use the /grpc prefix on the
   // same host as the UI is being served from
   client = new WaypointClient(`${config.apiAddress}/grpc`, null, {
-    unaryInterceptors: [new ApiWaiterUnaryInterceptor()],
+    unaryInterceptors: this.unaryInterceptors(),
   });
+
+  unaryInterceptors(): UnaryInterceptor<Message, Message>[] {
+    if (DEBUG) {
+      return [new ApiWaiterUnaryInterceptor()];
+    } else {
+      return [];
+    }
+  }
 
   // Merges metadata with required metadata for the request
   WithMeta(meta?: Metadata): Metadata {

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import { WaypointClient } from 'waypoint-client';
 import SessionService from 'waypoint/services/session';
 import { inject as service } from '@ember/service';
+import { buildWaiter } from '@ember/test-waiters';
 import {
   Application,
   Build,
@@ -22,9 +23,14 @@ import {
   Variable,
   UI,
 } from 'waypoint-pb';
-import { Metadata } from 'grpc-web';
+import { Request, Metadata, UnaryResponse, UnaryInterceptor } from 'grpc-web';
+import { Message } from 'google-protobuf';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import config from 'waypoint/config/environment';
+
+// The docs for @ember/test-waiters recommend building waiters in module scope.
+// https://github.com/emberjs/ember-test-waiters#use-buildwaiter-in-module-scope
+const waiter = buildWaiter('waypoint-api-service:waiter');
 
 const protocolVersions = {
   // These map to upstream protocol versions
@@ -54,7 +60,9 @@ export default class ApiService extends Service {
   @service session!: SessionService;
   // If the the apiAddress is not set, this will use the /grpc prefix on the
   // same host as the UI is being served from
-  client = new WaypointClient(`${config.apiAddress}/grpc`, null, null);
+  client = new WaypointClient(`${config.apiAddress}/grpc`, null, {
+    unaryInterceptors: [new ApiWaiterUnaryInterceptor()],
+  });
 
   // Merges metadata with required metadata for the request
   WithMeta(meta?: Metadata): Metadata {
@@ -366,4 +374,24 @@ function has<T, K extends keyof T>(key: K): (obj: T) => obj is T & Required<Pick
   return function (obj): obj is T & Required<Pick<T, K>> {
     return !!obj[key];
   };
+}
+
+/**
+ * This class uses grpc-web’s interceptor system to track requests using ember’s
+ * test waiter system. For more info, see:
+ * https://github.com/emberjs/ember-test-waiters
+ */
+class ApiWaiterUnaryInterceptor implements UnaryInterceptor<Message, Message> {
+  async intercept(
+    request: Request<Message, Message>,
+    invoker: (request: Request<Message, Message>) => Promise<UnaryResponse<Message, Message>>
+  ) {
+    let token = waiter.beginAsync();
+
+    try {
+      return await invoker(request);
+    } finally {
+      waiter.endAsync(token);
+    }
+  }
 }

--- a/ui/tests/integration/components/project-config-variables-list-test.ts
+++ b/ui/tests/integration/components/project-config-variables-list-test.ts
@@ -84,7 +84,6 @@ module('Integration | Component | project-config-variables-list', function (hook
     await page.varNameIsPath();
     await page.varInternal();
     await page.saveButton();
-    await settled(); // TODO(jgwhite): Figure out why we need this
     assert.notOk(page.hasForm, 'Create Variable: the form disappears after creation');
     assert.equal(page.variablesList.length, 4, 'Create Variable: the list has the new variable');
     assert.equal(page.variablesList.objectAt(3).varName, 'var_name', 'Var name is correct');
@@ -116,7 +115,6 @@ module('Integration | Component | project-config-variables-list', function (hook
     await page.variablesList.objectAt(0).dropdownEdit();
     await page.varStatic('foozbarz');
     await page.saveButton();
-    await settled(); // TODO(jgwhite): Figure out why we need this
     assert.notOk(page.hasForm, 'Create Variable: the form disappears after creation');
   });
 


### PR DESCRIPTION
## Why the change?

Paying down TODO debt and making our test suite more robust.

## How does it work?

This change hooks up grpc-web’s interceptor system to ember’s test waiter system, giving us automatic tracking of in-flight gRPC requests.

## How do I test it?

Probably the thing to test for here is that this code doesn’t interfere with anything in production mode. It *should* be a no-op but I’ll confess I didn’t check this in full yet.