### PR TITLE
More helpful error when no HEAD reference is found.

### DIFF
--- a/internal/config/funcs/vcs_git.go
+++ b/internal/config/funcs/vcs_git.go
@@ -62,14 +62,14 @@ func (s *VCSGit) refPrettyFunc(args []cty.Value, retType cty.Type) (cty.Value, e
 
 	ref, err := s.repo.Head()
 	if err != nil {
-		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %s", err)
+		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %w", err)
 	}
 	result := ref.Hash().String()
 
 	// Get the tags
 	iter, err := s.repo.Tags()
 	if err != nil {
-		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo tags: %s", err)
+		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo tags: %w", err)
 	}
 	defer iter.Close()
 	for {
@@ -154,7 +154,7 @@ func (s *VCSGit) refHashFunc(args []cty.Value, retType cty.Type) (cty.Value, err
 
 	ref, err := s.repo.Head()
 	if err != nil {
-		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %s", err)
+		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %w", err)
 	}
 
 	return cty.StringVal(ref.Hash().String()), nil
@@ -178,13 +178,13 @@ func (s *VCSGit) refTagFunc(args []cty.Value, retType cty.Type) (cty.Value, erro
 
 	ref, err := s.repo.Head()
 	if err != nil {
-		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %s", err)
+		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo HEAD reference - this repo may have no commits: %w", err)
 	}
 
 	// Get the tags
 	iter, err := s.repo.Tags()
 	if err != nil {
-		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo tags: %s", err)
+		return cty.UnknownVal(cty.String), fmt.Errorf("error getting repo tags: %w", err)
 	}
 
 	var tagRefStr string


### PR DESCRIPTION
If the git repo doesn't exist, or git isn't installed, the init command will fail. The only case I can think of where Head will fail is when a repo has been initialized, but no commit has yet been made, which isn't that uncommon for a brand new app.

What this looks like on a repo with no commit:

```
» Building backend...
! /Users/izaak/dev/izaakprodapp/waypoint.hcl:10,17-30: Error in function call;
  Call to function "gitrefpretty" failed: error getting repo HEAD reference - this
  repo may have no commits: reference not found., and 1 other diagnostic(s)
```

Also added more context to the tags lookup error.