### PR TITLE
ui: upgrade to ember-a11y-testing@4.3.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "codemirror": "^5.62.2",
     "date-fns": "^2.15.0",
     "docker-parse-image": "^3.0.1",
-    "ember-a11y-testing": "^4.0.7",
+    "ember-a11y-testing": "^4.3.0",
     "ember-auto-import": "^1.10.1",
     "ember-auto-import-typescript": "^0.4.0",
     "ember-changeset": "^3.15.0",

--- a/ui/tests/helpers/a11y.ts
+++ b/ui/tests/helpers/a11y.ts
@@ -1,5 +1,16 @@
 import { ContextObject, RunOptions } from 'axe-core';
-import { setupGlobalA11yHooks, setEnableA11yAudit, setRunOptions } from 'ember-a11y-testing/test-support';
+import {
+  setupGlobalA11yHooks,
+  setEnableA11yAudit,
+  setRunOptions,
+  DEFAULT_A11Y_TEST_HELPER_NAMES,
+} from 'ember-a11y-testing/test-support';
+
+const A11Y_TEST_HELPER_NAMES: typeof DEFAULT_A11Y_TEST_HELPER_NAMES = [
+  ...DEFAULT_A11Y_TEST_HELPER_NAMES,
+  'render',
+  'focus',
+];
 
 // ember-a11y-testing allows us to pass `include` and `exclude` context
 // parameters as run options. This isn’t documented, and isn’t represented in
@@ -16,7 +27,7 @@ const include = [['#ember-testing-container']];
 const exclude = [['.pds-logomark'], ['.pds-tabNav'], ['.card-header'], ['.x-toggle-btn']];
 
 export function setup(): void {
-  setupGlobalA11yHooks(() => true);
+  setupGlobalA11yHooks(() => true, { helpers: A11Y_TEST_HELPER_NAMES });
   setEnableA11yAudit(true);
   setRunOptions({ include, exclude } as OptionsWithContext);
 }

--- a/ui/tests/integration/components/app-item/build-test.ts
+++ b/ui/tests/integration/components/app-item/build-test.ts
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { getUnixTime, subMinutes } from 'date-fns';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 module('Integration | Component | app-item/build', function (hooks) {
@@ -39,7 +38,6 @@ module('Integration | Component | app-item/build', function (hooks) {
         <AppItem::Build @build={{this.build}} />
       </ul>
     `);
-    await a11yAudit();
 
     assert.dom('[data-test-app-item-build]').includesText('v3');
     assert.dom('[data-test-icon-type="logo-docker-color"]').exists();
@@ -69,7 +67,6 @@ module('Integration | Component | app-item/build', function (hooks) {
         <AppItem::Build @build={{this.build}} />
       </ul>
     `);
-    await a11yAudit();
 
     assert.dom('[data-test-app-item-build]').includesText('v3');
     assert.dom('[data-test-icon-type="logo-docker-color"]').exists();

--- a/ui/tests/integration/components/operation-status-indicator-test.ts
+++ b/ui/tests/integration/components/operation-status-indicator-test.ts
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, focus } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { getUnixTime, subDays } from 'date-fns';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | operation-status-indicator', function (hooks) {
   setupRenderingTest(hooks);
@@ -36,7 +35,6 @@ module('Integration | Component | operation-status-indicator', function (hooks) 
     assert.dom('[data-test-icon-type]').hasAttribute('data-test-icon-type', 'logo-docker-color');
     assert.dom('.icon-text-group').containsText('Deployed to Docker');
     await focus('[data-test-operation-status-indicator]');
-    await a11yAudit();
 
     assert.dom('[data-test-operation-status-indicator]').hasClass('timestamp--success');
     assert.dom('[data-test-operation-status-indicator]').includesText('1 day ago');
@@ -63,7 +61,6 @@ module('Integration | Component | operation-status-indicator', function (hooks) 
       <OperationStatusIndicator @operation={{this.build}} @isDetailed={{true}}/>
     `);
     await focus('[data-test-operation-status-indicator]');
-    await a11yAudit();
 
     assert.dom('[data-test-operation-status-indicator]').includesText('2 days ago');
   });
@@ -88,8 +85,6 @@ module('Integration | Component | operation-status-indicator', function (hooks) 
       <OperationStatusIndicator @operation={{this.build}}/>
     `);
     await focus('[data-test-operation-status-indicator]');
-
-    await a11yAudit();
 
     assert.dom('[data-test-tooltip]').doesNotExist();
     assert.dom('[data-test-time-icon]').doesNotExist();

--- a/ui/tests/integration/components/panel-header-test.ts
+++ b/ui/tests/integration/components/panel-header-test.ts
@@ -7,10 +7,9 @@ module('Integration | Component | panel-header', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders an empty component when params not passed', async function (assert) {
-    await render(hbs`<PanelHeader/>`);
+    await render(hbs`<PanelHeader @artifact="build" />`);
 
-    assert.dom('[data-test-panel-header]').exists();
-    assert.equal(this.element?.textContent?.trim(), '');
+    assert.dom('[data-test-panel-header]').containsText('Build');
   });
 
   test('it renders an empty component when params passed', async function (assert) {

--- a/ui/tests/integration/components/status-report-indicator-test.ts
+++ b/ui/tests/integration/components/status-report-indicator-test.ts
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, focus } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { getUnixTime, subDays } from 'date-fns';
-import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | status-report-indicator', function (hooks) {
   setupRenderingTest(hooks);
@@ -26,7 +25,6 @@ module('Integration | Component | status-report-indicator', function (hooks) {
       <StatusReportIndicator @statusReport={{this.statusReport}} />
     `);
     await focus('[data-test-status-report-indicator]');
-    await a11yAudit();
 
     assert.dom('[data-test-status-report-indicator]').hasClass('status-report-indicator--alive');
     assert.dom('[data-test-status-report-indicator]').includesText('Starting…');
@@ -49,7 +47,6 @@ module('Integration | Component | status-report-indicator', function (hooks) {
       <StatusReportIndicator @statusReport={{this.statusReport}} />
     `);
     await focus('[data-test-status-report-indicator]');
-    await a11yAudit();
 
     assert.dom('[data-test-status-report-indicator]').hasClass('status-report-indicator--unknown');
     assert.dom('[data-test-status-report-indicator]').includesText('Unknown');
@@ -71,7 +68,6 @@ module('Integration | Component | status-report-indicator', function (hooks) {
       <StatusReportIndicator @statusReport={{this.statusReport}} />
     `);
     await focus('[data-test-status-report-indicator]');
-    await a11yAudit();
 
     assert.dom('.ember-tooltip').doesNotIncludeText('Last checked');
   });

--- a/ui/tests/integration/modifiers/code-mirror-test.ts
+++ b/ui/tests/integration/modifiers/code-mirror-test.ts
@@ -12,9 +12,15 @@ module('Integration | Modifier | code-mirror', function (hooks) {
     this.set('onInput', () => null);
 
     await render(
-      hbs`<div
-      {{code-mirror value=this.value onInput=this.onInput}}
-    />`
+      hbs`
+      <div
+        {{code-mirror
+          value=this.value
+          onInput=this.onInput
+          options=(hash screenReaderLabel="test")
+        }}
+      />
+    `
     );
 
     assert.dom('.CodeMirror').exists();
@@ -27,7 +33,11 @@ module('Integration | Modifier | code-mirror', function (hooks) {
 
     await render(hbs`
       <div
-        {{code-mirror value=this.value onInput=this.onInput}}
+        {{code-mirror
+          value=this.value
+          onInput=this.onInput
+          options=(hash screenReaderLabel="test")
+        }}
       />
     `);
     assert.dom('.CodeMirror').exists();
@@ -38,9 +48,18 @@ module('Integration | Modifier | code-mirror', function (hooks) {
     this.set('onInput', (value: string) => this.set('value', value));
     this.set('options', {
       lineNumbers: false,
+      screenReaderLabel: 'test',
     }); // otherwise the #s appear when comparing text
 
-    await render(hbs`<div {{code-mirror value=this.value onInput=this.onInput options=this.options}}/>`);
+    await render(hbs`
+      <div
+        {{code-mirror
+          value=this.value
+          onInput=this.onInput
+          options=this.options
+        }}
+      />
+    `);
 
     let textArea = this.element.querySelector('textarea') as HTMLElement;
     // if set as value on initial render, it won't get deleted on the second fillIn call
@@ -64,14 +83,33 @@ module('Integration | Modifier | code-mirror', function (hooks) {
     this.set('options', {
       lineNumbers: false,
       theme: 'default',
+      screenReaderLabel: 'test',
     });
 
-    await render(hbs`<div {{code-mirror value=this.value onInput=this.onInput}}/>`); // without options
+    await render(hbs`
+      <div
+        {{code-mirror
+          value=this.value
+          onInput=this.onInput
+          options=(hash
+            screenReaderLabel="test"
+          )
+        }}
+      />
+    `); // without options
     // default options
     assert.dom('.cm-s-monokai').exists();
     assert.dom('.CodeMirror-code').containsText('1');
 
-    await render(hbs`<div {{code-mirror value=this.value onInput=this.onInput options=this.options}}/>`); // with options
+    await render(hbs`
+      <div
+        {{code-mirror
+          value=this.value
+          onInput=this.onInput
+          options=this.options
+        }}
+      />
+    `); // with options
     // codemirror's real default theme should be set and linenumbers gone
     assert.dom('.cm-s-monokai').doesNotExist();
     assert.dom('.CodeMirror-code').doesNotContainText('1');

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -922,17 +922,10 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-transform-typescript" "^7.10.4"
 
-"@babel/runtime@7.12.18":
+"@babel/runtime@7.12.18", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.12.18"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.18.tgz#af137bd7e7d9705a412b3caaf991fe6aaa97831b"
   integrity sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1051,18 +1044,7 @@
     ember-cli-htmlbars "^5.7.1"
     ember-destroyable-polyfill "^2.0.3"
 
-"@ember/test-waiters@^2.4.3":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-2.4.4.tgz#4239d4cd9c60dc081d83e031463c22a628db028e"
-  integrity sha512-dhz4WplPWEPZ0Z8iJBI0uvUurv6Sk4aogNiI1XQxDXDNT13aE4WI/uQdsZXZtC+4xOUkz5V6Ob7iaEHDMixjbw==
-  dependencies:
-    calculate-cache-key-for-tree "^2.0.0"
-    ember-cli-babel "^7.26.2"
-    ember-cli-typescript "^4.1.0"
-    ember-cli-version-checker "^5.1.2"
-    semver "^7.3.2"
-
-"@ember/test-waiters@^3.0.0":
+"@ember/test-waiters@^2.4.3 || ^3.0.0", "@ember/test-waiters@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-3.0.0.tgz#b66a35cd5b78ec3c296a6f5f5fb3852780a5d3c8"
   integrity sha512-z6+gIlq/rXLKroWv2wxAoiiLtgSOGQFCw6nUufERausV+jLnA7CYbWwzEo5R7XaOejSDpgA5d6haXIBsD5j0oQ==
@@ -2019,6 +2001,16 @@
   dependencies:
     "@percy/logger" "^1.0.0-beta.58"
 
+"@scalvert/ember-setup-middleware-reporter@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@scalvert/ember-setup-middleware-reporter/-/ember-setup-middleware-reporter-0.1.1.tgz#bdd74c19d99feeef8807dea9c9ee2d272b6c1923"
+  integrity sha512-C5DHU6YlKaISB5utGQ+jpsMB57ZtY0uZ8UkD29j855BjqG6eJ98lhA2h/BoJbyPw89RKLP1EEXroy9+5JPoyVw==
+  dependencies:
+    "@types/fs-extra" "^9.0.12"
+    body-parser "^1.19.0"
+    errorhandler "^1.5.1"
+    fs-extra "^10.0.0"
+
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
@@ -2299,6 +2291,13 @@
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
   integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/fs-extra@^9.0.12":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
   dependencies:
     "@types/node" "*"
 
@@ -2865,12 +2864,12 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-to-html@^0.6.6:
-  version "0.6.14"
-  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.14.tgz#65fe6d08bba5dd9db33f44a20aec331e0010dad8"
-  integrity sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==
+ansi-to-html@^0.6.15, ansi-to-html@^0.6.6:
+  version "0.6.15"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.15.tgz#ac6ad4798a00f6aa045535d7f6a9cb9294eebea7"
+  integrity sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==
   dependencies:
-    entities "^1.1.2"
+    entities "^2.0.0"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -3109,10 +3108,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-axe-core@^4.1.4:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.0.tgz#6594db4ee62f78be79e32a7295d21b099b60668d"
-  integrity sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg==
+axe-core@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
+  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -6106,22 +6105,24 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-testing@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.0.7.tgz#1e6f23831a7926c1c35f7449e2bb9e3d8db56982"
-  integrity sha512-RbV4fKDnKHuIpJOnjVWs+ePlivXbv+B7JWPLsCM4bU9nGR+tbJGv49y5SaN1+hTcHg0bD0mnD5YUehpHf453Fw==
+ember-a11y-testing@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.3.0.tgz#30bd1f206998335d621b5138a5cdc12c729a50e9"
+  integrity sha512-w+2BEZv4gLjehYd+QP+BeAzOOdhx5jByjfrU496H8MnNBGjoNUCt7ovvdW5tuDdtQLR06ZaYkxrUrFg1zl7J4A==
   dependencies:
-    "@ember/test-waiters" "^2.4.3"
-    axe-core "^4.1.4"
+    "@ember/test-waiters" "^2.4.3 || ^3.0.0"
+    "@scalvert/ember-setup-middleware-reporter" "^0.1.1"
+    axe-core "^4.3.5"
     body-parser "^1.19.0"
+    broccoli-persistent-filter "^3.1.2"
     date-and-time "^1.0.0"
     ember-auto-import "^1.11.2"
     ember-cli-babel "^7.26.3"
-    ember-cli-typescript "^3.0.0"
+    ember-cli-typescript "^4.2.1"
     ember-cli-version-checker "^5.1.2"
     ember-destroyable-polyfill "^2.0.1"
-    fs-extra "^9.0.1"
-    validate-peer-dependencies "^1.1.0"
+    fs-extra "^10.0.0"
+    validate-peer-dependencies "^2.0.0"
 
 ember-assign-polyfill@^2.5.0:
   version "2.7.1"
@@ -6249,7 +6250,7 @@ ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.2, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.2, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6577,7 +6578,7 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3, ember-cli-typescript@^3.1.4:
+ember-cli-typescript@^3.1.3, ember-cli-typescript@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
   integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
@@ -6597,12 +6598,12 @@ ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3, ember-cli-typescript@^
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.1.0.tgz#2ff17be2e6d26b58c88b1764cb73887e7176618b"
-  integrity sha512-zSuKG8IQuYE3vS+c7V0mHJqwrN/4Wo9Wr50+0NUjnZH3P99ChynczQHu/P7WSifkO6pF6jaxwzf09XzWvG8sVw==
+ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
+  integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
   dependencies:
-    ansi-to-html "^0.6.6"
+    ansi-to-html "^0.6.15"
     broccoli-stew "^3.0.0"
     debug "^4.0.0"
     execa "^4.0.0"
@@ -7278,12 +7279,12 @@ ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2, en
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
   integrity sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==
 
-entities@^1.1.1, entities@^1.1.2, entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-entities@~2.1.0:
+entities@^2.0.0, entities@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
@@ -7313,6 +7314,14 @@ error@^7.0.0:
   integrity sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==
   dependencies:
     string-template "~0.2.1"
+
+errorhandler@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
+  integrity sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==
+  dependencies:
+    accepts "~1.3.7"
+    escape-html "~1.0.3"
 
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.18.2:
   version "1.18.3"
@@ -8254,6 +8263,15 @@ fs-extra@^0.24.0:
     jsonfile "^2.1.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
@@ -12019,7 +12037,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", "readable-stream@2 || 3", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -12032,7 +12050,7 @@ read-pkg@^3.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -12346,7 +12364,7 @@ resolve-package-path@^3.1.0:
     path-root "^0.1.1"
     resolve "^1.17.0"
 
-resolve-package-path@^4.0.1:
+resolve-package-path@^4.0.0, resolve-package-path@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-4.0.3.tgz#31dab6897236ea6613c72b83658d88898a9040aa"
   integrity sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==
@@ -12514,12 +12532,12 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0:
+safe-buffer@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -14092,6 +14110,14 @@ validate-peer-dependencies@^1.1.0:
   integrity sha512-eHHxI3fNMqu8bzWPRWWgV72kBJkWwRCeEua7yC7UI6dsqC55orhxKAC3uyQfCjjToOyAZ8mpNrbQH+NMoYBn1w==
   dependencies:
     resolve-package-path "^3.1.0"
+    semver "^7.3.2"
+
+validate-peer-dependencies@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/validate-peer-dependencies/-/validate-peer-dependencies-2.0.0.tgz#a1bd33472517932d7c859e6c03eb849849207794"
+  integrity sha512-i2I3vl+9yk+gI0YCruDa29mzaNykLbSbUVVNQY/mBTLLYjQxVbklqBdTdH2iTpxV9AHH1u0dKlk/zl1sjHTfug==
+  dependencies:
+    resolve-package-path "^4.0.0"
     semver "^7.3.2"
 
 validated-changeset@1.0.0, validated-changeset@~1.0.0:


### PR DESCRIPTION
## Why the change?

https://github.com/ember-a11y/ember-a11y-testing/pull/319 added the ability to specify additional helpers that will trigger an automated a11y audit. This allow us to enable automatic audits after `render` and `focus`, and generally improve the a11y coverage in our test suite.

Previously, the audit did not happen automatically on `render` and as such we missed out on some very important automated a11y coverage in our component tests. This matters, because component tests are where we get to render all the edge cases and exotic states of our components, making it the ideal place to check those states for accessibility.

## What does it look like?

**Note:** the following video has audio

https://user-images.githubusercontent.com/34030/141459143-de0a6f6a-bb9f-4569-b887-ee81e8f7e64a.mp4

## How much slower does it make our test suite?

| [Before](https://app.circleci.com/pipelines/github/hashicorp/waypoint/12511/workflows/7eae623c-6c6e-472d-8337-5234e084d222/jobs/120802) | [After](https://app.circleci.com/pipelines/github/hashicorp/waypoint/12515/workflows/36fa0090-a891-45cf-aa61-aa5875232723/jobs/120857) |
| --- | --- |
| 1m 26s | 1m 24s |

So no impact whatsoever 😃 

## What’s the catch?

If you watch the test suite in the browser, you’ll notice it “flashes” even more than before. This is the most price of all the extra audits.

## How do I test it?

Try introducing and accessibility violation in a component and see if the suite picks up on it.