### PR TITLE
tests: Ensure app status poll interval is set when turned on

### DIFF
--- a/internal/server/singleprocess/poll_test.go
+++ b/internal/server/singleprocess/poll_test.go
@@ -481,7 +481,7 @@ func TestApplicationPollHandler(t *testing.T) {
 			},
 			StatusReportPoll: &pb.Project_AppStatusPoll{
 				Enabled:  false,
-				Interval: "15ms",
+				Interval: "30ms",
 			},
 			Applications: []*pb.Application{
 				{
@@ -522,7 +522,8 @@ func TestApplicationPollHandler(t *testing.T) {
 
 	// Update the app to start polling
 	project.StatusReportPoll = &pb.Project_AppStatusPoll{
-		Enabled: true,
+		Enabled:  true,
+		Interval: "30ms",
 	}
 	_, err = client.UpsertProject(ctx, &pb.UpsertProjectRequest{
 		Project: project,


### PR DESCRIPTION
This commit ensures the interval is set when enabling an app to start
polling. Previously even though it had been set, passing in a "new"
proto struct without the interval means it was set to the default

I'm not sure yet if this will fix the flake, but it was def a bug in the tests.