### PR TITLE
website: document workspace/label scoping for app config

### DIFF
--- a/website/content/docs/app-config/scope.mdx
+++ b/website/content/docs/app-config/scope.mdx
@@ -1,0 +1,133 @@
+---
+layout: docs
+page_title: Workspace and Label Scoping - Application Configuration
+description: |-
+  Waypoint allows you to set different configuration values for specific workspaces or labels. For example, you might set a database URL for staging different from production using workspaces, or you might use labels to set different addresses for different regions or any other metadata.
+---
+
+# Workspace and Label Scoping
+
+Waypoint allows you to set different configuration values for specific
+[workspaces](/docs/workspaces) or [labels](/docs/waypoint-hcl/variables/labels).
+For example, you might set a database URL for staging different from production
+using workspaces, or you might use labels to set different addresses for
+different regions or any other metadata.
+
+By default, Waypoint application configuration is exposed to the application
+in every scenario. By using the additional scoping constraints described in
+this document, you can limit what configuration values are set in what
+situations.
+
+## Workspace Scoping
+
+You can use workspace scoping to expose configuration only in specific,
+exact [workspaces](/docs/workspaces):
+
+```hcl
+config {
+  env = {
+    "DB_ADDR" = "dev.example.com"
+  }
+
+  workspace "production" {
+    env = {
+      "DB_ADDR" = "prod.example.com"
+    }
+  }
+}
+```
+
+In this example, the `DB_ADDR` environment variable will be set to
+"prod.example.com" only in the "production" workspace. Within the `workspace`
+stanza, you can use all available configuration parameters such as `env`,
+`internal`, `files`, etc.
+
+-> **Note:** Values aren't inherited from the global scope. For example, you
+cannot set an [internal variable](/docs/app-config/internal) at the root
+and access it within the `workspace` stanza. You must redeclare any internal
+variables used.
+
+### Non-Exact Workspace Matching
+
+The `workspace` stanza does not support non-exact workspace matching. However,
+you can use the `label` stanza documented below to do this. All workspaces
+automatically are exposed via the `waypoint/workspace` label and label
+selectors support
+[operators](https://www.consul.io/api-docs/features/filtering#matching-operators)
+such as `contains`, `matches`, etc. For example, you could match all workspaces
+that contain "dev" this way:
+
+```hcl
+config {
+  env = {
+    "DB_ADDR" = "dev.example.com"
+  }
+
+  label "waypoint/env contains \"dev\"" {
+    env = {
+      "DB_ADDR" = "prod.example.com"
+    }
+  }
+}
+```
+
+## Label Scoping
+
+You can use the `label` stanza to expose configuration only in specific
+label contexts:
+
+```hcl
+config {
+  env = {
+    "DB_ADDR" = "dev.example.com"
+  }
+
+  label "env == production and region == us-east-1" {
+    env = {
+      "DB_ADDR" = "prod.example.com"
+    }
+  }
+}
+```
+
+This will only expose the "prod.example.com" value for the `DB_ADDR`
+environment variable if the labels of the deployment match the given
+selector.
+
+~> **Warning!** This is an advanced use case. Most cases can be satisfied
+using the `workspace` stanza which is much simpler to understand and debug.
+Under the covers, the `workspace` stanza is functionally equivalent to a
+label selector of `waypoint/workspace == <name>`.
+
+## Inheritence
+
+Based on the structural syntax of workspace and label selectors, it
+may appear that there is some ability to reference or inherit "parent"
+configuration values, such as [internal values](/docs/app-config/internal).
+**This is not possible.**
+
+For example, given the following configuration:
+
+```hcl
+config {
+  internal = {
+    "db_host" = "example.com"
+  }
+
+  env = {
+    "DB_ADDR" = "dev@${config.internal.db_host}"
+  }
+
+  workspace "production" {
+    # THIS DOES NOT WORK!
+    env = {
+      "DB_ADDR" = "prod@${config.internal.db_host}"
+    }
+  }
+}
+```
+
+This does not work. The environment variable value inside the `workspace`
+stanza does not have access to the internal variables in the root `config`
+stanza. Any `workspace` or `label` stanzas must redeclare internal variables
+that are commonly used.

--- a/website/content/docs/app-config/scope.mdx
+++ b/website/content/docs/app-config/scope.mdx
@@ -99,7 +99,7 @@ using the `workspace` stanza which is much simpler to understand and debug.
 Under the covers, the `workspace` stanza is functionally equivalent to a
 label selector of `waypoint/workspace == <name>`.
 
-## Inheritence
+## Inheritance
 
 Based on the structural syntax of workspace and label selectors, it
 may appear that there is some ability to reference or inherit "parent"

--- a/website/content/docs/app-config/scope.mdx
+++ b/website/content/docs/app-config/scope.mdx
@@ -53,7 +53,7 @@ The `workspace` stanza does not support non-exact workspace matching. However,
 you can use the `label` stanza documented below to do this. All workspaces
 automatically are exposed via the `waypoint/workspace` label and label
 selectors support
-[operators](https://www.consul.io/api-docs/features/filtering#matching-operators)
+[Consul style matching operators](https://www.consul.io/api-docs/features/filtering#matching-operators)
 such as `contains`, `matches`, etc. For example, you could match all workspaces
 that contain "dev" this way:
 

--- a/website/content/docs/app-config/scope.mdx
+++ b/website/content/docs/app-config/scope.mdx
@@ -63,7 +63,7 @@ config {
     "DB_ADDR" = "dev.example.com"
   }
 
-  label "waypoint/env contains \"dev\"" {
+  label "waypoint/workspace contains \"dev\"" {
     env = {
       "DB_ADDR" = "prod.example.com"
     }

--- a/website/content/docs/waypoint-hcl/config.mdx
+++ b/website/content/docs/waypoint-hcl/config.mdx
@@ -53,6 +53,13 @@ app "frontend" {
 }
 ```
 
+### Further Scoping: Workspaces and Labels
+
+In both the project and app scope, a configuration can be further scoped
+to only exist in a specific workspace or label set for a deployment.
+For more information, see the
+[workspace and label-scoping documentation](/docs/app-config/scope).
+
 ## Syncing
 
 Changes to `config` in the `waypoint.hcl` file take effect only during
@@ -95,6 +102,14 @@ changed.
   these values may be referenced using `config.internal.NAME` within `env`
   values or `file` values. See the
   [internal values documentation](/docs/app-config/internal) for more information.
+
+- `workspace` <code>([config](#config-parameters))</code> - Define
+  [workspace-scoped configuration](/docs/app-config/scope#workspace-scoping).
+  The label for the stanza is the name of a workspace to exactly match.
+
+- `label` <code>([config](#config-parameters))</code> - Define
+  [label-scoped configuration](/docs/app-config/scope#label-scoping).
+  The label for the stanza is a label selector.
 
 ## `ConfigValue`
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -310,6 +310,10 @@
       {
         "title": "Internal Values",
         "path": "app-config/internal"
+      },
+      {
+        "title": "Workspace and Label Scoping",
+        "path": "app-config/scope"
       }
     ]
   },


### PR DESCRIPTION
This adds documentation for workspace and label scopes for application configuration that was introduced in Waypoint 0.6.