### PR TITLE
cli: add alias for -app and -workspace flags

### DIFF
--- a/.changelog/2700.txt
+++ b/.changelog/2700.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add alias for -app and -workspace flags
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -522,10 +522,10 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 		})
 
 		f.StringVar(&flag.StringVar{
-			Name:   "workspace",
-			Target: &c.flagWorkspace,
+			Name:    "workspace",
+			Target:  &c.flagWorkspace,
 			Aliases: []string{"w"},
-			Usage:  "Workspace to operate in.",
+			Usage:   "Workspace to operate in.",
 		})
 
 		f.StringVar(&flag.StringVar{

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -522,18 +522,18 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 		})
 
 		f.StringVar(&flag.StringVar{
-			Name:    "workspace",
-			Target:  &c.flagWorkspace,
-			Aliases: []string{"w"},
-			Usage:   "Workspace to operate in.",
-		})
-
-		f.StringVar(&flag.StringVar{
 			Name:    "project",
 			Target:  &c.flagProject,
 			Aliases: []string{"p"},
 			Default: "",
 			Usage:   "Project to target.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "workspace",
+			Target:  &c.flagWorkspace,
+			Aliases: []string{"w"},
+			Usage:   "Workspace to operate in.",
 		})
 	}
 

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -514,6 +514,7 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "app",
 			Target:  &c.flagApp,
+			Aliases: []string{"a"},
 			Default: "",
 			Usage: "App to target. Certain commands require a single app target for " +
 				"Waypoint configurations with multiple apps. If you have a single app, " +
@@ -523,6 +524,7 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:   "workspace",
 			Target: &c.flagWorkspace,
+			Aliases: []string{"w"},
 			Usage:  "Workspace to operate in.",
 		})
 

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -24,8 +24,8 @@ Build a new versioned artifact from source.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -25,8 +25,8 @@ Build a new versioned artifact from source.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/artifact-list-builds.mdx
+++ b/website/content/commands/artifact-list-builds.mdx
@@ -24,8 +24,8 @@ expected to be stored in a registry.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/artifact-list-builds.mdx
+++ b/website/content/commands/artifact-list-builds.mdx
@@ -25,8 +25,8 @@ expected to be stored in a registry.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/artifact-list.mdx
+++ b/website/content/commands/artifact-list.mdx
@@ -24,8 +24,8 @@ list the artifacts that are just part of local builds.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/artifact-list.mdx
+++ b/website/content/commands/artifact-list.mdx
@@ -23,8 +23,8 @@ list the artifacts that are just part of local builds.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -26,8 +26,8 @@ local builds using "artifact list-builds" command.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -27,8 +27,8 @@ local builds using "artifact list-builds" command.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/auth-method-delete.mdx
+++ b/website/content/commands/auth-method-delete.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint auth-method delete NAME`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/auth-method-delete_more.mdx"

--- a/website/content/commands/auth-method-delete.mdx
+++ b/website/content/commands/auth-method-delete.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint auth-method delete NAME`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/auth-method-delete_more.mdx"

--- a/website/content/commands/auth-method-inspect.mdx
+++ b/website/content/commands/auth-method-inspect.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint auth-method inspect NAME`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/auth-method-inspect_more.mdx"

--- a/website/content/commands/auth-method-inspect.mdx
+++ b/website/content/commands/auth-method-inspect.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint auth-method inspect NAME`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/auth-method-inspect_more.mdx"

--- a/website/content/commands/auth-method-list.mdx
+++ b/website/content/commands/auth-method-list.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint auth-method list`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/auth-method-list_more.mdx"

--- a/website/content/commands/auth-method-list.mdx
+++ b/website/content/commands/auth-method-list.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint auth-method list`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/auth-method-list_more.mdx"

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -23,8 +23,8 @@ Configure an OIDC auth method.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -22,8 +22,8 @@ Configure an OIDC auth method.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -24,8 +24,8 @@ Build a new versioned artifact from source.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -25,8 +25,8 @@ Build a new versioned artifact from source.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -44,8 +44,8 @@ as well.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -43,8 +43,8 @@ as well.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -30,8 +30,8 @@ Specify the "-app" flag to set a config variable for a specific app.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -31,8 +31,8 @@ Specify the "-app" flag to set a config variable for a specific app.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -29,8 +29,8 @@ To use this command, you must specify a "-type" flag.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -28,8 +28,8 @@ To use this command, you must specify a "-type" flag.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -32,8 +32,8 @@ you're configuring for details on what configuration fields are available.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -31,8 +31,8 @@ you're configuring for details on what configuration fields are available.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/config-sync.mdx
+++ b/website/content/commands/config-sync.mdx
@@ -28,7 +28,7 @@ be deleted.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/config-sync_more.mdx"

--- a/website/content/commands/config-sync.mdx
+++ b/website/content/commands/config-sync.mdx
@@ -27,8 +27,8 @@ be deleted.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/config-sync_more.mdx"

--- a/website/content/commands/context-clear.mdx
+++ b/website/content/commands/context-clear.mdx
@@ -31,7 +31,7 @@ the project.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-clear_more.mdx"

--- a/website/content/commands/context-clear.mdx
+++ b/website/content/commands/context-clear.mdx
@@ -30,8 +30,8 @@ the project.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-clear_more.mdx"

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -23,8 +23,8 @@ Creates a new context.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -22,8 +22,8 @@ Creates a new context.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/context-delete.mdx
+++ b/website/content/commands/context-delete.mdx
@@ -22,8 +22,8 @@ Deletes a context. This will succeed if the context is already deleted.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/context-delete.mdx
+++ b/website/content/commands/context-delete.mdx
@@ -23,8 +23,8 @@ Deletes a context. This will succeed if the context is already deleted.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -22,8 +22,8 @@ Output information about a waypoint context or general context info.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -23,8 +23,8 @@ Output information about a waypoint context or general context info.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/context-list.mdx
+++ b/website/content/commands/context-list.mdx
@@ -23,7 +23,7 @@ Lists the contexts available to the CLI.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-list_more.mdx"

--- a/website/content/commands/context-list.mdx
+++ b/website/content/commands/context-list.mdx
@@ -22,8 +22,8 @@ Lists the contexts available to the CLI.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-list_more.mdx"

--- a/website/content/commands/context-rename.mdx
+++ b/website/content/commands/context-rename.mdx
@@ -26,7 +26,7 @@ exists. If the current default is FROM, the default will be set to TO.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-rename_more.mdx"

--- a/website/content/commands/context-rename.mdx
+++ b/website/content/commands/context-rename.mdx
@@ -25,8 +25,8 @@ exists. If the current default is FROM, the default will be set to TO.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-rename_more.mdx"

--- a/website/content/commands/context-set.mdx
+++ b/website/content/commands/context-set.mdx
@@ -29,8 +29,8 @@ To restore this CLI context to use the default workspace, use
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-set_more.mdx"

--- a/website/content/commands/context-set.mdx
+++ b/website/content/commands/context-set.mdx
@@ -30,7 +30,7 @@ To restore this CLI context to use the default workspace, use
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-set_more.mdx"

--- a/website/content/commands/context-use.mdx
+++ b/website/content/commands/context-use.mdx
@@ -22,8 +22,8 @@ Set the default context for the CLI.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-use_more.mdx"

--- a/website/content/commands/context-use.mdx
+++ b/website/content/commands/context-use.mdx
@@ -23,7 +23,7 @@ Set the default context for the CLI.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-use_more.mdx"

--- a/website/content/commands/context-verify.mdx
+++ b/website/content/commands/context-verify.mdx
@@ -27,7 +27,7 @@ connection information is valid.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context-verify_more.mdx"

--- a/website/content/commands/context-verify.mdx
+++ b/website/content/commands/context-verify.mdx
@@ -26,8 +26,8 @@ connection information is valid.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context-verify_more.mdx"

--- a/website/content/commands/context.mdx
+++ b/website/content/commands/context.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint context [options]`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/context_more.mdx"

--- a/website/content/commands/context.mdx
+++ b/website/content/commands/context.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint context [options]`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/context_more.mdx"

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -27,8 +27,8 @@ using the "artifact list" command.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -26,8 +26,8 @@ using the "artifact list" command.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -27,8 +27,8 @@ using the "artifact list" command.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -26,8 +26,8 @@ using the "artifact list" command.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -27,8 +27,8 @@ by the user unless the force flag (-force) is specified.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -28,8 +28,8 @@ by the user unless the force flag (-force) is specified.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/deployment-list.mdx
+++ b/website/content/commands/deployment-list.mdx
@@ -23,8 +23,8 @@ Lists the deployments that were created.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/deployment-list.mdx
+++ b/website/content/commands/deployment-list.mdx
@@ -22,8 +22,8 @@ Lists the deployments that were created.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -33,8 +33,8 @@ you've used if you want to destroy everything.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -34,8 +34,8 @@ you've used if you want to destroy everything.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -25,8 +25,8 @@ The flags can change which plugins are listed and in which format.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -26,8 +26,8 @@ The flags can change which plugins are listed and in which format.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -27,8 +27,8 @@ For example, you could run one of the following commands:
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -28,8 +28,8 @@ For example, you could run one of the following commands:
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -33,8 +33,8 @@ work for older and newer configuration formats.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -32,8 +32,8 @@ work for older and newer configuration formats.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/hostname-delete.mdx
+++ b/website/content/commands/hostname-delete.mdx
@@ -23,7 +23,7 @@ Delete a previously registered hostname.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/hostname-delete_more.mdx"

--- a/website/content/commands/hostname-delete.mdx
+++ b/website/content/commands/hostname-delete.mdx
@@ -22,8 +22,8 @@ Delete a previously registered hostname.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/hostname-delete_more.mdx"

--- a/website/content/commands/hostname-list.mdx
+++ b/website/content/commands/hostname-list.mdx
@@ -25,7 +25,7 @@ This will list all the registered hostnames for all applications.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/hostname-list_more.mdx"

--- a/website/content/commands/hostname-list.mdx
+++ b/website/content/commands/hostname-list.mdx
@@ -24,8 +24,8 @@ This will list all the registered hostnames for all applications.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/hostname-list_more.mdx"

--- a/website/content/commands/hostname-register.mdx
+++ b/website/content/commands/hostname-register.mdx
@@ -27,7 +27,7 @@ routing immediately.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/hostname-register_more.mdx"

--- a/website/content/commands/hostname-register.mdx
+++ b/website/content/commands/hostname-register.mdx
@@ -26,8 +26,8 @@ routing immediately.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/hostname-register_more.mdx"

--- a/website/content/commands/init.mdx
+++ b/website/content/commands/init.mdx
@@ -29,8 +29,8 @@ delete your configuration or any data in the server.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/init.mdx
+++ b/website/content/commands/init.mdx
@@ -30,8 +30,8 @@ delete your configuration or any data in the server.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -48,8 +48,8 @@ and disable the UI, the command would be:
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -47,8 +47,8 @@ and disable the UI, the command would be:
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/k8s-bootstrap.mdx
+++ b/website/content/commands/k8s-bootstrap.mdx
@@ -41,8 +41,8 @@ should be no concern of data loss in the event of a bootstrap failure.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Connection Options
 

--- a/website/content/commands/k8s-bootstrap.mdx
+++ b/website/content/commands/k8s-bootstrap.mdx
@@ -40,8 +40,8 @@ should be no concern of data loss in the event of a bootstrap failure.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Connection Options

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -39,8 +39,8 @@ or file.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Connection Options
 

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -38,8 +38,8 @@ or file.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Connection Options

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -30,7 +30,7 @@ to a specific deployment or filter out certain log messages.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/logs_more.mdx"

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -29,8 +29,8 @@ to a specific deployment or filter out certain log messages.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/logs_more.mdx"

--- a/website/content/commands/plugin.mdx
+++ b/website/content/commands/plugin.mdx
@@ -21,8 +21,8 @@ Usage: `waypoint plugin [options]`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/plugin.mdx
+++ b/website/content/commands/plugin.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint plugin [options]`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -33,8 +33,8 @@ some fields using flags by specifying the -waypoint-hcl flag.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -34,8 +34,8 @@ some fields using flags by specifying the -waypoint-hcl flag.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/project-inspect.mdx
+++ b/website/content/commands/project-inspect.mdx
@@ -30,8 +30,8 @@ or "waypoint init".
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/project-inspect.mdx
+++ b/website/content/commands/project-inspect.mdx
@@ -29,8 +29,8 @@ or "waypoint init".
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/project-list.mdx
+++ b/website/content/commands/project-list.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint project list`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/project-list_more.mdx"

--- a/website/content/commands/project-list.mdx
+++ b/website/content/commands/project-list.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint project list`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/project-list_more.mdx"

--- a/website/content/commands/release-list.mdx
+++ b/website/content/commands/release-list.mdx
@@ -23,8 +23,8 @@ Lists the releases that were created if the platform includes a releaser.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/release-list.mdx
+++ b/website/content/commands/release-list.mdx
@@ -22,8 +22,8 @@ Lists the releases that were created if the platform includes a releaser.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -26,8 +26,8 @@ specified by ID using the '-deployment' flag.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -25,8 +25,8 @@ specified by ID using the '-deployment' flag.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -23,8 +23,8 @@ Run a runner for executing remote operations.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -22,8 +22,8 @@ Run a runner for executing remote operations.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/runner-profile-inspect.mdx
+++ b/website/content/commands/runner-profile-inspect.mdx
@@ -21,8 +21,8 @@ Usage: `waypoint runner profile inspect NAME`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/runner-profile-inspect.mdx
+++ b/website/content/commands/runner-profile-inspect.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint runner profile inspect NAME`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/runner-profile-list.mdx
+++ b/website/content/commands/runner-profile-list.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint runner profile list`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/runner-profile-list_more.mdx"

--- a/website/content/commands/runner-profile-list.mdx
+++ b/website/content/commands/runner-profile-list.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint runner profile list`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/runner-profile-list_more.mdx"

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -31,8 +31,8 @@ lifecycle operation.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -30,8 +30,8 @@ lifecycle operation.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -36,8 +36,8 @@ a CLI context by default.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Connection Options
 

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -35,8 +35,8 @@ a CLI context by default.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Connection Options

--- a/website/content/commands/server-config-set.mdx
+++ b/website/content/commands/server-config-set.mdx
@@ -31,8 +31,8 @@ together in one call.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-config-set.mdx
+++ b/website/content/commands/server-config-set.mdx
@@ -30,8 +30,8 @@ together in one call.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -48,8 +48,8 @@ and disable the UI, the command would be:
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -47,8 +47,8 @@ and disable the UI, the command would be:
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -34,8 +34,8 @@ standard input. Using a name of '-' will force reading from standard input.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -33,8 +33,8 @@ standard input. Using a name of '-' will force reading from standard input.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -26,8 +26,8 @@ environment.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -27,8 +27,8 @@ environment.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -25,8 +25,8 @@ to standard out.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/server-snapshot_more.mdx"

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -26,7 +26,7 @@ to standard out.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/server-snapshot_more.mdx"

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -40,8 +40,8 @@ command) will not be affected.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -41,8 +41,8 @@ command) will not be affected.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -30,8 +30,8 @@ manually installed runners will not be automatically upgraded.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -29,8 +29,8 @@ manually installed runners will not be automatically upgraded.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -28,8 +28,8 @@ data sourced projects.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -27,8 +27,8 @@ data sourced projects.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/token-exchange.mdx
+++ b/website/content/commands/token-exchange.mdx
@@ -27,8 +27,8 @@ the "waypoint user" set of commands. Everything that was possible with
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/token-exchange.mdx
+++ b/website/content/commands/token-exchange.mdx
@@ -28,8 +28,8 @@ the "waypoint user" set of commands. Everything that was possible with
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/token-invite.mdx
+++ b/website/content/commands/token-invite.mdx
@@ -27,8 +27,8 @@ the "waypoint user" set of commands. Everything that was possible with
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/token-invite.mdx
+++ b/website/content/commands/token-invite.mdx
@@ -28,8 +28,8 @@ the "waypoint user" set of commands. Everything that was possible with
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/token-new.mdx
+++ b/website/content/commands/token-new.mdx
@@ -28,7 +28,7 @@ the "waypoint user" set of commands. Everything that was possible with
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/token-new_more.mdx"

--- a/website/content/commands/token-new.mdx
+++ b/website/content/commands/token-new.mdx
@@ -27,8 +27,8 @@ the "waypoint user" set of commands. Everything that was possible with
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/token-new_more.mdx"

--- a/website/content/commands/ui.mdx
+++ b/website/content/commands/ui.mdx
@@ -23,8 +23,8 @@ token invite page with an invite token for authentication.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/ui.mdx
+++ b/website/content/commands/ui.mdx
@@ -24,8 +24,8 @@ token invite page with an invite token for authentication.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -22,8 +22,8 @@ Perform the build, deploy, and release steps.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Operation Options

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -23,8 +23,8 @@ Perform the build, deploy, and release steps.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Operation Options
 

--- a/website/content/commands/user-inspect.mdx
+++ b/website/content/commands/user-inspect.mdx
@@ -25,8 +25,8 @@ is specified via flags.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/user-inspect.mdx
+++ b/website/content/commands/user-inspect.mdx
@@ -26,8 +26,8 @@ is specified via flags.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/user-invite.mdx
+++ b/website/content/commands/user-invite.mdx
@@ -31,8 +31,8 @@ via "waypoint login".
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/user-invite.mdx
+++ b/website/content/commands/user-invite.mdx
@@ -30,8 +30,8 @@ via "waypoint login".
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/user-modify.mdx
+++ b/website/content/commands/user-modify.mdx
@@ -25,8 +25,8 @@ Use "waypoint user inspect" to see the current attributes for a user.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/user-modify.mdx
+++ b/website/content/commands/user-modify.mdx
@@ -26,8 +26,8 @@ Use "waypoint user inspect" to see the current attributes for a user.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/user-token.mdx
+++ b/website/content/commands/user-token.mdx
@@ -36,8 +36,8 @@ the "waypoint user" set of commands. Everything that was possible with
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 

--- a/website/content/commands/user-token.mdx
+++ b/website/content/commands/user-token.mdx
@@ -35,8 +35,8 @@ the "waypoint user" set of commands. Everything that was possible with
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 #### Command Options

--- a/website/content/commands/version.mdx
+++ b/website/content/commands/version.mdx
@@ -20,8 +20,8 @@ Usage: `waypoint version`
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/version_more.mdx"

--- a/website/content/commands/version.mdx
+++ b/website/content/commands/version.mdx
@@ -21,7 +21,7 @@ Usage: `waypoint version`
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/version_more.mdx"

--- a/website/content/commands/workspace-inspect.mdx
+++ b/website/content/commands/workspace-inspect.mdx
@@ -24,7 +24,7 @@ last known activity timestamp
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/workspace-inspect_more.mdx"

--- a/website/content/commands/workspace-inspect.mdx
+++ b/website/content/commands/workspace-inspect.mdx
@@ -23,8 +23,8 @@ last known activity timestamp
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/workspace-inspect_more.mdx"

--- a/website/content/commands/workspace-list.mdx
+++ b/website/content/commands/workspace-list.mdx
@@ -23,8 +23,8 @@ context.
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation.
-- `-app=<string>` - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` - Workspace to operate in.
+- `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
 
 @include "commands/workspace-list_more.mdx"

--- a/website/content/commands/workspace-list.mdx
+++ b/website/content/commands/workspace-list.mdx
@@ -24,7 +24,7 @@ context.
 
 - `-plain` - Plain output: no colors, no animation.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
-- `-workspace=<string>` (`-w`) - Workspace to operate in.
 - `-project=<string>` (`-p`) - Project to target.
+- `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 @include "commands/workspace-list_more.mdx"


### PR DESCRIPTION
This is piece of foundational work for further
improvements to the CLI's UX. This is a separate
PR from the bulk of that redesign, since this
change affects a large number of files and could
be distracting in PR review of the larger scope
of work.

As a bonus, I also reordered the global "targeting" commands to be in order of precedence, which happens to also match their alphabetical order. This reads nicer in both respects.