### PR TITLE
Refactor: moving job initialization work into the client package

### DIFF
--- a/builtin/aws/lambda/platform_logs.go
+++ b/builtin/aws/lambda/platform_logs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
+	"github.com/pkg/errors"
 )
 
 // Logs fetches logs from cloudwatch
@@ -48,7 +49,7 @@ func (p *Platform) Logs(
 		})
 
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to describe log stream for group %q in region %q", group, p.config.Region)
 		}
 
 		if len(streams.LogStreams) == 0 {

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -24,7 +24,6 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/artifact_push.go
+++ b/internal/cli/artifact_push.go
@@ -22,7 +22,6 @@ func (c *ArtifactPushCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 
@@ -390,99 +389,6 @@ func (c *baseCommand) Init(opts ...Option) error {
 	}
 
 	return nil
-}
-
-// remoteOpPreferred attempts to determine if the current waypoint infrastructure will be successful
-// performing a remote operation against this project. It verifies the project's datasource,
-// it's ODR runner profile, and detects if a remote runner is currently registered.
-// If an operation can occur successfully remotely, we prefer the remote environment for consistency
-// and security reasons.
-//
-// Note that this cannot guarantee that an operation will succeed remotely - the remote environment
-// may not have the right auth configured, the right plugins configured, etc.
-func remoteOpPreferred(ctx context.Context, client pb.WaypointClient, project *pb.Project, log hclog.Logger) (bool, error) {
-
-	if !project.RemoteEnabled {
-		log.Debug("Remote operations are disabled for this project - operation cannot occur remotely")
-		return false, nil
-	}
-
-	if project.DataSource == nil {
-		log.Debug("Project has no datasource configured - operation cannot occur remotely")
-		// This is probably going to be fatal somewhere downstream
-		return false, nil
-	}
-
-	var hasRemoteDataSource bool
-	switch project.DataSource.GetSource().(type) {
-	case *pb.Job_DataSource_Git:
-		hasRemoteDataSource = true
-	default:
-		hasRemoteDataSource = false
-	}
-
-	if !hasRemoteDataSource {
-		log.Debug("Project does not have a remote data source - operation cannot occur remotely")
-		return false, nil
-	}
-
-	// We know the project can handle remote ops at this point - but do we have runners?
-
-	runnersResp, err := client.ListRunners(ctx, &pb.ListRunnersRequest{})
-	if err != nil {
-		return false, err
-	}
-	hasRemoteRunner := false
-	for _, runner := range runnersResp.Runners {
-		if !runner.Odr {
-			// NOTE(izaak): There is currently no way to distinguish between a remote runner and a CLI runner.
-			// So if some other waypoint client is performing an operation at this moment, we will interpret
-			// that as a remote runner, and this will return a false positive.
-
-			// Also note that this is designed to run before se start our own CLI runner.
-			hasRemoteRunner = true
-			break
-		}
-	}
-	if !hasRemoteRunner {
-		log.Debug("No remote runner detected - operation cannot occur remotely")
-		return false, nil
-	}
-
-	// Check to see if we have a runner profile assigned to this project
-	if project.OndemandRunner != nil {
-		log.Debug("Project has an explicit ODR profile set - operation is possible remotely")
-		return true, nil
-	}
-
-	// Check to see if we have a global default ODR profile
-
-	// TODO: it would be more efficient if we had an arg to filter to just get default profiles.
-	configsResp, err := client.ListOnDemandRunnerConfigs(ctx, &empty.Empty{})
-	if err != nil {
-		return false, err
-	}
-
-	defaultRunnerProfileExists := false
-	for _, odrConfig := range configsResp.Configs {
-		if odrConfig.Default {
-			defaultRunnerProfileExists = true
-			break
-		}
-	}
-
-	if defaultRunnerProfileExists {
-		log.Debug("Default runner profile exists - operation is possible remotely.")
-		return true, nil
-	}
-
-	log.Debug("No runner profile is set for this project and no global default exists - operation should happen locally")
-
-	// The operation here _could_ still happen remotely - executed on the remote runner itself without ODR.
-	// If it's a container build op it will probably fail (because no kaniko), and if it's a deploy/release op it
-	// very well might fail do to incorrect/insufficient permissions. Because it probably won't work, we won't try,
-	// but the user could force it to happen locally by setting -local=false.
-	return false, nil
 }
 
 // DoApp calls the callback for each app. This lets you execute logic

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -106,6 +106,10 @@ func (c *baseCommand) initClient(
 		opts = append(opts, clientpkg.WithNoLocalServer())
 	}
 
+	if c.flagLocal != nil {
+		opts = append(opts, clientpkg.WithUseLocalRunner(*c.flagLocal))
+	}
+
 	if c.ui != nil {
 		opts = append(opts, clientpkg.WithUI(c.ui))
 	}

--- a/internal/cli/base_test.go
+++ b/internal/cli/base_test.go
@@ -1,17 +1,13 @@
 package cli
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	pb "github.com/hashicorp/waypoint/internal/server/gen"
-	"github.com/hashicorp/waypoint/internal/server/singleprocess"
 )
 
 func TestCheckFlagsAfterArgs(t *testing.T) {
@@ -204,126 +200,4 @@ func TestWorkspacePrecedence(t *testing.T) {
 			os.Unsetenv(defaultWorkspaceEnvName)
 		})
 	}
-}
-
-func Test_remoteOpPreferred(t *testing.T) {
-	log := hclog.Default()
-	require := require.New(t)
-
-	ctx := context.Background()
-
-	client := singleprocess.TestServer(t)
-
-	project := &pb.Project{
-		Name: "test",
-	}
-
-	_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-	require.Nil(err)
-
-	t.Run("Choose local if remote enabled is false for the project.", func(t *testing.T) {
-		project = &pb.Project{
-			Name:          "test",
-			RemoteEnabled: false,
-		}
-		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
-
-		remote, err := remoteOpPreferred(ctx, client, project, log)
-		require.Nil(err)
-		require.False(remote)
-	})
-
-	t.Run("Choose local if the datasource is not remote-capable.", func(t *testing.T) {
-		project = &pb.Project{
-			Name:          "test",
-			RemoteEnabled: true,
-			DataSource: &pb.Job_DataSource{
-				Source: &pb.Job_DataSource_Local{},
-			},
-		}
-		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
-
-		remote, err := remoteOpPreferred(ctx, client, project, log)
-		require.Nil(err)
-		require.False(remote)
-	})
-
-	remoteCapableDataSource := &pb.Job_DataSource{
-		Source: &pb.Job_DataSource_Git{
-			Git: &pb.Job_Git{
-				Ref: "main",
-				Url: "git.test",
-			},
-		},
-	}
-
-	// Register a remote runner
-	_, remoteRunnerClose := singleprocess.TestRunner(t, client, &pb.Runner{Odr: false})
-	defer remoteRunnerClose()
-
-	// Register a non-default runner profile
-	odrProfileName := "project-specific ODR profile"
-	_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
-		Config: &pb.OnDemandRunnerConfig{
-			Name:       odrProfileName,
-			PluginType: "docker",
-			Default:    false,
-		},
-	})
-	require.Nil(err)
-
-	t.Run("Choose remote if the datasource is good, a remote runner exists, and a runner profile is set for the project", func(t *testing.T) {
-		project = &pb.Project{
-			Name:           "test",
-			RemoteEnabled:  true,
-			DataSource:     remoteCapableDataSource,
-			OndemandRunner: &pb.Ref_OnDemandRunnerConfig{Name: odrProfileName},
-		}
-		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
-
-		remote, err := remoteOpPreferred(ctx, client, project, log)
-		require.Nil(err)
-		require.True(remote)
-	})
-
-	t.Run("Choose local if no runner profile is set for the project, and there is no default", func(t *testing.T) {
-		project = &pb.Project{
-			Name:          "test",
-			RemoteEnabled: true,
-			DataSource:    remoteCapableDataSource,
-		}
-		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
-
-		remote, err := remoteOpPreferred(ctx, client, project, log)
-		require.Nil(err)
-		require.False(remote)
-	})
-
-	// Register a default runner profile
-	_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
-		Config: &pb.OnDemandRunnerConfig{
-			Name:       "the default",
-			PluginType: "docker",
-			Default:    true,
-		},
-	})
-	require.Nil(err)
-
-	t.Run("Choose remote if the project is good and the default runner is set", func(t *testing.T) {
-		project = &pb.Project{
-			Name:          "test",
-			RemoteEnabled: true,
-			DataSource:    remoteCapableDataSource,
-		}
-		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
-
-		remote, err := remoteOpPreferred(ctx, client, project, log)
-		require.Nil(err)
-		require.True(remote)
-	})
 }

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -25,7 +25,6 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -30,7 +30,6 @@ func (c *DeploymentDestroyCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flags),
 		WithSingleAppTarget(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -63,7 +63,6 @@ func (c *DeploymentListCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -24,7 +24,6 @@ func (c *DestroyCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -102,7 +102,6 @@ func (c *ExecCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(flagSet),
 		WithSingleAppTarget(),
-		WithRunnerRequired(), // Some platforms require an exec plugin
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -160,7 +160,7 @@ func (c *ExecCommand) Run(args []string) int {
 }
 
 func (c *ExecCommand) Flags() *flag.Sets {
-	return c.flagSet(0, func(s *flag.Sets) {
+	return c.flagSet(flagSetOperation, func(s *flag.Sets) {
 		f := s.NewSet("Command Options")
 		f.StringVar(&flag.StringVar{
 			Name:   "instance",

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -144,7 +144,7 @@ func (c *ExecCommand) Run(args []string) int {
 			return ErrSentinel
 		}
 
-		exitCode, err = ec.Run()
+		exitCode, err = app.Exec(ctx, ec)
 		if err != nil {
 			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -30,7 +30,6 @@ func (c *LogsCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithSingleAppTarget(),
-		WithRunnerRequired(), // Some platforms have a separate logs plugin that require a runner
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -100,7 +100,7 @@ func (c *LogsCommand) Run(args []string) int {
 }
 
 func (c *LogsCommand) Flags() *flag.Sets {
-	return c.flagSet(0, nil)
+	return c.flagSet(flagSetOperation, nil)
 }
 
 func (c *LogsCommand) AutocompleteArgs() complete.Predictor {

--- a/internal/cli/option.go
+++ b/internal/cli/option.go
@@ -93,20 +93,10 @@ func WithConnectionArg() Option {
 	}
 }
 
-// WithRunnerRequired indicates that the command will trigger an operation that needs a runner.
-// The framework will then determine if a local runner will be necessary (and start it), or
-// if it can rely on remote runners/ODR.
-func WithRunnerRequired() Option {
-	return func(c *baseConfig) {
-		c.RunnerRequired = true
-	}
-}
-
 type baseConfig struct {
 	Args  []string
 	Flags *flag.Sets
 
-	RunnerRequired        bool
 	ProjectTargetRequired bool
 	NoClient              bool
 	SingleAppTarget       bool

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -34,7 +34,6 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -134,14 +134,6 @@ func (c *StatusCommand) RefreshApplicationStatus() error {
 	// Get our API client
 	client := c.project.Client()
 
-	// We now know that we're going to need a runner for the refresh job.
-	if !c.remoteOpPreferred() {
-		_, err := c.startLocalRunner()
-		if err != nil {
-			return err
-		}
-	}
-
 	// Get the entire list of apps
 	// Determine project locality
 	// Do the Work (local or remote)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -27,7 +27,6 @@ func (c *UpCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 		WithMultiAppTargets(),
-		WithRunnerRequired(),
 	); err != nil {
 		return 1
 	}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -53,10 +53,10 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 // the job state processing loop.
 func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.UI, monCh chan pb.Job_State) (*pb.Job_Result, error) {
 
+	// Automatically determine if we should use a local or a remote runner
 	if c.useLocalRunner == nil {
-		// Automatically determine if we should use local or remote
 
-		// NOTE(izaak): If in the future we need this in other places too, we should probably cache it on the parent struct.
+		// NOTE(izaak): If in the future we need the full project in other places, we should probably cache it on the parent struct.
 		getProjectResp, err := c.client.GetProject(ctx, &pb.GetProjectRequest{Project: c.project})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get project %s", c.project.Project)
@@ -74,7 +74,7 @@ func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.U
 	if *c.useLocalRunner && c.activeRunner == nil {
 		// we need a local runner and we haven't started it yet
 		if err := c.startRunner(); err != nil {
-			return nil, errors.Wrapf(err, "failed to start local runner for job %s, err")
+			return nil, errors.Wrapf(err, "failed to start local runner for job %s", err)
 		}
 	}
 

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -49,7 +49,7 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 // - figure out if jobs should be executed locally or remotely.
 // - if job should be executed locally, start a local runner
 // - FUTURE: if a job should be executed remotely, but local VCS is present and dirty, warn.
-// This lives separately from DoJob because the logs command needs to conditionally warm up the
+// This lives separately from DoJob because the logs and exec commands need to conditionally warm up the
 // local job infrastructure, but don't actually create a job (the server does).
 func (c *Project) setupLocalJobSystem(ctx context.Context) (isLocal bool, newCtx context.Context, err error) {
 	// Automatically determine if we should use a local or a remote runner

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -6,17 +6,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
-
-	"github.com/pkg/errors"
-
 	"github.com/hashicorp/go-hclog"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/finalcontext"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
 )
 
 // job returns the basic job skeleton prepoulated with the correct

--- a/internal/client/job_test.go
+++ b/internal/client/job_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/waypoint/internal/server/grpcmetadata"
+
+	"github.com/hashicorp/go-hclog"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_setupLocalJobSystem(t *testing.T) {
+	hclog.Default().SetLevel(hclog.Debug)
+	require := require.New(t)
+
+	ctx := context.Background()
+	var err error
+
+	// Validates the side effects of running setupLocalJobSystem
+	validateLocalSetupSideEffects := func(ctx context.Context, c *Project, expectLocal bool) {
+		// Validate saved locality setting for future operations
+		require.NotNil(c.useLocalRunner)
+		require.Equal(*c.useLocalRunner, expectLocal)
+
+		// Validate started local runner (or not)
+		hasActiveLocalRunner := c.activeRunner != nil
+		require.Equal(hasActiveLocalRunner, expectLocal)
+
+		// Validate set GRPC metadata
+		_, hasRunnerId := grpcmetadata.OutgoingRunnerId(ctx)
+		require.Equal(hasRunnerId, expectLocal)
+
+		// TODO(izaak): check the context
+	}
+
+	t.Run("Respects project settings", func(t *testing.T) {
+		for _, requestLocal := range []bool{true, false} {
+			c := TestProject(t,
+				WithClient(singleprocess.TestServer(t)),
+				WithUseLocalRunner(requestLocal),
+			)
+			defer c.Close()
+
+			// We don't need to upsert the project - it shouldn't need to make any API calls to
+			// choose a locality if we set it explicitly on the client.
+
+			isLocal, newCtx, err := c.setupLocalJobSystem(ctx)
+			require.Nil(err)
+			require.Equal(requestLocal, isLocal)
+
+			// Check that running setupLocalJobSystem had the right side effects
+			validateLocalSetupSideEffects(newCtx, c, requestLocal)
+		}
+	})
+
+	t.Run("Automatically determines locality if unset", func(t *testing.T) {
+
+		// Simple setup, uses a
+		c := TestProject(t,
+			WithClient(singleprocess.TestServer(t)),
+		)
+		defer c.Close()
+
+		project := &pb.Project{
+			Name:          c.project.Project,
+			RemoteEnabled: false,
+		}
+
+		_, err = c.Client().UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		isLocal, newCtx, err := c.setupLocalJobSystem(ctx)
+		require.Nil(err)
+
+		// we don't care what the value of isLocal is for this test - just that it picked _something_,
+		// saved it, and performed its side-effects.
+		validateLocalSetupSideEffects(newCtx, c, isLocal)
+	})
+}

--- a/internal/client/operation.go
+++ b/internal/client/operation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/waypoint/internal/server/execclient"
-
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 

--- a/internal/client/operation.go
+++ b/internal/client/operation.go
@@ -197,6 +197,15 @@ func (c *App) Release(ctx context.Context, op *pb.Job_ReleaseOp) (*pb.Job_Releas
 func (a *App) Logs(ctx context.Context) (pb.Waypoint_GetLogStreamClient, error) {
 	log := a.project.logger.Named("logs")
 
+	// Depending on which deployments are at play, and which plugins those deployments
+	// correspond to, we may need a local runner. It'll be up to the server to actually
+	// create the job, but we'll need to create the local runner if necessary, error
+	// if vcs is dirty, etc.
+	_, ctx, err := a.project.setupLocalJobSystem(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// First we attempt to query the server for logs for this deployment.
 	log.Info("requesting log stream")
 	client, err := a.project.client.GetLogStream(ctx, &pb.GetLogStreamRequest{

--- a/internal/client/operation.go
+++ b/internal/client/operation.go
@@ -144,26 +144,6 @@ func (c *App) Deploy(ctx context.Context, op *pb.Job_DeployOp) (*pb.Job_DeployRe
 	return result.Deploy, nil
 }
 
-func (c *App) Release(ctx context.Context, op *pb.Job_ReleaseOp) (*pb.Job_ReleaseResult, error) {
-	if op == nil {
-		op = &pb.Job_ReleaseOp{}
-	}
-
-	// Build our job
-	job := c.job()
-	job.Operation = &pb.Job_Release{
-		Release: op,
-	}
-
-	// Execute it
-	result, err := c.doJob(ctx, job)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Release, nil
-}
-
 func (c *App) Destroy(ctx context.Context, op *pb.Job_DestroyOp) error {
 	if op == nil {
 		op = &pb.Job_DestroyOp{}
@@ -193,6 +173,26 @@ func (c *App) Exec(ctx context.Context, ec *execclient.Client) (exitCode int, er
 
 	ec.Context = ctx
 	return ec.Run()
+}
+
+func (c *App) Release(ctx context.Context, op *pb.Job_ReleaseOp) (*pb.Job_ReleaseResult, error) {
+	if op == nil {
+		op = &pb.Job_ReleaseOp{}
+	}
+
+	// Build our job
+	job := c.job()
+	job.Operation = &pb.Job_Release{
+		Release: op,
+	}
+
+	// Execute it
+	result, err := c.doJob(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Release, nil
 }
 
 func (a *App) Logs(ctx context.Context) (pb.Waypoint_GetLogStreamClient, error) {

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -30,8 +30,10 @@ type Project struct {
 	cleanupFunc         func()
 	serverVersion       *pb.VersionInfo
 
-	useLocalRunner *bool
-
+	// useLocalRunner indicates if a local runner should be created for new jobs. True if a local runner
+	// should be created to handle jobs, false if jobs should be left to the remote runner. If nil, a value
+	// will be determined and saved when a job is first executed.
+	useLocalRunner     *bool
 	noLocalServer      bool // config setting - indicates the project should never create a local server
 	localServer        bool // True when a local server is created
 	executeJobsLocally bool // True to force the project to execute all jobs locally

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -33,10 +33,13 @@ type Project struct {
 	// useLocalRunner indicates if a local runner should be created for new jobs. True if a local runner
 	// should be created to handle jobs, false if jobs should be left to the remote runner. If nil, a value
 	// will be determined and saved when a job is first executed.
-	useLocalRunner     *bool
-	noLocalServer      bool // config setting - indicates the project should never create a local server
-	localServer        bool // True when a local server is created
-	executeJobsLocally bool // True to force the project to execute all jobs locally
+	useLocalRunner *bool
+
+	// noLocalServer is a config setting - it indicates the project should never create a local server.
+	// If unset, a local server may be created.
+	noLocalServer bool
+
+	localServer bool // True when a local server is created
 
 	// These are used to manage a local runner and its job processing
 	// in a goroutine.

--- a/internal/client/runner.go
+++ b/internal/client/runner.go
@@ -1,12 +1,21 @@
 package client
 
 import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint/internal/runner"
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )
 
-// startRunner initializes and starts a local runner. If the returned
-// runner is non-nil, you must call Close on it to clean up resources properly.
-func (c *Project) startRunner() (*runner.Runner, error) {
+// startRunner initializes and starts a local runner.
+// It stores it on the parent struct, and will deactivate it
+// when the parent is closed.
+func (c *Project) startRunner() error {
+
+	c.logger.Debug("starting runner to process local jobs")
+
 	// Initialize our runner
 	r, err := runner.New(
 		runner.WithClient(c.client),
@@ -15,13 +24,119 @@ func (c *Project) startRunner() (*runner.Runner, error) {
 		runner.WithLocal(c.UI), // Local mode
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Start the runner
 	if err := r.Start(); err != nil {
-		return nil, err
+		return err
 	}
 
-	return r, nil
+	c.activeRunner = r
+
+	// We spin up the job processing here. Anything that spawns jobs (either locally spawned
+	// or server spawned) will be processed by this runner ONLY if the runner is directly targeted.
+	// Because this runner's lifetime is bound to a CLI context and therefore transient, we don't
+	// want to accept jobs that aren't related to local activities (jobs queued or RPCs made)
+	// because they'll hang the CLI randomly as those jobs run (it's also a security issue).
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		r.AcceptMany(c.bg)
+	}()
+
+	return nil
+}
+
+// remoteOpPreferred attempts to determine if the current waypoint infrastructure will be successful
+// performing a remote operation against this project. It verifies the project's datasource,
+// it's ODR runner profile, and detects if a remote runner is currently registered.
+// If an operation can occur successfully remotely, we prefer the remote environment for consistency
+// and security reasons.
+//
+// Note that this cannot guarantee that an operation will succeed remotely - the remote environment
+// may not have the right auth configured, the right plugins configured, etc.
+func remoteOpPreferred(ctx context.Context, client pb.WaypointClient, project *pb.Project, log hclog.Logger) (bool, error) {
+
+	if !project.RemoteEnabled {
+		log.Debug("Remote operations are disabled for this project - operation cannot occur remotely")
+		return false, nil
+	}
+
+	if project.DataSource == nil {
+		log.Debug("Project has no datasource configured - operation cannot occur remotely")
+		// This is probably going to be fatal somewhere downstream
+		return false, nil
+	}
+
+	var hasRemoteDataSource bool
+	switch project.DataSource.GetSource().(type) {
+	case *pb.Job_DataSource_Git:
+		hasRemoteDataSource = true
+	default:
+		hasRemoteDataSource = false
+	}
+
+	if !hasRemoteDataSource {
+		log.Debug("Project does not have a remote data source - operation cannot occur remotely")
+		return false, nil
+	}
+
+	// We know the project can handle remote ops at this point - but do we have runners?
+
+	runnersResp, err := client.ListRunners(ctx, &pb.ListRunnersRequest{})
+	if err != nil {
+		return false, err
+	}
+	hasRemoteRunner := false
+	for _, runner := range runnersResp.Runners {
+		if !runner.Odr {
+			// NOTE(izaak): There is currently no way to distinguish between a remote runner and a CLI runner.
+			// So if some other waypoint client is performing an operation at this moment, we will interpret
+			// that as a remote runner, and this will return a false positive.
+
+			// Also note that this is designed to run before se start our own CLI runner.
+			hasRemoteRunner = true
+			break
+		}
+	}
+	if !hasRemoteRunner {
+		log.Debug("No remote runner detected - operation cannot occur remotely")
+		return false, nil
+	}
+
+	// Check to see if we have a runner profile assigned to this project
+	if project.OndemandRunner != nil {
+		log.Debug("Project has an explicit ODR profile set - operation is possible remotely")
+		return true, nil
+	}
+
+	// Check to see if we have a global default ODR profile
+
+	// TODO: it would be more efficient if we had an arg to filter to just get default profiles.
+	configsResp, err := client.ListOnDemandRunnerConfigs(ctx, &empty.Empty{})
+	if err != nil {
+		return false, err
+	}
+
+	defaultRunnerProfileExists := false
+	for _, odrConfig := range configsResp.Configs {
+		if odrConfig.Default {
+			defaultRunnerProfileExists = true
+			break
+		}
+	}
+
+	if defaultRunnerProfileExists {
+		log.Debug("Default runner profile exists - operation is possible remotely.")
+		return true, nil
+	}
+
+	log.Debug("No runner profile is set for this project and no global default exists - operation should happen locally")
+
+	// The operation here _could_ still happen remotely - executed on the remote runner itself without ODR.
+	// If it's a container build op it will probably fail (because no kaniko), and if it's a deploy/release op it
+	// very well might fail do to incorrect/insufficient permissions. Because it probably won't work, we won't try,
+	// but the user could force it to happen locally by setting -local=false.
+	return false, nil
 }

--- a/internal/client/runner.go
+++ b/internal/client/runner.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/waypoint/internal/runner"
 	pb "github.com/hashicorp/waypoint/internal/server/gen"
 )

--- a/internal/client/runner_test.go
+++ b/internal/client/runner_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/hashicorp/waypoint/internal/server/gen"
+	"github.com/hashicorp/waypoint/internal/server/singleprocess"
+)
+
+func Test_remoteOpPreferred(t *testing.T) {
+	log := hclog.Default()
+	require := require.New(t)
+
+	ctx := context.Background()
+
+	client := singleprocess.TestServer(t)
+
+	project := &pb.Project{
+		Name: "test",
+	}
+
+	_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+	require.Nil(err)
+
+	t.Run("Choose local if remote enabled is false for the project.", func(t *testing.T) {
+		project = &pb.Project{
+			Name:          "test",
+			RemoteEnabled: false,
+		}
+		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		remote, err := remoteOpPreferred(ctx, client, project, log)
+		require.Nil(err)
+		require.False(remote)
+	})
+
+	t.Run("Choose local if the datasource is not remote-capable.", func(t *testing.T) {
+		project = &pb.Project{
+			Name:          "test",
+			RemoteEnabled: true,
+			DataSource: &pb.Job_DataSource{
+				Source: &pb.Job_DataSource_Local{},
+			},
+		}
+		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		remote, err := remoteOpPreferred(ctx, client, project, log)
+		require.Nil(err)
+		require.False(remote)
+	})
+
+	remoteCapableDataSource := &pb.Job_DataSource{
+		Source: &pb.Job_DataSource_Git{
+			Git: &pb.Job_Git{
+				Ref: "main",
+				Url: "git.test",
+			},
+		},
+	}
+
+	// Register a remote runner
+	_, remoteRunnerClose := singleprocess.TestRunner(t, client, &pb.Runner{Odr: false})
+	defer remoteRunnerClose()
+
+	// Register a non-default runner profile
+	odrProfileName := "project-specific ODR profile"
+	_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
+		Config: &pb.OnDemandRunnerConfig{
+			Name:       odrProfileName,
+			PluginType: "docker",
+			Default:    false,
+		},
+	})
+	require.Nil(err)
+
+	t.Run("Choose remote if the datasource is good, a remote runner exists, and a runner profile is set for the project", func(t *testing.T) {
+		project = &pb.Project{
+			Name:           "test",
+			RemoteEnabled:  true,
+			DataSource:     remoteCapableDataSource,
+			OndemandRunner: &pb.Ref_OnDemandRunnerConfig{Name: odrProfileName},
+		}
+		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		remote, err := remoteOpPreferred(ctx, client, project, log)
+		require.Nil(err)
+		require.True(remote)
+	})
+
+	t.Run("Choose local if no runner profile is set for the project, and there is no default", func(t *testing.T) {
+		project = &pb.Project{
+			Name:          "test",
+			RemoteEnabled: true,
+			DataSource:    remoteCapableDataSource,
+		}
+		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		remote, err := remoteOpPreferred(ctx, client, project, log)
+		require.Nil(err)
+		require.False(remote)
+	})
+
+	// Register a default runner profile
+	_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
+		Config: &pb.OnDemandRunnerConfig{
+			Name:       "the default",
+			PluginType: "docker",
+			Default:    true,
+		},
+	})
+	require.Nil(err)
+
+	t.Run("Choose remote if the project is good and the default runner is set", func(t *testing.T) {
+		project = &pb.Project{
+			Name:          "test",
+			RemoteEnabled: true,
+			DataSource:    remoteCapableDataSource,
+		}
+		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
+		require.Nil(err)
+
+		remote, err := remoteOpPreferred(ctx, client, project, log)
+		require.Nil(err)
+		require.True(remote)
+	})
+}

--- a/internal/client/testing.go
+++ b/internal/client/testing.go
@@ -33,10 +33,6 @@ func TestProject(t testing.T, opts ...Option) *Project {
 	}, opts...)...)
 	require.NoError(err)
 
-	// Start the local runner
-	_, err = result.StartLocalRunner()
-	require.NoError(err)
-
 	// Move into a temporary directory
 	td := testTempDir(t)
 	testChdir(t, td)

--- a/internal/server/grpcmetadata/grpc.go
+++ b/internal/server/grpcmetadata/grpc.go
@@ -13,18 +13,35 @@ import (
 // spawn jobs back on that client in response to an RPC.
 const grpcMetadataRunnerId = "waypoint-runner-id"
 
-// AddRunner adds gRPC metadata to indicate that RPCs sent with the returned
-// context having the given runner (specified by id) attached to the sending client,
-// allow the server to target jobs back to the client that performed an RPC call.
+// AddRunner adds gRPC metadata to an outgoing context to indicate that RPCs sent
+// with the returned context having the given runner (specified by id) attached to
+// the sending client, allow the server to target jobs back to the client that
+// performed an RPC call.
 func AddRunner(ctx context.Context, id string) context.Context {
 	return metadata.AppendToOutgoingContext(ctx, grpcMetadataRunnerId, id)
 }
 
-// Returns the runner id attached to the context as grpc Metadata.
+// RunnerId returns the runner id attached to the incoming context as grpc Metadata.
 // This would be set by the client to indicate there is a runner attached
 // directly to it.
 func RunnerId(ctx context.Context) (string, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+
+	val := md.Get(grpcMetadataRunnerId)
+	if len(val) == 0 {
+		return "", false
+	}
+
+	return val[0], true
+}
+
+// OutgoingRunnerId returns the runner id attached to the context as grpc Metadata.
+// This is primarily used in tests, to validate that a context was set correctly.
+func OutgoingRunnerId(ctx context.Context) (string, bool) {
+	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		return "", false
 	}

--- a/internal/server/grpcmetadata/grpc.go
+++ b/internal/server/grpcmetadata/grpc.go
@@ -13,7 +13,7 @@ import (
 // spawn jobs back on that client in response to an RPC.
 const grpcMetadataRunnerId = "waypoint-runner-id"
 
-// AddRunner adds gRPC metadata to indicate that that RPCs sent with the returned
+// AddRunner adds gRPC metadata to indicate that RPCs sent with the returned
 // context having the given runner (specified by id) attached to the sending client,
 // allow the server to target jobs back to the client that performed an RPC call.
 func AddRunner(ctx context.Context, id string) context.Context {

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -31,6 +31,16 @@ For example, you could run one of the following commands:
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, Waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
 #### Command Options
 
 - `-instance=<string>` - Start an exec session on this specific instance

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -33,4 +33,14 @@ to a specific deployment or filter out certain log messages.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, Waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
 @include "commands/logs_more.mdx"


### PR DESCRIPTION
### What changed

This PR primarily moves the local runner trigger logic out of the CLI and into the project client. Rather than rely on each command to declare ahead of time if they require a runner, and start the runner before the command can run, now we wait until a CLI command actually attempts to spawn a job, and start the runner there.

Upsides to doing this:
- CLI commands don't need to explicitly declare if they need a runner. This is a big win for the `status` command, which only needs a runner conditionally (if `-refresh` is present). 
- The client package seems like the "right" place for this logic to live - as the primary internal interface to the waypoint APIs, it seems like it should be responsible for abstracting these details. With this change, all of the logic around handling the local runner lives inside the client package.

Downsides to doing this:
- The details of `logs` and `exec` _within_ the client package get a little bit messier. Unlike every other command, `logs` and `exec` don't create jobs from the CLI side. Instead, they need to start a local runner, call a server API, and then the server creates the job and decides if it needs to be assigned back to the local runner. So for logs and exec, we need to become ready to accept local jobs, but _not_ create a job. To make that happen, I've split all of the job spoolup logic into a function called `setupLocalJobSystem`, which is normally called within `doJob` but is _also_ called by the logs and exec client operation funcs.

This also sets the stage for us to add more complexity into the `setupLocalJobSystem` sequence - namely checking if VCS is dirty and issuing a warning or forwarding the `waypoint.hcl` file along with the job.

### Smaller incidental changes:
- Adds the operation set flags to logs and exec. They both could trigger operations, and without them you have no control over if those operations happen locally or remotely. As a result, up until now, it hasn't been possible to run exec or logs non-locally! I tested them both, and they work with remotely ODR.
- Wires in `remoteOpPreferred`, initially introduced in https://github.com/hashicorp/waypoint/pull/2749. Operations will now occur remotely if they're likely to work remotely, unless `-local` is specified.
- Misc typo fixes and improved logging



