### PR TITLE
Do not error on existing cluster roles, and clean up rbac on uninstall

### DIFF
--- a/.changelog/2654.txt
+++ b/.changelog/2654.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serverinstall/k8s: Clean up rbac resources on uninstall, and do not error when existing rbac resources are detected during server upgrade.
+```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/2452
Fixes https://github.com/hashicorp/waypoint/issues/2647

It's not beautiful - could be dryer, and it would be better long-term if we discovered what rbac resources we were managing based on tags instead of names I think. This is good enough though, especially seeing as we're likely replacing the this functionality with the helm chart eventually.