### PR TITLE
website: Add docs for waypoint install command

### DIFF
--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -13,6 +13,12 @@ This command will install a server into Docker, Kubernetes, AWS ECS, or Nomad,
 bootstrap the server, and configure your local CLI to access that server.
 It is a single command to get up and running with Waypoint.
 
+This command is configured to install recommended defaults out of the box, while
+giving enough dials and options for users to tweak to still be useful. If there's
+a specific setup that doesn't work for you with `waypoint install`, we recommend
+looking at the [server run](/docs/server/run) documentation instead or opening
+an issue on GitHub and requesting a feature enhancement.
+
 ## Officially Supported Server Platforms
 
 Currently, Waypoint supports running its server on the following platforms:
@@ -24,14 +30,17 @@ Currently, Waypoint supports running its server on the following platforms:
 
 ### Kubernetes Platform
 
-Installing Waypoint server onto Kubernetes has a couple of options:
+Installing Waypoint server onto Kubernetes has a couple of options: Using the
+waypoint-helm chart or using `waypoint install`.
 
 The officially supported [hashicorp/waypoint-helm](https://github.com/hashicorp/waypoint-helm)
-chart for deploying Waypoint server directly onto a Kubernetes cluster with Helm charts.
+chart can be used to deploy Waypoint server directly onto a Kubernetes cluster with Helm charts.
+We recommend reading the README detailed on that project for more information on
+how to get going using Helm and Waypoint.
 
-Using the `waypoint install` command, which is what these docs cover. In a future
-release of Waypoint, we plan on updating the `waypoint install` command to use
-this Helm chart directly.
+You can also install Waypoint server onto Kubernetes using the `waypoint install`
+command. This command sets up a Service, Statefulset, Deployment, and Replicatset
+and deploys Waypoint server and its runner as two separate pods by default.
 
 ### Nomad Platform
 
@@ -42,7 +51,10 @@ You must use a CSI or Host volume to store Waypoint servers database in. A host 
 or CSI volume can be specified as a command line option to `waypoint install` and
 should be registered in Nomad prior to running the `waypoint install` command.
 
-~> **NOTE**: We **strongly recommend using Consul** for networking support in Nomad running Waypoint server.
+This command sets up a Nomad job for running Waypoint server and its
+runner as two separate jobs by default.
+
+~> **NOTE**: **We strongly recommend using Consul** for networking support in Nomad running Waypoint server.
 
 By default, the CLI installer will automatically create a service for Consul in
 Nomad for running Waypoint Server. This is an important default, as it gives
@@ -106,3 +118,6 @@ This section still needs to be filled out.
 Waypoint supports running the Waypoint server directly in Docker. Generally, this flow
 is recommended only for development to get started using Waypoint. We do not
 recommend using Waypoint running in Docker for production workflows.
+
+This command sets up a Nomad job for running Waypoint server and its
+runner as two separate jobs by default.

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -57,7 +57,7 @@ runner as two separate jobs by default.
 ~> **NOTE**: **We strongly recommend using Consul** for networking support in Nomad running Waypoint server.
 
 By default, the CLI installer will automatically create a service for Consul in
-Nomad for running Waypoint Server. This is an important default, as it gives
+Nomad for running Waypoint server. This is an important default, as it gives
 Waypoint server a stable hostname for your clients to point at, or remote
 runners to use for calling back to the Waypoint server. There are a handful of
 installer flags that let you configure what tags the Waypoint server and UI

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -1,0 +1,108 @@
+---
+layout: docs
+page_title: Server Install
+description: |-
+  The recommended way to install the server is using the waypoint install command. This command will install a server into Docker, Kubernetes, AWS ECS, or Nomad, bootstrap the server, and configure your local CLI to access that server. It is a single command to get up and running with Waypoint.
+---
+
+# Waypoint Server Install
+
+The recommended way to install the server is using the
+[`waypoint install`](/commands/install) command.
+This command will install a server into Docker, Kubernetes, AWS ECS, or Nomad,
+bootstrap the server, and configure your local CLI to access that server.
+It is a single command to get up and running with Waypoint.
+
+## Officially Supported Server Platforms
+
+Currently, Waypoint supports running its server on the following platforms:
+
+- [Kubernetes](/docs/server/install#kubernetes-platform)
+- [Nomad](/docs/server/install#nomad-platform)
+- [Amazon ECS](/docs/server/install#aws-ecs-platform)
+- [Docker](/docs/server/install#docker-platform)
+
+### Kubernetes Platform
+
+Installing Waypoint server onto Kubernetes has a couple of options:
+
+The officially supported [hashicorp/waypoint-helm](https://github.com/hashicorp/waypoint-helm)
+chart for deploying Waypoint server directly onto a Kubernetes cluster with Helm charts.
+
+Using the `waypoint install` command, which is what these docs cover. In a future
+release of Waypoint, we plan on updating the `waypoint install` command to use
+this Helm chart directly.
+
+### Nomad Platform
+
+To install Waypoint server on Nomad, there are a few requirements that should be
+met prior to running the install:
+
+You must use a CSI or Host volume to store Waypoint servers database in. A host volume
+or CSI volume can be specified as a command line option to `waypoint install` and
+should be registered in Nomad prior to running the `waypoint install` command.
+
+~> **NOTE**: We **strongly recommend using Consul** for networking support in Nomad running Waypoint server.
+
+By default, the CLI installer will automatically create a service for Consul in
+Nomad for running Waypoint Server. This is an important default, as it gives
+Waypoint server a stable hostname for your clients to point at, or remote
+runners to use for calling back to the Waypoint server. There are a handful of
+installer flags that let you configure what tags the Waypoint server and UI
+service should have, what datacenter or domain Consul is in, or if you wish you
+may define your own Consul service hostname to use. By default, the
+`waypoint install` helper will return a hostname crafted using the default
+expected host for a Consul service, i.e. `waypoint-server.service.dc1.consul`.
+
+When running the install helper, the CLI should show the Consul DNS backed hostname of Waypoint
+server at the end of an install:
+
+```shell
+waypoint@hashicorp:waypoint λ waypoint install -platform=nomad -accept-tos -nomad-host-volume="waypoint"
+✓ Waypoint server ready
+✓ The CLI has been configured to automatically install a Consul service for
+the Waypoint service backend and ui service in Nomad.
+✓ Server installed and configured!
+✓ Successfully connected to Waypoint server in Nomad!
+✓ Installing runner...
+✓ Waypoint runner installed
+Waypoint server successfully installed and configured!
+
+The CLI has been configured to connect to the server automatically. This
+connection information is saved in the CLI context named "install-1635801894".
+Use the "waypoint context" CLI to manage CLI contexts.
+
+The server has been configured to advertise the following address for
+entrypoint communications. This must be a reachable address for all your
+deployments. If this is incorrect, manually set it using the CLI command
+"waypoint server config-set".
+
+To launch and authenticate into the Web UI, run:
+waypoint ui -authenticate
+
+Advertise Address: waypoint-server.service.dc1.consul:9701
+Web UI Address: https://waypoint-ui.service.dc1.consul:9702
+```
+
+Notice that the advertise and web ui address is shown as a hostname, rather than an IP.
+
+Without using Consul, if the Waypoint server allocation ever gets restarted in Nomad, the IP
+address will no longer be valid, and you will have to upgrade every server clients context.
+There are ways around this issue that are considered more advanced, and are likely
+better candidates for using the [server run](/docs/server/run) flow for setting
+up Waypoint Server.
+
+If you do not wish to automatically register a Consul service in Nomad for
+Waypoint Server by default with `waypoint install`, it can always be disabled
+with the `-nomad-consul-service=false` flag included. You should then see
+an IP address from the Nomad allocation after the Waypoint install helper finishes.
+
+### AWS ECS Platform
+
+This section still needs to be filled out.
+
+### Docker Platform
+
+Waypoint supports running the Waypoint server directly in Docker. Generally, this flow
+is recommended only for development to get started using Waypoint. We do not
+recommend using Waypoint running in Docker for production workflows.

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -47,7 +47,7 @@ and deploys Waypoint server and its runner as two separate pods by default.
 To install Waypoint server on Nomad, there are a few requirements that should be
 met prior to running the install:
 
-You must use a CSI or Host volume to store Waypoint servers database in. A host volume
+You must use a CSI or Host volume to store Waypoint server's database. A host volume
 or CSI volume provider can be specified as a command line option to `waypoint install` and
 should be registered in Nomad prior to running the `waypoint install` command.
 

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -119,5 +119,5 @@ Waypoint supports running the Waypoint server directly in Docker. Generally, thi
 is recommended only for development to get started using Waypoint. We do not
 recommend using Waypoint running in Docker for production workflows.
 
-This command sets up a Nomad job for running Waypoint server and its
+This command sets up Docker containers for running Waypoint server and its
 runner as two separate containers by default.

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -106,7 +106,7 @@ up Waypoint server.
 
 If you do not wish to automatically register a Consul service in Nomad for
 Waypoint Server by default with `waypoint install`, it can always be disabled
-with the `-nomad-consul-service=false` flag included. You should then see
+by including the `-nomad-consul-service=false` flag. You should then see
 an IP address from the Nomad allocation after the Waypoint install helper finishes.
 
 ### AWS ECS Platform

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -61,8 +61,8 @@ Nomad for running Waypoint server. This is an important default, as it gives
 Waypoint server a stable hostname for your clients to point at, or remote
 runners to use for calling back to the Waypoint server. There are a handful of
 installer flags that let you configure what tags the Waypoint server and UI
-service should have, what datacenter or domain Consul is in, or if you wish you
-may define your own Consul service hostname to use. By default, the
+service should have, what datacenter or domain Consul is in, or
+define your own Consul service hostname to use. By default, the
 `waypoint install` helper will return a hostname crafted using the default
 expected host for a Consul service, i.e. `waypoint-server.service.dc1.consul`.
 

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -120,4 +120,4 @@ is recommended only for development to get started using Waypoint. We do not
 recommend using Waypoint running in Docker for production workflows.
 
 This command sets up a Nomad job for running Waypoint server and its
-runner as two separate jobs by default.
+runner as two separate containers by default.

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -99,7 +99,7 @@ Web UI Address: https://waypoint-ui.service.dc1.consul:9702
 Notice that the advertise and web ui address is shown as a hostname, rather than an IP.
 
 Without using Consul, if the Waypoint server allocation ever gets restarted in Nomad, the IP
-address will no longer be valid, and you will have to upgrade every server clients context.
+address will no longer be valid, and you will have to upgrade every server client's context.
 There are ways around this issue that are considered more advanced, and are likely
 better candidates for using the [server run](/docs/server/run) flow for setting
 up Waypoint Server.

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -105,7 +105,7 @@ better candidates for using the [server run](/docs/server/run) flow for setting
 up Waypoint server.
 
 If you do not wish to automatically register a Consul service in Nomad for
-Waypoint Server by default with `waypoint install`, it can always be disabled
+Waypoint server by default with `waypoint install`, it can always be disabled
 by including the `-nomad-consul-service=false` flag. You should then see
 an IP address from the Nomad allocation after the Waypoint install helper finishes.
 

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -102,7 +102,7 @@ Without using Consul, if the Waypoint server allocation ever gets restarted in N
 address will no longer be valid, and you will have to upgrade every server client's context.
 There are ways around this issue that are considered more advanced, and are likely
 better candidates for using the [server run](/docs/server/run) flow for setting
-up Waypoint Server.
+up Waypoint server.
 
 If you do not wish to automatically register a Consul service in Nomad for
 Waypoint Server by default with `waypoint install`, it can always be disabled

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -48,7 +48,7 @@ To install Waypoint server on Nomad, there are a few requirements that should be
 met prior to running the install:
 
 You must use a CSI or Host volume to store Waypoint servers database in. A host volume
-or CSI volume can be specified as a command line option to `waypoint install` and
+or CSI volume provider can be specified as a command line option to `waypoint install` and
 should be registered in Nomad prior to running the `waypoint install` command.
 
 This command sets up a Nomad job for running Waypoint server and its

--- a/website/content/docs/server/run/index.mdx
+++ b/website/content/docs/server/run/index.mdx
@@ -41,7 +41,7 @@ For details on upgrading the server, please see the
 
 ## Easy Installation
 
-We provide an opinionated, easy express install method for users who wish to get
+We provide an opinionated install method for users who wish to get
 off the ground quickly on certain server platforms with [waypoint install](/docs/server/install).
 
 For more details on what this command provides, as well as any supported server

--- a/website/content/docs/server/run/index.mdx
+++ b/website/content/docs/server/run/index.mdx
@@ -2,14 +2,14 @@
 layout: docs
 page_title: Running a Server
 description: |-
-  The recommended way to install the server is using the waypoint install command. This command will install a server into Docker, Kubernetes, or Nomad, bootstrap the server, and configure your local CLI to access that server. It is a single command to get up and running with Waypoint.
+  The recommended way to install the server is using the waypoint install command. This command will install a server into Docker, Kubernetes, AWS ECS, or Nomad, bootstrap the server, and configure your local CLI to access that server. It is a single command to get up and running with Waypoint.
 ---
 
 # Waypoint Server Installation
 
 The recommended way to install the server is using the
 [`waypoint install`](/commands/install) command.
-This command will install a server into Docker, Kubernetes, or Nomad,
+This command will install a server into Docker, Kubernetes, AWS ECS, or Nomad,
 bootstrap the server, and configure your local CLI to access that server.
 It is a single command to get up and running with Waypoint.
 
@@ -38,6 +38,14 @@ In this case, see the documentation on
 
 For details on upgrading the server, please see the
 [general Waypoint upgrade documentation](/docs/upgrading).
+
+## Easy Installation
+
+We provide an opinionated, easy express install method for users who wish to get
+off the ground quickly on certain server platforms with [waypoint install](/docs/server/install).
+
+For more details on what this command provides, as well as any supported server
+platform caveats, please check out the documentation for `waypoint install`.
 
 ## Manually Running the Server
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -341,6 +341,10 @@
             "path": "server/run"
           },
           {
+            "title": "Express Install",
+            "path": "server/install"
+          },
+          {
             "title": "Maintenance",
             "path": "server/run/maintenance"
           },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -341,10 +341,6 @@
             "path": "server/run"
           },
           {
-            "title": "Express Install",
-            "path": "server/install"
-          },
-          {
             "title": "Maintenance",
             "path": "server/run/maintenance"
           },
@@ -357,6 +353,10 @@
             "path": "server/run/security"
           }
         ]
+      },
+      {
+        "title": "Express Server Install",
+        "path": "server/install"
       }
     ]
   },


### PR DESCRIPTION
This pull request adds some basic docs for the `waypoint install` command for the website. It's not the full CLI command docs, which are found under the CLI section. This is more a higher level introduction to what the CLI helper provides since we already cover running the server manually with `server run`.

Fixes https://github.com/hashicorp/waypoint/issues/2631