### PR TITLE
docs, serverinstall: updates to docs & naming of runner install

### DIFF
--- a/.changelog/2713.txt
+++ b/.changelog/2713.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+serverinstall: Set Nomad's ODR profile name to "nomad"
+```

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -1101,6 +1101,7 @@ func (i *NomadInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	}
 
 	return &pb.OnDemandRunnerConfig{
+		Name:         "nomad",
 		OciUrl:       i.config.odrImage,
 		PluginType:   "nomad",
 		Default:      true,

--- a/website/content/docs/runner/profiles.mdx
+++ b/website/content/docs/runner/profiles.mdx
@@ -13,7 +13,7 @@ necessary to create an on-demand runner. Profiles can be used globally, or by sp
 
 ## Viewing runner profiles
 
-Waypoint installations performed on Kubernetes and ECS with the `waypoint install` command come with a default
+Waypoint installations performed with the `waypoint install` command come with a default
 runner profile already configured. You can view runner profiles with the `waypoint runner profile list` command:
 
 ```shell-session


### PR DESCRIPTION
We support ODR in all builting install platforms now,
so our documentation should reflect that.

Also updates the Nomad ODR config to list the Name as the platform name, matching our other builtin install platforms.