### PR TITLE
ui: update icons to use the FlightIcon package

### DIFF
--- a/.changelog/2681.txt
+++ b/.changelog/2681.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: upgraded icons to flight icons library
+```

--- a/ui/app/components/actions/context.hbs
+++ b/ui/app/components/actions/context.hbs
@@ -1,5 +1,5 @@
 <span class="hint-link connect-link" role="button" {{on "click" this.toggleHint}}>
-  <Pds::Icon @type="bolt" class="nav-icon" />
+  <FlightIcon @name="zap" class="nav-icon" />
   CLI
 </span>
 

--- a/ui/app/components/actions/deploy.hbs
+++ b/ui/app/components/actions/deploy.hbs
@@ -1,5 +1,5 @@
 <button class="button button--secondary" type="button" {{on "click" this.toggleHint}}>
-  <Pds::Icon @type="upload" class="icon" />
+  <FlightIcon @name="upload" class="icon" />
   <span>Deploy...</span>
 </button>
 

--- a/ui/app/components/actions/invite.hbs
+++ b/ui/app/components/actions/invite.hbs
@@ -1,5 +1,5 @@
 <span class="hint-link" role="button" {{on "click" this.toggleHint}}>
-  <Pds::Icon @type="plus-circle-outline" class="nav-icon" />
+  <FlightIcon @name="plus-circle" class="nav-icon" />
   Invite
 </span>
 
@@ -14,9 +14,9 @@
       @clipboardTarget="#invite-token"
       @success={{this.onSuccess}}
     >
-      <Pds::Icon @type={{if this.copySuccess 'copy-success' 'copy-action'}} class="icon" />
+      <FlightIcon @name={{if this.copySuccess 'clipboard-checked' 'clipboard'}} class="icon" />
     </CopyButton>
-    <button class="button button--secondary button--compact" type="button" {{on "click" this.createToken}}><Pds::Icon @type="refresh-default" class="icon" /></button>
+    <button class="button button--secondary button--compact" type="button" {{on "click" this.createToken}}><FlightIcon @name="reload" class="icon" /></button>
   </div>
   <small>To share a Waypoint instance the server must be run in a location that the users can access. <br />
     <ExternalLink href="https://waypointproject.io/docs">Read more in our documentation</ExternalLink>

--- a/ui/app/components/actions/release.hbs
+++ b/ui/app/components/actions/release.hbs
@@ -1,5 +1,5 @@
 <button class="button button--primary" type="button" {{on "click" this.toggleHint}}>
-  <Pds::Icon @type="public-default" class="icon" />
+  <FlightIcon @name="globe" class="icon" />
   <span>Release...</span>
 </button>
 

--- a/ui/app/components/app-breadcrumbs/index.hbs
+++ b/ui/app/components/app-breadcrumbs/index.hbs
@@ -6,7 +6,7 @@
       {{else}}
         <LinkTo @route={{breadcrumb.route}} data-test-breadcrumb={{breadcrumb.route}}>
           {{#if breadcrumb.icon}}
-            <Pds::Icon @type={{breadcrumb.icon}} />
+            <FlightIcon @name={{breadcrumb.icon}} />
           {{/if}}
           <span>{{breadcrumb.label}}</span>
         </LinkTo>

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -10,7 +10,7 @@
 
   {{#if (and (eq @build.status.state 2) (eq @build.pushedArtifact.status.state 2))}}
     <b class="badge badge--info">
-      <Pds::Icon @type="clock-outline" class="icon" />
+      <FlightIcon @name="clock" class="icon" />
       <span>
         {{t "app_item_build.built_in"
           duration=(date-format-distance

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -26,7 +26,7 @@
       <:badge>
         {{#if (eq @deployment.state 4)}}
           <b data-test-destroyed-badge class="badge badge--destroyed">
-            <Pds::Icon @type="trash" class="icon" />&nbsp; {{t "page.deployments.destroyed_label"}}
+            <FlightIcon @name="trash" class="icon" />&nbsp; {{t "page.deployments.destroyed_label"}}
           </b>
         {{/if}}
       </:badge>

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -19,7 +19,7 @@
       href={{enforce-protocol @release.url}}
       class="button button--primary button--external-link">
       <span>{{@release.url}}</span>
-      <Pds::Icon @type="exit" class="icon" />
+      <FlightIcon @name="external-link" class="icon" />
     </ExternalLink>
   {{/if}}
 </li>

--- a/ui/app/components/copyable-code/index.hbs
+++ b/ui/app/components/copyable-code/index.hbs
@@ -7,6 +7,6 @@
    class={{if this.copySuccess 'copy-success'}}
    title="Copy"
   >
-    <Pds::Icon @type={{if this.copySuccess 'copy-success' 'copy-action'}} class="icon" />
+    <FlightIcon @name={{if this.copySuccess 'copy-success' 'copy-action'}} class="icon" />
   </CopyButton>
 </span>

--- a/ui/app/components/copyable-code/index.hbs
+++ b/ui/app/components/copyable-code/index.hbs
@@ -7,6 +7,6 @@
    class={{if this.copySuccess 'copy-success'}}
    title="Copy"
   >
-    <FlightIcon @name={{if this.copySuccess 'copy-success' 'copy-action'}} class="icon" />
+    <FlightIcon @name={{if this.copySuccess 'clipboard-checked' 'clipboard'}} class="icon" />
   </CopyButton>
 </span>

--- a/ui/app/components/git-commit.hbs
+++ b/ui/app/components/git-commit.hbs
@@ -1,6 +1,6 @@
 {{#if @commit}}
   <span class="git-commit" title="Triggered by commit: {{@commit}}">
-    <Pds::Icon @type="git-commit"/>
+    <FlightIcon @name="git-commit"/>
     {{!-- TODO: add git profile picture of user whose commit it was when possible --}}
     <CopyButton @clipboardText={{@commit}}>
      <span class="git-commit__sha">{{truncate-commit @commit}}</span>

--- a/ui/app/components/header/index.hbs
+++ b/ui/app/components/header/index.hbs
@@ -1,11 +1,11 @@
 <header id="header">
   <LinkTo @route="application" class="brand">
-    <Pds::Icon @type="brand" class="logo" />
+    <FlightIcon @name="brand" class="logo" />
     <span class="pds--visuallyHidden">{{t "product.name"}}</span>
   </LinkTo>
   <nav>
     <ExternalLink href="https://waypointproject.io/docs">
-      <Pds::Icon @type="docs" class="nav-icon" />
+      <FlightIcon @name="docs-link" class="nav-icon" />
       Documentation
     </ExternalLink>
     {{#if this.canLogout}}

--- a/ui/app/components/header/index.hbs
+++ b/ui/app/components/header/index.hbs
@@ -1,6 +1,6 @@
 <header id="header">
   <LinkTo @route="application" class="brand">
-    <FlightIcon @name="brand" class="logo" />
+    <FlightIcon @name="waypoint-color" @size="24"/>
     <span class="pds--visuallyHidden">{{t "product.name"}}</span>
   </LinkTo>
   <nav>

--- a/ui/app/components/icon-tile.hbs
+++ b/ui/app/components/icon-tile.hbs
@@ -1,6 +1,6 @@
-<div class="icon-tile
-  {{if @isSmall 'icon-tile--small'}}
-  {{if @isLarge 'icon-tile--large'}}
-  {{if @isBold 'icon-tile--bold'}}">
-  <FlightIcon @name={{@icon}}/>
+<div class="icon-tile">
+  <FlightIcon
+    @name={{@icon}}
+    @size={{if @isSmall '16' '24'}}
+  />
 </div>

--- a/ui/app/components/icon-tile.hbs
+++ b/ui/app/components/icon-tile.hbs
@@ -2,5 +2,5 @@
   {{if @isSmall 'icon-tile--small'}}
   {{if @isLarge 'icon-tile--large'}}
   {{if @isBold 'icon-tile--bold'}}">
-  <Pds::Icon @type={{@icon}} class="icon" />
+  <FlightIcon @name={{@icon}}/>
 </div>

--- a/ui/app/components/image-ref.hbs
+++ b/ui/app/components/image-ref.hbs
@@ -16,7 +16,7 @@
       class="image-ref__copy-button focus-ring"
       title={{t "image-ref.copy-button-title"}}
     >
-      <Pds::Icon @type={{if this.displayCopySuccess.isRunning "copy-success" "copy-action"}} />
+      <FlightIcon @name={{if this.displayCopySuccess.isRunning "copy-success" "copy-action"}} />
     </CopyButton>
   {{/if}}
 </span> 

--- a/ui/app/components/latest-release-url/index.hbs
+++ b/ui/app/components/latest-release-url/index.hbs
@@ -1,6 +1,6 @@
 {{#if this.firstRelease.url}}
 <ExternalLink href={{enforce-protocol this.firstRelease.url}} class="button button--primary button--external-link">
   <span>{{this.firstRelease.url}}</span>
-  <Pds::Icon @type="exit" class="icon" />
+  <FlightIcon @name="external-link" class="icon" />
 </ExternalLink>
 {{/if}}

--- a/ui/app/components/logout/index.hbs
+++ b/ui/app/components/logout/index.hbs
@@ -1,11 +1,11 @@
 {{#if @canLogout}}
   <button class="auth-link" type="button" {{on "click" this.logout}}>
-    <Pds::Icon @type="logout" class="nav-icon" />
+    <FlightIcon @name="sign-out" class="nav-icon" />
     Logout
   </button>
 {{else}}
   <LinkTo class="auth-link" @route="auth">
-    <Pds::Icon @type="lock-open" class="nav-icon" />
+    <FlightIcon @name="unlock" class="nav-icon" />
     Authenticate
   </LinkTo>
 {{/if}}

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -26,9 +26,10 @@
 --}}
 <div class="operation-status-indicator">
   <span class="icon-text-group">
-    <Pds::Icon
+    <FlightIcon
       data-test-icon-type={{icon-for-component @operation.component.name}}
-      @type={{icon-for-component @operation.component.name}}
+      @name={{icon-for-component @operation.component.name}}
+      @size="16"
     />
     <span>
       {{yield to="status-text"}}
@@ -64,12 +65,12 @@
         tabindex="0"
       >
         {{#if @isDetailed}}
-          <Pds::Icon
+          <FlightIcon
             data-test-time-icon
-            @type={{or
-              (and (eq vars.state "unknown") "help-circle-outline")
-              (and (eq vars.state "running") "clock-outline")
-              (and (eq vars.state "success") "check-plain")
+            @name={{or
+              (and (eq vars.state "unknown") "help")
+              (and (eq vars.state "running") "clock")
+              (and (eq vars.state "success") "check")
               (and (eq vars.state "error") "alert-triangle")
             }}
             @size="16"

--- a/ui/app/components/project-config-variables/list.hbs
+++ b/ui/app/components/project-config-variables/list.hbs
@@ -21,7 +21,7 @@
   </ul>
   <Pds::ButtonSet>
     <Pds::Button data-test-config-variables-add-variable disabled={{this.isCreating}} @variant="primary" {{on "click" this.addVariable}}>
-      <Pds::Icon @type="plus-plain" />{{t "form.config_variables_settings.button_apply"}}
+      <FlightIcon @name="plus" />{{t "form.config_variables_settings.button_apply"}}
     </Pds::Button>
   </Pds::ButtonSet>
 {{else}}
@@ -32,7 +32,7 @@
     </P.Body>
     <P.Footer>
       <Pds::Button data-test-config-variables-add-variable @variant="primary" {{on "click" this.addVariable}}>
-        <Pds::Icon @type="plus-plain" />{{t "form.config_variables_settings.button_apply"}}
+        <FlightIcon @name="plus" />{{t "form.config_variables_settings.button_apply"}}
       </Pds::Button>
     </P.Footer>
   </Pds::EmptyState>

--- a/ui/app/components/project-config-variables/list.hbs
+++ b/ui/app/components/project-config-variables/list.hbs
@@ -20,7 +20,7 @@
     {{/each}}
   </ul>
   <Pds::ButtonSet>
-    <Pds::Button data-test-config-variables-add-variable disabled={{this.isCreating}} @variant="primary" {{on "click" this.addVariable}}>
+    <Pds::Button data-test-config-variables-add-variable disabled={{this.isCreating}} @variant="primary" class="button--add-variable" {{on "click" this.addVariable}}>
       <FlightIcon @name="plus" />{{t "form.config_variables_settings.button_apply"}}
     </Pds::Button>
   </Pds::ButtonSet>
@@ -31,7 +31,7 @@
       {{t "form.config_variables_settings.empty_state_content"}}
     </P.Body>
     <P.Footer>
-      <Pds::Button data-test-config-variables-add-variable @variant="primary" {{on "click" this.addVariable}}>
+      <Pds::Button data-test-config-variables-add-variable @variant="primary" class="button--add-variable" {{on "click" this.addVariable}}>
         <FlightIcon @name="plus" />{{t "form.config_variables_settings.button_apply"}}
       </Pds::Button>
     </P.Footer>

--- a/ui/app/components/project-init-error.hbs
+++ b/ui/app/components/project-init-error.hbs
@@ -1,5 +1,5 @@
 <p>
-  <Pds::Icon @type="alert-triangle" />
+  <FlightIcon @name="alert-triangle" />
   {{t "project-init-error.title.prefix"}}
   <code class="code-block">{{@project.dataSource.git.url}}</code>
 </p>

--- a/ui/app/components/project-input-variables/list.hbs
+++ b/ui/app/components/project-input-variables/list.hbs
@@ -14,7 +14,7 @@
   </ul>
   <Pds::ButtonSet>
     <Pds::Button data-test-input-variables-add-variable disabled={{this.isCreating}} @variant="primary" {{on "click" this.addVariable}}>
-      <Pds::Icon @type="plus-plain" />{{t "form.project_variables_settings.button_apply"}}
+      <FlightIcon @name="plus" />{{t "form.project_variables_settings.button_apply"}}
     </Pds::Button>
   </Pds::ButtonSet>
 {{else}}
@@ -25,7 +25,7 @@
     </P.Body>
     <P.Footer>
       <Pds::Button data-test-input-variables-add-variable @variant="primary" {{on "click" this.addVariable}}>
-        <Pds::Icon @type="plus-plain" />{{t "form.project_variables_settings.button_apply"}}
+        <FlightIcon @name="plus" />{{t "form.project_variables_settings.button_apply"}}
       </Pds::Button>
     </P.Footer>
   </Pds::EmptyState>

--- a/ui/app/components/project-input-variables/list.hbs
+++ b/ui/app/components/project-input-variables/list.hbs
@@ -24,7 +24,7 @@
       {{t "form.project_variables_settings.empty_state_content"}}
     </P.Body>
     <P.Footer>
-      <Pds::Button data-test-input-variables-add-variable @variant="primary" {{on "click" this.addVariable}}>
+      <Pds::Button data-test-input-variables-add-variable @variant="primary" class="button--add-variable" {{on "click" this.addVariable}}>
         <FlightIcon @name="plus" />{{t "form.project_variables_settings.button_apply"}}
       </Pds::Button>
     </P.Footer>

--- a/ui/app/components/render-terminal/index.hbs
+++ b/ui/app/components/render-terminal/index.hbs
@@ -1,7 +1,7 @@
 <div class="xterm-wrapper">
   {{#unless this.isFollowingLogs}}
     <button class="follow-logs" type="button" {{on "click" this.followLogs}}>
-      <Pds::Icon @type="arrow-down" class="icon" />
+      <FlightIcon @name="arrow-down" class="icon" />
     </button>
   {{/unless}}
   <div class="xterm-pane"

--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -32,7 +32,7 @@
             {{resource.name}}
           </LinkTo>
         </th>
-        <td><Pds::Icon @type={{icon-for-component resource.platform}} /> {{resource.type}}</td>
+        <td><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
         <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
         <td><ResourceHealthIndicator @resource={{resource}} /></td>
       </tr>

--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -32,7 +32,7 @@
             {{resource.name}}
           </LinkTo>
         </th>
-        <td><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
+        <td class="resource-icon"><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
         <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
         <td><ResourceHealthIndicator @resource={{resource}} /></td>
       </tr>

--- a/ui/app/components/section.hbs
+++ b/ui/app/components/section.hbs
@@ -7,8 +7,8 @@
   <div class="section__header">
     <h2 class="section__heading">
       {{#if this.isExpandable}}
-        <Pds::Icon
-          @type={{if this.expanded "chevron-down" "chevron-right"}}
+        <FlightIcon
+          @name={{if this.expanded "chevron-down" "chevron-right"}}
         />
       {{/if}}
       <span>

--- a/ui/app/components/version-info/index.hbs
+++ b/ui/app/components/version-info/index.hbs
@@ -9,7 +9,7 @@
         (gt this.versionInfo.entrypoint.minimum this.versionInfo.entrypoint.current)
       )}}
       <b class="badge badge--error">
-        <Pds::Icon @type="alert-triangle" class="icon" />
+        <FlightIcon @name="alert-triangle" class="icon" />
         Update available
       </b>
     {{/if}}

--- a/ui/app/components/workspace-switcher.hbs
+++ b/ui/app/components/workspace-switcher.hbs
@@ -37,7 +37,7 @@
               >
                 <span class="workspace-switcher__link-contents">
                   {{#if (eq workspace.name @current)}}
-                    <FlightIcon @name="check-plain" />
+                    <FlightIcon @name="check" />
                   {{/if}}
                   {{workspace.name}}
                 </span>

--- a/ui/app/components/workspace-switcher.hbs
+++ b/ui/app/components/workspace-switcher.hbs
@@ -20,7 +20,7 @@
                 data-test-workspace-switcher-error-state
                 class="workspace-switcher__error-state"
               >
-                <Pds::Icon @type="alert-triangle" />
+                <FlightIcon @name="alert-triangle" />
                 {{t "workspace-switcher.error"}}
                 ({{this.loadWorkspaces.last.value.error.message}})
               </div>
@@ -37,7 +37,7 @@
               >
                 <span class="workspace-switcher__link-contents">
                   {{#if (eq workspace.name @current)}}
-                    <Pds::Icon @type="check-plain" />
+                    <FlightIcon @name="check-plain" />
                   {{/if}}
                   {{workspace.name}}
                 </span>

--- a/ui/app/helpers/icon-for-component.ts
+++ b/ui/app/helpers/icon-for-component.ts
@@ -6,21 +6,21 @@ export function iconForComponent([component]: [string]): string {
     case 'aws-ec2':
     case 'aws-ecs':
     case 'aws-ecr':
-      return 'logo-aws-color';
+      return 'aws-color';
     case 'azure-container-instances':
-      return 'logo-azure-color';
+      return 'azure-color';
     case 'docker':
-      return 'logo-docker-color';
+      return 'docker-color';
     case 'google-cloud-run':
-      return 'logo-gcp-color';
+      return 'gcp-color';
     case 'kubernetes':
     case 'kubernetes-apply':
-      return 'logo-kubernetes-color-alt';
+      return 'kubernetes-color';
     case 'nomad':
     case 'nomad-jobspec':
-      return 'logo-nomad-color';
+      return 'nomad-color';
     case 'pack':
-      return 'logo-pack-color';
+      return 'package';
     default:
       return 'more-horizontal';
   }

--- a/ui/app/helpers/icon-for-component.ts
+++ b/ui/app/helpers/icon-for-component.ts
@@ -20,7 +20,7 @@ export function iconForComponent([component]: [string]): string {
     case 'nomad-jobspec':
       return 'nomad-color';
     case 'pack':
-      return 'package';
+      return 'pack-color';
     default:
       return 'more-horizontal';
   }

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -39,7 +39,7 @@ export default class App extends Route {
     return [
       {
         label: model.application.project,
-        icon: 'folder-outline',
+        icon: 'folder',
         route: 'workspace.projects.project.apps',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -39,7 +39,6 @@ export default class App extends Route {
     return [
       {
         label: model.application.project,
-        icon: 'folder',
         route: 'workspace.projects.project.apps',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -39,6 +39,7 @@ export default class App extends Route {
     return [
       {
         label: model.application.project,
+        icon: 'folder',
         route: 'workspace.projects.project.apps',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -22,12 +22,10 @@ export default class BuildDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repository',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Builds',
-        icon: 'build',
         route: 'workspace.projects.project.app.builds',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -22,10 +22,12 @@ export default class BuildDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
+        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Builds',
+        icon: 'hammer',
         route: 'workspace.projects.project.app.builds',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
@@ -20,7 +20,7 @@ export default class DeploymentDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repository',
+        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -17,12 +17,10 @@ export default class ReleaseDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repository',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Releases',
-        icon: 'public-default',
         route: 'workspace.projects.project.app.releases',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -17,10 +17,12 @@ export default class ReleaseDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
+        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Releases',
+        icon: 'globe',
         route: 'workspace.projects.project.app.releases',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/release/resource.ts
+++ b/ui/app/routes/workspace/projects/project/app/release/resource.ts
@@ -18,7 +18,6 @@ export default class extends Route {
       {
         label: `v${release.sequence}`,
         route: 'workspace.projects.project.app.release',
-        icon: 'public-default',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/release/resource.ts
+++ b/ui/app/routes/workspace/projects/project/app/release/resource.ts
@@ -17,6 +17,7 @@ export default class extends Route {
     return [
       {
         label: `v${release.sequence}`,
+        icon: 'globe',
         route: 'workspace.projects.project.app.release',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/settings.ts
+++ b/ui/app/routes/workspace/projects/project/settings.ts
@@ -15,7 +15,7 @@ export default class WorkspaceProjectsProjectSettings extends Route {
     return [
       {
         label: model.name,
-        icon: 'folder-outline',
+        icon: 'folder',
         route: 'workspace.projects.project.index',
       },
       {

--- a/ui/app/routes/workspace/projects/project/settings.ts
+++ b/ui/app/routes/workspace/projects/project/settings.ts
@@ -15,12 +15,10 @@ export default class WorkspaceProjectsProjectSettings extends Route {
     return [
       {
         label: model.name,
-        icon: 'folder',
         route: 'workspace.projects.project.index',
       },
       {
         label: 'Settings',
-        icon: 'settings',
         route: 'workspace.projects.project.settings',
       },
     ];

--- a/ui/app/styles/_layout.scss
+++ b/ui/app/styles/_layout.scss
@@ -128,6 +128,9 @@ hr {
   border-top: 1px solid rgb(var(--border));
 }
 
+button .icon {
+  margin-right: scale.$sm-3;
+}
 // Set a default size for icons
 
 svg.icon {
@@ -136,8 +139,3 @@ svg.icon {
   flex-shrink: 0;
 }
 
-.pds-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/ui/app/styles/_layout.scss
+++ b/ui/app/styles/_layout.scss
@@ -127,7 +127,3 @@ hr {
   border: none;
   border-top: 1px solid rgb(var(--border));
 }
-
-button .icon {
-  margin-right: scale.$sm-3;
-}

--- a/ui/app/styles/_layout.scss
+++ b/ui/app/styles/_layout.scss
@@ -131,11 +131,3 @@ hr {
 button .icon {
   margin-right: scale.$sm-3;
 }
-// Set a default size for icons
-
-svg.icon {
-  width: scale.$lg-2;
-  height: scale.$lg-2;
-  flex-shrink: 0;
-}
-

--- a/ui/app/styles/components/button.scss
+++ b/ui/app/styles/components/button.scss
@@ -45,12 +45,6 @@ a[href].button {
   cursor: pointer;
   min-height: 36px;
 
-  > .pds-icon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
   &--compact {
     padding: 0 scale.$sm-2;
     min-height: 22px;
@@ -92,8 +86,20 @@ a[href].button {
   }
 
   &--external-link {
-    > .pds-icon {
+    > svg {
       align-items: flex-end;
+    }
+  }
+
+  &--add-variable {
+    > span {
+      display: flex;
+      align-items: stretch;
+      margin-left: calc(-1 * 0.25rem);
+
+      svg {
+        margin-right: scale.$sm-3;
+      }
     }
   }
 

--- a/ui/app/styles/components/git-commit.scss
+++ b/ui/app/styles/components/git-commit.scss
@@ -2,6 +2,9 @@
   @include Typography.Interface(S);
   border-radius: 2px;
   padding: scale.$sm-4 scale.$sm-4;
+  display: flex;
+  align-items: center;
+
   &__sha {
     color: rgb(var(--text-muted));
     background: rgb(var(--badge));

--- a/ui/app/styles/components/icon-tile.scss
+++ b/ui/app/styles/components/icon-tile.scss
@@ -23,27 +23,7 @@
   border-radius: 2px;
   font-size: scale.$lg-1;
 
-  > .pds-icon {
-    height: unset;
-    width: unset;
-  }
-
   @media (prefers-color-scheme: dark) {
     box-shadow: inset 0 0 0 1px rgba(var(--border), 0.5);
-  }
-
-  &--small {
-    width: scale.$lg-6;
-    height: scale.$lg-6;
-  }
-
-  &--large {
-    width: scale.$lg-12;
-    height: scale.$lg-12;
-
-    .icon {
-      width: scale.$lg-8;
-      height: scale.$lg-8;
-    }
   }
 }

--- a/ui/app/styles/components/navigation/breadcrumbs.scss
+++ b/ui/app/styles/components/navigation/breadcrumbs.scss
@@ -20,17 +20,11 @@ ul.breadcrumbs {
       }
 
       span {
+        font-weight: normal;
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
       }
-    }
-
-    .pds-icon {
-      width: 16px;
-      height: 16px;
-      margin-right: scale.$sm-3;
-      flex-shrink: 0;
     }
 
     &::after {

--- a/ui/app/styles/components/navigation/breadcrumbs.scss
+++ b/ui/app/styles/components/navigation/breadcrumbs.scss
@@ -15,6 +15,10 @@ ul.breadcrumbs {
       align-items: center;
       overflow: hidden;
 
+      svg {
+        margin-right: scale.$sm-3;
+      }
+
       &:hover {
         color: rgb(var(--link));
       }

--- a/ui/app/styles/components/navigation/header.scss
+++ b/ui/app/styles/components/navigation/header.scss
@@ -42,10 +42,6 @@
       align-items: center;
       margin: 0 scale.$sm-2;
       text-decoration: none;
-
-      > .pds-icon {
-        display: flex;
-      }
     }
 
     .nav-icon {

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -1,4 +1,7 @@
 .operation-status-indicator {
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
 
   > span {
     margin-right: scale.$sm-4;
@@ -19,8 +22,9 @@
   .icon-text-group {
     display: inline-flex;
     align-items: center;
-    line-height: initial;
+    line-height: 100%;
     @include Typography.Interface(M);
+    font-weight: inherit;
 
     span {
       overflow: hidden;
@@ -32,8 +36,11 @@
   .timestamp {
     display: inline-flex;
     align-items: center;
+    line-height: 100%;
     color: rgb(var(--text-muted));
     cursor: default;
+    font-size: inherit;
+    font-weight: inherit;
 
     &--error {
       color: rgb(var(--error-text));

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -15,10 +15,6 @@
     margin-right: scale.$sm-3;
   }
 
-  .pds-icon {
-    font-size: 16px;
-  }
-
   .icon-text-group {
     display: inline-flex;
     align-items: center;

--- a/ui/app/styles/components/output-pane.scss
+++ b/ui/app/styles/components/output-pane.scss
@@ -169,8 +169,6 @@
       position: absolute;
       left: scale.$sm-1;
       top: 13px;
-      width: 24px;
-      height: 24px;
       pointer-events: none;
       color: rgb(var(--text-muted));
     }

--- a/ui/app/styles/components/section.scss
+++ b/ui/app/styles/components/section.scss
@@ -22,13 +22,11 @@
     font-weight: 600;
     line-height: 1;
 
-    .pds-icon {
+    svg {
       margin-left: -4px;
       margin-right: 4px;
 
       color: rgb(var(--text-muted));
-
-      font-size: 20px;
     }
   }
 

--- a/ui/app/styles/components/structure/pds-tabnav.scss
+++ b/ui/app/styles/components/structure/pds-tabnav.scss
@@ -5,10 +5,10 @@
     display: flex;
   }
 
-  .icon {
-    display: flex;
+  .tab-icon {
     margin-right: scale.$sm-3;
   }
+
   a {
     color: rgb(var(--text-muted));
     display: flex;

--- a/ui/app/styles/components/table.scss
+++ b/ui/app/styles/components/table.scss
@@ -55,6 +55,15 @@
     }
   }
 
+  .resource-icon {
+    display: flex;
+    align-items: flex-end;
+
+    svg {
+      margin-right: scale.$sm-3;
+    }
+  }
+
   .w-1\/2 {
     width: 50%;
   }

--- a/ui/app/styles/components/workspace-switcher.scss
+++ b/ui/app/styles/components/workspace-switcher.scss
@@ -12,12 +12,11 @@
 .workspace-switcher__link-contents {
   display: flex;
   position: relative;
-  padding-left: scale.$lg--2;
+  padding-left: scale.$lg-1;
 
-  .pds-icon {
+  svg {
     position: absolute;
-    top: -2px;
-    left: -4px;
+    left: -3px;
     font-size: scale.$lg--1;
     color: rgb(var(--link));
   }
@@ -31,7 +30,7 @@
   line-height: var(--pds-lineHeight--dense);
   padding-left: scale.$lg--2;
 
-  .pds-icon {
+  svg {
     position: absolute;
     font-size: scale.$lg--1;
     left: -4px;
@@ -39,6 +38,6 @@
   }
 }
 
-.workspace-switcher__error-state .pds-icon {
+.workspace-switcher__error-state svg {
   color: rgb(var(--error-text));
 }

--- a/ui/app/styles/pages/auth-page.scss
+++ b/ui/app/styles/pages/auth-page.scss
@@ -31,8 +31,10 @@
 
     .icon.brand {
       display: flex;
+      width: scale.$lg-14;
+      height: scale.$lg-14;
 
-      path {
+      use {
         fill: color.$black;
         stroke: $brand-color;
       }

--- a/ui/app/styles/pages/projects/new.scss
+++ b/ui/app/styles/pages/projects/new.scss
@@ -1,3 +1,15 @@
-#create-git-help-text .pds-helpText {
-  margin-top: scale.$sm--3;
+#create-git-help-text {
+
+  span {
+    display: flex;
+    align-items: center;
+
+    svg {
+      margin-right: scale.$sm-3;
+    }
+  }
+
+  &.pds-helpText {
+    margin-top: scale.$sm--3;
+  }
 }

--- a/ui/app/templates/auth.hbs
+++ b/ui/app/templates/auth.hbs
@@ -1,7 +1,7 @@
 <div class="auth-page">
   <Card>
     <div class="auth-header">
-      <Pds::Icon @type="brand" class="icon brand" />
+      <FlightIcon @name="waypoint" class="icon brand" @size="24" />
     </div>
 
     {{outlet}}

--- a/ui/app/templates/error.hbs
+++ b/ui/app/templates/error.hbs
@@ -1,6 +1,6 @@
 <div class="flash flash--error">
   <div class="flash-header">
-    <Pds::Icon @type="alert-triangle" class="icon" />
+    <FlightIcon @name="alert-triangle" class="icon" />
     <p>An error occurred</p>
   </div>
   <hr />

--- a/ui/app/templates/lab.hbs
+++ b/ui/app/templates/lab.hbs
@@ -1,6 +1,6 @@
 <div class="lab/header">
   <LinkTo @route="lab">
-    <Pds::Icon @type="folder-fill" />
+    <FlightIcon @name="folder-fill" />
     Lab Home
   </LinkTo>
 </div>

--- a/ui/app/templates/onboarding/connect.hbs
+++ b/ui/app/templates/onboarding/connect.hbs
@@ -1,5 +1,5 @@
 <div class="onboarding-header">
-  <IconTile @icon="bolt" />
+  <IconTile @icon="zap" />
   <div class="onboarding-header-content">
     <h1>Connect to your Waypoint instance</h1>
     <p>Now you can connect to the existing Waypoint instance.</p>

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -3,7 +3,7 @@
 {{#if this.cli}}
 <div class="flash flash--success">
   <div class="flash-header">
-    <Pds::Icon @type="check-circle-fill" class="icon" />
+    <FlightIcon @name="check-circle-fill" class="icon" />
     <p>Authenticated successfully via the Waypoint CLI</p>
   </div>
 </div>
@@ -21,7 +21,7 @@
     </small>
   </div>
   <Pds::CtaLink @route="workspace.projects.new" @variant="secondary "class="pds--iconStart">
-    <Pds::Icon @type="plus-plain" class="pds-button__iconStart"/>
+    <FlightIcon @name="plus" class="pds-button__iconStart"/>
     &nbsp;{{t "form.project_new.title"}}
   </Pds::CtaLink>
 </PageHeader>
@@ -31,7 +31,7 @@
   <Card>
     <LinkTo @route="workspace.projects.project" @model={{project.project}}>
       <div class="row">
-        <IconTile @icon="folder-outline" @isSmall={{true}} />
+        <IconTile @icon="folder" @isSmall={{true}} />
         <div class="meta">
           <h2>{{project.project}}</h2>
           {{!-- todo(pearkes): get full project objects from list api --}}

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -31,7 +31,7 @@
   <Card>
     <LinkTo @route="workspace.projects.project" @model={{project.project}}>
       <div class="row">
-        <IconTile @icon="folder" @isSmall={{true}} />
+        <IconTile @icon="folder" />
         <div class="meta">
           <h2>{{project.project}}</h2>
           {{!-- todo(pearkes): get full project objects from list api --}}

--- a/ui/app/templates/workspace/projects/new.hbs
+++ b/ui/app/templates/workspace/projects/new.hbs
@@ -1,7 +1,7 @@
 {{page-title (t 'form.project_new.title')}}
 
 <AppBreadcrumbs/>
-<PageHeader @iconName="plus-plain">
+<PageHeader @iconName="plus">
   <div class="title">
     <h1>{{t 'form.project_new.title'}}</h1>
   </div>
@@ -28,7 +28,7 @@
     <fieldset class="pds-formFieldSet">
       <div class="pds-formField">
         <div class="pds-fieldName" id="create-git-help-text">
-          <Pds::Icon @type="git-repository" class="icon" />
+          <FlightIcon @name="git-repo" class="icon" />
           {{t 'form.project_new.create_git_label'}}
           <Pds::HelpText>
             {{t 'form.project_new.create_git_helptext'}}

--- a/ui/app/templates/workspace/projects/new.hbs
+++ b/ui/app/templates/workspace/projects/new.hbs
@@ -28,8 +28,10 @@
     <fieldset class="pds-formFieldSet">
       <div class="pds-formField">
         <div class="pds-fieldName" id="create-git-help-text">
-          <FlightIcon @name="git-repo" class="icon" />
-          {{t 'form.project_new.create_git_label'}}
+          <span>
+            <FlightIcon @name="git-repo" @size="16" class="icon" />
+            {{t 'form.project_new.create_git_label'}}
+          </span>
           <Pds::HelpText>
             {{t 'form.project_new.create_git_helptext'}}
           </Pds::HelpText>

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -49,27 +49,27 @@
 <Pds::TabNav>
   <LinkTo @route="workspace.projects.project.app.deployment"
     @models={{array @model.application.project @model.application.application }}>
-    <FlightIcon @name="upload" class="icon" />
+    <FlightIcon @name="upload" class="tab-icon" />
     {{t "nav.deployments"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.builds"
     @models={{array @model.application.project @model.application.application }}>
-    <FlightIcon @name="build" class="icon" />
+    <FlightIcon @name="hammer" class="tab-icon" />
     {{t "nav.builds"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.releases"
     @models={{array @model.application.project @model.application.application }}>
-    <FlightIcon @name="globe" class="icon" />
+    <FlightIcon @name="globe" class="tab-icon" />
     {{t "nav.releases"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.logs"
     @models={{array @model.application.project @model.application.application }}>
-    <FlightIcon @name="outline" class="icon" />
+    <FlightIcon @name="outline" class="tab-icon" />
     {{t "nav.logs"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.exec"
     @models={{array @model.application.project @model.application.application }}>
-    <FlightIcon @name="terminal-screen" class="icon" />
+    <FlightIcon @name="terminal-screen" class="tab-icon" />
     {{t "nav.exec"}}
   </LinkTo>
 </Pds::TabNav>

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -4,7 +4,7 @@
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment.deployment-seq.resource')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.release.resource')
 )}}
-<PageHeader @iconName="git-repository">
+<PageHeader @iconName="git-repo">
   <div class="title">
     <div class="title-wrapper">
       <h1>{{@model.application.application}}</h1>
@@ -49,27 +49,27 @@
 <Pds::TabNav>
   <LinkTo @route="workspace.projects.project.app.deployment"
     @models={{array @model.application.project @model.application.application }}>
-    <Pds::Icon @type="upload" class="icon" />
+    <FlightIcon @name="upload" class="icon" />
     {{t "nav.deployments"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.builds"
     @models={{array @model.application.project @model.application.application }}>
-    <Pds::Icon @type="build" class="icon" />
+    <FlightIcon @name="build" class="icon" />
     {{t "nav.builds"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.releases"
     @models={{array @model.application.project @model.application.application }}>
-    <Pds::Icon @type="public-default" class="icon" />
+    <FlightIcon @name="globe" class="icon" />
     {{t "nav.releases"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.logs"
     @models={{array @model.application.project @model.application.application }}>
-    <Pds::Icon @type="page-outline" class="icon" />
+    <FlightIcon @name="outline" class="icon" />
     {{t "nav.logs"}}
   </LinkTo>
   <LinkTo @route="workspace.projects.project.app.exec"
     @models={{array @model.application.project @model.application.application }}>
-    <Pds::Icon @type="exec" class="icon" />
+    <FlightIcon @name="terminal-screen" class="icon" />
     {{t "nav.exec"}}
   </LinkTo>
 </Pds::TabNav>

--- a/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
@@ -8,7 +8,7 @@
             href={{enforce-protocol @model.preload.deployUrl}}
             class="button button--secondary button--external-link">
             <span>{{lowercase @model.preload.deployUrl}}</span>
-            <FlightIcon @name="exit" class="icon" />
+            <FlightIcon @name="external-link" class="icon" />
           </ExternalLink>
         {{/if}}
         <Actions::Release @sequence={{@model.sequence}} />

--- a/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
@@ -8,7 +8,7 @@
             href={{enforce-protocol @model.preload.deployUrl}}
             class="button button--secondary button--external-link">
             <span>{{lowercase @model.preload.deployUrl}}</span>
-            <Pds::Icon @type="exit" class="icon" />
+            <FlightIcon @name="exit" class="icon" />
           </ExternalLink>
         {{/if}}
         <Actions::Release @sequence={{@model.sequence}} />
@@ -23,10 +23,7 @@
         <tr>
           <th scope="row">{{t "page.deployment.overview.status"}}</th>
           <td>
-            <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
-            <span>Deployed by <b>{{component-name @model.component.name}}</b>
-              {{date-format-distance-to-now @model.status.startTime.seconds }}
-            </span>
+            <OperationStatusIndicator::Deployment @operation={{@model}} />
           </td>
         </tr>
       </StatusReportMetaTable>

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -16,10 +16,10 @@
   {{/if}}
 
   <div class="run-prompt">
-    <Pds::Icon @type="chevron-right" class="prompt-icon" />
+    <FlightIcon @name="chevron-right" class="prompt-icon" />
     <input type="text" class="run-prompt-input" disabled aria-label="Command" />
     <button type="button" class="button button--primary" disabled>
-      <Pds::Icon @type="sub-right" class="icon" />
+      <FlightIcon @name="corner-down-right" class="icon" />
       <span>Run</span>
     </button>
   </div>

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -16,7 +16,7 @@
   {{/if}}
 
   <div class="run-prompt">
-    <FlightIcon @name="chevron-right" class="prompt-icon" />
+    <FlightIcon @name="chevron-right" @size='24' class="prompt-icon" />
     <input type="text" class="run-prompt-input" disabled aria-label="Command" />
     <button type="button" class="button button--primary" disabled>
       <FlightIcon @name="corner-down-right" class="icon" />

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -6,7 +6,7 @@
       {{#if @isLatest}}
         <button class="button button--primary" type="button">
           <span>{{@model.release.url}}</span>
-          <Pds::Icon @type="exit" class="icon" />
+          <FlightIcon @name="external-link" class="icon" />
         </button>
       {{/if}}
     </:actions>

--- a/ui/app/templates/workspace/projects/project/apps.hbs
+++ b/ui/app/templates/workspace/projects/project/apps.hbs
@@ -1,12 +1,12 @@
 {{page-title @model.name}}
 
-<PageHeader @iconName="folder-outline">
+<PageHeader @iconName="folder">
   <div class="title">
     <h1>{{@model.name}}</h1>
     <small>{{pluralize @model.applicationsList.length "application"}}</small>
   </div>
   <Pds::CtaLink @route="workspace.projects.project.settings" @model={{@model.name}} @variant="ghost "class="pds--iconStart">
-    <Pds::Icon @type="settings" class="pds-button__iconStart"/>
+    <FlightIcon @name="settings" class="pds-button__iconStart"/>
     &nbsp;Manage settings
   </Pds::CtaLink>
 </PageHeader>
@@ -15,7 +15,7 @@
   <Card>
     <LinkTo @route="workspace.projects.project.app" @model={{app.name}}>
       <div class="row">
-        <IconTile @icon="git-repository" @isSmall={{true}} />
+        <IconTile @icon="git-repo" @isSmall={{true}} />
         <div class="meta">
           <h2>{{app.name}}</h2>
         </div>

--- a/ui/app/templates/workspace/projects/project/apps.hbs
+++ b/ui/app/templates/workspace/projects/project/apps.hbs
@@ -15,7 +15,7 @@
   <Card>
     <LinkTo @route="workspace.projects.project.app" @model={{app.name}}>
       <div class="row">
-        <IconTile @icon="git-repo" @isSmall={{true}} />
+        <IconTile @icon="git-repo" />
         <div class="meta">
           <h2>{{app.name}}</h2>
         </div>

--- a/ui/package.json
+++ b/ui/package.json
@@ -129,7 +129,7 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@hashicorp/ember-flight-icons": "^1.1.0",
+    "@hashicorp/ember-flight-icons": "^2.0.0",
     "@types/google-protobuf": "^3.7.2",
     "api-common-protos": "link:./lib/api-common-protos",
     "ember-cli-typescript-blueprints": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -129,6 +129,7 @@
     "edition": "octane"
   },
   "dependencies": {
+    "@hashicorp/ember-flight-icons": "^1.1.0",
     "@types/google-protobuf": "^3.7.2",
     "api-common-protos": "link:./lib/api-common-protos",
     "ember-cli-typescript-blueprints": "^3.0.0",

--- a/ui/tests/integration/components/app-item/build-test.ts
+++ b/ui/tests/integration/components/app-item/build-test.ts
@@ -40,7 +40,7 @@ module('Integration | Component | app-item/build', function (hooks) {
     `);
 
     assert.dom('[data-test-app-item-build]').includesText('v3');
-    assert.dom('[data-test-icon-type="logo-docker-color"]').exists();
+    assert.dom('[data-test-icon-type="docker-color"]').exists();
     assert.dom('[data-test-app-item-build]').includesText('Pushed to Docker');
     assert.dom('[data-test-operation-status-indicator="success"]').exists();
     assert.dom('[data-test-app-item-build]').includesText('1 minute ago');
@@ -69,7 +69,7 @@ module('Integration | Component | app-item/build', function (hooks) {
     `);
 
     assert.dom('[data-test-app-item-build]').includesText('v3');
-    assert.dom('[data-test-icon-type="logo-docker-color"]').exists();
+    assert.dom('[data-test-icon-type="docker-color"]').exists();
     assert.dom('[data-test-app-item-build]').includesText('Built with Docker');
     assert.dom('[data-test-operation-status-indicator="success"]').exists();
     assert.dom('[data-test-app-item-build]').includesText('2 minutes ago');

--- a/ui/tests/integration/components/operation-status-indicator-test.ts
+++ b/ui/tests/integration/components/operation-status-indicator-test.ts
@@ -32,7 +32,7 @@ module('Integration | Component | operation-status-indicator', function (hooks) 
       </OperationStatusIndicator>
     `);
 
-    assert.dom('[data-test-icon-type]').hasAttribute('data-test-icon-type', 'logo-docker-color');
+    assert.dom('[data-test-icon-type]').hasAttribute('data-test-icon-type', 'docker-color');
     assert.dom('.icon-text-group').containsText('Deployed to Docker');
     await focus('[data-test-operation-status-indicator]');
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1439,19 +1439,19 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@hashicorp/ember-flight-icons@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-1.1.0.tgz#0305cce3e6538d20c1433a900cb448f9eefcf9a7"
-  integrity sha512-qJCpGYmsXqsjMZNA+AJO6xhCWM0lk2uRGrDhJX7qzZ3OjLvp7eFCy/jrMVYYRSt1DT0X/etc2Ta4AbxmkWzduA==
+"@hashicorp/ember-flight-icons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.0.tgz#d4eb9082fe6579c54d481de4f1644f0c3188f37c"
+  integrity sha512-mCOyha0YnZjQcEomm2FKKL74BBvTrVJVjicxh+P5yu+Yo8hmiFOr0PbaoOuLrFOxsHsd33VW6Y5uskcZivR1tQ==
   dependencies:
-    "@hashicorp/flight-icons" "^1.2.0"
+    "@hashicorp/flight-icons" "^2.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-htmlbars "^5.7.1"
 
-"@hashicorp/flight-icons@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-1.3.0.tgz#ac51dc130c34d0fe019a9d9c2acbab543271b018"
-  integrity sha512-m4GkuYocXv54cBc+7sCkD+xorSxGPYovACpk8/A8I9rCFwdkX3WSZM8osT2/ws4IkCfeNYoxB1dz6a2SRhRfDg==
+"@hashicorp/flight-icons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.0.0.tgz#84910c97f2bc643a6ca039ca7ed9be0bf14f8ee2"
+  integrity sha512-jNRHHCFvptOHLXPIlnZ4A1LIFtS6m+Bv72NsE3Pl7KHMwcqkLHDN8gNa6AHf80cvFE+pR3sEx6Yjxu79jWJczQ==
 
 "@hashicorp/pds-ember@^0.6.0":
   version "0.6.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1439,6 +1439,20 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
+"@hashicorp/ember-flight-icons@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-1.1.0.tgz#0305cce3e6538d20c1433a900cb448f9eefcf9a7"
+  integrity sha512-qJCpGYmsXqsjMZNA+AJO6xhCWM0lk2uRGrDhJX7qzZ3OjLvp7eFCy/jrMVYYRSt1DT0X/etc2Ta4AbxmkWzduA==
+  dependencies:
+    "@hashicorp/flight-icons" "^1.2.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
+
+"@hashicorp/flight-icons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-1.3.0.tgz#ac51dc130c34d0fe019a9d9c2acbab543271b018"
+  integrity sha512-m4GkuYocXv54cBc+7sCkD+xorSxGPYovACpk8/A8I9rCFwdkX3WSZM8osT2/ws4IkCfeNYoxB1dz6a2SRhRfDg==
+
 "@hashicorp/pds-ember@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@hashicorp/pds-ember/-/pds-ember-0.6.0.tgz#70cc8025828168ea4dd824ef7ef0f2fbaac5f157"


### PR DESCRIPTION
## Related Issue
#2392 

## Description
This PR intends to transfer the Waypoint Ui over from using the `Pds::Icon` components to the new `FlightIcon` ones.

## How to Test
1. Pull this branch down `git checkout ui/flight-icon-update`
2. `yarn` to download the new packages
3. `yarn start` to boot up UI with mock data
4. Click around to ensure all icons are looking as expected!


## Additional Notes
`flight-icons` currently doesn't have any animated icons, so our `loading` spinner is not present. There's [discussion](https://github.com/hashicorp/flight/issues/282) about adding it that's picked up in recent days, so I imagine this will be added soon but I'm not planning on holding this PR back any longer since it's just 1 icon left.

## Screenshots
### Deployments Page
<img width="1438" alt="Screen Shot 2021-12-08 at 3 40 06 PM" src="https://user-images.githubusercontent.com/60155296/145282835-47bf5bb3-5bb2-4a05-87ec-608c6be64b40.png">

### Auth Page
<img width="1440" alt="Screen Shot 2021-12-08 at 3 51 04 PM" src="https://user-images.githubusercontent.com/60155296/145282878-86b5209e-253a-40d1-860f-4437c87693e6.png">


_As of making this PR, the method for altering the colors of the icons in `Flight` requires altering the `use` element instead of `path`. This also seems to prevent us from changing the stroke width. Feedback on how we could change the stroke width would be helpful (since I'm pretty sure it was thinner before)_
