### PR TITLE
ui: add `mirage/types`, declare `RouteHandler` properly

### DIFF
--- a/ui/mirage/services/build.ts
+++ b/ui/mirage/services/build.ts
@@ -1,5 +1,6 @@
 import { ListBuildsRequest, ListBuildsResponse, GetBuildRequest } from 'waypoint-pb';
-import { RouteHandler, Request, Response } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/ui/mirage/services/config.ts
+++ b/ui/mirage/services/config.ts
@@ -1,5 +1,6 @@
 import { ConfigGetRequest, ConfigGetResponse, ConfigSetRequest, ConfigSetResponse } from 'waypoint-pb';
-import { RouteHandler, Request, Response } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/ui/mirage/services/deployment.ts
+++ b/ui/mirage/services/deployment.ts
@@ -1,5 +1,6 @@
 import { GetDeploymentRequest, Job, ListDeploymentsRequest, ListDeploymentsResponse, UI } from 'waypoint-pb';
-import { RouteHandler, Request, Response } from 'ember-cli-mirage';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/ui/mirage/services/invite-token.ts
+++ b/ui/mirage/services/invite-token.ts
@@ -1,5 +1,6 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
-import { RouteHandler, Response } from 'miragejs';
+import { Response } from 'miragejs';
+import { RouteHandler } from '../types';
 
 function createToken(): Token {
   let token = new Token();

--- a/ui/mirage/services/job.ts
+++ b/ui/mirage/services/job.ts
@@ -1,4 +1,5 @@
-import { RouteHandler, Response } from 'miragejs';
+import { Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { GetJobStreamResponse } from 'waypoint-pb';
 
 export function stream(this: RouteHandler): Response {

--- a/ui/mirage/services/log.ts
+++ b/ui/mirage/services/log.ts
@@ -1,6 +1,7 @@
 import { LogBatch } from 'waypoint-pb';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
-import { RouteHandler, Response } from 'miragejs';
+import { Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { getUnixTime } from 'date-fns';
 
 export function stream(this: RouteHandler): Response {

--- a/ui/mirage/services/oidc-auth-methods.ts
+++ b/ui/mirage/services/oidc-auth-methods.ts
@@ -1,4 +1,5 @@
-import { Request, Response, RouteHandler } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 
 import { ListOIDCAuthMethodsResponse } from 'waypoint-pb';
 

--- a/ui/mirage/services/project.ts
+++ b/ui/mirage/services/project.ts
@@ -1,7 +1,8 @@
 import { ListProjectsResponse, GetProjectResponse, UpsertProjectResponse } from 'waypoint-pb';
 import { decode } from '../helpers/protobufs';
 import { UI, GetProjectRequest, UpsertProjectRequest, Job, Project } from 'waypoint-pb';
-import { RouteHandler, Request, Response } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export function list(this: RouteHandler, schema: any): Response {

--- a/ui/mirage/services/pushed-artifact.ts
+++ b/ui/mirage/services/pushed-artifact.ts
@@ -1,4 +1,5 @@
-import { RouteHandler, Request, Response } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { ListPushedArtifactsRequest, ListPushedArtifactsResponse } from 'waypoint-pb';
 import { decode } from '../helpers/protobufs';
 

--- a/ui/mirage/services/release.ts
+++ b/ui/mirage/services/release.ts
@@ -1,5 +1,6 @@
 import { ListReleasesRequest, ListReleasesResponse, GetReleaseRequest, UI } from 'waypoint-pb';
-import { RouteHandler, Request, Response } from 'ember-cli-mirage';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import { decode } from '../helpers/protobufs';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/ui/mirage/services/status-report.ts
+++ b/ui/mirage/services/status-report.ts
@@ -1,4 +1,5 @@
-import { RouteHandler, Request, Response } from 'miragejs';
+import { Request, Response } from 'miragejs';
+import { RouteHandler } from '../types';
 import {
   ListStatusReportsRequest,
   ListStatusReportsResponse,

--- a/ui/mirage/services/token.ts
+++ b/ui/mirage/services/token.ts
@@ -1,5 +1,6 @@
 import { Token, NewTokenResponse } from 'waypoint-pb';
-import { RouteHandler, Response } from 'miragejs';
+import { Response } from 'miragejs';
+import { RouteHandler } from '../types';
 
 function createToken(): Token {
   let token = new Token();

--- a/ui/mirage/services/version-info.ts
+++ b/ui/mirage/services/version-info.ts
@@ -1,5 +1,6 @@
 import { VersionInfo, GetVersionInfoResponse } from 'waypoint-pb';
-import { Response, RouteHandler } from 'miragejs';
+import { Response } from 'miragejs';
+import { RouteHandler } from '../types';
 
 function createVersionInfo(): VersionInfo {
   let versionInfo = new VersionInfo();

--- a/ui/mirage/types/index.d.ts
+++ b/ui/mirage/types/index.d.ts
@@ -1,0 +1,1 @@
+export { default as RouteHandler } from './route-handler';

--- a/ui/mirage/types/route-handler.d.ts
+++ b/ui/mirage/types/route-handler.d.ts
@@ -1,0 +1,5 @@
+import { Response } from 'miragejs';
+
+export default interface RouteHandler {
+  serialize(response: unknown, serializerType: string): Response;
+}

--- a/ui/types/global.d.ts
+++ b/ui/types/global.d.ts
@@ -15,14 +15,3 @@ declare module 'ember-a11y-testing/test-support/audit' {
     axeOptions?: Record<string, unknown>
   ): Promise<void>;
 }
-
-declare module 'miragejs' {
-  /**
-   * RouteHandler is the context (the `this`) in which our Mirage route handlers
-   * are executed. Mirage itself does not export this type declaration in any
-   * form so we’re merging it into the module declaration.
-   */
-  export interface RouteHandler {
-    serialize(response: unknown, serializerType: string): Response;
-  }
-}


### PR DESCRIPTION
## Why the change?

My previous attempt at declaring the interface for `RouteHandler` was a bit wonky. This is more robust, and opens the door for adding more stuff to the `types` directory.

## How do I test it?

Check out the branch and see if anything weird happens in your editor.