### PR TITLE
ui: make `<JsonViewer>` test more robust

### DIFF
--- a/ui/app/components/json-viewer.hbs
+++ b/ui/app/components/json-viewer.hbs
@@ -3,7 +3,7 @@
   class="json-viewer"
 >
   {{#if this.parseResult.error}}
-    <Pds::ErrorMessage>{{this.parseResult.error.message}}</Pds::ErrorMessage>
+    <Pds::ErrorMessage data-test-error-message>{{this.parseResult.error.message}}</Pds::ErrorMessage>
   {{else}}
     <div
       {{code-mirror

--- a/ui/tests/integration/components/json-viewer-test.ts
+++ b/ui/tests/integration/components/json-viewer-test.ts
@@ -41,6 +41,6 @@ module('Integration | Component | json-viewer', function (hooks) {
       <JsonViewer @json={{this.json}} />
     `);
 
-    assert.dom('[data-test-json-viewer]').containsText('Unexpected end of JSON input');
+    assert.dom('[data-test-error-message]').exists();
   });
 });


### PR DESCRIPTION
## Why the change?

Turns out Safari and Chrome emit different error messages when they can’t parse JSON.

## How do I test it?

Try running the test suite in Safari.