### PR TITLE
Replace -remote flag with -local

### DIFF
--- a/.changelog/2771.txt
+++ b/.changelog/2771.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Deprecate -remote flag for operations, replace with -local flag
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -655,14 +655,14 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Name:   "remote",
 			Target: &c.deprecatedFlagRemote,
 			Hidden: true,
-			Usage:  "True to use a remote runner to execute.",
+			Usage:  "True to use a remote runner to execute the operation.",
 		})
 
 		f.BoolPtrVar(&flag.BoolPtrVar{
 			Name:   "local",
 			Target: &c.flagLocal,
 			Usage: "True to use a local runner to execute the operation, false to use a remote runner. \n" +
-				"If unset, waypoint will automatically determine where the operation will occur, \n" +
+				"If unset, Waypoint will automatically determine where the operation will occur, \n" +
 				"defaulting to remote if possible.",
 		})
 

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -102,9 +102,9 @@ type baseCommand struct {
 	// for defined input variables
 	flagVarFile []string
 
-	// flagRemote is whether to execute using a remote runner or use
-	// a local runner.
-	flagRemote bool
+	// flagLocal indicates that any operations performed must happen with a local runner
+	// not a remote runner.
+	flagLocal *bool
 
 	// flagRemoteSource are the remote data source overrides for jobs.
 	flagRemoteSource map[string]string
@@ -132,6 +132,10 @@ type baseCommand struct {
 
 	// The home directory that we loaded the waypoint config from
 	homeConfigPath string
+
+	// deprecatedFlagRemote is whether to execute using a remote runner or use
+	// a local runner.
+	deprecatedFlagRemote *bool
 }
 
 // Close cleans up any resources that the command created. This should be
@@ -148,6 +152,25 @@ func (c *baseCommand) Close() error {
 		closer.Close()
 	}
 
+	return nil
+}
+
+// Checks for deprecated flags and args.
+func (c *baseCommand) checkDeprecatedFlags() error {
+	// Check for deprecated project/app syntax.
+	// NOTE(izaak): we should remove this in the next major (v0.8.0) because it
+	// collides with arguments that contain a single slash (i.e. `waypoint exec bin/bash`)
+	if len(c.args) > 0 {
+		match := reAppTarget.FindStringSubmatch(c.args[0])
+		if match != nil {
+			return errors.New(errDeprecatedProjectAppArg)
+		}
+	}
+
+	// Check for deprecated remote flag
+	if c.deprecatedFlagRemote != nil {
+		return fmt.Errorf("The -remote flag has been deprecated. Use -local=%t instead", !*c.deprecatedFlagRemote)
+	}
 	return nil
 }
 
@@ -202,16 +225,9 @@ func (c *baseCommand) Init(opts ...Option) error {
 		return err
 	}
 
-	// Check for deprecated project/app syntax.
-	// NOTE(izaak): we should remove this in the next major (v0.8.0) because it
-	// collides with arguments that contain a single slash (i.e. `waypoint exec bin/bash`)
-	if len(c.args) > 0 {
-		match := reAppTarget.FindStringSubmatch(c.args[0])
-		if match != nil {
-			err := errors.New(errDeprecatedProjectAppArg)
-			c.logError(c.Log, "", err)
-			return err
-		}
+	if err := c.checkDeprecatedFlags(); err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+		return err
 	}
 
 	// Reset the UI to plain if that was set
@@ -408,7 +424,11 @@ func (c *baseCommand) startLocalRunner() (*runner.Runner, error) {
 // should happen remotely.
 func (c *baseCommand) remoteOpPreferred() bool {
 	// NOTE(izaak): will be significantly improved in the near future.
-	return c.flagRemote
+	if c.flagLocal != nil {
+		return !*c.flagLocal
+	} else {
+		return false
+	}
 }
 
 // remoteOpPreferred attempts to determine if the current waypoint infrastructure will be successful
@@ -631,12 +651,19 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Usage:  "Labels to set for this operation. Can be specified multiple times.",
 		})
 
-		f.BoolVar(&flag.BoolVar{
-			Name:    "remote",
-			Target:  &c.flagRemote,
-			Default: false,
-			Usage: "True to use a remote runner to execute. This defaults to false \n" +
-				"unless 'runner.default' is set in your configuration.",
+		f.BoolPtrVar(&flag.BoolPtrVar{
+			Name:   "remote",
+			Target: &c.deprecatedFlagRemote,
+			Hidden: true,
+			Usage:  "True to use a remote runner to execute.",
+		})
+
+		f.BoolPtrVar(&flag.BoolPtrVar{
+			Name:   "local",
+			Target: &c.flagLocal,
+			Usage: "True to use a local runner to execute the operation, false to use a remote runner. \n" +
+				"If unset, waypoint will automatically determine where the operation will occur, \n" +
+				"defaulting to remote if possible.",
 		})
 
 		f.StringMapVar(&flag.StringMapVar{

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -11,8 +11,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/waypoint/internal/config/variables"
-
 	"github.com/adrg/xdg"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
@@ -23,6 +21,7 @@ import (
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/config"
+	"github.com/hashicorp/waypoint/internal/config/variables"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/runner"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -32,7 +32,7 @@ Build a new versioned artifact from source.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -31,8 +31,9 @@ Build a new versioned artifact from source.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -34,7 +34,7 @@ local builds using "artifact list-builds" command.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -33,8 +33,9 @@ local builds using "artifact list-builds" command.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -32,7 +32,7 @@ Build a new versioned artifact from source.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -31,8 +31,9 @@ Build a new versioned artifact from source.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -34,7 +34,7 @@ using the "artifact list" command.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -33,8 +33,9 @@ using the "artifact list" command.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -34,7 +34,7 @@ using the "artifact list" command.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -33,8 +33,9 @@ using the "artifact list" command.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -35,7 +35,7 @@ by the user unless the force flag (-force) is specified.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -34,8 +34,9 @@ by the user unless the force flag (-force) is specified.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -41,7 +41,7 @@ you've used if you want to destroy everything.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -40,8 +40,9 @@ you've used if you want to destroy everything.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -32,8 +32,9 @@ The flags can change which plugins are listed and in which format.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -33,7 +33,7 @@ The flags can change which plugins are listed and in which format.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -32,8 +32,9 @@ specified by ID using the '-deployment' flag.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -33,7 +33,7 @@ specified by ID using the '-deployment' flag.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -35,7 +35,7 @@ data sourced projects.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -34,8 +34,9 @@ data sourced projects.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -30,7 +30,7 @@ Perform the build, deploy, and release steps.
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 - `-local` - True to use a local runner to execute the operation, false to use a remote runner.
-  If unset, waypoint will automatically determine where the operation will occur,
+  If unset, Waypoint will automatically determine where the operation will occur,
   defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -29,8 +29,9 @@ Perform the build, deploy, and release steps.
 #### Operation Options
 
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
-- `-remote` - True to use a remote runner to execute. This defaults to false
-  unless 'runner.default' is set in your configuration.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
 - `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
 - `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
 - `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.


### PR DESCRIPTION
Merge after https://github.com/hashicorp/waypoint/pull/2760/files

Replaces the -remote flag with the -local flag. Nice deprecation warning for -remote.

The impetus for this change is that shortly, waypoint will automatically default operations to happen remotely if they're likely to succeed remotely, and locally if otherwise. With that change in place, it will be much more likely that users will want to override an operation to happen locally, and adding `-local` is more friendly than adding `-remote=false`.

### How to verify

Flag usage
```
$ waypoint artifact build -local

» Building web...
✓ Initializing Docker client...
✓ Building image...
 │ Step 1/3 : FROM nginx:stable
 │  ---> c8d03f6b8b91
 │ Step 2/3 : COPY ./public/ /var/www
 │  ---> Using cache
 │  ---> 61409f8fbdaf
 │ Step 3/3 : COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 │  ---> Using cache
 │  ---> 5e11c4551189
 │ Successfully built 5e11c4551189
 │ Successfully tagged waypoint.local/web:latest
✓ Injecting Waypoint Entrypoint...
Image built: waypoint.local/web:latest (amd64)

$ waypoint artifact build -local=false

» Building web...
! Project nginx-project does not have a data source configured. Remote jobs
  require a data source such as Git to be configured with the project. Data
  sources can be configured via the CLI or UI. For help, see :
  https://www.waypointproject.io/docs/projects/git#configuring-the-project
```

-remote deprecation
```
$ waypoint artifact build -remote
! The -remote flag has been deprecated. Use -local=false instead

$ waypoint artifact build -remote=false
! The -remote flag has been deprecated. Use -local=true instead

```