### PR TITLE
Fix issue where you can't disable Project polling

### DIFF
--- a/.changelog/2673.txt
+++ b/.changelog/2673.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix issue where users could not disable project polling from the CLI
+```

--- a/internal/pkg/flag/flag_bool_ptr.go
+++ b/internal/pkg/flag/flag_bool_ptr.go
@@ -1,0 +1,79 @@
+package flag
+
+import (
+	"strconv"
+
+	"github.com/posener/complete"
+)
+
+// -- BoolPtrVar  and boolPtr
+// BoolPtrVar is used to discern between values provided via CLI flags for
+// "true", "false", and "not specified". Because of this there is no default
+// value offered. If you want to use a boolean flag with a default, see
+// flag_bool.go
+type BoolPtrVar struct {
+	Name       string
+	Aliases    []string
+	Usage      string
+	Hidden     bool
+	EnvVar     string
+	Target     **bool
+	Completion complete.Predictor
+	SetHook    func(val bool)
+}
+
+func (f *Set) BoolPtrVar(i *BoolPtrVar) {
+	f.VarFlag(&VarFlag{
+		Name:       i.Name,
+		Aliases:    i.Aliases,
+		Usage:      i.Usage,
+		EnvVar:     i.EnvVar,
+		Value:      newBoolPtr(i, i.Target, i.Hidden),
+		Completion: i.Completion,
+	})
+}
+
+type boolPtrValue struct {
+	v      *BoolPtrVar
+	hidden bool
+	target **bool
+}
+
+func newBoolPtr(v *BoolPtrVar, target **bool, hidden bool) *boolPtrValue {
+	return &boolPtrValue{
+		v:      v,
+		hidden: hidden,
+		target: target,
+	}
+}
+
+func (b *boolPtrValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	*b.target = &v
+
+	if b.v.SetHook != nil {
+		b.v.SetHook(v)
+	}
+
+	return nil
+}
+
+func (b *boolPtrValue) Get() interface{} {
+	if b.target != nil {
+		return *b.target
+	}
+	return nil
+}
+
+func (b *boolPtrValue) String() string {
+	if *b.target != nil {
+		return strconv.FormatBool(**b.target)
+	}
+	return ""
+}
+func (b *boolPtrValue) Example() string  { return "" }
+func (b *boolPtrValue) Hidden() bool     { return b.hidden }
+func (b *boolPtrValue) IsBoolFlag() bool { return true }

--- a/internal/pkg/flag/flag_bool_ptr_test.go
+++ b/internal/pkg/flag/flag_bool_ptr_test.go
@@ -1,0 +1,94 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolPtrVar(t *testing.T) {
+	varTrue := true
+	varFalse := false
+	cases := map[string]struct {
+		input     *string
+		expected  *bool
+		omitValue bool // e.g. -poll instead of -poll=true
+		shouldErr bool
+	}{
+		"omitted": {
+			expected: nil,
+		},
+		// support -flag for "true"
+		"bool flag behavior": {
+			omitValue: true,
+			expected:  &varTrue,
+		},
+		"true": {
+			input:    strPtr("TRUE"),
+			expected: &varTrue,
+		},
+		"false": {
+			input:    strPtr("False"),
+			expected: &varFalse,
+		},
+		// empty is equivilant to a user supplying -flag="", and not a scenario
+		// where the flag is simply omittied.
+		"empty": {
+			input:     strPtr(""),
+			shouldErr: true,
+		},
+		"bad input": {
+			input:     strPtr("a non-truthy value"),
+			shouldErr: true,
+		},
+		// only accept values Go's ParseBool would accept
+		"weird truthy input": {
+			input:     strPtr("tRuE"),
+			shouldErr: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var valA *bool
+			var valB string
+			sets := NewSets()
+			{
+				set := sets.NewSet("A")
+				set.BoolPtrVar(&BoolPtrVar{
+					Name:   "a",
+					Target: &valA,
+				})
+			}
+			{
+				// borrowed from string_slice_test, just to have another input
+				set := sets.NewSet("B")
+				set.StringVar(&StringVar{
+					Name:   "b",
+					Target: &valB,
+				})
+			}
+
+			var err error
+			inputs := []string{"-b=somevalueB"}
+			if c.input != nil {
+				inputs = append(inputs, "-a="+*c.input)
+			}
+			if c.omitValue == true {
+				inputs = append(inputs, "-a")
+			}
+			err = sets.Parse(inputs)
+			if c.shouldErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, c.expected, valA)
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Currently with `waypoint project apply`, users [need to provide several flags][flags] in order to enable git or app status polling. Two flags are problematic (`flagPoll` and `flagAppStatusPoll`) because they are declared as `bool` values, and our flag parsing package cannot discern between a `false` boolean value supplied versus the zero value `false` if either flag is simply omitted. That, coupled with a [logical truthy check][check], currently prevent users from turning either polling or app status polling off with the CLI once they are enabled (users can still disable git polling from the UI).

This PR adds a new flag value `BoolPtrVar`, for boolean values that need to discern between `true`,`false`, and omitted. `BoolPtrVar` is a `*bool` value which contains a pointer to `true`, `false`, or `nil`. There is no default value (or you could say `nil` is the default). This enables users to omit the flag and not have that be interpreted as supplying `false`.

Fixes #2037
Supersedes #2610 

*Note:* I added `pr/no-changelog` label for now while this is discussed/considered. If this is accepted, we probably need to survey the rest of Waypoints CLI to spot other places where this is needed, if any.

[flags]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/cli/project_apply.go#L162-L185
[check]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/cli/project_apply.go#L169
[boolvar]: https://github.com/hashicorp/waypoint/blob/751129bd6718b5172135738baa9440c96798b3a7/internal/pkg/flag/flag_bool.go