### PR TITLE
Introduce workspace and label scoping into the waypoint.hcl file

### DIFF
--- a/.changelog/2699.txt
+++ b/.changelog/2699.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+**Workspace and Label-scoped Configuration:** Build, registry, deploy, and
+release configurations can now be changed depending on the current workspace
+or label sets. This can be used to alter configurations between environments
+(staging, production, etc.) or metadata (region, etc.).
+```

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -200,9 +200,20 @@ func (c *App) Registry(ctx *hcl.EvalContext) (*Registry, error) {
 		return nil, nil
 	}
 
+	body := c.BuildRaw.Registry.Body
+	scope, err := scopeMatchStage(ctx,
+		c.BuildRaw.Registry.WorkspaceScoped,
+		c.BuildRaw.Registry.LabelScoped)
+	if err != nil {
+		return nil, err
+	}
+	if scope != nil {
+		body = scope.Body
+	}
+
 	var b Registry
 	ctx = appendContext(c.ctx, ctx)
-	if diag := gohcl.DecodeBody(c.BuildRaw.Registry.Body, finalizeContext(ctx), &b); diag.HasErrors() {
+	if diag := gohcl.DecodeBody(body, finalizeContext(ctx), &b); diag.HasErrors() {
 		return nil, diag
 	}
 	b.ctx = ctx
@@ -214,8 +225,17 @@ func (c *App) Registry(ctx *hcl.EvalContext) (*Registry, error) {
 func (c *App) Deploy(ctx *hcl.EvalContext) (*Deploy, error) {
 	ctx = appendContext(c.ctx, ctx)
 
+	body := c.DeployRaw.Body
+	scope, err := scopeMatchStage(ctx, c.DeployRaw.WorkspaceScoped, c.DeployRaw.LabelScoped)
+	if err != nil {
+		return nil, err
+	}
+	if scope != nil {
+		body = scope.Body
+	}
+
 	var b Deploy
-	if diag := gohcl.DecodeBody(c.DeployRaw.Body, finalizeContext(ctx), &b); diag.HasErrors() {
+	if diag := gohcl.DecodeBody(body, finalizeContext(ctx), &b); diag.HasErrors() {
 		return nil, diag
 	}
 	b.ctx = ctx
@@ -229,9 +249,18 @@ func (c *App) Release(ctx *hcl.EvalContext) (*Release, error) {
 		return nil, nil
 	}
 
+	body := c.ReleaseRaw.Body
+	scope, err := scopeMatchStage(ctx, c.ReleaseRaw.WorkspaceScoped, c.ReleaseRaw.LabelScoped)
+	if err != nil {
+		return nil, err
+	}
+	if scope != nil {
+		body = scope.Body
+	}
+
 	var b Release
 	ctx = appendContext(c.ctx, ctx)
-	if diag := gohcl.DecodeBody(c.ReleaseRaw.Body, finalizeContext(ctx), &b); diag.HasErrors() {
+	if diag := gohcl.DecodeBody(body, finalizeContext(ctx), &b); diag.HasErrors() {
 		return nil, diag
 	}
 	b.ctx = ctx
@@ -240,39 +269,75 @@ func (c *App) Release(ctx *hcl.EvalContext) (*Release, error) {
 }
 
 // BuildUse returns the plugin "use" value.
-func (c *App) BuildUse() string {
+func (c *App) BuildUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil {
-		return ""
+		return "", nil
 	}
 
-	return c.BuildRaw.Use.Type
+	useType := c.BuildRaw.Use.Type
+	stage, err := scopeMatchStage(ctx, c.BuildRaw.WorkspaceScoped, c.BuildRaw.LabelScoped)
+	if err != nil {
+		return "", err
+	}
+	if stage != nil {
+		useType = stage.Use.Type
+	}
+
+	return useType, nil
 }
 
 // RegistryUse returns the plugin "use" value.
-func (c *App) RegistryUse() string {
+func (c *App) RegistryUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil || c.BuildRaw.Registry == nil {
-		return ""
+		return "", nil
 	}
 
-	return c.BuildRaw.Registry.Use.Type
+	useType := c.BuildRaw.Registry.Use.Type
+	stage, err := scopeMatchStage(ctx, c.BuildRaw.Registry.WorkspaceScoped, c.BuildRaw.Registry.LabelScoped)
+	if err != nil {
+		return "", err
+	}
+	if stage != nil {
+		useType = stage.Use.Type
+	}
+
+	return useType, nil
 }
 
 // DeployUse returns the plugin "use" value.
-func (c *App) DeployUse() string {
+func (c *App) DeployUse(ctx *hcl.EvalContext) (string, error) {
 	if c.DeployRaw == nil {
-		return ""
+		return "", nil
 	}
 
-	return c.DeployRaw.Use.Type
+	useType := c.DeployRaw.Use.Type
+	stage, err := scopeMatchStage(ctx, c.DeployRaw.WorkspaceScoped, c.DeployRaw.LabelScoped)
+	if err != nil {
+		return "", err
+	}
+	if stage != nil {
+		useType = stage.Use.Type
+	}
+
+	return useType, nil
 }
 
 // ReleaseUse returns the plugin "use" value.
-func (c *App) ReleaseUse() string {
+func (c *App) ReleaseUse(ctx *hcl.EvalContext) (string, error) {
 	if c.ReleaseRaw == nil {
-		return ""
+		return "", nil
 	}
 
-	return c.ReleaseRaw.Use.Type
+	useType := c.ReleaseRaw.Use.Type
+	stage, err := scopeMatchStage(ctx, c.ReleaseRaw.WorkspaceScoped, c.ReleaseRaw.LabelScoped)
+	if err != nil {
+		return "", err
+	}
+	if stage != nil {
+		useType = stage.Use.Type
+	}
+
+	return useType, nil
 }
 
 // BuildLabels returns the labels for this stage.

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -385,9 +385,6 @@ func scopeMatchStage(
 				return s, nil
 			}
 		}
-
-		// No match
-		return nil, nil
 	}
 
 	// Label selector matching.

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -451,6 +452,14 @@ func scopeMatchStage(
 			}
 		}
 	}
+
+	// For label selectors, we want to sort by scope length so that
+	// the longest label selectors match first. This is our rule for
+	// tiebreaking.
+	sort.Slice(labelScopes, func(i, j int) bool {
+		x, y := labelScopes[i], labelScopes[j]
+		return len(x.Scope) > len(y.Scope)
+	})
 
 	// Label selector matching.
 	for _, s := range labelScopes {

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -152,6 +152,24 @@ func TestConfigApp_compare(t *testing.T) {
 		},
 
 		{
+			"build_registry_scoped.hcl",
+			"test",
+			func(t *testing.T, c *App) {
+				// Default
+				b, err := c.Registry(nil)
+				require.NoError(t, err)
+				require.Equal(t, "A", b.Use.Type)
+
+				// Production workspace
+				b, err = c.Registry(labelsCtx(map[string]string{
+					"waypoint/workspace": "production",
+				}))
+				require.NoError(t, err)
+				require.Equal(t, "B", b.Use.Type)
+			},
+		},
+
+		{
 			"config_env.hcl",
 			"test",
 			func(t *testing.T, c *App) {

--- a/internal/config/app_test.go
+++ b/internal/config/app_test.go
@@ -110,6 +110,13 @@ func TestConfigApp_compare(t *testing.T) {
 				}))
 				require.NoError(t, err)
 				require.Equal(t, "A", b.Use.Type)
+
+				// Labels
+				b, err = c.Build(labelsCtx(map[string]string{
+					"waypoint/workspace": "staging",
+				}))
+				require.NoError(t, err)
+				require.Equal(t, "C", b.Use.Type)
 			},
 		},
 

--- a/internal/config/stages.go
+++ b/internal/config/stages.go
@@ -8,6 +8,12 @@ type hclStage struct {
 	Use    *Use     `hcl:"use,block"`
 	Body   hcl.Body `hcl:",body"`
 	Remain hcl.Body `hcl:",remain"`
+
+	// WorkspaceScoped are workspace-scoped stages.
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+
+	// LabelScoped are label-selector-scoped stages.
+	LabelScoped []*scopedStage `hcl:"label,block"`
 }
 
 type hclBuild struct {
@@ -15,6 +21,24 @@ type hclBuild struct {
 	Use      *Use      `hcl:"use,block"`
 	Body     hcl.Body  `hcl:",body"`
 	Remain   hcl.Body  `hcl:",remain"`
+
+	// WorkspaceScoped are workspace-scoped stages.
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+
+	// LabelScoped are label-selector-scoped stages.
+	LabelScoped []*scopedStage `hcl:"label,block"`
+}
+
+// scopedStage is used within hclStage for workspace/label scoping.
+type scopedStage struct {
+	// Scope is the label for the block. This is reused for both workspace
+	// and label scoped variables so this could be either of those.
+	Scope string `hcl:",label"`
+
+	// Same as hclStage
+	Use    *Use     `hcl:"use,block"`
+	Body   hcl.Body `hcl:",body"`
+	Remain hcl.Body `hcl:",remain"`
 }
 
 // Build are the build settings.
@@ -27,6 +51,12 @@ type Build struct {
 	// Instead, use App.Registry().
 	Registry *Registry `hcl:"registry,block"`
 
+	// Unused for practical reasons, but we need this here so that
+	// the decoding validates successfully (HCL doesn't error of
+	// unexpected things).
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+	LabelScoped     []*scopedStage `hcl:"label,block"`
+
 	ctx *hcl.EvalContext
 }
 
@@ -35,6 +65,10 @@ type Registry struct {
 	Labels map[string]string `hcl:"labels,optional"`
 	Hooks  []*Hook           `hcl:"hook,block"`
 	Use    *Use              `hcl:"use,block"`
+
+	// Unused, see Build
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+	LabelScoped     []*scopedStage `hcl:"label,block"`
 
 	ctx *hcl.EvalContext
 }
@@ -45,6 +79,10 @@ type Deploy struct {
 	Hooks  []*Hook           `hcl:"hook,block"`
 	Use    *Use              `hcl:"use,block"`
 
+	// Unused, see Build
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+	LabelScoped     []*scopedStage `hcl:"label,block"`
+
 	ctx *hcl.EvalContext
 }
 
@@ -53,6 +91,10 @@ type Release struct {
 	Labels map[string]string `hcl:"labels,optional"`
 	Hooks  []*Hook           `hcl:"hook,block"`
 	Use    *Use              `hcl:"use,block"`
+
+	// Unused, see Build
+	WorkspaceScoped []*scopedStage `hcl:"workspace,block"`
+	LabelScoped     []*scopedStage `hcl:"label,block"`
 
 	ctx *hcl.EvalContext
 }

--- a/internal/config/testdata/compare/build_registry_scoped.hcl
+++ b/internal/config/testdata/compare/build_registry_scoped.hcl
@@ -1,0 +1,19 @@
+project = "foo"
+
+app "test" {
+    build {
+        labels = {
+            "foo" = "bar"
+        }
+
+        use "docker" {}
+
+        registry {
+          use "A" {}
+
+          workspace "production" {
+            use "B" {}
+          }
+        }
+    }
+}

--- a/internal/config/testdata/compare/build_scoped.hcl
+++ b/internal/config/testdata/compare/build_scoped.hcl
@@ -1,0 +1,15 @@
+project = "foo"
+
+app "test" {
+    build {
+        labels = {
+            "foo" = "bar"
+        }
+
+        use "A" {}
+
+        workspace "production" {
+          use "B" {}
+        }
+    }
+}

--- a/internal/config/testdata/compare/build_scoped.hcl
+++ b/internal/config/testdata/compare/build_scoped.hcl
@@ -11,5 +11,9 @@ app "test" {
         workspace "production" {
           use "B" {}
         }
+
+        label "waypoint/workspace == staging" {
+          use "C" {}
+        }
     }
 }

--- a/internal/config/testdata/validate/build_no_use.hcl
+++ b/internal/config/testdata/validate/build_no_use.hcl
@@ -1,0 +1,7 @@
+project = "foo"
+
+app "foo" {
+    build {}
+
+    deploy {}
+}

--- a/internal/config/testdata/validate/build_scoped.hcl
+++ b/internal/config/testdata/validate/build_scoped.hcl
@@ -1,0 +1,13 @@
+project = "foo"
+
+app "foo" {
+    build {
+        workspace "foo" {
+            use "docker" {}
+        }
+
+        label "bar" {}
+    }
+
+    deploy {}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -154,12 +154,46 @@ func (c *App) Validate() error {
 
 	if c.BuildRaw == nil || c.BuildRaw.Use == nil || c.BuildRaw.Use.Type == "" {
 		result = multierror.Append(result, fmt.Errorf(
-			"build stage with a 'use' stanza is required"))
+			"build stage with a default 'use' stanza is required"))
 	}
 
 	if c.DeployRaw == nil || c.DeployRaw.Use == nil || c.DeployRaw.Use.Type == "" {
 		result = multierror.Append(result, fmt.Errorf(
-			"deploy stage with a 'use' stanza is required"))
+			"deploy stage with a default 'use' stanza is required"))
+	}
+
+	for _, scope := range c.BuildRaw.WorkspaceScoped {
+		if scope.Use == nil || scope.Use.Type == "" {
+			result = multierror.Append(result, fmt.Errorf(
+				"build: workspace scope %q: 'use' stanza is required",
+				scope.Scope,
+			))
+		}
+	}
+	for _, scope := range c.BuildRaw.LabelScoped {
+		if scope.Use == nil || scope.Use.Type == "" {
+			result = multierror.Append(result, fmt.Errorf(
+				"build: label scope %q: 'use' stanza is required",
+				scope.Scope,
+			))
+		}
+	}
+
+	for _, scope := range c.DeployRaw.WorkspaceScoped {
+		if scope.Use == nil || scope.Use.Type == "" {
+			result = multierror.Append(result, fmt.Errorf(
+				"deploy: workspace scope %q: 'use' stanza is required",
+				scope.Scope,
+			))
+		}
+	}
+	for _, scope := range c.DeployRaw.LabelScoped {
+		if scope.Use == nil || scope.Use.Type == "" {
+			result = multierror.Append(result, fmt.Errorf(
+				"deploy: label scope %q: 'use' stanza is required",
+				scope.Scope,
+			))
+		}
 	}
 
 	return result

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -20,6 +20,12 @@ func TestConfigValidate(t *testing.T) {
 			"no_build.hcl",
 			"'build' stanza",
 		},
+
+		// This isn't an error because we want to catch this at runtime.
+		{
+			"build_no_use.hcl",
+			"",
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -26,6 +26,11 @@ func TestConfigValidate(t *testing.T) {
 			"build_no_use.hcl",
 			"",
 		},
+
+		{
+			"build_scoped.hcl",
+			"",
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -54,7 +54,7 @@ func (a *App) Build(ctx context.Context, optFuncs ...BuildOption) (
 	_, msg, err := a.doOperation(ctx, a.logger.Named("build"), &buildOperation{
 		Component:   c,
 		Registry:    cr,
-		HasRegistry: a.config.RegistryUse() != "",
+		HasRegistry: cr != nil,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/core/component_creator.go
+++ b/internal/core/component_creator.go
@@ -57,7 +57,7 @@ func (c *Component) Close() error {
 // for a given application.
 type componentCreator struct {
 	Type       component.Type
-	UseType    func(*App) (string, error)
+	UseType    func(*App, *hcl.EvalContext) (string, error)
 	ConfigFunc func(*App, *hcl.EvalContext) (interface{}, error)
 
 	// Labels should return the labels defined for this component. This is
@@ -71,8 +71,8 @@ type componentCreator struct {
 var componentCreatorMap = map[component.Type]*componentCreator{
 	component.BuilderType: {
 		Type: component.BuilderType,
-		UseType: func(a *App) (string, error) {
-			return a.config.BuildUse(), nil
+		UseType: func(a *App, ctx *hcl.EvalContext) (string, error) {
+			return a.config.BuildUse(ctx)
 		},
 		Labels: func(a *App, ctx *hcl.EvalContext) (map[string]string, error) {
 			return a.config.BuildLabels(ctx)
@@ -84,8 +84,8 @@ var componentCreatorMap = map[component.Type]*componentCreator{
 
 	component.RegistryType: {
 		Type: component.RegistryType,
-		UseType: func(a *App) (string, error) {
-			return a.config.RegistryUse(), nil
+		UseType: func(a *App, ctx *hcl.EvalContext) (string, error) {
+			return a.config.RegistryUse(ctx)
 		},
 		Labels: func(a *App, ctx *hcl.EvalContext) (map[string]string, error) {
 			return a.config.RegistryLabels(ctx)
@@ -97,8 +97,8 @@ var componentCreatorMap = map[component.Type]*componentCreator{
 
 	component.PlatformType: {
 		Type: component.PlatformType,
-		UseType: func(a *App) (string, error) {
-			return a.config.DeployUse(), nil
+		UseType: func(a *App, ctx *hcl.EvalContext) (string, error) {
+			return a.config.DeployUse(ctx)
 		},
 		Labels: func(a *App, ctx *hcl.EvalContext) (map[string]string, error) {
 			return a.config.DeployLabels(ctx)
@@ -110,8 +110,8 @@ var componentCreatorMap = map[component.Type]*componentCreator{
 
 	component.ReleaseManagerType: {
 		Type: component.ReleaseManagerType,
-		UseType: func(a *App) (string, error) {
-			return a.config.ReleaseUse(), nil
+		UseType: func(a *App, ctx *hcl.EvalContext) (string, error) {
+			return a.config.ReleaseUse(ctx)
 		},
 		Labels: func(a *App, ctx *hcl.EvalContext) (map[string]string, error) {
 			return a.config.ReleaseLabels(ctx)
@@ -154,7 +154,7 @@ func (cc *componentCreator) create(
 		return nil, err
 	}
 
-	useType, err := cc.UseType(app)
+	useType, err := cc.UseType(app, hclCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/website/content/docs/lifecycle/scope.mdx
+++ b/website/content/docs/lifecycle/scope.mdx
@@ -137,6 +137,11 @@ workspaces, copying the entire configuration between the different stanzas
 will become error prone, aesthetically displeasing, and verbose. For
 single fields, you should use other features.
 
+-> **Important:** The `workspace` and `label` stanzas _do not_ inherit
+any values from the "default" stanza. You must respecify ALL configurations.
+(For example, you can't set the Kubernetes namespace in the default `deploy`
+stanza and then omit it in a `workspace`-scoped stanza; it must be duplicated).
+
 ### Map Lookup
 
 One option is to use a map lookup as a way to change behavior. For example,

--- a/website/content/docs/lifecycle/scope.mdx
+++ b/website/content/docs/lifecycle/scope.mdx
@@ -1,0 +1,161 @@
+---
+layout: docs
+page_title: 'Lifecycle: Workspace and Label Scoping'
+description: |-
+  You can specify alternate configurations for lifecycle operations based on the current workspace or labels. This can be used to change configurations between environments such as development, staging, production.
+---
+
+# Workspace and Label Scoping
+
+You can specify alternate configurations for lifecycle operations
+based on the current [workspace](/docs/workspaces) or
+[labels](/docs/lifecycle/labels). This can be used to change
+configurations between environments such as development, staging,
+production or by specific metadata like region.
+
+This documentation page will use the [deploy](/docs/lifecycle/deploy)
+operation for examples, but the scoping stanzas may be used by
+all lifecycle stages and is not limited to only the deploy stage.
+The basic example below will deploy to the "default" Kubernetes
+namespace no matter what workspace or set of labels are in use:
+
+```hcl
+app "my-app" {
+  deploy {
+    use "kubernetes" {}
+  }
+}
+```
+
+-> **Note:** Scoping is just one way to alter configuration depending
+on workspaces or labels. In particular, it is useful for
+_whole configuration_ differences: where the configuration is wholly different
+between workspaces or labels. For smaller differences, you may want to look
+at alternative methods such as conditionals. See
+[partial configuration changes](#partial-configuration-changes).
+
+## Workspace Scoping
+
+We can use [workspaces](/docs/workspaces) as one way to model environments
+such as staging, production, etc. And we might use multiple Kubernetes
+namespaces as a way to separate these stages. The example below uses
+the "default" namespace by default, but uses the "production" namespace
+if the workspace is also "production":
+
+```hcl
+app "my-app" {
+  deploy {
+    use "kubernetes" {}
+
+    workspace "production" {
+      use "kubernetes" {
+        namespace = "production"
+      }
+    }
+  }
+}
+```
+
+Note that we could go further and completely change the plugin in use as well.
+Perhaps we are testing a migration to [Nomad](https://www.nomadproject.io/)
+if we're in the "new-platform" workspace:
+
+```hcl
+app "my-app" {
+  deploy {
+    use "kubernetes" {}
+
+    workspace "production" {
+      use "kubernetes" {
+        namespace = "production"
+      }
+    }
+
+    workspace "new-platform" {
+      use "nomad" {
+        // nomad configuration here
+      }
+    }
+  }
+}
+```
+
+## Label Scoping
+
+The `label` stanza can be used to configure operations based on
+[label selectors](/docs/lifecycle/labels#label-selector-syntax).
+
+~> **Warning!** This is an advanced use case. Most cases can be satisfied
+using the `workspace` stanza which is much simpler to understand and debug.
+Under the covers, the `workspace` stanza is functionally equivalent to a
+label selector of `waypoint/workspace == <name>`.
+
+For example, perhaps we have a different configuration
+depending on the `region` label at is set for operations. (This label
+must be manually set. See [labels](/docs/lifecycle/labels).)
+
+```hcl
+app "my-app" {
+  deploy {
+    use "kubernetes" {}
+
+    workspace "region == us-east" {
+      use "kubernetes" {
+        // us-east configs
+      }
+    }
+
+    workspace "region == us-west" {
+      // In us-west we're still migrating from bare ec2
+      use "aws-ec2" {}
+    }
+  }
+}
+```
+
+-> **Mixing:** `label` and `workspace` stanzas can be used together.
+See [multiple match ordering](#multiple-match-ordering) to determine
+the behavior when there are multiple matches.
+
+## Multiple Match Ordering
+
+If multiple `workspace` and/or `label` stanzas are used, there may be
+scenarios where multiple are valid choices for the current operation.
+In this scenario, the following rules are used. The first matching rule
+halts the lookup.
+
+1. An exact match `workspace` matches over any `label`.
+
+2. The longest label selector string by byte count (ignoring preceding or trailing
+whitespace) matches before shorter label selector strings.
+
+## Partial Configuration Changes
+
+The `workspace` and `label` stanzas are particularly powerful for
+_whole configuration differences_. If only one field is changing between
+workspaces, copying the entire configuration between the different stanzas
+will become error prone, aesthetically displeasing, and verbose. For
+single fields, you should use other features.
+
+### Map Lookup
+
+One option is to use a map lookup as a way to change behavior. For example,
+if we are only changing the `namespace` for Kubernetes based on the workspace,
+we can do the following:
+
+```hcl
+app "my-app" {
+  deploy {
+    use "kubernetes" {
+      namespace = {
+        "default"    = "default"
+        "production" = "prod"
+      }[workspace.name]
+    }
+  }
+}
+```
+
+This is admittedly not obvious. To explain: we are creating an HCL map
+with the `{}` syntax and then doing a lookup using `[]` keyed on
+the [`workspace` variable](/docs/waypoint-hcl/variables/workspace).

--- a/website/content/docs/lifecycle/scope.mdx
+++ b/website/content/docs/lifecycle/scope.mdx
@@ -91,7 +91,7 @@ Under the covers, the `workspace` stanza is functionally equivalent to a
 label selector of `waypoint/workspace == <name>`.
 
 For example, perhaps we have a different configuration
-depending on the `region` label at is set for operations. (This label
+depending on if the `region` label is set for operations. (This label
 must be manually set. See [labels](/docs/lifecycle/labels).)
 
 ```hcl

--- a/website/content/docs/lifecycle/scope.mdx
+++ b/website/content/docs/lifecycle/scope.mdx
@@ -99,13 +99,13 @@ app "my-app" {
   deploy {
     use "kubernetes" {}
 
-    workspace "region == us-east" {
+    label "region == us-east" {
       use "kubernetes" {
         // us-east configs
       }
     }
 
-    workspace "region == us-west" {
+    label "region == us-west" {
       // In us-west we're still migrating from bare ec2
       use "aws-ec2" {}
     }
@@ -117,6 +117,40 @@ app "my-app" {
 See [multiple match ordering](#multiple-match-ordering) to determine
 the behavior when there are multiple matches.
 
+## Scoped Registry Configuration
+
+The `registry` configuration can be scoped as well, but only within
+the root `build` stanza. This does not limit the functionality of scoping
+registry configuration at all.
+
+For example, the following specifies a custom build and registry configuration
+for the "production" workspace. Note that we don't use `registry` within
+the workspace-scoped build configuration. We still use `registry` within
+the top-level `build` and apply a duplicate `workspace` stanza.
+
+```hcl
+app "my-app" {
+  build {
+    use "docker" {}
+
+    registry {
+      use "docker" {
+        local = true
+      }
+
+      workspace "production" {
+        use "docker" {}
+      }
+    }
+
+    // Alternate build configuration for production.
+    workspace "production" {
+      use "pack" {}
+    }
+  }
+}
+```
+
 ## Multiple Match Ordering
 
 If multiple `workspace` and/or `label` stanzas are used, there may be
@@ -127,7 +161,7 @@ halts the lookup.
 1. An exact match `workspace` matches over any `label`.
 
 2. The longest label selector string by byte count (ignoring preceding or trailing
-whitespace) matches before shorter label selector strings.
+   whitespace) matches before shorter label selector strings.
 
 ## Partial Configuration Changes
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -153,6 +153,10 @@
       {
         "title": "Labels",
         "path": "lifecycle/labels"
+      },
+      {
+        "title": "Workspace and Label Scoping",
+        "path": "lifecycle/scope"
       }
     ]
   },


### PR DESCRIPTION
This PR introduces a new feature that lets workspace or label-specific configurations for build, deploy, release, etc. The docs are fully updated in this PR so please take a look at those for more details!

Example:

```hcl
app "my-app" {
  deploy {
    use "kubernetes" {}

    workspace "production" {
      use "kubernetes" {
        namespace = "production"
      }
    }

    workspace "new-platform" {
      use "nomad" {
        // nomad configuration here
      }
    }
  }
}
```