### PR TITLE
ui/ci: reuse ember-build-test output in ember-test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,7 +441,7 @@ jobs:
           at: ui
       - run:
           working_directory: ui
-          command: yarn test:ember:percy
+          command: yarn test:ember:percy:ci
       - store_test_results:
           path: ui/test-results
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,8 @@
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
-    "test:ember:percy": "percy exec ember test"
+    "test:ember:percy": "percy exec ember test",
+    "test:ember:percy:ci": "percy exec ember test --path=dist"
   },
   "devDependencies": {
     "@ember-decorators/component": "^6.1.1",


### PR DESCRIPTION
## Why the change?

We have this `ember-build-tests` step in our Circle config:

https://github.com/hashicorp/waypoint/blob/7fc5a50959d3e3821b41b7c8d0478a23c6949c44/.circleci/config.yml#L318-L329

Its job is to produce a test build ahead of time, and store it in `ui/dist`. This is good. What’s less good is that the subsequent `ember-test` step does not automatically reuse the existing build, and merrily rebuilds the project, costing us an unnecessary minute:

https://github.com/hashicorp/waypoint/blob/7fc5a50959d3e3821b41b7c8d0478a23c6949c44/.circleci/config.yml#L442-L444

This PR adds the `--path` flag to tell `ember test` to reuse the existing build.

https://github.com/hashicorp/waypoint/blob/5bcf07396b9c670b42222b47968314b4b21bf702/ui/package.json#L26

## What does it look like?

### [Before](https://app.circleci.com/pipelines/github/hashicorp/waypoint/12403/workflows/80e1c33f-4c57-407b-99b4-4f64d86d8cc1)

<img width="1386" alt="CleanShot 2021-11-11 at 15 12 55@2x" src="https://user-images.githubusercontent.com/34030/141312701-3acd6303-9e68-43c7-83f1-d244f4bcb5c9.png">

### [After](https://app.circleci.com/pipelines/github/hashicorp/waypoint/12432/workflows/136eb252-256e-4d46-9d2d-8ba6a0d30088)

<img width="1386" alt="CleanShot 2021-11-11 at 15 13 06@2x" src="https://user-images.githubusercontent.com/34030/141312730-e57803bc-e4a3-450b-9279-1db211cc1bbb.png">

### What should I take from these screenshots?

There’s a bit of noise in the timings, but you should be able to see the `ember-test` step is a clear minute faster in the `after` run.

## How do I test it?

Scrutinize the CircleCI output and verify the tests are indeed running correctly.