### PR TITLE
ui: make `<RenderTerminal>` test more robust

### DIFF
--- a/ui/tests/integration/components/render-terminal-test.ts
+++ b/ui/tests/integration/components/render-terminal-test.ts
@@ -35,7 +35,7 @@ module('Integration | Component | render-terminal', function (hooks) {
     await settled();
   });
 
-  test('non-canvas rendering renders tha proper html output', async function (assert) {
+  test('non-canvas rendering renders the proper html output', async function (assert) {
     // Setup terminal externally, as expected by the component
     let terminal = createTerminal({ inputDisabled: true, domRendering: true });
     this.set('terminal', terminal);
@@ -46,7 +46,7 @@ module('Integration | Component | render-terminal', function (hooks) {
     // We have to use the runloop as writeln isn't async
     // Note that even the xterm.js rendering tests use polling to evaluate rendering
     later(() => {
-      assert.equal(terminal?.element?.innerText, 'WelcometoWaypoint!');
+      assert.dom(terminal?.element).includesText('Welcome to Waypoint!');
     }, 50);
     assert.dom('[data-test-xterm-pane]').exists('the xterm pane renders');
     assert.dom('.xterm').exists('the xterm terminal renders');


### PR DESCRIPTION
## Why the change?

The test was behaving slightly differently in Safari. This change should make it more robust.

## How do I test it?

Run the suite in Safari.