### PR TITLE
docs: Remove section about resource and health tracking

### DIFF
--- a/website/content/docs/roadmap.mdx
+++ b/website/content/docs/roadmap.mdx
@@ -23,20 +23,6 @@ The initial Waypoint releases have a minimal featureset around running the Waypo
 We plan to improve the `waypoint install` and `waypoint server run` interfaces
 to support more options, such as custom TLS certs.
 
-### Fine-Grained Resource and Health Tracking
-
-Waypoint currently gives you a history of operations such as builds and deploys.
-We will expand this so that history knows the _resources_ that were created
-by operations such as Docker Images, Kubernetes StatefulSets and Services, AWS
-ALBs, etc.
-
-Further, for supported resources, we will surface health information either
-by actively checking or pulling health information from an external source.
-
-This feature will allow users of Waypoint to drill down from the list of
-projects in their organization across multiple deployment platforms down
-to the individual resources created.
-
 ### Deployment Templates
 
 Waypoint currently associates a [waypoint.hcl](/docs/waypoint-hcl)


### PR DESCRIPTION
We've implemented this feature, so it's no longer a future TODO on the
Waypoint roadmap