### PR TITLE
Handle both unauthenticated error messages

### DIFF
--- a/.changelog/2696.txt
+++ b/.changelog/2696.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix edge case issue where users would not be redirected to the authentication screen if no api token was set
+```

--- a/ui/app/routes/application.ts
+++ b/ui/app/routes/application.ts
@@ -6,6 +6,10 @@ import { inject as service } from '@ember/service';
 
 const ErrsInvalidToken = ['invalid authentication token', 'Authorization token is not supplied'];
 
+interface ApiError extends Error {
+  code: number;
+}
+
 export default class Application extends Route {
   @service session!: SessionService;
 
@@ -18,15 +22,9 @@ export default class Application extends Route {
   }
 
   @action
-  error(error: Error): boolean | void {
+  error(error: ApiError): boolean | void {
     console.log(error);
-    let hasAuthError = false;
-    ErrsInvalidToken.forEach((msg) => {
-      if (error.message.includes(msg)) {
-        hasAuthError = true;
-      }
-    });
-
+    let hasAuthError = ErrsInvalidToken.some((msg) => error.message.includes(msg)) || error.code === 16;
     if (hasAuthError) {
       this.session.invalidate();
       this.transitionTo('auth');

--- a/ui/app/routes/application.ts
+++ b/ui/app/routes/application.ts
@@ -4,7 +4,7 @@ import Transition from '@ember/routing/-private/transition';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-const ErrInvalidToken = 'invalid authentication token';
+const ErrsInvalidToken = ['invalid authentication token', 'Authorization token is not supplied'];
 
 export default class Application extends Route {
   @service session!: SessionService;
@@ -20,8 +20,14 @@ export default class Application extends Route {
   @action
   error(error: Error): boolean | void {
     console.log(error);
+    let hasAuthError = false;
+    ErrsInvalidToken.forEach((msg) => {
+      if (error.message.includes(msg)) {
+        hasAuthError = true;
+      }
+    });
 
-    if (error.message.includes(ErrInvalidToken)) {
+    if (hasAuthError) {
       this.session.invalidate();
       this.transitionTo('auth');
     }

--- a/ui/tests/acceptance/auth-test.ts
+++ b/ui/tests/acceptance/auth-test.ts
@@ -1,0 +1,22 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import login from 'waypoint/tests/helpers/login';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | auth', function (hooks: NestedHooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('redirects to /auth from authenticated routes when logged out', async function (assert) {
+    await visit(`/default`);
+    assert.equal(currentURL(), `/auth`);
+  });
+
+  test('does not redirect to /auth from authenticated routes when logged in', async function (assert) {
+    await login();
+    await visit(`/default`);
+    assert.equal(currentURL(), `/default`);
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/waypoint/issues/2695 

In summary: 
- the error message on an unauthenticated request changed to `Authorization token is not supplied`
- the error handler that would invalidate the session wasn't firing

This PR also adds an auth acceptance test, just cause that's nice to have