### PR TITLE
ui: set `Project.remote_enabled` appropriately

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   rules: {
     'prefer-let/prefer-let': 'error',
     'prefer-const': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
   },
   overrides: [
     // node files

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -304,12 +304,16 @@ export default class ApiService extends Service {
         git.clearBasic();
         git.clearSsh();
       }
+
+      ref.setRemoteEnabled(true);
     } else {
       // if we set up a project without connecting it to a git repo
       // but we want to set input variables, a git URL is required
       // for updating a project's settings. this silences that error
       // while not adding settings the user did not specify
       git.setUrl('\n');
+
+      ref.setRemoteEnabled(project.remoteEnabled);
     }
 
     dataSource.setGit(git);

--- a/ui/tests/unit/services/api-test.ts
+++ b/ui/tests/unit/services/api-test.ts
@@ -1,12 +1,88 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import ApiService from 'waypoint/services/api';
+import { UpsertProjectRequest, UpsertProjectResponse, Project, Hcl } from 'waypoint-pb';
+import { WaypointClient } from 'waypoint-client';
 
 module('Unit | Service | api', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('service:api');
-    assert.ok(service);
+  module('upsertProject', function () {
+    test('sets remote_enabled to true when a data source is present', async function (assert) {
+      let api: ApiService = this.owner.lookup('service:api');
+      let result = setupMockUpsertProject(api.client);
+      let project = projectObject({
+        dataSource: {
+          git: {
+            url: 'https://github.com/hashicorp/waypoint-examples',
+            ref: 'head',
+            path: '',
+            ignoreChangesOutsidePath: true,
+          },
+        },
+        remoteEnabled: false,
+      });
+
+      api.upsertProject(project);
+
+      assert.equal(result.request?.getProject()?.getRemoteEnabled(), true);
+    });
+
+    test('leaves remote_enabled alone when data source is absent', async function (assert) {
+      let api: ApiService = this.owner.lookup('service:api');
+      let result = setupMockUpsertProject(api.client);
+      let project = projectObject({
+        dataSource: undefined,
+        remoteEnabled: true,
+      });
+
+      api.upsertProject(project);
+
+      assert.equal(result.request?.getProject()?.getRemoteEnabled(), true);
+    });
   });
 });
+
+/**
+ * Mocks out the `upsertProject` method on a WaypointClient instance.
+ *
+ * Yes we could use a library like Sinon, but things get complicated making all
+ * that work with TypeScript.
+ *
+ * @param client {WaypointClient}
+ * @returns {MockResult} object that records interactions with upsertProject
+ */
+function setupMockUpsertProject(client: WaypointClient): MockResult {
+  let result: MockResult = {};
+  let upsertProject = (request: UpsertProjectRequest, _meta: never) => {
+    result.request = request;
+    return Promise.resolve(new UpsertProjectResponse());
+  };
+
+  client.upsertProject = upsertProject as WaypointClient['upsertProject'];
+
+  return result;
+}
+
+interface MockResult {
+  request?: UpsertProjectRequest;
+}
+
+/**
+ * Provides defaults for a Project.AsObject.
+ * @param attrs {Partial<Project.AsObject>} attributes to override
+ * @returns {Project.AsObject} a complete Project.AsObject
+ */
+function projectObject(attrs: Partial<Project.AsObject>): Project.AsObject {
+  return {
+    applicationsList: [],
+    dataSource: undefined,
+    fileChangeSignal: 'HUP',
+    name: 'test-project',
+    remoteEnabled: false,
+    variablesList: [],
+    waypointHcl: '',
+    waypointHclFormat: Hcl.Format.HCL,
+    ...attrs,
+  };
+}


### PR DESCRIPTION
## Why the change?

Closes #2712

## What does it look like?

https://user-images.githubusercontent.com/34030/144088962-f5ad15ea-d39b-46b9-a544-8aacc13bc3a7.mp4

## How do I test it?

1. `git checkout ui/remote-enabled-fix`
2. [Run the UI dev server against a local Waypoint server](https://github.com/hashicorp/waypoint/tree/main/ui#running-with-a-local-waypoint-server)
3. Follow the repro steps in #2712
4. Verify `remote_enabled` is set correctly