### PR TITLE
statetest: Make the timing of the watchset tests more forgiving

### DIFF
--- a/internal/serverstate/statetest/statetest.go
+++ b/internal/serverstate/statetest/statetest.go
@@ -2,6 +2,7 @@ package statetest
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	ulidpkg "github.com/oklog/ulid"
@@ -37,6 +38,20 @@ func Test(t *testing.T, f Factory, rf RestartFactory) {
 			}
 		})
 	}
+}
+
+// TestGroup runs a specific group of validation tests for a state implementation.
+func TestGroup(t *testing.T, name string, f Factory, rf RestartFactory) {
+	funcs, ok := tests[name]
+	if !ok {
+		panic(fmt.Sprintf("unknown test group: %s", name))
+	}
+
+	t.Run(name, func(t *testing.T) {
+		for _, tf := range funcs {
+			tf(t, f, rf)
+		}
+	})
 }
 
 // tests is the list of tests to run.

--- a/internal/serverstate/statetest/test_project.go
+++ b/internal/serverstate/statetest/test_project.go
@@ -242,7 +242,7 @@ func TestProjectPollPeek(t *testing.T, factory Factory, restartF RestartFactory)
 		})))
 
 		// Should be triggered.
-		require.False(ws.Watch(time.After(100 * time.Millisecond)))
+		require.False(ws.Watch(time.After(2 * time.Second)))
 
 		// Get exact
 		{
@@ -306,7 +306,7 @@ func TestProjectPollPeek(t *testing.T, factory Factory, restartF RestartFactory)
 		require.NoError(s.ProjectPollComplete(pA, now.Add(1*time.Second)))
 
 		// Should be triggered.
-		require.False(ws.Watch(time.After(100 * time.Millisecond)))
+		require.False(ws.Watch(time.After(2 * time.Second)))
 
 		// Get exact
 		{


### PR DESCRIPTION
This gives the watchset implementor a little more latitude about how quickly it detects the new data.