### PR TITLE
test: Add a test print log to help triage flakey test

### DIFF
--- a/internal/server/singleprocess/poll_test.go
+++ b/internal/server/singleprocess/poll_test.go
@@ -570,6 +570,7 @@ func TestApplicationPollHandler(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(a)
 	require.NotNil(nextPollTime)
+	t.Logf("nextPollTime %q should be after initial pollTime %q", nextPollTime.String(), pollTime.String())
 	require.True(nextPollTime.After(pollTime))
 }
 


### PR DESCRIPTION
This commit prints the next poll time and initial poll time. The test
seems to flake enough but it's unclear why the nextPollTime isn't after
the initial poll time. This commit should hopefully show us each poll
time.