### PR TITLE
UI: fix flaky auth test

### DIFF
--- a/ui/tests/acceptance/auth-test.ts
+++ b/ui/tests/acceptance/auth-test.ts
@@ -1,7 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import { invalidateSession } from 'ember-simple-auth/test-support';
 import login from 'waypoint/tests/helpers/login';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -11,21 +10,17 @@ module('Acceptance | auth', function (hooks: NestedHooks) {
   setupMirage(hooks);
 
   test('redirects to /auth from authenticated routes when logged out', async function (assert) {
-    await invalidateSession();
     await visit(`/default`);
     assert.equal(currentURL(), `/auth`);
   });
 
   test('has an OIDC provider button when it exists', async function (assert) {
-    await invalidateSession();
     this.server.create('auth-method', 'google');
-    await visit(`/default`);
-    assert.equal(currentURL(), `/auth`);
+    await visit(`/auth`);
     assert.dom('[data-test-oidc-provider="google"]').exists();
   });
 
   test('does not redirect to /auth from authenticated routes when logged in', async function (assert) {
-    await invalidateSession();
     await login();
     await visit(`/default`);
     assert.equal(currentURL(), `/default`);


### PR DESCRIPTION
**Update from @jgwhite:**

See the commit message for more detail, but essentially the fix is to remove the `invalidateSession` calls entirely, as we never authenticate in the first place.

I *think* the bug occurs when one calls `invalidateSession` without previously authenticating but I couldn't tell you why. Nevertheless, I can get 10 passes in a row with this change, where it consistently fails within 10 without the change.