### PR TITLE
internal/core: log variable value source

### DIFF
--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -150,6 +150,16 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 	}
 
 	p.logger.Info("project initialized", "workspace", p.workspace)
+
+	// Output all the variables that this project will used along with
+	// the source of that variable. This can be used to debug unexpected
+	// variable values.
+	for name, value := range p.variables {
+		// We purposely do NOT log the value because it may be sensitive
+		// and we have no way currently to mark a variable sensitive or not.
+		p.logger.Debug("variable info", "name", name, "source", value.Source)
+	}
+
 	return p, nil
 }
 

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -151,7 +151,7 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 
 	p.logger.Info("project initialized", "workspace", p.workspace)
 
-	// Output all the variables that this project will used along with
+	// Output all the variables that this project will use along with
 	// the source of that variable. This can be used to debug unexpected
 	// variable values.
 	for name, value := range p.variables {


### PR DESCRIPTION
Add a debug-level log that shows up in runners that shows where variables are sourced by job. This can be used by callers to more easily debug Waypoint configurations. I think we can make this even easier later but this is a bandaid for now to have SOMETHING to let us know.