### PR TITLE
ui/lab: add runners page

### DIFF
--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -29,6 +29,7 @@ Router.map(function () {
   });
   this.route('lab', { path: '/-lab' }, function () {
     this.route('runner-profiles');
+    this.route('runners');
   });
   this.route('workspaces', { path: '/' }, function () {
     this.route('projects', function () {

--- a/ui/app/routes/lab/runners.ts
+++ b/ui/app/routes/lab/runners.ts
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import ApiService from 'waypoint/services/api';
+import { ListRunnersRequest, Runner } from 'waypoint-pb';
+
+type Model = Runner.AsObject[];
+
+export default class extends Route {
+  @service api!: ApiService;
+
+  async model(): Promise<Model> {
+    let request = new ListRunnersRequest();
+    let response = await this.api.client.listRunners(request, this.api.WithMeta());
+
+    return response.toObject().runnersList;
+  }
+}

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -17,3 +17,5 @@
 @import 'components';
 
 @import 'pages';
+
+@import 'lab';

--- a/ui/app/styles/lab.scss
+++ b/ui/app/styles/lab.scss
@@ -1,0 +1,5 @@
+.lab\/header {
+  padding-bottom: scale.$base;
+  margin-bottom: scale.$base;
+  border-bottom: 1px solid rgb(var(--border));
+}

--- a/ui/app/styles/lab.scss
+++ b/ui/app/styles/lab.scss
@@ -3,3 +3,45 @@
   margin-bottom: scale.$base;
   border-bottom: 1px solid rgb(var(--border));
 }
+
+.lab\/runner-table {
+  background: rgb(var(--panel));
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 14px;
+  line-height: 17px;
+  color: rgb(var(--text-muted));
+
+  table {
+    background: rgb(var(--background));
+    border-radius: 5px;
+    border-spacing: 0;
+    border: 1px solid;
+    border-color: rgb(var(--border));
+    overflow: hidden;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  caption {
+    font-weight: normal;
+    text-align: left;
+    margin-bottom: 10px;
+  }
+
+  th,
+  td {
+    padding: 8px 10px;
+    text-align: left;
+  }
+
+  tbody {
+    th {
+      font-weight: normal;
+    }
+    th,
+    td {
+      border-top: 1px solid rgb(var(--border));
+    }
+  }
+}

--- a/ui/app/templates/lab.hbs
+++ b/ui/app/templates/lab.hbs
@@ -1,3 +1,8 @@
-<LinkTo @route="lab">Lab Home</LinkTo>
+<div class="lab/header">
+  <LinkTo @route="lab">
+    <Pds::Icon @type="folder-fill" />
+    Lab Home
+  </LinkTo>
+</div>
 
 {{outlet}}

--- a/ui/app/templates/lab/index.hbs
+++ b/ui/app/templates/lab/index.hbs
@@ -1,1 +1,2 @@
 <LinkTo @route="lab.runner-profiles">Runner Profiles</LinkTo>
+<LinkTo @route="lab.runners">Runners</LinkTo>

--- a/ui/app/templates/lab/runners.hbs
+++ b/ui/app/templates/lab/runners.hbs
@@ -1,0 +1,22 @@
+<h1>Runners</h1>
+
+<div class="lab/runner-table">
+  <table>
+    <thead>
+      <tr>
+        <th>id</th>
+        <th>by_id_only</th>
+        <th>odr</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @model as |runner|}}
+        <tr>
+          <th scope="row">{{runner.id}}</th>
+          <td>{{runner.byIdOnly}}</td>
+          <td>{{runner.odr}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
## Why the change?

`ListRunners` recently landed, so this is a quick experiment to try it out.

## What does it look like?

<img width="1360" alt="CleanShot 2021-11-25 at 14 27 20@2x" src="https://user-images.githubusercontent.com/34030/143449836-4f611b93-019c-415c-9209-e89cf5b8aff2.png">

## How do I test it?

1. Check out the branch
2. Boot the dev server against a real waypoint server (`yarn start local`)
3. Visit [localhost:4200/-lab/runners](http://localhost:4200/-lab/runners)
4. Verify you see some runner info