### PR TITLE
ui: address some ember-simple-auth type warnings

### DIFF
--- a/ui/app/components/actions/invite.ts
+++ b/ui/app/components/actions/invite.ts
@@ -1,7 +1,7 @@
 import ApiService from 'waypoint/services/api';
 import Component from '@glimmer/component';
 import { InviteTokenRequest } from 'waypoint-pb';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';

--- a/ui/app/components/header/index.ts
+++ b/ui/app/components/header/index.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { inject as service } from '@ember/service';
 export default class Header extends Component {
   @service session!: SessionService;

--- a/ui/app/components/login-invite/index.ts
+++ b/ui/app/components/login-invite/index.ts
@@ -2,7 +2,7 @@ import ApiService from 'waypoint/services/api';
 import Component from '@glimmer/component';
 import { ConvertInviteTokenRequest } from 'waypoint-pb';
 import RouterService from '@ember/routing/router-service';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/ui/app/components/login-token/index.ts
+++ b/ui/app/components/login-token/index.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import RouterService from '@ember/routing/router-service';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 

--- a/ui/app/components/logout/index.ts
+++ b/ui/app/components/logout/index.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import RouterService from '@ember/routing/router-service';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 

--- a/ui/app/routes/application.ts
+++ b/ui/app/routes/application.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import Transition from '@ember/routing/-private/transition';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -24,7 +24,7 @@ import { DEBUG } from '@glimmer/env';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Message } from 'google-protobuf';
 import Service from '@ember/service';
-import { SessionService } from 'ember-simple-auth/services/session';
+import SessionService from 'ember-simple-auth/services/session';
 import { WaypointClient } from 'waypoint-client';
 import { buildWaiter } from '@ember/test-waiters';
 import config from 'waypoint/config/environment';
@@ -84,7 +84,7 @@ export default class ApiService extends Service {
 
   get meta(): Metadata {
     if (this.session.isAuthenticated) {
-      return { ...protocolVersions, authorization: this.session.data.authenticated.token };
+      return { ...protocolVersions, authorization: this.session.data.authenticated?.token as string };
     } else {
       return { ...protocolVersions };
     }

--- a/ui/types/ember-simple-auth/services/session.d.ts
+++ b/ui/types/ember-simple-auth/services/session.d.ts
@@ -2,7 +2,7 @@ import type RouterService from '@ember/routing/router-service';
 type Transition = ReturnType<RouterService['transitionTo']>;
 
 declare module 'ember-simple-auth/services/session' {
-  interface SessionService {
+  export default interface SessionService {
     authenticate(authenticator: string, params: unknown): Promise<void>;
     isAuthenticated: boolean;
     invalidate(): Promise<void>;
@@ -11,6 +11,6 @@ declare module 'ember-simple-auth/services/session' {
   }
 
   interface SessionData {
-    authenticated?: unknown;
+    authenticated?: Record<string, unknown>;
   }
 }

--- a/ui/types/ember-simple-auth/test-support.d.ts
+++ b/ui/types/ember-simple-auth/test-support.d.ts
@@ -1,0 +1,7 @@
+import SessionService from 'ember-simple-auth/services/session';
+
+declare module 'ember-simple-auth/test-support' {
+  export function authenticateSession(sessionData?: Record<string, unknown>): Promise<void>;
+  export function currentSession(): SessionService;
+  export function invalidateSession(): Promise<void>;
+}


### PR DESCRIPTION
## Why the change?

Does what it says on the tin, specifically these two warnings:

<img width="1126" alt="CleanShot 2021-11-04 at 12 22 20@2x" src="https://user-images.githubusercontent.com/34030/140305304-55ada9e1-0a7f-42e5-a162-d54643b1a568.png">
<img width="1126" alt="CleanShot 2021-11-04 at 12 22 05@2x" src="https://user-images.githubusercontent.com/34030/140305313-933abeb4-1833-481b-8bcc-ef344c07534a.png">


## How do I test it?

This mostly changes type declarations, but it couldn’t hurt to check out the branch and smoke test it (both against your own editor’s intellisense and against a real Waypoint server).