### PR TITLE
ui: improve mirage handler types

### DIFF
--- a/ui/mirage/services/build.ts
+++ b/ui/mirage/services/build.ts
@@ -1,13 +1,13 @@
 import { ListBuildsRequest, ListBuildsResponse, GetBuildRequest } from 'waypoint-pb';
-import { Request, Response } from 'miragejs';
+import { RouteHandler, Request, Response } from 'miragejs';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function list(schema: any, { requestBody }: Request): Response {
+export function list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListBuildsRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });
@@ -23,9 +23,9 @@ export function list(schema: any, { requestBody }: Request): Response {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function get(schema: any, { requestBody }: Request): Response {
+export function get(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetBuildRequest, requestBody);
-  let id = requestMsg.getRef().getId();
+  let id = requestMsg.getRef()?.getId();
   let model = schema.builds.find(id);
   let build = model?.toProtobuf();
 

--- a/ui/mirage/services/config.ts
+++ b/ui/mirage/services/config.ts
@@ -1,11 +1,11 @@
 import { ConfigGetRequest, ConfigGetResponse, ConfigSetRequest, ConfigSetResponse } from 'waypoint-pb';
-import { Request, Response } from 'miragejs';
+import { RouteHandler, Request, Response } from 'miragejs';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function get(schema: any, { requestBody }: Request): Response {
+export function get(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ConfigGetRequest, requestBody);
-  let projectName = requestMsg.getProject().getProject();
+  let projectName = requestMsg.getProject()?.getProject();
   let project = schema.projects.findBy({ name: projectName });
   let variables = schema.configVariables.where({ projectId: project.id }).models;
   // The API returns config variables sorted alphabetically by name
@@ -19,7 +19,7 @@ export function get(schema: any, { requestBody }: Request): Response {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function set(schema: any, { requestBody }: Request): Response {
+export function set(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   // This implementation faithfully recreates the behavior that leads to
   // https://github.com/hashicorp/waypoint/issues/2339.
   // If core changes, we should update this implementation too.

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -1,13 +1,13 @@
 import { GetDeploymentRequest, ListDeploymentsRequest, ListDeploymentsResponse, UI } from 'waypoint-pb';
-import { Request, Response } from 'ember-cli-mirage';
+import { RouteHandler, Request, Response } from 'ember-cli-mirage';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function list(schema: any, { requestBody }: Request): Response {
+export function list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListDeploymentsRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project?.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });
@@ -23,11 +23,11 @@ export function list(schema: any, { requestBody }: Request): Response {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function ui_list(schema: any, { requestBody }: Request): Response {
+export function ui_list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(UI.ListDeploymentsRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project?.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });
@@ -54,9 +54,9 @@ export function ui_list(schema: any, { requestBody }: Request): Response {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function get(schema: any, { requestBody }: Request): Response {
+export function get(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetDeploymentRequest, requestBody);
-  let id = requestMsg.getRef().getId();
+  let id = requestMsg.getRef()?.getId();
   let model = schema.deployments.find(id);
   let protobuf = model?.toProtobuf();
 

--- a/ui/mirage/services/invite-token.ts
+++ b/ui/mirage/services/invite-token.ts
@@ -1,5 +1,5 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
-import { Response } from 'miragejs';
+import { RouteHandler, Response } from 'miragejs';
 
 function createToken(): Token {
   let token = new Token();
@@ -11,7 +11,7 @@ function createToken(): Token {
   return token;
 }
 
-export function create(): Response {
+export function create(this: RouteHandler): Response {
   let resp = new NewTokenResponse();
   resp.setToken(createToken().getAccessorId_asB64());
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/job.ts
+++ b/ui/mirage/services/job.ts
@@ -1,7 +1,7 @@
-import { Response } from 'miragejs';
+import { RouteHandler, Response } from 'miragejs';
 import { GetJobStreamResponse } from 'waypoint-pb';
 
-export function stream(): Response {
+export function stream(this: RouteHandler): Response {
   let result = new GetJobStreamResponse();
 
   // TODO(jgwhite): Implement GetJobStream handler

--- a/ui/mirage/services/log.ts
+++ b/ui/mirage/services/log.ts
@@ -1,9 +1,9 @@
 import { LogBatch } from 'waypoint-pb';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
-import { Response } from 'miragejs';
+import { RouteHandler, Response } from 'miragejs';
 import { getUnixTime } from 'date-fns';
 
-export function stream(): Response {
+export function stream(this: RouteHandler): Response {
   // TODO(jgwhite): Implement GetLogStream handler (+ models & factories)
 
   let result = new LogBatch();

--- a/ui/mirage/services/pushed-artifact.ts
+++ b/ui/mirage/services/pushed-artifact.ts
@@ -1,13 +1,13 @@
-import { Request, Response } from 'miragejs';
+import { RouteHandler, Request, Response } from 'miragejs';
 import { ListPushedArtifactsRequest, ListPushedArtifactsResponse } from 'waypoint-pb';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function list(schema: any, request: Request): Response {
+export function list(this: RouteHandler, schema: any, request: Request): Response {
   let requestMsg = decode(ListPushedArtifactsRequest, request.requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });

--- a/ui/mirage/services/release.ts
+++ b/ui/mirage/services/release.ts
@@ -1,13 +1,13 @@
 import { ListReleasesRequest, ListReleasesResponse, GetReleaseRequest, UI } from 'waypoint-pb';
-import { Request, Response } from 'ember-cli-mirage';
+import { RouteHandler, Request, Response } from 'ember-cli-mirage';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function list(schema: any, { requestBody }: Request): Response {
+export function list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListReleasesRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project?.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });
@@ -23,11 +23,11 @@ export function list(schema: any, { requestBody }: Request): Response {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function ui_list(schema: any, { requestBody }: Request): Response {
+export function ui_list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(UI.ListReleasesRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
-  let workspaceName = requestMsg.getWorkspace().getWorkspace();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
+  let workspaceName = requestMsg.getWorkspace()?.getWorkspace();
   let project = schema.projects.findBy({ name: projectName });
   let application = schema.applications.findBy({ name: appName, projectId: project?.id });
   let workspace = schema.workspaces.findBy({ name: workspaceName });
@@ -49,9 +49,9 @@ export function ui_list(schema: any, { requestBody }: Request): Response {
   return this.serialize(resp, 'application');
 }
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function get(schema: any, { requestBody }: Request): Response {
+export function get(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(GetReleaseRequest, requestBody);
-  let id = requestMsg.getRef().getId();
+  let id = requestMsg.getRef()?.getId();
   let model = schema.releases.find(id);
   let protobuf = model?.toProtobuf();
 

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'miragejs';
+import { RouteHandler, Request, Response } from 'miragejs';
 import {
   ListStatusReportsRequest,
   ListStatusReportsResponse,
@@ -8,10 +8,10 @@ import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-export function list(schema: any, { requestBody }: Request): Response {
+export function list(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(ListStatusReportsRequest, requestBody);
-  let projectName = requestMsg.getApplication().getProject();
-  let appName = requestMsg.getApplication().getApplication();
+  let projectName = requestMsg.getApplication()?.getProject();
+  let appName = requestMsg.getApplication()?.getApplication();
   let project = schema.projects.findBy({ name: projectName });
   let app = schema.applications.findBy({ projectId: project.id, name: appName });
   // TODO: account for filters
@@ -25,11 +25,11 @@ export function list(schema: any, { requestBody }: Request): Response {
   return this.serialize(result, 'application');
 }
 
-export function getLatest(): Response {
+export function getLatest(this: RouteHandler): Response {
   return this.serialize(new Empty(), 'application');
 }
 
-export function expediteStatusReport(): Response {
+export function expediteStatusReport(this: RouteHandler): Response {
   // while this is not being used in the current implementation to generate the mocked job id response
   // i'm leaving this here in case we want to update this to handle specific requests
   // let requestMsg = decode(ExpediteStatusReportRequest, requestBody);

--- a/ui/mirage/services/token.ts
+++ b/ui/mirage/services/token.ts
@@ -1,5 +1,5 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
-import { Response } from 'miragejs';
+import { RouteHandler, Response } from 'miragejs';
 
 function createToken(): Token {
   let token = new Token();
@@ -9,7 +9,7 @@ function createToken(): Token {
   return token;
 }
 
-export function create(): Response {
+export function create(this: RouteHandler): Response {
   let resp = new NewTokenResponse();
   resp.setToken(createToken().getAccessorId_asB64());
   return this.serialize(resp, 'application');

--- a/ui/mirage/services/version-info.ts
+++ b/ui/mirage/services/version-info.ts
@@ -1,5 +1,5 @@
 import { VersionInfo, GetVersionInfoResponse } from 'waypoint-pb';
-import { Response } from 'miragejs';
+import { Response, RouteHandler } from 'miragejs';
 
 function createVersionInfo(): VersionInfo {
   let versionInfo = new VersionInfo();
@@ -11,7 +11,7 @@ function createVersionInfo(): VersionInfo {
   return versionInfo;
 }
 
-export function get(): Response {
+export function get(this: RouteHandler): Response {
   let resp = new GetVersionInfoResponse();
   let versionInfo = createVersionInfo();
   resp.setInfo(versionInfo);

--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -15,3 +15,14 @@ declare module 'ember-a11y-testing/test-support/audit' {
     axeOptions?: Record<string, unknown>
   ): Promise<void>;
 }
+
+declare module 'miragejs' {
+  /**
+   * RouteHandler is the context (the `this`) in which our Mirage route handlers
+   * are executed. Mirage itself does not export this type declaration in any
+   * form so we’re merging it into the module declaration.
+   */
+  export interface RouteHandler {
+    serialize(response: unknown, serializerType: string): Response;
+  }
+}


### PR DESCRIPTION
## Why the change?

Currently, we’re not actually type-checking files in the `mirage` directory, due to this:

https://github.com/hashicorp/waypoint/blob/dddaff9375d713bf0416bf00ad81b4f70e8ce810/ui/tsconfig.json#L33

This is the first in a series of PRs to address type errors in the mirage directory, building up to a PR which will add `mirage/**/*.ts` to the config line above.

## How do I test it?

If CI succeeds then we should be good.

## What’s the next step?

Address type errors in the `mirage/models` directory.