### PR TITLE
make install: make sure go/bin directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ bin/entrypoint: # create the entrypoint for the current platform
 
 .PHONY: install
 install: bin # build and copy binaries to $GOPATH/bin/waypoint
-	mkdir -p $(GOPATH)/bin/waypoint
+	mkdir -p $(GOPATH)/bin
 	cp ./waypoint $(GOPATH)/bin/waypoint
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ bin/entrypoint: # create the entrypoint for the current platform
 
 .PHONY: install
 install: bin # build and copy binaries to $GOPATH/bin/waypoint
+	mkdir -p $(GOPATH)/bin/waypoint
 	cp ./waypoint $(GOPATH)/bin/waypoint
 
 .PHONY: test


### PR DESCRIPTION
In case you do a fresh checkout and you have never compiled a go project "make install" will fail because the go bin directory does not exist. 

This might be a rare problem for a developer machine, but might cause issues in CI builds and it looks to me it is easy to fix.  