### PR TITLE
ui: use node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
   images:
     go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.16
     middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
-    ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:12-browsers
+    ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
     website: &WEBSITE_IMAGE docker.mirror.hashicorp.services/node:14
 
   paths:

--- a/ui/README.md
+++ b/ui/README.md
@@ -7,8 +7,8 @@ A short introduction of this app could easily go here.
 
 You will need the following things properly installed on your computer.
 
-- [Node.js v12](https://nodejs.org/)
-  - The current codebase has been tested to run well with `node` version 12 so it is _**strongly recommended**_ that you use this version
+- [Node.js v14](https://nodejs.org/)
+  - The current codebase has been tested to run well with `node` version 14 so it is _**strongly recommended**_ that you use this version
   - You can use node version managers to manage all of your node versions, for example [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n), etc.
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Ember CLI](https://ember-cli.com/)

--- a/ui/package.json
+++ b/ui/package.json
@@ -122,7 +122,7 @@
     "xterm-addon-fit": "^0.5.0"
   },
   "engines": {
-    "node": "12"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Why the change?

Node v12 enters end-of-life on 2022-04-30 so now seems like a reasonable time to move to Node v14, which will be in maintenance status until 2023-04-30. This also brings us in line with both the website and cloud-ui.

## How do I test it?

CI should give a good indication, but worth checking out the branch, switching to Node v14, and making sure things work as you expect.