### PR TITLE
ui: add git commit mock data to mirage

### DIFF
--- a/ui/mirage/factories/build.ts
+++ b/ui/mirage/factories/build.ts
@@ -5,6 +5,29 @@ export default Factory.extend({
   id: () => fakeId(),
   sequence: (i) => i + 1,
 
+  /**
+   * `gitCommitRef` is a shorthand for setting the commit SHA for this build.
+   * Provide a value here and it will appear in the `preload` field for the
+   * build, wrapped in a `Job.DataSource.Ref` protobuf containing a
+   * `Job.Git.Ref` protobuf.
+   *
+   * @example
+   * let build = server.create('build', { gitCommitRef: 'abc123' });
+   * console.log(build.toProtobuf().toObject());
+   * {
+   *   preload: {
+   *     jobDataSourceRef: {
+   *       git: {
+   *         commit: 'abc123'
+   *       }
+   *     }
+   *   }
+   * }
+   *
+   * @type {string | undefined}
+   */
+  gitCommitRef: undefined,
+
   afterCreate(build, server) {
     if (!build.workspace) {
       let workspace =
@@ -21,6 +44,7 @@ export default Factory.extend({
       'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
       'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
     }),
+    gitCommitRef: '0d56a9f8456b088dd0e4a7b689b842876fd47352',
     component: association('builder', 'with-random-name'),
     status: association('random'),
     pushedArtifact: association('random'),

--- a/ui/mirage/factories/deployment.ts
+++ b/ui/mirage/factories/deployment.ts
@@ -5,6 +5,31 @@ export default Factory.extend({
   id: () => fakeId(),
   sequence: (i) => i + 1,
 
+  /**
+   * `gitCommitRef` is a shorthand for setting the commit SHA for this
+   * deployment.  Provide a value here and it will appear in the `preload` field
+   * for the deployment, wrapped in a `Job.DataSource.Ref` protobuf containing a
+   * `Job.Git.Ref` protobuf. Additionally, it will appear in the
+   * `UI.DeploymentBundle` protobuf when fetching this data via
+   * `UI_ListDeployments`.
+   *
+   * @example
+   * let deployment = server.create('deployment', { gitCommitRef: 'abc123' });
+   * console.log(deployment.toProtobuf().toObject());
+   * {
+   *   preload: {
+   *     jobDataSourceRef: {
+   *       git: {
+   *         commit: 'abc123'
+   *       }
+   *     }
+   *   }
+   * }
+   *
+   * @type {string | undefined}
+   */
+  gitCommitRef: undefined,
+
   afterCreate(deployment, server) {
     if (!deployment.workspace) {
       let workspace =
@@ -21,6 +46,7 @@ export default Factory.extend({
       'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
       'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
     }),
+    gitCommitRef: '0d56a9f8456b088dd0e4a7b689b842876fd47352',
 
     afterCreate(deployment) {
       let url = `https://wildly-intent-honeybee--v${deployment.sequence}.waypoint.run`;

--- a/ui/mirage/models/build.ts
+++ b/ui/mirage/models/build.ts
@@ -1,5 +1,5 @@
 import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
-import { Build } from 'waypoint-pb';
+import { Build, Job } from 'waypoint-pb';
 
 export default Model.extend({
   application: belongsTo(),
@@ -18,6 +18,7 @@ export default Model.extend({
     result.setComponent(this.component?.toProtobuf());
     result.setId(this.id);
     result.setJobId(this.JobId);
+    result.setPreload(this.preloadProtobuf());
     result.setSequence(this.sequence);
     result.setStatus(this.status?.toProtobuf());
     result.setTemplateData(this.templateData);
@@ -25,6 +26,22 @@ export default Model.extend({
 
     for (let [key, value] of Object.entries<string>(this.labels ?? {})) {
       result.getLabelsMap().set(key, value);
+    }
+
+    return result;
+  },
+
+  preloadProtobuf(): Build.Preload {
+    let result = new Build.Preload();
+
+    if (this.gitCommitRef) {
+      let dataSourceRef = new Job.DataSource.Ref();
+      let gitRef = new Job.Git.Ref();
+
+      gitRef.setCommit(this.gitCommitRef);
+      dataSourceRef.setGit(gitRef);
+
+      result.setJobDataSourceRef(dataSourceRef);
     }
 
     return result;

--- a/ui/mirage/models/deployment.ts
+++ b/ui/mirage/models/deployment.ts
@@ -1,5 +1,5 @@
 import { Model, belongsTo } from 'ember-cli-mirage';
-import { Deployment, Operation } from 'waypoint-pb';
+import { Deployment, Operation, Job } from 'waypoint-pb';
 
 const { PhysicalState } = Operation;
 type StateName = keyof typeof PhysicalState;
@@ -45,6 +45,16 @@ export default Model.extend({
     result.setArtifact(this.build?.pushedArtifact?.toProtobuf());
     result.setBuild(this.build?.toProtobuf());
     result.setDeployUrl(this.deployUrl);
+
+    if (this.gitCommitRef) {
+      let dataSourceRef = new Job.DataSource.Ref();
+      let gitRef = new Job.Git.Ref();
+
+      gitRef.setCommit(this.gitCommitRef);
+      dataSourceRef.setGit(gitRef);
+
+      result.setJobDataSourceRef(dataSourceRef);
+    }
 
     return result;
   },

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -1,4 +1,4 @@
-import { GetDeploymentRequest, ListDeploymentsRequest, ListDeploymentsResponse, UI } from 'waypoint-pb';
+import { GetDeploymentRequest, Job, ListDeploymentsRequest, ListDeploymentsResponse, UI } from 'waypoint-pb';
 import { RouteHandler, Request, Response } from 'ember-cli-mirage';
 import { decode } from '../helpers/protobufs';
 
@@ -42,7 +42,16 @@ export function ui_list(this: RouteHandler, schema: any, { requestBody }: Reques
     bundle.setBuild(deployment.build?.toProtobuf());
     bundle.setDeployUrl(deployment.deployUrl);
     bundle.setLatestStatusReport(deployment.statusReport?.toProtobuf());
-    // TODO(jgwhite): bundle.setJobDataSourceRef
+
+    if (deployment.gitCommitRef) {
+      let dataSourceRef = new Job.DataSource.Ref();
+      let gitRef = new Job.Git.Ref();
+
+      gitRef.setCommit(this.gitCommitRef);
+      dataSourceRef.setGit(gitRef);
+
+      bundle.setJobDataSourceRef(dataSourceRef);
+    }
 
     return bundle;
   });


### PR DESCRIPTION
## Why the change?

Closes #2680

## Any other notes?

This is cheap-and-cheerful solution, and an example of where I think it’s worth cutting corners in Mirage. A full-fidelity solution would include modeling and simulating `Job`, which is one of the largest and most complex protobufs in the system, and therefore more work than is currently justified (in my opinion). As we push further into introspecting data about jobs, I’m pretty confident the situation the time to dive into simulating Job will clearly present itself.

## How do I test it?

I would try adding/changing git commit SHAs in our default scenario data, to see if you can get them to show up in the UI.