### PR TITLE
Refactor CLI init sequence

### DIFF
--- a/builtin/aws/lambda/platform_logs.go
+++ b/builtin/aws/lambda/platform_logs.go
@@ -14,8 +14,7 @@ import (
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
-// Exec creates an ECS task using the given deployments ECR image and then
-// ssh's to it to provide the shell.
+// Logs fetches logs from cloudwatch
 func (p *Platform) Logs(
 	ctx context.Context,
 	log hclog.Logger,

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -23,7 +23,8 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/artifact_list.go
+++ b/internal/cli/artifact_list.go
@@ -35,7 +35,7 @@ func (c *ArtifactListCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -21,7 +21,8 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/auth_method_delete.go
+++ b/internal/cli/auth_method_delete.go
@@ -22,7 +22,7 @@ func (c *AuthMethodDeleteCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoAutoServer(), // no auth in local mode
+		WithNoLocalServer(), // no auth in local mode
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/auth_method_inspect.go
+++ b/internal/cli/auth_method_inspect.go
@@ -21,7 +21,7 @@ func (c *AuthMethodInspectCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoAutoServer(), // no auth in local mode
+		WithNoLocalServer(), // no auth in local mode
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/auth_method_list.go
+++ b/internal/cli/auth_method_list.go
@@ -21,7 +21,7 @@ func (c *AuthMethodListCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoAutoServer(), // no auth in local mode
+		WithNoLocalServer(), // no auth in local mode
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/auth_method_set_oidc.go
+++ b/internal/cli/auth_method_set_oidc.go
@@ -22,7 +22,7 @@ func (c *AuthMethodSetOIDCCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoAutoServer(), // no auth in local mode
+		WithNoLocalServer(), // no auth in local mode
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -157,6 +157,16 @@ func (c *baseCommand) Close() error {
 //
 // Init should be called FIRST within the Run function implementation. Many
 // options will affect behavior of other functions that can be called later.
+//
+// In broad strokes, Init populates fields on the baseCommand by doing the following:
+// - Parse flags
+// - Parse input variables
+// - Creates a project client
+// - Triggers creation of the in-memory server (if necessary)
+// - Starts a local runner (if necessary)
+// - Attempts to find a waypoint.hcl config file, and parse it
+// - Determines which project/apps are being targeted, by looking at
+//   the -project and -app flags, the local config, the waypoint server.
 func (c *baseCommand) Init(opts ...Option) error {
 	baseCfg := baseConfig{}
 

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	stdflag "flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/waypoint/internal/runner"
+	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
 
 	"github.com/adrg/xdg"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -23,7 +27,6 @@ import (
 	"github.com/hashicorp/waypoint/internal/config/variables"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
 )
 
 const (
@@ -69,9 +72,15 @@ type baseCommand struct {
 	// contextStorage is for CLI contexts.
 	contextStorage *clicontext.Storage
 
-	// refProject and refWorkspace the references for this CLI invocation.
-	refProject   *pb.Ref_Project
-	refApp       *pb.Ref_Application
+	// refProject references the project for this CLI invocation. A project
+	// reference will be looked for in config, or in the -project flag.
+	refProject *pb.Ref_Project
+
+	// refApps references the apps for this CLI invocation. An app
+	// reference will be looked for in config, or in the -app flag.
+	refApps []*pb.Ref_Application
+
+	// refWorkspace referenced the workspace for this CLI invocation
 	refWorkspace *pb.Ref_Workspace
 
 	// variables hold the values set via flags and local env vars
@@ -118,9 +127,8 @@ type baseCommand struct {
 	// options passed in at the global level
 	globalOptions []Option
 
-	// autoServer will be set to true if an automatic in-memory server
-	// is allowd.
-	autoServer bool
+	// noLocalServer prevents the creation of a local in-memory server
+	noLocalServer bool
 
 	// The home directory that we loaded the waypoint config from
 	homeConfigPath string
@@ -150,10 +158,7 @@ func (c *baseCommand) Close() error {
 // Init should be called FIRST within the Run function implementation. Many
 // options will affect behavior of other functions that can be called later.
 func (c *baseCommand) Init(opts ...Option) error {
-	baseCfg := baseConfig{
-		Config: true,
-		Client: true,
-	}
+	baseCfg := baseConfig{}
 
 	for _, opt := range c.globalOptions {
 		opt(&baseCfg)
@@ -164,7 +169,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 	}
 
 	// Set some basic internal fields
-	c.autoServer = !baseCfg.NoAutoServer
+	c.noLocalServer = baseCfg.NoLocalServer
 
 	// Init our UI first so we can write output to the user immediately.
 	ui := baseCfg.UI
@@ -233,114 +238,55 @@ func (c *baseCommand) Init(opts ...Option) error {
 	// Parse the configuration
 	c.cfg = &config.Config{}
 
-	// If we have an app target requirement, we have to get it from the args
-	// or the config.
-	if baseCfg.AppTargetRequired {
-		// If we have args, attempt to extract there first.
-		if len(c.args) > 0 {
-			match := reAppTarget.FindStringSubmatch(c.args[0])
-			if match != nil {
-				// Set our refs
-				c.refProject = &pb.Ref_Project{Project: match[1]}
-				c.refApp = &pb.Ref_Application{
-					Project:     match[1],
-					Application: match[2],
-				}
-
-				// Shift the args
-				c.args = c.args[1:]
-
-				// Explicitly set remote
-				c.flagRemote = true
-			}
-		}
-
-		// If we didn't get our ref, then we need to load config
-		if c.refApp == nil {
-			baseCfg.Config = true
-		}
-	}
-
-	// Some CLIs don't explicitly need an app, but sometimes need to load a config
-	// and setup the project client with the proper project refs.
-	if baseCfg.AppOptional || baseCfg.ProjectTargetRequired {
-		// If we have args, attempt to extract there first.
-		if len(c.args) > 0 {
-			match := reAppTarget.FindStringSubmatch(c.args[0])
-			if match != nil {
-				// Set our refs
-				c.refProject = &pb.Ref_Project{Project: match[1]}
-				c.refApp = &pb.Ref_Application{
-					Project:     match[1],
-					Application: match[2],
-				}
-
-				// Shift the args
-				c.args = c.args[1:]
-
-				// Explicitly set remote
-				c.flagRemote = true
-
-				// the below should only be used for commands that don't accept
-				// other arguments
-			} else if !baseCfg.ProjectTargetRequired {
-				// Assume the target is just project
-				p := c.args[0]
-				c.refProject = &pb.Ref_Project{Project: p}
-				// We don't explicitly set the app because there was none requested,
-				// and we might or might not be working on an app later.
-
-				// Shift the args
-				c.args = c.args[1:]
-
-				// Explicitly set remote
-				c.flagRemote = true
-			}
-		}
-
-		// If we didn't get our ref, then we need to load config
-		if c.refApp == nil && c.refProject == nil {
-			// We look at both app and project for the case where no target was specified
-			// i.e. already in a project directory
-			baseCfg.Config = true
-		}
-	}
-
-	// If we're loading the config, then get it.
-	if baseCfg.Config {
-		cfg, err := c.initConfig("", baseCfg.ConfigOptional)
+	if !baseCfg.NoConfig {
+		// Try parsing config
+		cfg, err := c.initConfig("")
 		if err != nil {
 			c.logError(c.Log, "failed to load config", err)
 			return err
 		}
 
-		c.cfg = cfg
+		// If that worked, set our refs
 		if cfg != nil {
-			project := &pb.Ref_Project{Project: cfg.Project}
-
-			// If we're loading config, we'll have a project, and we set it now.
-			// If they didn't provide a value via flag, we default to
-			// the project from initConfig.
-			if c.flagProject != "" {
-				project = &pb.Ref_Project{Project: c.flagProject}
-			}
-			if c.refProject == nil {
-				c.refProject = project
-			}
-
-			// If we require an app target and we still haven't set it,
-			// and the user provided it via the CLI, set it now. This code
-			// path is only reached if it wasn't set via the args either
-			// above.
-			if baseCfg.AppTargetRequired &&
-				c.refApp == nil &&
-				c.flagApp != "" {
-				c.refApp = &pb.Ref_Application{
-					Project:     project.Project,
-					Application: c.flagApp,
-				}
+			c.refProject = &pb.Ref_Project{Project: cfg.Project}
+			for _, app := range cfg.Apps() {
+				c.refApps = append(c.refApps, &pb.Ref_Application{
+					Project:     cfg.Project,
+					Application: app,
+				})
 			}
 		}
+	}
+
+	// Parse project flags
+	if c.flagProject != "" {
+		c.refProject = &pb.Ref_Project{Project: c.flagProject}
+	}
+
+	if baseCfg.ProjectTargetRequired && c.refProject == nil {
+		// The user must not have specified a project flag, and config parsing didn't produce one either.
+
+		// NOTE(izaak) The UX here will be refined in the next pass - it's ok that this is terse for now.
+		err := errors.New("No project specified, and no waypoint.hcl found.")
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return err
+	}
+
+	// Parse app flags
+	if c.flagApp != "" {
+		// NOTE: we could allow app to be specified multiple times in the future
+		c.refApps = []*pb.Ref_Application{{Application: c.flagApp}}
+	}
+
+	if (baseCfg.SingleAppTarget || baseCfg.MultiAppTarget) && len(c.refApps) == 0 {
+		err = fmt.Errorf("This command requires an app to be targeted, but no apps were found in project %q.", c.refProject.Project)
+		c.logError(c.Log, "", err)
+		return err
+	}
+
+	if baseCfg.SingleAppTarget && len(c.refApps) != 0 {
+		c.ui.Output(errAppModeSingle, terminal.WithErrorStyle())
+		return ErrSentinel
 	}
 
 	// Collect variable values from -var and -varfile flags,
@@ -355,7 +301,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 	c.variables = vars
 
 	// Create our client
-	if baseCfg.Client {
+	if !baseCfg.NoClient {
 		c.project, err = c.initClient(nil)
 
 		if err != nil {
@@ -364,39 +310,39 @@ func (c *baseCommand) Init(opts ...Option) error {
 		}
 	}
 
-	// Validate remote vs. local operations.
-	if !baseCfg.AppOptional {
-		if c.flagRemote && c.refApp == nil {
-			if c.cfg == nil || c.cfg.Runner == nil || !c.cfg.Runner.Enabled {
-				err := errors.New(
-					"The `-remote` flag was specified but remote operations are not supported\n" +
-						"for this project.\n\n" +
-						"Remote operations must be manually enabled by using setting the 'runner.enabled'\n" +
-						"setting in your Waypoint configuration file. Please see the documentation\n" +
-						"on this setting for more information.")
-				c.logError(c.Log, "", err)
-				return err
-			}
-		}
-	}
-
-	// If this is a single app mode then make sure that we only have
-	// one app or that we have an app target.
-	if baseCfg.AppTargetRequired {
-		if c.refApp == nil {
-			if len(c.cfg.Apps()) != 1 {
-				c.ui.Output(errAppModeSingle, terminal.WithErrorStyle())
-				return ErrSentinel
-			}
-
-			c.refApp = &pb.Ref_Application{
-				Project:     c.cfg.Project,
-				Application: c.cfg.Apps()[0],
-			}
+	// Start a local runner if necessary
+	if baseCfg.RunnerRequired && !c.remoteOpPreferred() {
+		_, err := c.startLocalRunner()
+		if err != nil {
+			c.logError(c.Log, "failed to start a local runner", err)
+			return err
 		}
 	}
 
 	return nil
+}
+
+// startLocalRunner starts a local runner, and adds its id to the grpc context.
+func (c *baseCommand) startLocalRunner() (*runner.Runner, error) {
+	// NOTE(izaak): For now, we just start the local runner every time one is required - we may not end up using it.
+	// Will start this more selectively in a future PR.
+	r, err := c.project.StartLocalRunner()
+	if err != nil {
+		c.logError(c.Log, "failed to start a local runner", err)
+		return nil, err
+	}
+
+	// Inject the metadata about the client, such as the runner id if it is running
+	// a local runner.
+	c.Ctx = grpcmetadata.AddRunner(c.Ctx, r.Id())
+	return r, nil
+}
+
+// remoteOpPreferred determines if any operations that occur during the invocation of this command
+// should happen remotely.
+func (c *baseCommand) remoteOpPreferred() bool {
+	// NOTE(izaak): will be significantly improved in the near future.
+	return c.flagRemote
 }
 
 // remoteOpPreferred attempts to determine if the current waypoint infrastructure will be successful
@@ -526,31 +472,11 @@ func (c *baseCommand) DoApp(ctx context.Context, f func(context.Context, *client
 		}
 	}
 
-	if c.flagApp != "" {
-		c.refApp = &pb.Ref_Application{
-			Application: c.flagApp,
-		}
-	}
-
-	// if we specifically target an app, we no longer care about the rest
-	// of the apps in the project that we set above
-	if c.refApp != nil {
-		appTargets = []string{c.refApp.Application}
-	} else if c.cfg != nil && len(appTargets) == 0 {
-		appTargets = append(appTargets, c.cfg.Apps()...)
-	}
-
 	var apps []*clientpkg.App
-	for _, appName := range appTargets {
-		app := c.project.App(appName)
-		c.Log.Debug("will operate on app", "name", appName)
+	for _, refApp := range c.refApps {
+		app := c.project.App(refApp.Application)
+		c.Log.Debug("will operate on app", "name", refApp.Application)
 		apps = append(apps, app)
-	}
-
-	// Inject the metadata about the client, such as the runner id if it is running
-	// a local runner.
-	if id, ok := c.project.LocalRunnerId(); ok {
-		ctx = grpcmetadata.AddRunner(ctx, id)
 	}
 
 	// Just a serialize loop for now, one day we'll parallelize.

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -202,6 +202,18 @@ func (c *baseCommand) Init(opts ...Option) error {
 		return err
 	}
 
+	// Check for deprecated project/app syntax.
+	// NOTE(izaak): we should remove this in the next major (v0.8.0) because it
+	// collides with arguments that contain a single slash (i.e. `waypoint exec bin/bash`)
+	if len(c.args) > 0 {
+		match := reAppTarget.FindStringSubmatch(c.args[0])
+		if match != nil {
+			err := errors.New(errDeprecatedProjectAppArg)
+			c.logError(c.Log, "", err)
+			return err
+		}
+	}
+
 	// Reset the UI to plain if that was set
 	if c.flagPlain {
 		c.ui = terminal.NonInteractiveUI(c.Ctx)
@@ -796,6 +808,11 @@ so you can specify the app to target using the "-app" flag.
 
 	// matches either "project" or "project/app"
 	reAppTarget = regexp.MustCompile(`^(?P<project>[-0-9A-Za-z_]+)/(?P<app>[-0-9A-Za-z_]+)$`)
+
+	errDeprecatedProjectAppArg = strings.TrimSpace(`
+The project/app argument has been deprecated. Instead, use -project and -app flags, or their
+short notation -p and -a.
+`)
 
 	snapshotUnimplementedErr = strings.TrimSpace(`
 The current Waypoint server does not support snapshots. Rerunning the command

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -11,9 +11,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/waypoint/internal/runner"
-	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
-
 	"github.com/adrg/xdg"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
@@ -26,7 +23,9 @@ import (
 	"github.com/hashicorp/waypoint/internal/config"
 	"github.com/hashicorp/waypoint/internal/config/variables"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/runner"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
 )
 
 const (
@@ -284,7 +283,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 		return err
 	}
 
-	if baseCfg.SingleAppTarget && len(c.refApps) != 0 {
+	if baseCfg.SingleAppTarget && len(c.refApps) > 1 {
 		c.ui.Output(errAppModeSingle, terminal.WithErrorStyle())
 		return ErrSentinel
 	}

--- a/internal/cli/build_list.go
+++ b/internal/cli/build_list.go
@@ -28,7 +28,7 @@ func (c *BuildListCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -28,7 +28,7 @@ func (c *ConfigGetCommand) Run(args []string) int {
 
 		// Don't allow a local in-mem server because configuration
 		// makes no sense with the local server.
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	}
 
 	// We parse our flags twice in this command because we need to

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -30,7 +30,7 @@ func (c *ConfigSetCommand) Run(args []string) int {
 
 		// Don't allow a local in-mem server because configuration
 		// makes no sense with the local server.
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	}
 
 	// We parse our flags twice in this command because we need to

--- a/internal/cli/config_source_get.go
+++ b/internal/cli/config_source_get.go
@@ -19,7 +19,6 @@ func (c *ConfigSourceGetCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoConfig(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/config_source_set.go
+++ b/internal/cli/config_source_set.go
@@ -21,7 +21,6 @@ func (c *ConfigSourceSetCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoConfig(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/config_sync.go
+++ b/internal/cli/config_sync.go
@@ -21,7 +21,7 @@ func (c *ConfigSyncCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_clear.go
+++ b/internal/cli/context_clear.go
@@ -19,7 +19,7 @@ func (c *ContextClearCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -23,7 +23,7 @@ func (c *ContextCreateCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_delete.go
+++ b/internal/cli/context_delete.go
@@ -21,7 +21,7 @@ func (c *ContextDeleteCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_help.go
+++ b/internal/cli/context_help.go
@@ -24,7 +24,7 @@ func (c *ContextHelpCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_inspect.go
+++ b/internal/cli/context_inspect.go
@@ -21,7 +21,7 @@ func (c *ContextInspectCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_list.go
+++ b/internal/cli/context_list.go
@@ -19,7 +19,7 @@ func (c *ContextListCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_rename.go
+++ b/internal/cli/context_rename.go
@@ -19,7 +19,7 @@ func (c *ContextRenameCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_set.go
+++ b/internal/cli/context_set.go
@@ -21,7 +21,7 @@ func (c *ContextSetCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_use.go
+++ b/internal/cli/context_use.go
@@ -22,7 +22,7 @@ func (c *ContextUseCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/context_verify.go
+++ b/internal/cli/context_verify.go
@@ -25,7 +25,7 @@ func (c *ContextVerifyCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithClient(false),
+		WithNoClient(),
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -24,7 +24,8 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -62,7 +62,8 @@ func (c *DeploymentListCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -23,7 +23,8 @@ func (c *DestroyCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -101,7 +101,7 @@ func (c *ExecCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(flagSet),
-		WithSingleApp(),
+		WithSingleAppTarget(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -102,6 +102,7 @@ func (c *ExecCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithSingleAppTarget(),
+		WithRunnerRequired(), // Some platforms require an exec plugin
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -26,7 +26,7 @@ func (c *FmtCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/hostname_register.go
+++ b/internal/cli/hostname_register.go
@@ -20,7 +20,7 @@ func (c *HostnameRegisterCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,9 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	getter "github.com/hashicorp/go-getter"
+	"github.com/pkg/errors"
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -42,7 +42,7 @@ func (c *InitCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}
@@ -220,7 +220,7 @@ func (c *InitCommand) validateConfig() bool {
 	defer sg.Wait()
 
 	s := sg.Add("Validating configuration file...")
-	cfg, err := c.initConfig(c.fromProject, false)
+	cfg, err := c.initConfig(c.fromProject)
 	if err != nil {
 		c.stepError(s, initStepConfig, err)
 		return false

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	getter "github.com/hashicorp/go-getter"
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
@@ -225,6 +227,14 @@ func (c *InitCommand) validateConfig() bool {
 		c.stepError(s, initStepConfig, err)
 		return false
 	}
+	if cfg == nil {
+		// This should never happen, because if there is no config, init should have created
+		// it an exited earlier.
+		err = errors.New("No configuration file found")
+		c.stepError(s, initStepConfig, err)
+		return false
+	}
+
 	c.cfg = cfg
 	c.refProject = &pb.Ref_Project{Project: cfg.Project}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -228,7 +228,7 @@ func (c *InitCommand) validateConfig() bool {
 	}
 	if cfg == nil {
 		// This should never happen, because if there is no config, init should have created
-		// it an exited earlier.
+		// it and exited earlier.
 		err = errors.New("No configuration file found")
 		c.stepError(s, initStepConfig, err)
 		return false

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -45,7 +45,7 @@ func (c *InstallCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/k8s_bootstrap.go
+++ b/internal/cli/k8s_bootstrap.go
@@ -45,11 +45,11 @@ func (c *K8SBootstrapCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 
 		// Don't initialize the client because this is called before
 		// the client is ready.
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -45,13 +45,13 @@ func (c *LoginCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(), // no need to login for local mode
+		WithNoLocalServer(), // no need to login for local mode
 		WithConnectionArg(),
 
 		// Don't initialize the client automatically because if we have
 		// -from-kubernetes set we may want to do more logic to detect the
 		// server URL.
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		// This error specifically comes if we attempt to run this without
 		// a server address configured.

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -29,7 +29,7 @@ func (c *LogsCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithSingleApp(),
+		WithSingleAppTarget(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -30,6 +30,7 @@ func (c *LogsCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithSingleAppTarget(),
+		WithRunnerRequired(), // Some platforms have a separate logs plugin that require a runner
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -3,7 +3,8 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/waypoint-plugin-sdk"
+
+	sdk "github.com/hashicorp/waypoint-plugin-sdk"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/plugin"
 )
@@ -20,8 +21,8 @@ func (c *PluginCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(flags),
-		WithClient(false),
-		WithNoAutoServer(),
+		WithNoClient(),
+		WithNoLocalServer(),
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/project_inspect.go
+++ b/internal/cli/project_inspect.go
@@ -25,7 +25,7 @@ func (c *ProjectInspectCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(flagSet),
-		WithConfig(true), // optional config loading
+		WithProjectTarget(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -33,7 +33,8 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/release_list.go
+++ b/internal/cli/release_list.go
@@ -39,7 +39,7 @@ func (c *ReleaseListCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -56,7 +56,7 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/runner_profile_inspect.go
+++ b/internal/cli/runner_profile_inspect.go
@@ -25,7 +25,7 @@ func (c *RunnerProfileInspectCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithNoAutoServer(), // no auth in local mode
+		WithNoLocalServer(), // no auth in local mode
 		WithNoConfig(),
 	); err != nil {
 		return 1

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -28,7 +28,7 @@ func (c *ServerBootstrapCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -89,7 +89,7 @@ func (c *ServerRunCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithClient(false),
+		WithNoClient(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -43,7 +43,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1268,13 +1268,13 @@ var (
 	wpStatusSuccessMsg = strings.TrimSpace(`
 The projects listed above represent their current state known
 in the Waypoint server. For more information about a project’s applications and
-their current state, run ‘waypoint status PROJECT-NAME’.
+their current state, run ‘waypoint status -project=PROJECT-NAME’.
 `)
 
 	wpStatusProjectSuccessMsg = strings.TrimSpace(`
 The project and its apps listed above represents its current state known
 in the Waypoint server. For more information about a project’s applications and
-their current state, run ‘waypoint status -app=APP-NAME PROJECT-NAME’.
+their current state, run ‘waypoint status -app=APP-NAME -project=PROJECT-NAME’.
 `)
 
 	wpStatusAppSuccessMsg = strings.TrimSpace(`
@@ -1307,7 +1307,7 @@ The projects listed above represent their current state known
 in Waypoint server. For more information about an application defined in the
 project %[1]q can be viewed by running the command:
 
-waypoint status -app=APP-NAME %[1]s
+waypoint status -app=APP-NAME -project=%[1]s
 `)
 
 	wpProjectNotFound = strings.TrimSpace(`
@@ -1315,7 +1315,7 @@ No project named %q was found for the server context %q. To see a list of
 currently configured projects, run “waypoint project list”.
 
 If you want more information for a specific application, use the '-app' flag
-with “waypoint status -app=APP-NAME PROJECT-NAME”.
+with “waypoint status -app=APP-NAME -project=PROJECT-NAME”.
 `)
 
 	wpAppNotFound = strings.TrimSpace(`

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,7 +41,6 @@ func (c *StatusCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(flagSet),
-		WithOptionalApp(), // optional config loading, no hard requirement on an app target
 	); err != nil {
 		return 1
 	}
@@ -68,43 +68,9 @@ func (c *StatusCommand) Run(args []string) int {
 		c.ui.Output(wpNoServerContext, terminal.WithWarningStyle())
 	}
 
-	cmdArgs := flagSet.Args()
-
-	if len(cmdArgs) > 1 {
-		c.ui.Output("No more than 1 argument required.\n\n"+c.Help(), terminal.WithErrorStyle())
-		return 1
-	}
-
-	// Determine which view to show based on user input
-	var projectTarget, appTarget string
-	if len(cmdArgs) >= 1 {
-		match := reAppTarget.FindStringSubmatch(cmdArgs[0])
-
-		if match != nil {
-			projectTarget = match[1]
-			appTarget = match[2]
-		} else {
-			projectTarget = cmdArgs[0]
-		}
-	} else if len(cmdArgs) == 0 {
-		// If we're in a project dir, load the name. Otherwise we'll
-		// show a list of all projects and their status and leave projectTarget
-		// blank
-		if c.project.Ref() != nil {
-			projectTarget = c.project.Ref().Project
-		}
-	}
-
-	if appTarget == "" && c.flagApp != "" {
-		appTarget = c.flagApp
-	} else if appTarget != "" && c.flagApp != "" {
-		// setting app target and passing the flag app is a collision
-		c.ui.Output(wpAppFlagAndTargetIncludedMsg, terminal.WithWarningStyle())
-	}
-
 	// Optionally refresh status
 	if c.flagRefreshAppStatus {
-		if err := c.RefreshApplicationStatus(projectTarget, appTarget); err != nil {
+		if err := c.RefreshApplicationStatus(); err != nil {
 			c.ui.Output("CLI failed to refresh project statuses: "+clierrors.Humanize(err), terminal.WithErrorStyle())
 			return 1
 		}
@@ -112,15 +78,16 @@ func (c *StatusCommand) Run(args []string) int {
 	}
 
 	// Generate a status view
-	if projectTarget == "" || c.flagAllProjects {
+	if c.refProject == nil || c.flagAllProjects {
 		// Show high-level status of all projects
 		err = c.FormatProjectStatus()
 		if err != nil {
 			c.ui.Output("CLI failed to build project statuses: "+clierrors.Humanize(err), terminal.WithErrorStyle())
 			return 1
 		}
-	} else if projectTarget != "" && appTarget == "" {
+	} else if c.refProject != nil && c.flagApp == "" {
 		// Show status of apps inside project
+		projectTarget := c.refProject.Project
 		err = c.FormatProjectAppStatus(projectTarget)
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
@@ -135,8 +102,10 @@ func (c *StatusCommand) Run(args []string) int {
 			}
 			return 1
 		}
-	} else if projectTarget != "" && appTarget != "" {
+	} else if c.refProject != nil && c.flagApp != "" {
 		// Advanced view of a single app status
+		projectTarget := c.refProject.Project
+		appTarget := c.flagApp
 		err = c.FormatAppStatus(projectTarget, appTarget)
 		if err != nil {
 			if status.Code(err) == codes.NotFound {
@@ -158,12 +127,20 @@ func (c *StatusCommand) Run(args []string) int {
 
 // RefreshApplicationStatus takes a project and application target and generates
 // a list of applications to refresh the status on. If all projects are requested
-// to be refreshed, the CLI will do its best to honor the request. However if
+// to be refreshed, the CLI will do its best to honor the request. However, if
 // a project is local and the CLI was not invoked inside that project dir, the
 // CLI won't be able to refresh that project's application statuses.
-func (c *StatusCommand) RefreshApplicationStatus(projectTarget, appTarget string) error {
+func (c *StatusCommand) RefreshApplicationStatus() error {
 	// Get our API client
 	client := c.project.Client()
+
+	// We now know that we're going to need a runner for the refresh job.
+	if !c.remoteOpPreferred() {
+		_, err := c.startLocalRunner()
+		if err != nil {
+			return err
+		}
+	}
 
 	// Get the entire list of apps
 	// Determine project locality
@@ -175,9 +152,19 @@ func (c *StatusCommand) RefreshApplicationStatus(projectTarget, appTarget string
 		return nil
 	}
 
+	if c.refProject == nil {
+		return errors.New("No project specified - use the -project flag")
+	}
+
+	if len(c.refApps) == 0 {
+		// Technically the user could have no apps in the
+		return errors.New("No apps specified - please use the -app flag, or run from within " +
+			"a project directory that contains apps.")
+	}
+
 	projectResp, err := client.GetProject(c.Ctx, &pb.GetProjectRequest{
 		Project: &pb.Ref_Project{
-			Project: projectTarget,
+			Project: c.refProject.Project,
 		},
 	})
 	if err != nil {
@@ -187,7 +174,7 @@ func (c *StatusCommand) RefreshApplicationStatus(projectTarget, appTarget string
 				serverAddress = c.serverCtx.Server.Address
 			}
 
-			c.ui.Output(wpProjectNotFound, projectTarget, serverAddress, terminal.WithErrorStyle())
+			c.ui.Output(wpProjectNotFound, c.refProject.Project, serverAddress, terminal.WithErrorStyle())
 		}
 		return err
 	}
@@ -198,35 +185,37 @@ func (c *StatusCommand) RefreshApplicationStatus(projectTarget, appTarget string
 		return err
 	}
 
-	if appTarget != "" {
-		// Single app refresh
-		var app *pb.Application
-		for _, a := range project.Applications {
-			if a.Name == appTarget {
-				app = a
-				break
+	// Only refresh specified applications
+	var appsToRefresh []*pb.Application
+	for _, refApp := range c.refApps {
+		for _, app := range project.Applications {
+			if app.Name == refApp.Application {
+				appsToRefresh = append(appsToRefresh, app)
 			}
 		}
-		if app == nil {
-			return fmt.Errorf("Did not find application %q in project %q", appTarget, projectTarget)
-		}
+	}
 
-		appList := []*pb.Application{app}
+	// Useful for printing
+	var appNames []string
+	for _, refApp := range c.refApps {
+		appNames = append(appNames, refApp.Application)
+	}
 
-		if err = c.doRefresh(project, appList, workspace); err != nil {
-			c.ui.Output("Failed to refresh app %q status in project %q: %s",
-				app.Name,
-				project.Name,
-				clierrors.Humanize(err), terminal.WithErrorStyle())
-			return err
-		}
-	} else {
-		if err = c.doRefresh(project, project.Applications, workspace); err != nil {
-			c.ui.Output("Failed to refresh app statuses in project %q: %s",
-				project.Name,
-				clierrors.Humanize(err), terminal.WithErrorStyle())
-			return err
-		}
+	if len(appsToRefresh) == 0 {
+		// Corner case - will happen if they typo an app given to the -app flag.
+		c.ui.Output("Specified app(s) %q not found in project %q",
+			strings.Join(appNames, ", "),
+			project.Name,
+			clierrors.Humanize(err), terminal.WithErrorStyle())
+		return err
+	}
+
+	if err = c.doRefresh(project, appsToRefresh, workspace); err != nil {
+		c.ui.Output("Failed to refresh app(s) %q status in project %q: %s",
+			strings.Join(appNames, ", "),
+			project.Name,
+			clierrors.Humanize(err), terminal.WithErrorStyle())
+		return err
 	}
 
 	return nil
@@ -280,14 +269,12 @@ func (c *StatusCommand) refreshAppStatus(
 	app *pb.Application,
 	workspace string,
 ) error {
-	if c.refApp == nil {
-		// We must setup app ref so DoApp has the context for which app to execute
-		// its operations on. WithOptionalApp does not setup this ref for us.
-		c.refApp = &pb.Ref_Application{
-			Application: app.Name,
-			Project:     project.Name,
-		}
-	}
+	// We must setup app ref so DoApp has the context for which app to execute
+	// its operations on.
+	c.refApps = []*pb.Ref_Application{{
+		Application: app.Name,
+		Project:     project.Name,
+	}}
 	err := c.DoApp(c.Ctx, func(ctx context.Context, appClient *clientpkg.App) error {
 		// Get our API client
 		client := c.project.Client()
@@ -1219,7 +1206,7 @@ func (c *StatusCommand) errAPIUnimplemented(err error) error {
 }
 
 func (c *StatusCommand) Flags() *flag.Sets {
-	return c.flagSet(0, func(set *flag.Sets) {
+	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
 		f := set.NewSet("Command Options")
 
 		f.BoolVar(&flag.BoolVar{
@@ -1329,11 +1316,6 @@ currently configured projects, run “waypoint project list”.
 
 If you want more information for a specific application, use the '-app' flag
 with “waypoint status -app=APP-NAME PROJECT-NAME”.
-`)
-
-	wpAppFlagAndTargetIncludedMsg = strings.TrimSpace(`
-The 'app' flag was included, but an application was also requested as an argument.
-The app flag will be ignored.
 `)
 
 	wpAppNotFound = strings.TrimSpace(`

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -40,7 +40,7 @@ func (c *UninstallCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(),
+		WithNoLocalServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -26,7 +26,8 @@ func (c *UpCommand) Run(args []string) int {
 	if err := c.Init(
 		WithArgs(args),
 		WithFlags(c.Flags()),
-		WithMultipleApp(),
+		WithMultiAppTargets(),
+		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/user_inspect.go
+++ b/internal/cli/user_inspect.go
@@ -24,7 +24,7 @@ func (c *UserInspectCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(), // local mode has no need for tokens
+		WithNoLocalServer(), // local mode has no need for tokens
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/user_invite.go
+++ b/internal/cli/user_invite.go
@@ -25,7 +25,7 @@ func (c *UserInviteCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(), // local mode has no need for tokens
+		WithNoLocalServer(), // local mode has no need for tokens
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/user_modify.go
+++ b/internal/cli/user_modify.go
@@ -25,7 +25,7 @@ func (c *UserModifyCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(), // local mode has no need for tokens
+		WithNoLocalServer(), // local mode has no need for tokens
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/user_token.go
+++ b/internal/cli/user_token.go
@@ -25,7 +25,7 @@ func (c *UserTokenCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
-		WithNoAutoServer(), // local mode has no need for tokens
+		WithNoLocalServer(), // local mode has no need for tokens
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -26,8 +26,8 @@ func (c *VersionCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithNoConfig(),
-		WithClient(false),
-		WithNoAutoServer(),
+		WithNoClient(),
+		WithNoLocalServer(),
 	); err != nil {
 		return 1
 	}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -60,7 +60,7 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 // The receiver must be careful to not block sending to mon as it will block
 // the job state processing loop.
 func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.UI, monCh chan pb.Job_State) (*pb.Job_Result, error) {
-	// Be sure that the monitor is closedthe reciever knows for sure the job isn't going
+	// Be sure that the monitor is closed so the receiver knows for sure the job isn't going
 	// anymore.
 	if monCh != nil {
 		defer close(monCh)

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -42,7 +42,7 @@ func (c *Project) job() *pb.Job {
 
 	// If we're not local, we set a nil data source so it defaults to
 	// wahtever the project has remotely.
-	if !c.local {
+	if !c.useLocalRunner {
 		job.DataSource = nil
 	}
 
@@ -60,14 +60,14 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 // The receiver must be careful to not block sending to mon as it will block
 // the job state processing loop.
 func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.UI, monCh chan pb.Job_State) (*pb.Job_Result, error) {
-	// Be sure that the monitor is closed so the reciever knows for sure the job isn't going
+	// Be sure that the monitor is closedthe reciever knows for sure the job isn't going
 	// anymore.
 	if monCh != nil {
 		defer close(monCh)
 	}
 
-	// In local mode we have to start a runner.
-	if c.local {
+	// In local mode we have to target the local runner.
+	if c.useLocalRunner {
 		// Modify the job to target this runner and use the local data source.
 		// The runner will have been started when we created the Project value and be
 		// used for all local jobs.
@@ -97,7 +97,7 @@ func (c *Project) queueAndStreamJob(
 	// cancel in the event of an error. This will ensure that the jobs don't
 	// remain queued forever. This is only for local ops.
 	expiration := ""
-	if c.local {
+	if c.useLocalRunner {
 		expiration = "30s"
 	}
 
@@ -151,7 +151,7 @@ func (c *Project) queueAndStreamJob(
 		steps = map[int32]*stepData{}
 	)
 
-	if c.local {
+	if c.useLocalRunner {
 		defer func() {
 			// If we completed then do nothing, or if the context is still
 			// active since this means that we're not cancelled.
@@ -207,7 +207,7 @@ func (c *Project) queueAndStreamJob(
 
 		case *pb.GetJobStreamResponse_Terminal_:
 			// Ignore this for local jobs since we're using our UI directly.
-			if c.local {
+			if c.useLocalRunner {
 				continue
 			}
 

--- a/internal/client/noop_test.go
+++ b/internal/client/noop_test.go
@@ -20,7 +20,7 @@ func TestProjectNoop(t *testing.T) {
 	client := singleprocess.TestServer(t)
 
 	// Build our client
-	c := TestProject(t, WithClient(client), WithLocal())
+	c := TestProject(t, WithClient(client))
 	defer c.Close()
 	app := c.App(TestApp(t, c))
 

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -106,7 +106,7 @@ func (c *Project) StartLocalRunner() (*runner.Runner, error) {
 	// We spin up the job processing here. Anything that spawns jobs (either locally spawned
 	// or server spawned) will be processed by this runner ONLY if the runner is directly targeted.
 	// Because this runner's lifetime is bound to a CLI context and therefore transient, we don't
-	// want to accept jobs that aren't related to local activities (job's queued or RPCs made)
+	// want to accept jobs that aren't related to local activities (jobs queued or RPCs made)
 	// because they'll hang the CLI randomly as those jobs run (it's also a security issue).
 	c.wg.Add(1)
 	go func() {

--- a/internal/client/server.go
+++ b/internal/client/server.go
@@ -38,8 +38,8 @@ func (c *Project) initServerClient(ctx context.Context, cfg *config) (*grpc.Clie
 
 	// If we're local, then connection is optional.
 	opts := cfg.connectOpts
-	if c.local {
-		log.Trace("WithLocal set, server credentials optional")
+	if !c.noLocalServer {
+		log.Trace("Local server may be created later - server credentials optional")
 		opts = append(opts, serverclient.Optional())
 	}
 

--- a/internal/client/testing.go
+++ b/internal/client/testing.go
@@ -29,9 +29,12 @@ func TestProject(t testing.T, opts ...Option) *Project {
 	// Initialize our client
 	result, err := New(ctx, append([]Option{
 		WithClient(client),
-		WithLocal(),
 		WithProjectRef(&pb.Ref_Project{Project: "test_p"}),
 	}, opts...)...)
+	require.NoError(err)
+
+	// Start the local runner
+	_, err = result.StartLocalRunner()
 	require.NoError(err)
 
 	// Move into a temporary directory

--- a/test-e2e/e2e_test.go
+++ b/test-e2e/e2e_test.go
@@ -18,7 +18,7 @@ import (
 // and set WP_PROJECT_TEMPLATE_PATH=/path/to/waypoint-examples/docker/static
 func TestCliE2E(t *testing.T) {
 
-	wpBinary = Getenv("waypoint", "waypoint")
+	wpBinary = Getenv("WP_BINARY", "waypoint")
 	projectTemplatePath := Getenv("WP_PROJECT_TEMPLATE_PATH", "")
 	if projectTemplatePath == "" {
 		t.Fatalf("Missing required environment variable WP_PROJECT_TEMPLATE_PATH")
@@ -136,9 +136,9 @@ func TestCliE2E(t *testing.T) {
 	t.Run("Runner profiles", func(t *testing.T) {
 		wp.Run("runner profile list") // Has no output right now
 
-		wp.Run("runner profile set -name=test -plugin-type=docker")
+		wp.Run("runner profile set -name=e2e-test -plugin-type=docker")
 
-		wp.RunTableExpectLength(1, "runner profile list")
+		wp.RunWithOutput("e2e-test", "runner profile list")
 	})
 
 	t.Run("Cleanup", func(t *testing.T) {

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -167,10 +167,10 @@ func (b *binary) Run(args string) (stdout string) {
 	fmt.Printf("running %s ...\n", args)
 	stdout, stderr, err := b.RunRaw(splitArgs(args)...)
 	if err != nil {
-		b.t.Fatalf("unexpected error running %q inside %q: %s", args, b.workingDir, err)
+		b.t.Fatalf("unexpected error running %q inside %q\nERROR:\n%s\n\nSTDERR:\n%s\n\nSTDOUT:\n%s", args, b.workingDir, err, stderr, stdout)
 	}
 	if stderr != "" {
-		b.t.Fatalf("unexpected stderr output running %s: %s", args, err)
+		b.t.Fatalf("unexpected stderr output running %s:\n%s", args, stderr)
 	}
 	return stdout
 }

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -31,6 +31,15 @@ data sourced projects.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-remote` - True to use a remote runner to execute. This defaults to false
+  unless 'runner.default' is set in your configuration.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
 #### Command Options
 
 - `-verbose` (`-V`) - Display more details.


### PR DESCRIPTION
I had two connected goals here:

- Give us a clear place to put the local/remote detection from https://github.com/hashicorp/waypoint/pull/2749
- Apply some of the simplifications laid out in the project UX rfc to simplify this hairy piece of our init sequence: https://github.com/hashicorp/waypoint/blob/eae4441084484d236caf6b635b883637c39ff57a/internal/cli/base.go#L237-L343

A fair amount of the surface area of this change is renaming, either to express subtly different behavior as a result of these changes, or for general clarity, explicitness, or consistency. Bikeshedding welcome.

### What functionality changed

- The project/app syntax is removed. To make an operation happen remotely now, add the -remote flag, and the -project/-app flags if required.
- The `status` command no longer requires a project argument (it uses the flag instead), and takes the operation flags so that the refresh job can happen remotely.


Still TODO:
- [x] One QA pass over all the commands and local/remote permutations (especially the status command r/e multiple apps)