### PR TITLE
ui/tests: simplify config var rename test

### DIFF
--- a/ui/tests/integration/components/project-config-variables-list-test.ts
+++ b/ui/tests/integration/components/project-config-variables-list-test.ts
@@ -121,9 +121,7 @@ module('Integration | Component | project-config-variables-list', function (hook
   test('renaming variables works', async function (assert) {
     let dbproj = await this.server.create('project', { name: 'Proj1' });
     let proj = dbproj.toProtobuf().toObject();
-    let dbVariablesList = this.server.createList('config-variable', 3, 'random', { project: dbproj });
-    let dynamicVar = this.server.create('config-variable', 'dynamic', { project: dbproj });
-    dbVariablesList.push(dynamicVar);
+    let dbVariablesList = this.server.createList('config-variable', 4, 'random', { project: dbproj });
     let varList = dbVariablesList.map((v) => {
       return v.toProtobuf().toObject();
     });
@@ -137,7 +135,6 @@ module('Integration | Component | project-config-variables-list', function (hook
     await page.variablesList.objectAt(0).dropdownEdit();
     await page.varName('edited_var_name');
     await page.saveButton();
-    await page.variablesList.objectAt(1).dropdown();
     assert.equal(
       page.variablesList.length,
       4,


### PR DESCRIPTION
## Why the change?

This test was brittle (see [CI output]) for the following reasons:

1. All the fixture config vars have random names
2. One of the fixture config vars was dynamic
3. We don’t show the dropdown for dynamic config vars
4. After renaming a config var, we attempt to click the dropdown for the second item
5. Depending on the number of times faker.hacker.noun has been called before, the dynamic var could land in that spot
6. Thus, no dropdown and a spuriously failing test

Phew!

This patch removes the dynamic config var and the final dropdown click from the test, as neither are material to the behavior under test.

## How do I test it?

If CI passes, we should be good.

[CI output]: https://app.circleci.com/pipelines/github/hashicorp/waypoint/11575/workflows/f352c4a8-d2ca-432f-a829-30f28741152a/jobs/110500