### PR TITLE
serverinstall/nomad: Spend more time looking at waypoint-runner allocation on install to ensure start up

### DIFF
--- a/.changelog/2698.txt
+++ b/.changelog/2698.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+install/nomad: Ensure static runner has started during install by validating its
+running status for a few seconds once it is in a "running" state.
+```

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -345,7 +345,7 @@ func (b *Builder) Build(
 	}
 
 	// We need to test if we're running in arm64 for the Docker server.
-	// Buildpacks has issues with arm64: https://github.com/buildpacks/pack/issues/907
+	// Buildpacks have issues with arm64: https://github.com/buildpacks/pack/issues/907
 	// We just do a warning in case buildpacks support arm64 and magically
 	// work later.
 	serverInfo, err := dockerClient.Info(ctx)

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -410,6 +410,7 @@ func (i *NomadInstaller) Upgrade(
 	s.Update("Waiting for allocation to be scheduled")
 	qopts := &api.QueryOptions{
 		WaitIndex: resp.EvalCreateIndex,
+		WaitTime:  time.Duration(500 * time.Millisecond),
 	}
 
 	eval, meta, err := i.waitForEvaluation(ctx, s, client, resp, qopts)
@@ -750,6 +751,7 @@ func (i *NomadInstaller) runJob(
 	s.Update("Waiting for allocation to be scheduled")
 	qopts := &api.QueryOptions{
 		WaitIndex: resp.EvalCreateIndex,
+		WaitTime:  time.Duration(500 * time.Millisecond),
 	}
 
 	eval, meta, err := i.waitForEvaluation(ctx, s, client, resp, qopts)


### PR DESCRIPTION
Prior to this commit, the server install command would look for the very
first instance for when an allocation was considered running. This is
generally ok, however if the Nomad job fails to get started a moment
later (like a static runner failing to connect back to Waypoint Server),
the runner allocation would exit later but the server install command
would consider the installation successful.

This is especially important when users are configuring Consul DNS
with Waypoint Server installed to Nomad. The static runner might
fail to properly make a connection through the Consul DNS hostname
and fail, leaving the installation without a static runner but the CLI claiming
the install succeeded.

This commit fixes that by doing a few retries for a few seconds on the scheduled
allocation once its in a "running" state to validate it properly started
up beyond the first few moments of the job.

Fixes #2683