### PR TITLE
Auto local/remote detection

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -445,7 +445,7 @@ func remoteOpPreferred(ctx context.Context, client pb.WaypointClient, project *p
 			// So if some other waypoint client is performing an operation at this moment, we will interpret
 			// that as a remote runner, and this will return a false positive.
 
-			// Also note that this is designed to run our own CLI runner.
+			// Also note that this is designed to run before se start our own CLI runner.
 			hasRemoteRunner = true
 			break
 		}

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 
@@ -356,6 +357,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 	// Create our client
 	if baseCfg.Client {
 		c.project, err = c.initClient(nil)
+
 		if err != nil {
 			c.logError(c.Log, "failed to create client", err)
 			return err
@@ -395,6 +397,95 @@ func (c *baseCommand) Init(opts ...Option) error {
 	}
 
 	return nil
+}
+
+// remoteIsPossible attempts to determine if the current waypoint infrastructure will be successful
+// performing a remote operation against this project. It verifies the project's datasource,
+// it's ODR runner profile, and detects if a remote runner is currently registered.
+func remoteIsPossible(ctx context.Context, client pb.WaypointClient, project *pb.Project, log hclog.Logger) (bool, error) {
+	// Check if remote is disabled in the waypoint.hcl
+
+	if !project.RemoteEnabled {
+		log.Debug("Remote operations are disabled for this project - operation cannot occur remotely")
+		return false, nil
+	}
+
+	if project.DataSource == nil {
+		log.Debug("Project has no datasource configured - operation cannot occur remotely")
+		// This is probably going to be fatal somewhere downstream
+		return false, nil
+	}
+
+	var hasRemoteDataSource bool
+	switch project.DataSource.GetSource().(type) {
+	case *pb.Job_DataSource_Git:
+		hasRemoteDataSource = true
+	default:
+		hasRemoteDataSource = false
+	}
+
+	if !hasRemoteDataSource {
+		log.Debug("Project does not have a remote data source - operation cannot occur remotely")
+		return false, nil
+	}
+
+	// We know the project can handle remote ops at this point - but do we have runners?
+
+	runnersResp, err := client.ListRunners(ctx, &pb.ListRunnersRequest{})
+	if err != nil {
+		return false, err
+	}
+	hasRemoteRunner := false
+	for _, runner := range runnersResp.Runners {
+		if !runner.Odr {
+			// NOTE(izaak): There is currently no way to distinguish between a remote runner and a CLI runner.
+			// So if some other waypoint client is performing an operation at this moment, we will interpret
+			// that as a remote runner, and this will return a false positive.
+
+			// Also note that this is designed to run our own CLI runner.
+			hasRemoteRunner = true
+			break
+		}
+	}
+	if !hasRemoteRunner {
+		log.Debug("No remote runner detected - operation cannot occur remotely")
+		return false, nil
+	}
+
+	// Check to see if we have a runner profile assigned to this project
+
+	if project.OndemandRunner != nil {
+		log.Debug("Project has an explicit ODR profile set - operation will work remotely")
+		return true, nil
+	}
+
+	// Check to see if we have a global default ODR profile
+
+	// TODO: it would be more efficient if we had an arg to filter to just get default profiles.
+	configsResp, err := client.ListOnDemandRunnerConfigs(ctx, &empty.Empty{})
+	if err != nil {
+		return false, err
+	}
+
+	defaultRunnerProfileExists := false
+	for _, odrConfig := range configsResp.Configs {
+		if odrConfig.Default {
+			defaultRunnerProfileExists = true
+			break
+		}
+	}
+
+	if defaultRunnerProfileExists {
+		log.Debug("Default runner profile exists - operation will work remotely.")
+		return true, nil
+	}
+
+	log.Debug("No runner profile is set for this project and no global default exists - operation should happen locally")
+	// The operation here _could_ still happen remotely - executed on the remote runner itself without ODR.
+	// If it's a container build op it will probably fail (because no kaniko), and if it's a deploy/release op it
+	// very well might fail do to incorrect/insufficient permissions. Because it probably won't work, we won't try,
+	// but the user could force it to happen locally by setting -local=false.
+	return false, nil
 }
 
 // DoApp calls the callback for each app. This lets you execute logic

--- a/internal/cli/base_test.go
+++ b/internal/cli/base_test.go
@@ -1,13 +1,19 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/server"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	pbmocks "github.com/hashicorp/waypoint/internal/server/gen/mocks"
 )
 
 func TestCheckFlagsAfterArgs(t *testing.T) {
@@ -198,6 +204,147 @@ func TestWorkspacePrecedence(t *testing.T) {
 
 			// reset the env after every test
 			os.Unsetenv(defaultWorkspaceEnvName)
+		})
+	}
+}
+
+func Test_remoteIsPossible(t *testing.T) {
+	log := hclog.Default()
+
+	type args struct {
+		project           *pb.Project
+		runnersResp       *pb.ListRunnersResponse
+		runnerConfigsResp *pb.ListOnDemandRunnerConfigsResponse
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Choose local if remote enabled is false for the project.",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: false,
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		{
+			name: "Choose local if the datasource is not remote-capable",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: true,
+					DataSource: &pb.Job_DataSource{
+						Source: &pb.Job_DataSource_Local{},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		{
+			name: "Choose local if there are no remote runners",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: true,
+					DataSource: &pb.Job_DataSource{
+						Source: &pb.Job_DataSource_Git{},
+					},
+				},
+				runnersResp: &pb.ListRunnersResponse{Runners: []*pb.Runner{{Odr: true}}},
+			},
+			want:    false,
+			wantErr: false,
+		},
+
+		{
+			name: "Choose remote if the datasource is good, a remote runner exists, and a runner profile is set",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: true,
+					DataSource: &pb.Job_DataSource{
+						Source: &pb.Job_DataSource_Git{},
+					},
+					OndemandRunner: &pb.Ref_OnDemandRunnerConfig{},
+				},
+				runnersResp: &pb.ListRunnersResponse{Runners: []*pb.Runner{{Odr: false}}},
+			},
+			want:    true,
+			wantErr: false,
+		},
+
+		{
+			name: "Choose local if no runner profile is set for the project, and there is no default",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: true,
+					DataSource: &pb.Job_DataSource{
+						Source: &pb.Job_DataSource_Git{},
+					},
+					OndemandRunner: nil,
+				},
+				runnerConfigsResp: &pb.ListOnDemandRunnerConfigsResponse{
+					Configs: []*pb.OnDemandRunnerConfig{{
+						Default: false,
+					}},
+				},
+				runnersResp: &pb.ListRunnersResponse{Runners: []*pb.Runner{{Odr: false}}},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Choose remote if the project is good and the default runner is set",
+			args: args{
+				project: &pb.Project{
+					RemoteEnabled: true,
+					DataSource: &pb.Job_DataSource{
+						Source: &pb.Job_DataSource_Git{},
+					},
+					OndemandRunner: nil,
+				},
+				runnerConfigsResp: &pb.ListOnDemandRunnerConfigsResponse{
+					Configs: []*pb.OnDemandRunnerConfig{{
+						Default: true,
+					}},
+				},
+				runnersResp: &pb.ListRunnersResponse{Runners: []*pb.Runner{{Odr: false}}},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			var client pb.WaypointClient
+			if tt.args.runnerConfigsResp != nil || tt.args.runnersResp != nil {
+				m := &pbmocks.WaypointServer{}
+				// Called when initializing the client
+				m.On("BootstrapToken", mock.Anything, mock.Anything).Return(&pb.NewTokenResponse{Token: "hello"}, nil)
+				m.On("GetVersionInfo", mock.Anything, mock.Anything).Return(server.TestVersionInfoResponse(), nil)
+
+				m.On("ListOnDemandRunnerConfigs", mock.Anything, mock.Anything).Return(tt.args.runnerConfigsResp, nil)
+				m.On("ListRunners", mock.Anything, mock.Anything).Return(tt.args.runnersResp, nil)
+				client = server.TestServer(t, m, server.TestWithContext(ctx))
+			}
+
+			got, err := remoteIsPossible(ctx, client, tt.args.project, log)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("remoteIsPossible() error = %v, wantErr %v", err, tt.wantErr)
+				cancel()
+				return
+			}
+			if got != tt.want {
+				t.Errorf("remoteIsPossible() got = %v, want %v", got, tt.want)
+			}
+			cancel()
 		})
 	}
 }

--- a/internal/server/gen/server.pb.go
+++ b/internal/server/gen/server.pb.go
@@ -8,6 +8,9 @@ package gen
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
@@ -17,8 +20,6 @@ import (
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (
@@ -1437,10 +1438,15 @@ type Project struct {
 	// The applications cannot be modified in any Project APIs. You must
 	// use the dedicated Application APIs.
 	Applications []*Application `protobuf:"bytes,2,rep,name=applications,proto3" json:"applications,omitempty"`
+
 	// If true, then the `-remote` flag or the `waypoint build project/app`
 	// syntax can be used with a remote runner. If this is false, then
 	// this is not allowed. This is typically configured using the
 	// `runner {}` block in the waypoint config.
+
+	// for the hcl - users should probably still be able to disable remote ops there,
+	// (or force remote ops?), and it would be nice if the syntax wasn't backwards-compat
+	// breaking
 	RemoteEnabled bool `protobuf:"varint,3,opt,name=remote_enabled,json=remoteEnabled,proto3" json:"remote_enabled,omitempty"`
 	// Where data is sourced for remote operations. If this isn't set, then
 	// there is no default data source and it will be an error if a job is

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -35,7 +35,7 @@ func TestRun_reconnect(t *testing.T) {
 
 	m := &pbmocks.WaypointServer{}
 	m.On("BootstrapToken", mock.Anything, mock.Anything).Return(&pb.NewTokenResponse{Token: "hello"}, nil)
-	m.On("GetVersionInfo", mock.Anything, mock.Anything).Return(testVersionInfoResponse(), nil)
+	m.On("GetVersionInfo", mock.Anything, mock.Anything).Return(TestVersionInfoResponse(), nil)
 	m.On("GetWorkspace", mock.Anything, mock.Anything).Return(&pb.GetWorkspaceResponse{}, nil)
 
 	// Create the server

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -82,7 +82,7 @@ func TestServer(t testing.T, impl pb.WaypointServer, opts ...TestOption) pb.Wayp
 	}
 
 	// Get our version info we'll set on the client
-	vsnInfo := testVersionInfoResponse().Info
+	vsnInfo := TestVersionInfoResponse().Info
 
 	// connect is a function since we need to connect multiple times:
 	// once to bootstrap, then again with our auth information.
@@ -134,7 +134,7 @@ func TestWithContext(ctx context.Context) TestOption {
 	}
 }
 
-// TestWithRestart specifies a channel that will be sent to to trigger
+// TestWithRestart specifies a channel that will be sent to trigger
 // a restart. The restart happens asynchronously. If you want to ensure the
 // server is shutdown first, use TestWithContext, shut it down, wait for
 // errors on the API, then restart.
@@ -144,7 +144,8 @@ func TestWithRestart(ch <-chan struct{}) TestOption {
 	}
 }
 
-func testVersionInfoResponse() *pb.GetVersionInfoResponse {
+// TestVersionInfoResponse generates a valid version info response for testing
+func TestVersionInfoResponse() *pb.GetVersionInfoResponse {
 	return &pb.GetVersionInfoResponse{
 		Info: &pb.VersionInfo{
 			Api: &pb.VersionInfo_ProtocolVersion{


### PR DESCRIPTION
This introduces the logic for automatic detection of local vs remote operations. It isn't used anywhere yet. 

I had some fun building tests that mocked the server - there are enough permutations that I didn't build a case for each one, but this covers the highlights.