### PR TITLE
WIP/Discussion: Change project apply flags to accept false and unset values

### DIFF
--- a/internal/pkg/flag/flag_string_bool.go
+++ b/internal/pkg/flag/flag_string_bool.go
@@ -1,0 +1,85 @@
+package flag
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/posener/complete"
+)
+
+// -- StringBoolVar and stringBoolValue
+type StringBoolVar struct {
+	Name       string
+	Aliases    []string
+	Usage      string
+	Default    string
+	Hidden     bool
+	EnvVar     string
+	Target     *string
+	Completion complete.Predictor
+	SetHook    func(val string)
+}
+
+func (f *Set) StringBoolVar(i *StringBoolVar) {
+	initial := i.Default
+	if v, exist := os.LookupEnv(i.EnvVar); exist {
+		initial = v
+	}
+
+	def := ""
+	if i.Default != "" {
+		def = i.Default
+	}
+
+	f.VarFlag(&VarFlag{
+		Name:       i.Name,
+		Aliases:    i.Aliases,
+		Usage:      i.Usage,
+		Default:    def,
+		EnvVar:     i.EnvVar,
+		Value:      newStringBoolValue(i, initial, i.Target, i.Hidden),
+		Completion: i.Completion,
+	})
+}
+
+type stringBoolValue struct {
+	v      *StringBoolVar
+	hidden bool
+	target *string
+}
+
+func newStringBoolValue(v *StringBoolVar, def string, target *string, hidden bool) *stringBoolValue {
+	*target = def
+	return &stringBoolValue{
+		v:      v,
+		hidden: hidden,
+		target: target,
+	}
+}
+
+func (s *stringBoolValue) Set(val string) error {
+	_, err := strconv.ParseBool(val)
+	if err != nil {
+		// omit the parsing error as it's only ever "invalid syntax" in favor of
+		// giving users a hint. This package will expand the error to include
+		// which flag had the invalid valid.
+		return errors.New("please use 'true' or 'false'")
+	}
+
+	// Stay consistent with Go's acceptable values for parsing booleans, so we
+	// only lowercase after the value is determined to be valid
+	*s.target = strings.ToLower(val)
+
+	if s.v.SetHook != nil {
+		s.v.SetHook(val)
+	}
+
+	return nil
+}
+
+func (s *stringBoolValue) Get() interface{} { return *s.target }
+func (s *stringBoolValue) String() string   { return *s.target }
+func (s *stringBoolValue) Example() string  { return "true" }
+func (s *stringBoolValue) Hidden() bool     { return s.hidden }

--- a/internal/pkg/flag/flag_string_bool.go
+++ b/internal/pkg/flag/flag_string_bool.go
@@ -83,3 +83,4 @@ func (s *stringBoolValue) Get() interface{} { return *s.target }
 func (s *stringBoolValue) String() string   { return *s.target }
 func (s *stringBoolValue) Example() string  { return "true" }
 func (s *stringBoolValue) Hidden() bool     { return s.hidden }
+func (s *stringBoolValue) IsBoolFlag() bool { return true }

--- a/internal/pkg/flag/flag_string_bool_test.go
+++ b/internal/pkg/flag/flag_string_bool_test.go
@@ -10,9 +10,17 @@ func TestStringBool(t *testing.T) {
 	cases := map[string]struct {
 		input     *string
 		expected  string
+		omitValue bool // add the flag, but omit any value
 		shouldErr bool
 	}{
-		"omitted": {},
+		"omitted": {
+			expected: "",
+		},
+		// support -flag for "true"
+		"bool flag behavior": {
+			omitValue: true,
+			expected:  "true",
+		},
 		"true": {
 			input:    strPtr("TRUE"),
 			expected: "true",
@@ -41,7 +49,7 @@ func TestStringBool(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			var valA string
-			var valB []string
+			var valB string
 			sets := NewSets()
 			{
 				set := sets.NewSet("A")
@@ -53,16 +61,19 @@ func TestStringBool(t *testing.T) {
 			{
 				// borrowed from string_slice_test, just to have another input
 				set := sets.NewSet("B")
-				set.StringSliceVar(&StringSliceVar{
+				set.StringVar(&StringVar{
 					Name:   "b",
 					Target: &valB,
 				})
 			}
 
 			var err error
-			inputs := []string{"-b", "somevalueB"}
+			inputs := []string{"-b=somevalueB"}
 			if c.input != nil {
-				inputs = append(inputs, "-a", *c.input)
+				inputs = append(inputs, "-a="+*c.input)
+			}
+			if c.omitValue == true {
+				inputs = append(inputs, "-a")
 			}
 			err = sets.Parse(inputs)
 			if c.shouldErr {

--- a/internal/pkg/flag/flag_string_bool_test.go
+++ b/internal/pkg/flag/flag_string_bool_test.go
@@ -1,0 +1,84 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringBool(t *testing.T) {
+	cases := map[string]struct {
+		input     *string
+		expected  string
+		shouldErr bool
+	}{
+		"omitted": {},
+		"true": {
+			input:    strPtr("TRUE"),
+			expected: "true",
+		},
+		"false": {
+			input:    strPtr("False"),
+			expected: "false",
+		},
+		// empty is equivilant to a user supplying -flag="", and not a scenario
+		// where the flag is simply omittied.
+		"empty": {
+			input:     strPtr(""),
+			shouldErr: true,
+		},
+		"bad input": {
+			input:     strPtr("a non-truthy value"),
+			shouldErr: true,
+		},
+		// only accept values Go's ParseBool would accept
+		"weird truthy input": {
+			input:     strPtr("tRuE"),
+			shouldErr: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var valA string
+			var valB []string
+			sets := NewSets()
+			{
+				set := sets.NewSet("A")
+				set.StringBoolVar(&StringBoolVar{
+					Name:   "a",
+					Target: &valA,
+				})
+			}
+			{
+				// borrowed from string_slice_test, just to have another input
+				set := sets.NewSet("B")
+				set.StringSliceVar(&StringSliceVar{
+					Name:   "b",
+					Target: &valB,
+				})
+			}
+
+			var err error
+			if c.input != nil {
+				err = sets.Parse([]string{
+					"-a", *c.input,
+					"-b", "somevalueB",
+				})
+			} else {
+				err = sets.Parse([]string{
+					"-b", "somevalueB",
+				})
+			}
+			if !c.shouldErr {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, c.expected, valA)
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/pkg/flag/flag_string_bool_test.go
+++ b/internal/pkg/flag/flag_string_bool_test.go
@@ -60,17 +60,14 @@ func TestStringBool(t *testing.T) {
 			}
 
 			var err error
+			inputs := []string{"-b", "somevalueB"}
 			if c.input != nil {
-				err = sets.Parse([]string{
-					"-a", *c.input,
-					"-b", "somevalueB",
-				})
-			} else {
-				err = sets.Parse([]string{
-					"-b", "somevalueB",
-				})
+				inputs = append(inputs, "-a", *c.input)
 			}
-			if !c.shouldErr {
+			err = sets.Parse(inputs)
+			if c.shouldErr {
+				assert.Error(t, err)
+			} else {
 				assert.NoError(t, err)
 			}
 

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -50,9 +50,9 @@ some fields using flags by specifying the -waypoint-hcl flag.
 - `-git-password=<string>` - Password for authentication when git-auth-type is 'basic'. For GitHub, this should be a personal access token (PAT).
 - `-git-private-key-path=<string>` - Path to a PEM-encoded private key for 'ssh'-based auth.
 - `-git-private-key-password=<string>` - Password for the private key specified by git-private-key-path if the key requires a password to decode. This is not required if the private key doesn't require a password.
-- `-poll` - Enable polling. This is only valid if a Git data source is supplied. This will watch the repo for changes and trigger a remote 'up'.
+- `-poll=<true>` - Enable polling. This is only valid if a Git data source is supplied. This will watch the repo for changes and trigger a remote 'up'.
 - `-poll-interval=<string>` - Interval between polling if polling is enabled.
-- `-app-status-poll` - Enable polling to continuously generate status reports for apps. This is only valid if a Git data source is supplied.
+- `-app-status-poll=<true>` - Enable polling to continuously generate status reports for apps. This is only valid if a Git data source is supplied.
 - `-app-status-poll-interval=<string>` - Interval between polling to generate status reports if polling is enabled.
 - `-runner-profile=<string>` - Name of a runner profile to be used for this project
 


### PR DESCRIPTION
Currently with `waypoint project apply`, users [need to provide several flags][flags] in order to enable git or app status polling. Two flags are problematic (`flagPoll` and `flagAppStatusPoll`) because they are declared as `bool` values, and our flag parsing package cannot discern between a `false` boolean value supplied versus the zero value `false` if either flag is simply omitted. That, coupled with a [logical truthy check][check], currently prevent users from turning either polling or app status polling off with the CLI once they are enabled (users can still disable git polling from the UI).

This PR adds a new flag value `StringBoolVar`, for boolean values that need to discern between `true`,`false`, and simply not specified. `StringBoolVar` is a string value which `true`, `false`, and "empty string" `""` are the only valid values. This enables users to omit either flag and not have that be interpreted as supplying `false`, at the cost of requiring developers to treat a string like a boolean and check for `== "true"` or `== "false"`. 

Fixe #2037

I don't find this solution to be ideal but my attempts to modify [`BoolVar`][boolvar] to use a `*bool` [ended in frustration/dissatisfaction][project-apply-booleans] and I found this to be an acceptable compromise. 

Example error message if providing the CLI a non-truthy value:

```
$ waypoint project apply -app-status-poll-interval="120s" -data-source="git" -git-url="https://github.com/some/repo" -poll= -app-status-poll=false hello-world
! invalid value "" for flag -poll: please use 'true' or 'false'
```

*Note:* I added `pr/no-changelog` label for now while this is discussed/considered

[flags]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/cli/project_apply.go#L162-L185
[check]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/cli/project_apply.go#L169
[boolvar]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/pkg/flag/flag_bool.go
[project-apply-booleans]: https://github.com/hashicorp/waypoint/compare/project-apply-booleans?expand=1