### PR TITLE
ui: workspace switcher

### DIFF
--- a/.changelog/2674.txt
+++ b/.changelog/2674.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: add workspace switcher to app pages
+```

--- a/ui/app/components/workspace-switcher.hbs
+++ b/ui/app/components/workspace-switcher.hbs
@@ -1,0 +1,51 @@
+{{#if this.shouldExist}}
+  <div
+    data-test-workspace-switcher
+    class="workspace-switcher"
+    ...attributes
+  >
+    <Pds::Dropdown @isOpen={{@isOpen}} as |D|>
+      <D.Trigger>
+        {{@current}}
+      </D.Trigger>
+
+      <D.Dialog
+        data-test-workspace-switcher-dialog
+        class="workspace-switcher__dialog"
+      >
+        {{#if this.loadWorkspaces.last.value.error}}
+          <section>
+            <D.ListItem>
+              <div
+                data-test-workspace-switcher-error-state
+                class="workspace-switcher__error-state"
+              >
+                <Pds::Icon @type="alert-triangle" />
+                {{t "workspace-switcher.error"}}
+                ({{this.loadWorkspaces.last.value.error.message}})
+              </div>
+            </D.ListItem>
+          </section>
+        {{else}}
+          {{#each this.loadWorkspaces.last.value.workspaces as |workspace|}}
+            <section>
+              <LinkTo
+                @route={{@route}}
+                @models={{array-concat workspace.name @models}}
+                aria-current={{if (eq workspace.name @current) "page" false}}
+                {{on "click" D.close}}
+              >
+                <span class="workspace-switcher__link-contents">
+                  {{#if (eq workspace.name @current)}}
+                    <Pds::Icon @type="check-plain" />
+                  {{/if}}
+                  {{workspace.name}}
+                </span>
+              </LinkTo>
+            </section>
+          {{/each}}
+        {{/if}}
+      </D.Dialog>
+    </Pds::Dropdown>
+  </div>
+{{/if}}

--- a/ui/app/components/workspace-switcher.ts
+++ b/ui/app/components/workspace-switcher.ts
@@ -1,0 +1,69 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { task, TaskGenerator } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import { Workspace } from 'waypoint-pb';
+import ApiService from 'waypoint/services/api';
+
+type Args = {
+  current?: string;
+  route?: string;
+  models?: string[];
+  isOpen?: boolean;
+};
+
+type Result = { workspaces: Workspace.AsObject[] } | { error: Error };
+
+export default class extends Component<Args> {
+  @service api!: ApiService;
+
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+
+    taskFor(this.loadWorkspaces).perform();
+  }
+
+  @task({ restartable: true })
+  *loadWorkspaces(): TaskGenerator<Result> {
+    try {
+      let workspaces = yield this.api.listWorkspaces();
+      return { workspaces };
+    } catch (error) {
+      return { error };
+    }
+  }
+
+  get shouldExist(): boolean {
+    let task = taskFor(this.loadWorkspaces);
+
+    if (task.isRunning) {
+      return false;
+    }
+
+    let value = task.last?.value;
+
+    if (!value) {
+      return false;
+    }
+
+    if ('error' in value) {
+      return true;
+    }
+
+    let { workspaces } = value;
+
+    if (workspaces.length > 1) {
+      return true;
+    }
+
+    if (workspaces.length === 0) {
+      return false;
+    }
+
+    if (workspaces[0].name === this.args.current) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/ui/app/controllers/workspace/projects/project/app.ts
+++ b/ui/app/controllers/workspace/projects/project/app.ts
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Controller {
+  @tracked isSwitchingWorkspace = false;
+  @service router!: RouterService;
+}

--- a/ui/app/helpers/array-concat.ts
+++ b/ui/app/helpers/array-concat.ts
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function (args: never[]): never[] {
+  return [].concat(...args);
+});

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -7,6 +7,7 @@ import {
   ListBuildsRequest,
   ListBuildsResponse,
   ListPushedArtifactsRequest,
+  ListWorkspacesRequest,
   OperationOrder,
   Project,
   PushedArtifact,
@@ -17,6 +18,7 @@ import {
   UI,
   UpsertProjectRequest,
   Variable,
+  Workspace,
 } from 'waypoint-pb';
 import { Metadata, Request, UnaryInterceptor, UnaryResponse } from 'grpc-web';
 
@@ -339,6 +341,18 @@ export default class ApiService extends Service {
     let resp = await this.client.upsertProject(req, this.WithMeta());
     let respProject = resp.toObject().project;
     return respProject;
+  }
+
+  async listWorkspaces(projectRef?: Ref.Project): Promise<Workspace.AsObject[]> {
+    let req = new ListWorkspacesRequest();
+
+    if (projectRef) {
+      req.setProject(projectRef);
+    }
+
+    let resp = await this.client.listWorkspaces(req, this.WithMeta());
+
+    return resp.toObject().workspacesList;
   }
 }
 

--- a/ui/app/styles/components/_index.scss
+++ b/ui/app/styles/components/_index.scss
@@ -34,4 +34,5 @@
 @import 'tooltip';
 @import 'up-button';
 @import 'variables-list';
+@import 'workspace-switcher';
 @import 'x-toggle';

--- a/ui/app/styles/components/navigation/page-header.scss
+++ b/ui/app/styles/components/navigation/page-header.scss
@@ -45,6 +45,18 @@
         margin-right: scale.$sm-3;
       }
     }
+
+    .title-wrapper {
+      display: flex;
+      align-items: center;
+
+      .workspace-switcher {
+        margin-left: scale.$base;
+      }
+      .workspace-switching-indicator {
+        margin-left: scale.$sm--2;
+      }
+    }
   }
 
   &.projects-header {

--- a/ui/app/styles/components/workspace-switcher.scss
+++ b/ui/app/styles/components/workspace-switcher.scss
@@ -1,0 +1,44 @@
+.workspace-switcher__dialog {
+  margin-top: scale.$sm--2;
+  width: auto;
+  min-width: 100%;
+  white-space: nowrap;
+  // Pds::DropDown does not support dark mode yet, so these rules just about
+  // keep it legible.
+  --pds-color: black;
+  --spinner-stroke: 0, 0, 0;
+}
+
+.workspace-switcher__link-contents {
+  display: flex;
+  position: relative;
+  padding-left: scale.$lg--2;
+
+  .pds-icon {
+    position: absolute;
+    top: -2px;
+    left: -4px;
+    font-size: scale.$lg--1;
+    color: rgb(var(--link));
+  }
+}
+
+.workspace-switcher__error-state {
+  display: flex;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  line-height: var(--pds-lineHeight--dense);
+  padding-left: scale.$lg--2;
+
+  .pds-icon {
+    position: absolute;
+    font-size: scale.$lg--1;
+    left: -4px;
+    top: -2px;
+  }
+}
+
+.workspace-switcher__error-state .pds-icon {
+  color: rgb(var(--error-text));
+}

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -9,7 +9,20 @@
 )}}
 <PageHeader @iconName="git-repository">
   <div class="title">
-    <h1>{{@model.application.application}}</h1>
+    <div class="title-wrapper">
+      <h1>{{@model.application.application}}</h1>
+      <WorkspaceSwitcher
+        @current={{@model.workspaceName}}
+        @route={{this.router.currentRoute.name}}
+        @models={{array @model.project.name @model.application.application}}
+      />
+      {{#if this.isSwitchingWorkspace}}
+        <span class="workspace-switching-indicator">
+          <Spinner @size={{20}} />
+          {{t "page.app.switching-workspace"}}
+        </span>
+      {{/if}}
+    </div>
   </div>
   <div class="actions">
     {{#if (and (project-is-remote-uppable @model.project) (not @model.releases.length))}}

--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -11,6 +11,7 @@ import * as release from './services/release';
 import * as statusReport from './services/status-report';
 import * as token from './services/token';
 import * as versionInfo from './services/version-info';
+import * as workspace from './services/workspace';
 
 import Ember from 'ember';
 import { Server } from 'miragejs';
@@ -59,6 +60,7 @@ export default function (this: Server): void {
   this.post('/GetConfig', config.get);
   this.post('/SetConfig', config.set);
   this.post('/ListOIDCAuthMethods', OIDCAuthMethods.list);
+  this.post('/ListWorkspaces', workspace.list);
 
   if (!Ember.testing) {
     // Pass through all other requests

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -33,6 +33,8 @@ export default Factory.extend({
     afterCreate(project, server) {
       let application = server.create('application', 'with-random-name', { project });
 
+      let prodWorkspace = server.create('workspace', { name: 'production' });
+
       server.create('config-variable', 'random', { project, name: 'test' });
 
       let builds = [
@@ -40,6 +42,14 @@ export default Factory.extend({
         server.create('build', 'random', 'minutes-old-success', { sequence: 3, application }),
         server.create('build', 'random', 'hours-old-success', { sequence: 2, application }),
         server.create('build', 'random', 'days-old-success', { sequence: 1, application }),
+      ];
+
+      let prodBuilds = [
+        server.create('build', 'random', 'seconds-old-success', {
+          sequence: 5,
+          application,
+          workspace: prodWorkspace,
+        }),
       ];
 
       let deployments = [
@@ -68,6 +78,16 @@ export default Factory.extend({
           application,
           build: builds[3],
           statusReport: server.create('status-report', 'down', 'with-deployment-resources', { application }),
+        }),
+      ];
+
+      let prodDeployments = [
+        server.create('deployment', 'random', 'seconds-old-success', {
+          sequence: 5,
+          application,
+          workspace: prodWorkspace,
+          build: prodBuilds[0],
+          statusReport: server.create('status-report', 'alive', 'with-deployment-resources', { application }),
         }),
       ];
 

--- a/ui/mirage/models/application.ts
+++ b/ui/mirage/models/application.ts
@@ -5,6 +5,7 @@ export default Model.extend({
   project: belongsTo(),
   builds: hasMany(),
   deployments: hasMany(),
+  releases: hasMany(),
   statusReports: hasMany(),
 
   toProtobuf(): Application {

--- a/ui/mirage/models/workspace.ts
+++ b/ui/mirage/models/workspace.ts
@@ -1,10 +1,7 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model } from 'ember-cli-mirage';
 import { Ref, Workspace } from 'waypoint-pb';
 
 export default Model.extend({
-  builds: hasMany(),
-  statusReports: hasMany(),
-
   toProtobuf(): Workspace {
     let result = new Workspace();
 

--- a/ui/mirage/services/workspace.ts
+++ b/ui/mirage/services/workspace.ts
@@ -1,0 +1,72 @@
+import { Request, Response } from 'miragejs';
+import { ListWorkspacesRequest, ListWorkspacesResponse, Ref } from 'waypoint-pb';
+import { decode } from '../helpers/protobufs';
+
+export function list(schema: any, request: Request): Response {
+  let requestMsg = decode(ListWorkspacesRequest, request.requestBody);
+  let response = new ListWorkspacesResponse();
+  let workspaces = [];
+
+  switch (requestMsg.getScopeCase()) {
+    case ListWorkspacesRequest.ScopeCase.GLOBAL:
+    case ListWorkspacesRequest.ScopeCase.SCOPE_NOT_SET:
+      workspaces = schema.all('workspace').models;
+      break;
+    case ListWorkspacesRequest.ScopeCase.PROJECT:
+      workspaces = workspacesForProject(schema, requestMsg.getProject());
+      break;
+    case ListWorkspacesRequest.ScopeCase.APPLICATION:
+      workspaces = workspacesForApplication(schema, requestMsg.getApplication());
+      break;
+  }
+
+  workspaces.sort((a, b) => a.name.localeCompare(b.name));
+
+  response.setWorkspacesList(workspaces.map((w) => w.toProtobuf()));
+
+  return this.serialize(response, 'application');
+}
+
+function workspacesForProject(schema, ref: Ref.Project) {
+  let name = ref.getProject();
+  let project = schema.findBy('project', { name });
+  if (!project) {
+    throw `Project ${name} not found`;
+  }
+  let ids = new Set();
+
+  for (let app of project.applications.models) {
+    let operations = [...app.builds.models, ...app.deployments.models, ...app.releases.models];
+    for (let op of operations) {
+      ids.add(op.workspaceId);
+    }
+  }
+
+  let result = schema.find('workspace', [...ids]).models;
+
+  return result;
+}
+
+function workspacesForApplication(schema, ref: Ref.Application) {
+  let projectName = ref.getProject();
+  let appName = ref.getApplication();
+  let project = schema.findBy('project', { name: projectName });
+  if (!project) {
+    throw `Project ${projectName} not found`;
+  }
+  let app = schema.findBy('application', { name: appName, projectId: project.id });
+  if (!app) {
+    throw `Application ${projectName}/${appName} not found`;
+  }
+  let ids = new Set();
+
+  let operations = [...app.builds.models, ...app.deployments.models, ...app.releases.models];
+
+  for (let op of operations) {
+    ids.add(op.workspaceId);
+  }
+
+  let result = schema.find('workspace', [...ids]).models;
+
+  return result;
+}

--- a/ui/tests/acceptance/workspaces-test.ts
+++ b/ui/tests/acceptance/workspaces-test.ts
@@ -1,0 +1,31 @@
+import { click, visit } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupSession } from '../helpers/login';
+
+module('Acceptance | workspaces', function (hooks) {
+  setupApplicationTest(hooks);
+  setupSession(hooks);
+  setupMirage(hooks);
+
+  test('switching workspaces', async function (assert) {
+    let staging = this.server.create('workspace', { name: 'staging' });
+    let production = this.server.create('workspace', { name: 'production' });
+    let project = this.server.create('project', { name: 'test-project' });
+    let application = this.server.create('application', { name: 'test-project', project });
+    this.server.create('build', 'random', { application, workspace: staging });
+    this.server.create('build', 'random', { application, workspace: production });
+
+    await visit(`/${staging.name}/${project.name}/app/${application.name}/builds`);
+
+    assert.dom('[data-test-workspace-switcher]').containsText('staging');
+    assert.dom('[data-test-app-item-build]').containsText('v1');
+
+    await click('[data-test-dropdown-trigger]');
+    await click(`a[href="/${production.name}/${project.name}/app/${application.name}/builds"]`);
+
+    assert.dom('[data-test-workspace-switcher]').containsText('production');
+    assert.dom('[data-test-app-item-build]').containsText('v2');
+  });
+});

--- a/ui/tests/integration/components/workspace-switcher-test.ts
+++ b/ui/tests/integration/components/workspace-switcher-test.ts
@@ -1,0 +1,112 @@
+import { render, waitFor, settled } from '@ember/test-helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { Response } from 'miragejs';
+
+module('Integration | Component | workspace-switcher', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('happy path', async function (assert) {
+    this.server.create('workspace', { name: 'default' });
+    this.server.create('workspace', { name: 'production' });
+
+    await render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+    `);
+    await a11yAudit();
+
+    assert.dom('[data-test-dropdown-trigger]').hasText('default');
+    assert.dom('a[href="/default/test-project/app/test-app/builds"]').hasAttribute('aria-current', 'page');
+    assert.dom('a[href="/production/test-project/app/test-app/builds"]').hasNoAttribute('aria-current');
+  });
+
+  test('while loading', async function (assert) {
+    this.server.create('workspace', { name: 'default' });
+    this.server.create('workspace', { name: 'production' });
+
+    render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+      <div data-test-sentinel />
+    `);
+
+    await waitFor('[data-test-sentinel]');
+
+    assert.dom('[data-test-workspace-switcher]').doesNotExist();
+
+    await settled();
+
+    assert.dom('[data-test-workspace-switcher]').exists();
+  });
+
+  test('when we fail to fetch workspaces from the API', async function (assert) {
+    this.server.post('/ListWorkspaces', () => new Response(500));
+
+    await render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+    `);
+
+    assert.dom('[data-test-workspace-switcher-error-state]').exists();
+  });
+
+  test('with no workspaces', async function (assert) {
+    await render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+    `);
+
+    assert.dom('[data-test-workspace-switcher]').doesNotExist();
+  });
+
+  test('with only one workspace', async function (assert) {
+    this.server.create('workspace', { name: 'default' });
+
+    await render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+    `);
+
+    assert.dom('[data-test-workspace-switcher]').doesNotExist();
+  });
+
+  test('with only one workspace, that differs from @current', async function (assert) {
+    this.server.create('workspace', { name: 'production' });
+
+    await render(hbs`
+      <WorkspaceSwitcher
+        @current="default"
+        @route="workspace.projects.project.app.builds"
+        @models={{array "test-project" "test-app"}}
+        @isOpen={{true}}
+      />
+    `);
+
+    assert.dom('[data-test-workspace-switcher]').exists();
+  });
+});

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -17,6 +17,8 @@ product:
   name: 'Waypoint'
 
 page:
+  app:
+    switching-workspace: Loading…
   artifact:
     overview:
       image: 'Image'
@@ -255,3 +257,6 @@ section:
 
 image-ref:
   copy-button-title: Copy full digest
+
+workspace-switcher:
+  error: Failed to load workspaces


### PR DESCRIPTION
## Why the change?

Addresses #1339 

## What’s the plan?

- [x] Add the switcher
- [x] Iron out loading states
- [x] Empty state
- [x] Add high-level test coverage
- [x] Add granular test coverage
  - [x] Happy path
  - [x] Error states
  - [x] Loading states
- [x] Use proper CSS, not cowboy CSS
- [x] Make dark mode look passable
- [x] Add changelog entry

### What’s not the plan?

Default workspace selection will be addressed in a separate PR. See #2662 for problem statement.

## What does it look like?

https://user-images.githubusercontent.com/34030/141003230-648a874e-f1c2-4bf0-a849-bd3d27525bc1.mp4

https://user-images.githubusercontent.com/34030/141003234-43f071d9-b2aa-40bf-b870-0dce60308aab.mp4

(note: the loading state no longer appear in the flow above, just the error)

## How do I test it?

1. `git checkout ui/workspace-switcher`
2. Boot the dev server in [mirage mode](https://github.com/hashicorp/waypoint/blob/main/ui/README.md#running-with-mocks) or [local mode](https://github.com/hashicorp/waypoint/blob/main/ui/README.md#running-with-a-local-waypoint-server)
3. Navigate to an app page
4. Try switching workspaces
5. Verify everything works as you’d expect