### PR TITLE
ui: add all operation info to OperationStatusIndicator

### DIFF
--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -3,22 +3,7 @@
     <b class="badge badge--version">v{{@build.sequence}}</b>
     <small class="app-item__meta__secondary">
       {{#let (or @build.pushedArtifact @build) as |operation|}}
-        <Pds::Icon
-          @type={{icon-for-component operation.component.name}}
-          class="icon"
-        />
-
-        <span>
-          {{t
-            (concat
-              "build_status"
-              ".type-" operation.component.type
-              ".state-" operation.status.state
-            )
-          }}
-          <b>{{component-name operation.component.name}}</b>
-          <OperationStatusIndicator @status={{operation.status}} @matchTypography={{true}} />
-        </span>
+        <OperationStatusIndicator::Build @operation={{operation}} @isDetailed={{true}}/>
       {{/let}}
     </small>
   </LinkTo>

--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -8,15 +8,7 @@
       <b class="badge badge--version">v{{@deployment.sequence}}</b>
     </p>
     <small class="app-item__meta__secondary">
-      <Pds::Icon @type={{icon-for-component @deployment.component.name}} class="icon" />
-      <span>{{t (concat "page.deployments.status_prefix." @deployment.status.state)}}
-        <b>{{component-name @deployment.component.name}}</b>
-        {{#if (eq @deployment.status.state 1)}}
-        (Started {{date-format-distance-to-now @deployment.status.startTime.seconds }})
-        {{else}}
-        {{date-format-distance-to-now @deployment.status.completeTime.seconds }}
-        {{/if}}
-      </span>
+      <OperationStatusIndicator::Deployment @operation={{@deployment}} />
     </small>
     {{#if (eq @deployment.state 4)}}
       <b data-test-destroyed-badge class="badge badge--destroyed">

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -4,15 +4,7 @@
       <b class="badge badge--version">v{{@release.sequence}}</b>
     </p>
     <small class="app-item__meta__secondary">
-      <Pds::Icon @type={{icon-for-component @release.component.name}} class="icon" />
-      <span>{{if (eq @release.status.state 1) 'Releasing' 'Released'}} on
-        <b>{{component-name @release.component.name}}</b>
-        {{#if (eq @release.status.state 1)}}
-          (Started {{date-format-distance-to-now @release.status.startTime.seconds }})
-        {{else}}
-          {{date-format-distance-to-now @release.status.completeTime.seconds }}
-        {{/if}}
-      </span>
+      <OperationStatusIndicator::Release @operation={{@release}} />
     </small>
   </LinkTo>
 

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -1,77 +1,105 @@
 {{!--
 
   ## Usage
-
-  <OperationStatusIndicator
-    @status={{build.status}}
-  />
+  {{#let (or @build.pushedArtifact @build) as |operation|}}
+    <OperationStatusIndicator
+      @operation={{build.status}}
+    />
+  {{/let}}
 
   If you would like the indicator to match the surrounding typography,
   pass `@matchTypography={{true}}`:
 
   <OperationStatusIndicator
-    @status={{build.status}}
+    @operation={{build}}
     @matchTypography={{true}}
   />
 
+  If you want the icon + tooltip for the time information,
+  pass `@isDetailed={{true}}`:
+
+  <OperationStatusIndicator
+    @operation={{build}}
+    @isDetailed={{true}}
+  />
+
 --}}
-
-{{#let
-  (hash
-    state=(or
-      (and (eq @status.state 0) "unknown")
-      (and (eq @status.state 1) "running")
-      (and (eq @status.state 2) "success")
-      (and (eq @status.state 3) "error")
-    )
-    message=(or
-      @status.error.message
-      @status.details
-    )
-  )
-  as |vars|
-}}
-  <span
-    data-test-operation-status-indicator={{vars.state}}
-    class="
-      operation-status-indicator
-      operation-status-indicator--{{vars.state}}
-      {{if @matchTypography "operation-status-indicator--match-typography"}}
-      focus-ring
-    "
-    tabindex="0"
-  >
+<div class="operation-status-indicator">
+  <span class="icon-text-group">
     <Pds::Icon
-      class="operation-status-indicator__badge"
-      @type={{or
-        (and (eq vars.state "unknown") "help-circle-outline")
-        (and (eq vars.state "running") "clock-outline")
-        (and (eq vars.state "success") "check-plain")
-        (and (eq vars.state "error") "alert-triangle")
-      }}
+      data-test-icon-type={{icon-for-component @operation.component.name}}
+      @type={{icon-for-component @operation.component.name}}
     />
-
-    <span class="operation-status-indicator__label">
-      {{#if (eq vars.state "running")}}
-        {{date-format-distance-to-now @status.startTime.seconds}}
-      {{else}}
-        {{date-format-distance-to-now @status.completeTime.seconds}}
-      {{/if}}
+    <span>
+      {{yield to="status-text"}}
+      <b>{{component-name @operation.component.name}}</b>
     </span>
-
-    {{#if vars.message}}
-      <EmberTooltip
-        @popperOptions={{hash
-          modifiers=(hash
-            preventOverflow=(hash
-              escapeWithReference=false
-              boundariesElement="viewport"
-            )
-          )
-        }}
-      >
-        {{vars.message}}
-      </EmberTooltip>
-    {{/if}}
   </span>
-{{/let}}
+
+  {{!-- Original OperationStatusIndicator, build time, status, and tooltip  --}}
+  {{#if @operation.status}}
+    {{#let
+      (hash
+        state=(or
+          (and (eq @operation.status.state 0) "unknown")
+          (and (eq @operation.status.state 1) "running")
+          (and (eq @operation.status.state 2) "success")
+          (and (eq @operation.status.state 3) "error")
+        )
+        message=(or
+          @operation.status.error.message
+          @operation.status.details
+        )
+      )
+      as |vars|
+    }}
+      <span
+        data-test-operation-status-indicator={{vars.state}}
+        class="
+          timestamp
+          timestamp--{{vars.state}}
+          {{if @matchTypography "timestamp--match-typography"}}
+          focus-ring
+        "
+        tabindex="0"
+      >
+        {{#if @isDetailed}}
+          <Pds::Icon
+            data-test-time-icon
+            @type={{or
+              (and (eq vars.state "unknown") "help-circle-outline")
+              (and (eq vars.state "running") "clock-outline")
+              (and (eq vars.state "success") "check-plain")
+              (and (eq vars.state "error") "alert-triangle")
+            }}
+            @size="16"
+          />
+        {{/if}}
+
+        <span class="timestamp__label">
+          {{#if (eq vars.state "running")}}
+            {{date-format-distance-to-now @operation.status.startTime.seconds}}
+          {{else}}
+            {{date-format-distance-to-now @operation.status.completeTime.seconds}}
+          {{/if}}
+        </span>
+
+        {{#if (and vars.message @isDetailed)}}
+          <EmberTooltip
+            data-test-tooltip
+            @popperOptions={{hash
+              modifiers=(hash
+                preventOverflow=(hash
+                  escapeWithReference=false
+                  boundariesElement="viewport"
+                )
+              )
+            }}
+          >
+            {{vars.message}}
+          </EmberTooltip>
+        {{/if}}
+      </span>
+    {{/let}}
+  {{/if}}
+</div>

--- a/ui/app/components/operation-status-indicator/build.hbs
+++ b/ui/app/components/operation-status-indicator/build.hbs
@@ -1,0 +1,11 @@
+<OperationStatusIndicator @operation={{@operation}} @isDetailed={{true}}>
+  <:status-text>
+    {{t
+      (concat
+        "build_status"
+        ".type-" @operation.component.type
+        ".state-" @operation.status.state
+      )
+    }}
+  </:status-text>
+</OperationStatusIndicator>

--- a/ui/app/components/operation-status-indicator/deployment.hbs
+++ b/ui/app/components/operation-status-indicator/deployment.hbs
@@ -1,0 +1,5 @@
+<OperationStatusIndicator @operation={{@operation}} @isDetailed={{false}}>
+  <:status-text>
+    {{t (concat "page.deployments.status_prefix." @operation.status.state)}}
+  </:status-text>
+</OperationStatusIndicator>

--- a/ui/app/components/operation-status-indicator/release.hbs
+++ b/ui/app/components/operation-status-indicator/release.hbs
@@ -1,0 +1,5 @@
+<OperationStatusIndicator @operation={{@operation}} @isDetailed={{false}}>
+  <:status-text>
+    {{if (eq @operation.status.state 1) 'Releasing' 'Released'}} on
+  </:status-text>
+</OperationStatusIndicator>

--- a/ui/app/styles/components/app-item.scss
+++ b/ui/app/styles/components/app-item.scss
@@ -52,16 +52,6 @@
     align-items: center;
     color: rgb(var(--text-muted));
     margin-right: scale.$sm-2;
-
-    b {
-      text-transform: capitalize;
-    }
-
-    .icon {
-      margin-right: scale.$sm-3;
-      font-size: scale.$lg-1;
-      display: flex;
-    }
   }
 
   .button {

--- a/ui/app/styles/components/navigation/artifact-overview.scss
+++ b/ui/app/styles/components/navigation/artifact-overview.scss
@@ -29,7 +29,7 @@
 
     .status-indicator {
       display: flex;
-      align-items: flex-end;
+      align-items: center;
       padding-bottom: 0.25rem;
     }
 

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -1,14 +1,41 @@
 .operation-status-indicator {
-  @include Typography.Interface(S);
-  color: rgb(var(--text-muted));
-  cursor: default;
+  display: inline-flex;
+  align-items: center;
 
-  &--error {
-    color: rgb(var(--error-text));
+  span, b {
+    margin-right: scale.$sm-4;
   }
 
-  &--match-typography {
-    font-size: inherit;
-    font-weight: inherit;
+  b {
+    text-transform: capitalize;
+  }
+
+  svg {
+    margin-right: scale.$sm-3;
+  }
+
+  .pds-icon {
+    font-size: 16px;
+  }
+
+  .icon-text-group {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .timestamp {
+    display: inline-flex;
+    align-items: center;
+    color: rgb(var(--text-muted));
+    cursor: default;
+
+    &--error {
+      color: rgb(var(--error-text));
+    }
+
+    &--match-typography {
+      font-size: inherit;
+      font-weight: inherit;
+    }
   }
 }

--- a/ui/app/styles/components/status-report-indicator.scss
+++ b/ui/app/styles/components/status-report-indicator.scss
@@ -15,7 +15,11 @@
     background: color.$black;
     margin-right: scale.$sm--3;
   }
-  
+
+  &__label {
+    line-height: 100%;
+  }
+
   // Status: Unknown
 
   &--unknown &__badge {

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -14,21 +14,7 @@
         <tr>
           <th scope="row">{{t "page.build.overview.status"}}</th>
           <td>
-            <Pds::Icon
-              @type={{icon-for-component operation.component.name}}
-              class="icon"
-            />
-            <span>
-              {{t
-                (concat
-                  "build_status"
-                  ".type-" operation.component.type
-                  ".state-" operation.status.state
-                )
-              }}
-              <b>{{component-name operation.component.name}}</b>
-            </span>
-            <OperationStatusIndicator @status={{operation.status}} />
+            <OperationStatusIndicator::Build @operation={{operation}} />
           </td>
         </tr>
       </StatusReportMetaTable>

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -22,10 +22,7 @@
         <tr>
           <th scope="row">{{t "page.deployment.overview.status"}}</th>
           <td>
-            <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
-            <span>Deployed by <b>{{component-name @model.component.name}}</b>
-              {{date-format-distance-to-now @model.status.startTime.seconds }}
-            </span>
+            <OperationStatusIndicator::Deployment @operation={{@model}} />
           </td>
         </tr>
       </StatusReportMetaTable>

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -19,10 +19,7 @@
         <tr>
           <th scope="row">{{t "page.release.overview.status"}}</th>
           <td>
-            <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
-            <span>Released on <b>{{component-name @model.component.name}}</b>
-              <small>{{date-format-distance-to-now @model.status.startTime.seconds}}</small>
-            </span>
+            <OperationStatusIndicator::Release @operation={{@model}}/>
           </td>
         </tr>
       </StatusReportMetaTable>

--- a/ui/tests/integration/components/operation-status-indicator-test.ts
+++ b/ui/tests/integration/components/operation-status-indicator-test.ts
@@ -8,51 +8,90 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 module('Integration | Component | operation-status-indicator', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('with a success status', async function (assert) {
-    this.set('status', {
-      state: 2, // success
-      details: 'Example details',
-      startTime: {
-        seconds: getUnixTime(subDays(new Date(), 2)),
-        nanos: 0,
+  test('with a success status (isDetailed)', async function (assert) {
+    this.set('build', {
+      component: {
+        name: 'docker',
       },
-      completeTime: {
-        seconds: getUnixTime(subDays(new Date(), 1)),
-        nanos: 0,
+      status: {
+        state: 2, // success
+        details: 'Example details',
+        startTime: {
+          seconds: getUnixTime(subDays(new Date(), 2)),
+          nanos: 0,
+        },
+        completeTime: {
+          seconds: getUnixTime(subDays(new Date(), 1)),
+          nanos: 0,
+        },
       },
     });
 
     await render(hbs`
-      <OperationStatusIndicator @status={{this.status}} />
+      <OperationStatusIndicator @operation={{this.build}} @isDetailed={{true}}>
+        Deployed to
+      </OperationStatusIndicator>
     `);
+
+    assert.dom('[data-test-icon-type]').hasAttribute('data-test-icon-type', 'logo-docker-color');
+    assert.dom('.icon-text-group').containsText('Deployed to Docker');
     await focus('[data-test-operation-status-indicator]');
     await a11yAudit();
 
-    assert.dom('[data-test-operation-status-indicator]').hasClass('operation-status-indicator--success');
+    assert.dom('[data-test-operation-status-indicator]').hasClass('timestamp--success');
     assert.dom('[data-test-operation-status-indicator]').includesText('1 day ago');
     assert.dom('.ember-tooltip').includesText('Example details');
   });
 
-  test('with a running status', async function (assert) {
-    this.set('status', {
-      state: 1, // running
-      details: 'Example details',
-      startTime: {
-        seconds: getUnixTime(subDays(new Date(), 2)),
-        nanos: 0,
-      },
-      completeTime: {
-        seconds: getUnixTime(subDays(new Date(), 1)),
-        nanos: 0,
+  test('with a running status (isDetailed)', async function (assert) {
+    this.set('build', {
+      status: {
+        state: 1, // running
+        details: 'Example details',
+        startTime: {
+          seconds: getUnixTime(subDays(new Date(), 2)),
+          nanos: 0,
+        },
+        completeTime: {
+          seconds: getUnixTime(subDays(new Date(), 1)),
+          nanos: 0,
+        },
       },
     });
 
     await render(hbs`
-      <OperationStatusIndicator @status={{this.status}} />
+      <OperationStatusIndicator @operation={{this.build}} @isDetailed={{true}}/>
     `);
     await focus('[data-test-operation-status-indicator]');
     await a11yAudit();
 
     assert.dom('[data-test-operation-status-indicator]').includesText('2 days ago');
+  });
+
+  test('icon and ember tooltip not rendered when isDetailed = false', async function (assert) {
+    this.set('build', {
+      status: {
+        state: 1, // running
+        details: 'Example details',
+        startTime: {
+          seconds: getUnixTime(subDays(new Date(), 2)),
+          nanos: 0,
+        },
+        completeTime: {
+          seconds: getUnixTime(subDays(new Date(), 1)),
+          nanos: 0,
+        },
+      },
+    });
+
+    await render(hbs`
+      <OperationStatusIndicator @operation={{this.build}}/>
+    `);
+    await focus('[data-test-operation-status-indicator]');
+
+    await a11yAudit();
+
+    assert.dom('[data-test-tooltip]').doesNotExist();
+    assert.dom('[data-test-time-icon]').doesNotExist();
   });
 });


### PR DESCRIPTION
## Description
Originally, the `OperationStatusIndicator` just encapsulated the time information related to an operation. This was always paired with the actual operation (ie: `Deployed to Docker`) which was being hard coded in every instance to account for the slight differences in code between each operation type. This PR combines the operation and the time information in `OperationStatusIndicator` and creates child versions for each operation type.
Additionally, this PR lays some groundwork for #2681 

## To Test
1. Pull down this branch `git checkout ui/operation-status-indicator`
2. `yarn start`
3. Check these areas for consistency across the app/with the previous version
   - Build/Deployment/Release lists
   - Build/Deployment/Release details page