### PR TITLE
support arm64 for the entrypoint, inject properly

### DIFF
--- a/.changelog/2692.txt
+++ b/.changelog/2692.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+plugin/docker: inject `arm64` Waypoint entrypoints for arm images
+```
+
+```release-note:improvement
+plugin/pack: detect non-Intel Docker server and show a warning
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 tmp/
 
 # Repo-specific
@@ -14,6 +15,5 @@ tmp/
 data.db
 
 # .vscode - We intentionally commit .vscode in order to share project-specific settings
-
 
 .idea

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ THIS_RELEASE?=$$(git rev-parse --abbrev-ref HEAD)
 .PHONY: bin
 bin: # bin creates the binaries for Waypoint for the current platform
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./internal/assets/ceb/ceb-arm64 ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
 
@@ -26,12 +27,14 @@ bin/cli-only: # bin/cli-only only recompiles waypoint
 .PHONY: bin/linux
 bin/linux: # bin creates the binaries for Waypoint for the linux platform
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./internal/assets/ceb/ceb-arm64 ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	GOOS=linux CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
 
 .PHONY: bin/windows
 bin/windows: # create windows binaries
-	GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./internal/assets/ceb/ceb-arm64 ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint.exe ./cmd/waypoint
 

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -313,15 +313,30 @@ func (b *Builder) Build(
 		return nil, err
 	}
 
+	// We need to determine the image architecture to inject the correct CEB.
+	// And we output our image architecture anyways.
+	inspect, _, err := cli.ImageInspectWithRaw(ctx, result.Name())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"error inspecting image: %s", err)
+	}
+
 	if !b.config.DisableCEB {
 		step = sg.Add("Injecting Waypoint Entrypoint...")
 
-		asset, err := assets.Asset("ceb/ceb")
+		assetName, ok := assets.CEBArch[strings.ToLower(inspect.Architecture)]
+		if !ok {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"Automatic Waypoint entrypoint injection only supports amd64 and arm64 "+
+					"image architectures. Got: %s", inspect.Architecture)
+		}
+
+		asset, err := assets.Asset(assetName)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
 		}
 
-		assetInfo, err := assets.AssetInfo("ceb/ceb")
+		assetInfo, err := assets.AssetInfo(assetName)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to restore custom entry point binary: %s", err)
 		}
@@ -347,6 +362,13 @@ func (b *Builder) Build(
 
 		step.Done()
 	}
+
+	// Complete the stepgroup and output our info. We output the architecture
+	// since a common mistake especially with newer Macs is that someone on
+	// Apple Silicon will try to deploy to Intel.
+	sg.Wait()
+	ui.Output("Image built: %s (%s)", result.Name(), inspect.Architecture,
+		terminal.WithSuccessStyle())
 
 	return result, nil
 }

--- a/internal/assets/.gitignore
+++ b/internal/assets/.gitignore
@@ -1,2 +1,3 @@
 ceb/ceb
+ceb/ceb-arm64
 prod.go

--- a/internal/assets/ceb.go
+++ b/internal/assets/ceb.go
@@ -9,5 +9,6 @@ var CEBArch = map[string]string{
 	// Docker sometimes uses "aarch64" and sometimes uses "arm64". I don't know
 	// why it switches between the two or when but our arm64 build works on
 	// both.
+	"x86_64":  "ceb/ceb",
 	"aarch64": "ceb/ceb-arm64",
 }

--- a/internal/assets/ceb.go
+++ b/internal/assets/ceb.go
@@ -1,0 +1,13 @@
+package assets
+
+// CEBArch contains the asset name by architecture. The OS is always
+// assumed to be "Linux".
+var CEBArch = map[string]string{
+	"amd64": "ceb/ceb",
+	"arm64": "ceb/ceb-arm64",
+
+	// Docker sometimes uses "aarch64" and sometimes uses "arm64". I don't know
+	// why it switches between the two or when but our arm64 build works on
+	// both.
+	"aarch64": "ceb/ceb-arm64",
+}


### PR DESCRIPTION
This adds a `linux/arm64` entrypoint asset to our Waypoint binary. This
increases binary size by ~30% but I think this is worthwhile as more of
the world's dev and deployment machines move to arm64.

This makes it so that Docker entrypoint injection injects the entrypoint
binary that matches the architecture and errors if it detects an
unsupported architecture.

This also adds detection for cloud native buildpacks to warn if the
Docker daemon isn't x86_64 since Buildpacks currently have issues with
arm64.

This also changes the Docker build to output the image architecture
since @jgwhite has built and deployed mismatching architecutures
many times.

Going to target this for backporting.