### PR TITLE
Use the platform name in the installation message

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -137,7 +137,7 @@ func (c *InstallCommand) Run(args []string) int {
 			sr.Status(terminal.StatusError)
 			// dont return the error yet
 		} else {
-			sr.Update("Successfully connected to Waypoint server in Nomad!")
+			sr.Update("Successfully connected to Waypoint server in %s!", strings.Title(c.platform))
 			sr.Done()
 			break
 		}


### PR DESCRIPTION
Use the capitalized form of the platform in the install message. 