### PR TITLE
Set the assigned runner ID on the job

### DIFF
--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -166,7 +166,7 @@ func (s *service) queueJobReqToJob(
 		}
 	}
 
-	// If the job can be run any any runner, then we attempt to see if we should spawn
+	// If the job can be run any runner, then we attempt to see if we should spawn
 	// on on-demand runner for it. We only consider jobs for any runner because ones
 	// that are targeted can not target on-demand runners, because they don't yet exist.
 	var od *pb.Ref_OnDemandRunnerConfig

--- a/internal/server/singleprocess/service_job_test.go
+++ b/internal/server/singleprocess/service_job_test.go
@@ -149,6 +149,9 @@ func TestServiceGetJobStream_complete(t *testing.T) {
 		require.NotNil(assignment)
 		require.Equal(queueResp.JobId, assignment.Assignment.Job.Id)
 
+		// The assigned runner ID has been set for the job
+		require.Equal(id, assignment.Assignment.Job.AssignedRunner.Id)
+
 		require.NoError(runnerStream.Send(&pb.RunnerJobStreamRequest{
 			Event: &pb.RunnerJobStreamRequest_Ack_{
 				Ack: &pb.RunnerJobStreamRequest_Ack{},
@@ -540,6 +543,7 @@ func TestServiceQueueJob_odr(t *testing.T) {
 	assignment, ok := resp.Event.(*pb.RunnerJobStreamResponse_Assignment)
 	require.True(ok, "should be an assignment")
 	require.NotNil(assignment)
+	require.Equal(id, assignment.Assignment.Job.AssignedRunner.Id)
 	require.NotEqual(queueResp.JobId, assignment.Assignment.Job.Id)
 	require.IsType(&pb.Job_StartTask{}, assignment.Assignment.Job.Operation)
 
@@ -590,6 +594,7 @@ func TestServiceQueueJob_odr(t *testing.T) {
 	require.NotNil(assignment)
 	require.Equal(queueResp.JobId, assignment.Assignment.Job.Id)
 	require.Equal(runnerId, assignment.Assignment.Job.TargetRunner.Target.(*pb.Ref_Runner_Id).Id.Id)
+	require.Equal(runnerId, assignment.Assignment.Job.AssignedRunner.Id)
 
 	require.NoError(rs2.Send(&pb.RunnerJobStreamRequest{
 		Event: &pb.RunnerJobStreamRequest_Ack_{

--- a/internal/server/singleprocess/state/job.go
+++ b/internal/server/singleprocess/state/job.go
@@ -490,6 +490,7 @@ RETRY_ASSIGN:
 		result, err := s.jobReadAndUpdate(txn, job.Id, func(jobpb *pb.Job) error {
 			jobpb.State = job.State
 			jobpb.AssignTime, err = ptypes.TimestampProto(time.Now())
+			jobpb.AssignedRunner = &pb.Ref_RunnerId{Id: r.Id}
 			if err != nil {
 				// This should never happen since encoding a time now should be safe
 				panic("time encoding failed: " + err.Error())
@@ -572,6 +573,7 @@ func (s *State) JobAck(id string, ack bool) (*serverstate.Job, error) {
 			job.State = pb.Job_QUEUED
 			jobpb.State = job.State
 			jobpb.AssignTime = nil
+			jobpb.AssignedRunner = nil
 		}
 
 		return nil


### PR DESCRIPTION
We had this field, but weren't using it! I'd like to use it to give the CLI more context as to where a job is running.