### PR TITLE
Resolved issue where checkbox had two labels.

### DIFF
--- a/ui/app/styles/pages/_index.scss
+++ b/ui/app/styles/pages/_index.scss
@@ -1,3 +1,4 @@
 @import 'auth-page';
 @import 'login';
 @import 'onboarding';
+@import 'projects/new';

--- a/ui/app/styles/pages/projects/new.scss
+++ b/ui/app/styles/pages/projects/new.scss
@@ -1,0 +1,3 @@
+#create-git-help-text .pds-helpText {
+  margin-top: scale.$sm--3;
+}

--- a/ui/app/templates/workspace/projects/new.hbs
+++ b/ui/app/templates/workspace/projects/new.hbs
@@ -27,17 +27,17 @@
     <hr />
     <fieldset class="pds-formFieldSet">
       <div class="pds-formField">
-        <label for="create-git" class="pds-fieldName">
+        <div class="pds-fieldName" id="create-git-help-text">
           <Pds::Icon @type="git-repository" class="icon" />
           {{t 'form.project_new.create_git_label'}}
-        </label>
-        <Pds::HelpText>
-          <p>{{t 'form.project_new.create_git_helptext'}}</p>
-        </Pds::HelpText>
-
+          <Pds::HelpText>
+            {{t 'form.project_new.create_git_helptext'}}
+          </Pds::HelpText>
+        </div>
         <Pds::CheckboxField
           @checked={{this.createGit}}
           @id="create-git"
+          aria-describedby="create-git-help-text"
           {{on "change" (set this "createGit" (not this.createGit))}}
         >
           {{t 'form.project_new.create_git_checkbox_label'}}


### PR DESCRIPTION
Co-authored-by: Jamie White <jamie@jgwhite.co.uk>

If merged, this PR resolves an issue where a checkbox had multiple labels. To fix, one of the labels was converted to fill the aria-describedby role for the checkbox. 

Accessibility tree shows that it works as intended.