### PR TITLE
ui: timeline component added to details pages

### DIFF
--- a/.changelog/2793.txt
+++ b/.changelog/2793.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Added timeline component to artifact details pages
+```

--- a/ui/app/components/section.hbs
+++ b/ui/app/components/section.hbs
@@ -1,8 +1,7 @@
 <section
   class="
     section
-    {{if this.expanded "section--expanded" "section--collapsed"}}
-  "
+    {{if this.expanded "section--expanded" "section--collapsed"}}"
 >
   <div class="section__header">
     <h2 class="section__heading">

--- a/ui/app/components/timeline.hbs
+++ b/ui/app/components/timeline.hbs
@@ -1,6 +1,6 @@
 <ul class="timeline">
   {{#each this.artifacts as |artifact|}}
-    <li>
+    <li data-test-timeline-li>
       <div class="timeline__dot"></div>
       <LinkTo
         title={{concat (t artifact.type) " v" artifact.sequence}}

--- a/ui/app/components/timeline.hbs
+++ b/ui/app/components/timeline.hbs
@@ -1,0 +1,28 @@
+<ul class="timeline">
+  {{#each this.artifacts as |artifact|}}
+    <li>
+      <div class="timeline__dot"></div>
+      <LinkTo
+        title={{concat (t artifact.type) " v" artifact.sequence}}
+        @route={{artifact.route}}
+        @models={{array artifact.sequence}}
+      >
+        <span><Pds::Icon @type="check-circle-outline"/> {{t artifact.type}}</span>
+        <b class="badge badge--version">v{{artifact.sequence}}</b>
+        {{#if artifact.isCurrentRoute}}
+          <span class="timeline__current-marker">{{t "page.artifact.timeline.current-marker"}}</span>
+        {{/if}}
+        {{#if artifact.status}}
+          <span class="timeline__li__timestamp">
+            {{#if (eq artifact.status.state 1)}}
+              {{date-format-distance-to-now artifact.status.startTime.seconds}}
+            {{else}}
+              {{date-format-distance-to-now artifact.status.completeTime.seconds}}
+            {{/if}}
+          </span>
+        {{/if}}
+      </LinkTo>
+      <div class="timeline__dash"/>
+    </li>
+  {{/each}}
+</ul>

--- a/ui/app/components/timeline.ts
+++ b/ui/app/components/timeline.ts
@@ -62,6 +62,7 @@ export default class Timeline extends Component<TimelineArgs> {
         isCurrentRoute: this.areWeHere(key),
       } as ArtifactModel);
     }
+    artifactsList.sort((a, b) => (a.type > b.type ? 1 : -1));
     return artifactsList;
   }
 }

--- a/ui/app/components/timeline.ts
+++ b/ui/app/components/timeline.ts
@@ -41,14 +41,8 @@ export default class Timeline extends Component<TimelineArgs> {
   @service router!: RouterService;
 
   areWeHere(currentArtifactKey: string): boolean {
-    let entry = Object.entries(_TYPE_ROUTES).find(([_, value]) =>
-      this.router.currentRouteName.includes(value)
-    );
-
-    if (entry) {
-      return entry[0] === currentArtifactKey;
-    }
-    return false;
+    let routeForKey = _TYPE_ROUTES[currentArtifactKey];
+    return this.router.currentRouteName.includes(routeForKey);
   }
 
   get artifacts(): ArtifactModel[] {

--- a/ui/app/components/timeline.ts
+++ b/ui/app/components/timeline.ts
@@ -1,0 +1,67 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import RouterService from '@ember/routing/router-service';
+import ApiService from 'waypoint/services/api';
+import { Status } from 'waypoint-pb';
+
+const _TYPE_TRANSLATIONS = {
+  build: 'page.artifact.timeline.build',
+  deployment: 'page.artifact.timeline.deployment',
+  release: 'page.artifact.timeline.release',
+};
+
+const _TYPE_ROUTES = {
+  build: 'workspace.projects.project.app.build',
+  deployment: 'workspace.projects.project.app.deployment.deployment-seq',
+  release: 'workspace.projects.project.app.release',
+};
+interface ArtifactModel {
+  sequence: number;
+  type: string;
+  route: string;
+  status?: Status.AsObject;
+  isCurrentRoute: boolean;
+}
+
+export interface TimelineModel {
+  build?: TimelineArtifact;
+  deployment?: TimelineArtifact;
+  release?: TimelineArtifact;
+}
+interface TimelineArtifact {
+  sequence: number;
+  status: Status.AsObject | undefined;
+}
+interface TimelineArgs {
+  model: TimelineModel;
+}
+
+export default class Timeline extends Component<TimelineArgs> {
+  @service api!: ApiService;
+  @service router!: RouterService;
+
+  areWeHere(currentArtifactKey: string): boolean {
+    let entry = Object.entries(_TYPE_ROUTES).find(([_, value]) =>
+      this.router.currentRouteName.includes(value)
+    );
+
+    if (entry) {
+      return entry[0] === currentArtifactKey;
+    }
+    return false;
+  }
+
+  get artifacts(): ArtifactModel[] {
+    let artifactsList: ArtifactModel[] = [];
+    for (let key in this.args.model) {
+      artifactsList.push({
+        sequence: this.args.model[key].sequence,
+        type: _TYPE_TRANSLATIONS[key],
+        route: _TYPE_ROUTES[key],
+        status: this.args.model[key].status,
+        isCurrentRoute: this.areWeHere(key),
+      } as ArtifactModel);
+    }
+    return artifactsList;
+  }
+}

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -4,6 +4,7 @@ import ApiService from 'waypoint/services/api';
 import { Ref, GetBuildRequest, Build, PushedArtifact } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
+import { TimelineModel } from '../../../../../components/timeline';
 
 type Params = { sequence: string };
 type Model = Build.AsObject & WithPushedArtifact;
@@ -12,7 +13,11 @@ interface WithPushedArtifact {
   pushedArtifact?: PushedArtifact.AsObject;
 }
 
-type BuildWithArtifact = Build.AsObject & WithPushedArtifact;
+interface WithTimeline {
+  timeline: TimelineModel;
+}
+
+type BuildWithArtifact = Build.AsObject & WithPushedArtifact & WithTimeline;
 
 export default class BuildDetail extends Route {
   @service api!: ApiService;
@@ -34,8 +39,12 @@ export default class BuildDetail extends Route {
   }
 
   async model(params: Params): Promise<Model> {
-    let { builds } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
+    let { builds, deployments, releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let buildFromAppRoute = builds.find((obj) => obj.sequence === Number(params.sequence));
+    let deploymentFromAppRoute = deployments.find(
+      (obj) => obj.artifactId === buildFromAppRoute?.pushedArtifact?.id
+    );
+    let releaseFromAppRoute = releases.find((obj) => obj.deploymentId === deploymentFromAppRoute?.id);
 
     if (!buildFromAppRoute) {
       throw new Error(`Build v${params.sequence} not found`);
@@ -50,6 +59,28 @@ export default class BuildDetail extends Route {
     let result: BuildWithArtifact = build.toObject();
 
     result.pushedArtifact = buildFromAppRoute.pushedArtifact;
+
+    let timeline: TimelineModel = {};
+    timeline.build = {
+      sequence: buildFromAppRoute.sequence,
+      status: buildFromAppRoute.status,
+    };
+
+    if (deploymentFromAppRoute) {
+      timeline.deployment = {
+        sequence: deploymentFromAppRoute.sequence,
+        status: deploymentFromAppRoute.status,
+      };
+    }
+
+    if (releaseFromAppRoute) {
+      timeline.release = {
+        sequence: releaseFromAppRoute.sequence,
+        status: releaseFromAppRoute.status,
+      };
+    }
+
+    result.timeline = timeline;
 
     return result;
   }

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -41,9 +41,12 @@ export default class BuildDetail extends Route {
   async model(params: Params): Promise<Model> {
     let { builds, deployments, releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let buildFromAppRoute = builds.find((obj) => obj.sequence === Number(params.sequence));
-    let deploymentFromAppRoute = deployments.find(
-      (obj) => obj.artifactId === buildFromAppRoute?.pushedArtifact?.id
-    );
+    let deploymentFromAppRoute = deployments.find((obj) => {
+      if (obj.preload && obj.preload.artifact) {
+        return obj.preload.artifact.id === buildFromAppRoute?.pushedArtifact?.id;
+      }
+      return obj.artifactId === buildFromAppRoute?.pushedArtifact?.id;
+    });
     let releaseFromAppRoute = releases.find((obj) => obj.deploymentId === deploymentFromAppRoute?.id);
 
     if (!buildFromAppRoute) {

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -4,7 +4,7 @@ import ApiService from 'waypoint/services/api';
 import { Ref, GetBuildRequest, Build, PushedArtifact } from 'waypoint-pb';
 import { Model as AppRouteModel } from '../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
-import { TimelineModel } from '../../../../../components/timeline';
+import { TimelineModel } from 'waypoint/components/timeline';
 
 type Params = { sequence: string };
 type Model = Build.AsObject & WithPushedArtifact;
@@ -17,7 +17,8 @@ interface WithTimeline {
   timeline: TimelineModel;
 }
 
-type BuildWithArtifact = Build.AsObject & WithPushedArtifact & WithTimeline;
+type BuildWithArtifact = Build.AsObject & WithPushedArtifact;
+type BuildWithArtifactAndTimeline = BuildWithArtifact & WithTimeline;
 
 export default class BuildDetail extends Route {
   @service api!: ApiService;
@@ -59,9 +60,9 @@ export default class BuildDetail extends Route {
     req.setRef(ref);
 
     let build = await this.api.client.getBuild(req, this.api.WithMeta());
-    let result: BuildWithArtifact = build.toObject();
+    let buildWithArtifact: BuildWithArtifact = build.toObject();
 
-    result.pushedArtifact = buildFromAppRoute.pushedArtifact;
+    buildWithArtifact.pushedArtifact = buildFromAppRoute.pushedArtifact;
 
     let timeline: TimelineModel = {};
     timeline.build = {
@@ -83,8 +84,7 @@ export default class BuildDetail extends Route {
       };
     }
 
-    result.timeline = timeline;
-
+    let result: BuildWithArtifactAndTimeline = { ...buildWithArtifact, timeline };
     return result;
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
@@ -1,17 +1,22 @@
+import Controller from '@ember/controller';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import Transition from '@ember/routing/-private/transition';
 import ApiService from 'waypoint/services/api';
 import { Model as AppRouteModel } from '../../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { DeploymentExtended, ReleaseExtended } from 'waypoint/services/api';
+import { TimelineModel } from '../../../../../../components/timeline';
 
 type Params = { sequence: string };
-export type Model = DeploymentExtended & WithRelease;
+export type Model = DeploymentExtended & WithRelease & WithTimeline;
 
 interface WithRelease {
   release?: ReleaseExtended;
 }
-
+interface WithTimeline {
+  timeline: TimelineModel;
+}
 export default class DeploymentDetail extends Route {
   @service api!: ApiService;
 
@@ -32,16 +37,46 @@ export default class DeploymentDetail extends Route {
   }
 
   async model(params: Params): Promise<Model> {
-    let { deployments } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
+    let { builds, deployments, releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let deployment = deployments.find((obj) => obj.sequence == Number(params.sequence));
+    let build = builds.find((obj) => obj.pushedArtifact.id === deployment?.pushedArtifact.id);
 
     if (!deployment) {
       throw new Error(`Deployment v${params.sequence} not found`);
     }
 
     let deploymentId = deployment.id;
-    let { releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let release = releases.find((r) => r.deploymentId === deploymentId);
-    return { ...deployment, release };
+
+    let timeline: TimelineModel = {};
+    if (build) {
+      timeline.build = {
+        sequence: build.sequence,
+        status: build.status,
+      };
+    }
+
+    timeline.deployment = {
+      sequence: deployment.sequence,
+      status: deployment.status,
+    };
+
+    if (release) {
+      timeline.release = {
+        sequence: release.sequence,
+        status: release.status,
+      };
+    }
+
+    return { ...deployment, release, timeline };
+  }
+
+  resetController(_: Controller, isExiting: boolean, transition: Transition): void {
+    if (isExiting && transition.to.name === 'workspace.projects.project.app.deployment.index') {
+      this.transitionTo(
+        'workspace.projects.project.app.deployment.deployment-seq',
+        (this.modelFor(this.routeName) as Model).sequence
+      );
+    }
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployment/deployment-seq.ts
@@ -39,7 +39,8 @@ export default class DeploymentDetail extends Route {
   async model(params: Params): Promise<Model> {
     let { builds, deployments, releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let deployment = deployments.find((obj) => obj.sequence == Number(params.sequence));
-    let build = builds.find((obj) => obj.pushedArtifact.id === deployment?.pushedArtifact.id);
+    let deploymentArtifactId = deployment?.pushedArtifact?.id ?? deployment?.artifactId;
+    let build = builds.find((obj) => obj.pushedArtifact?.id === deploymentArtifactId);
 
     if (!deployment) {
       throw new Error(`Deployment v${params.sequence} not found`);

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -4,9 +4,15 @@ import ApiService from 'waypoint/services/api';
 import { Model as AppRouteModel } from '../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { ReleaseExtended } from 'waypoint/services/api';
+import { TimelineModel } from '../../../../../components/timeline';
 
 type Params = { sequence: string };
-export type Model = ReleaseExtended;
+
+interface WithTimeline {
+  timeline: TimelineModel;
+}
+
+export type Model = ReleaseExtended & WithTimeline;
 
 export default class ReleaseDetail extends Route {
   @service api!: ApiService;
@@ -29,13 +35,38 @@ export default class ReleaseDetail extends Route {
   }
 
   async model(params: Params): Promise<Model> {
-    let { releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
+    let { builds, deployments, releases } = this.modelFor('workspace.projects.project.app') as AppRouteModel;
     let release = releases.find((obj) => obj.sequence === Number(params.sequence));
 
     if (!release) {
       throw new Error(`Release v${params.sequence} not found`);
     }
 
-    return release;
+    let deployment = deployments.find((obj) => obj.id === release.deploymentId);
+    let build = builds.find((obj) => obj.pushedArtifact.id === deployment.pushedArtifact.id);
+
+    let timeline: TimelineModel = {};
+    if (build) {
+      let buildObj = {
+        sequence: build.sequence,
+        status: build.status,
+      };
+      timeline.build = buildObj;
+    }
+
+    if (deployment) {
+      timeline.deployment = {
+        sequence: deployment.sequence,
+        status: deployment.status,
+      };
+    }
+
+    let releaseObj = {
+      sequence: release.sequence,
+      status: release.status,
+    };
+    timeline.release = releaseObj;
+
+    return { ...release, timeline };
   }
 }

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -42,8 +42,9 @@ export default class ReleaseDetail extends Route {
       throw new Error(`Release v${params.sequence} not found`);
     }
 
-    let deployment = deployments.find((obj) => obj.id === release.deploymentId);
-    let build = builds.find((obj) => obj.pushedArtifact.id === deployment.pushedArtifact.id);
+    let deployment = deployments.find((obj) => obj.id === release?.deploymentId);
+    let deploymentArtifactId = deployment?.pushedArtifact?.id ?? deployment?.artifactId;
+    let build = builds.find((obj) => obj.pushedArtifact?.id === deploymentArtifactId);
 
     let timeline: TimelineModel = {};
     if (build) {

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -46,6 +46,11 @@ const protocolVersions = {
   'client-version': 'ui-0.0.1',
 };
 
+export type BuildExtended = Build.AsObject & {
+  statusReport?: StatusReport.AsObject;
+  pushedArtifact?: PushedArtifact.AsObject;
+};
+
 // This is an adapter type. It exists to let us transition to
 // UI.DeploymentBundle incrementally.
 export type DeploymentExtended = Deployment.AsObject & {

--- a/ui/app/styles/_layout.scss
+++ b/ui/app/styles/_layout.scss
@@ -50,11 +50,20 @@ aside {
   padding-top: scale.$lg-6;
 }
 
-.grid--menu-with-panel {
+.grid {
   display: grid;
-  grid-gap: 36px;
-  grid-template-columns: 23vw auto;
-  grid-template-areas: 'menu panel';
+
+  &--menu-with-panel {
+    grid-gap: 36px;
+    grid-template-columns: 23vw auto;
+    grid-template-areas: 'menu panel';
+  }
+
+  &--overview-timeline {
+    width: 100%;
+    grid-gap: scale.$sm-2;
+    grid-template-columns: 50% 50%;
+  }
 }
 
 ul {

--- a/ui/app/styles/_variables.scss
+++ b/ui/app/styles/_variables.scss
@@ -24,6 +24,8 @@ $button-shadow: 0 3px 2px rgba(var(--shadow), 0.2);
   --card: #{dehex(color.$white)};
   --highlighted-list-item: #{dehex(color.$ui-cool-gray-100)};
   --panel: #{dehex(color.$ui-cool-gray-050)};
+  --timeline-dot: #{dehex(color.$ui-gray-400)};
+  --timeline-dash: #{dehex(color.$ui-gray-100)};
   --badge: #{dehex(color.$ui-gray-200)};
   --badge-text: #{dehex(color.$ui-gray-800)};
   --badge-neutral: #{dehex(color.$ui-cool-gray-100)};

--- a/ui/app/styles/components/_index.scss
+++ b/ui/app/styles/components/_index.scss
@@ -31,6 +31,7 @@
 @import 'structure/pds-tabnav';
 @import 'terminal';
 @import 'table';
+@import 'timeline';
 @import 'tooltip';
 @import 'up-button';
 @import 'variables-list';

--- a/ui/app/styles/components/image-ref.scss
+++ b/ui/app/styles/components/image-ref.scss
@@ -4,6 +4,7 @@
 
   &__tag {
     margin-left: 7px;
+    overflow-wrap: anywhere;
   }
 
   &__copy-button {

--- a/ui/app/styles/components/timeline.scss
+++ b/ui/app/styles/components/timeline.scss
@@ -1,0 +1,58 @@
+.timeline {
+  li {
+    display: grid;
+    grid-template-columns: scale.$sm-1 auto;
+    grid-template-rows: max-content 20px;
+    align-items: center;
+  }
+
+  svg {
+    font-size: 16px;
+    color: rgb(var(--text-subtle));
+    margin: 0 scale.$sm-4;
+  }
+
+  a:not(.button) {
+    width: 90%;
+    color: black;
+    @include Typography.Interface(M);
+
+    >* {
+      margin-right: scale.$sm-4;
+    }
+  }
+
+  &__li__timestamp {
+    color: rgb(var(--text-muted));
+    @include Typography.Interface(S);
+  }
+
+  &__dot {
+    border-radius: 8px;
+    height: 8px;
+    width: 8px;
+    background-color: rgb(var(--timeline-dot));
+    margin-right: 20px;
+  }
+
+  &__dash {
+    width: 2px;
+    height: 25px;
+    margin: 0 3px;
+    background-color: rgb(var(--timeline-dash));
+  }
+
+  &__current-marker {
+    background-color: rgb(var(--info));
+    color: rgb(var(--info-text));
+    @include Typography.Interface(S);
+    font-weight: 700;
+    border-radius: 22px;
+    padding: scale.$sm-4 scale.$sm-2;
+  }
+
+  li:last-child>.timeline__dash {
+    width: 0;
+    height: 0;
+  }
+}

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -1,6 +1,7 @@
 {{page-title @model.application.application}}
 {{#if (and
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.build')
+  (not-eq this.target.currentRouteName 'workspace.projects.project.app.release.index')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment.deployment-seq.resource')
   (not-eq this.target.currentRouteName 'workspace.projects.project.app.release.resource')
 )}}

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -21,12 +21,14 @@
         </StatusReportMetaTable>
       </:body>
     </Section>
-    <Section @isExpandable={{false}}>
-      <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
-      <:body>
-        <Timeline @model={{@model.timeline}} />
-      </:body>
-  </Section>
+    {{#if @model.timeline}}
+      <Section @isExpandable={{false}}>
+        <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+        <:body>
+          <Timeline @model={{@model.timeline}} />
+        </:body>
+      </Section>
+    {{/if}}
   </div>
 {{/let}}
 

--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -7,19 +7,27 @@
     </:actions>
   </PanelHeader>
 
-  <Section @isExpandable={{false}}>
-    <:heading>{{t "page.build.overview.heading"}}</:heading>
-    <:body>
-      <StatusReportMetaTable @model={{@model}} @artifactType="Build">
-        <tr>
-          <th scope="row">{{t "page.build.overview.status"}}</th>
-          <td>
-            <OperationStatusIndicator::Build @operation={{operation}} />
-          </td>
-        </tr>
-      </StatusReportMetaTable>
-    </:body>
+  <div class="grid grid--overview-timeline">
+    <Section @isExpandable={{false}}>
+      <:heading>{{t "page.artifact.overview.heading"}}</:heading>
+      <:body>
+        <StatusReportMetaTable @model={{@model}} @artifactType="Build">
+          <tr>
+            <th scope="row">{{t "page.artifact.overview.status"}}</th>
+            <td>
+              <OperationStatusIndicator::Build @operation={{operation}} />
+            </td>
+          </tr>
+        </StatusReportMetaTable>
+      </:body>
+    </Section>
+    <Section @isExpandable={{false}}>
+      <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+      <:body>
+        <Timeline @model={{@model.timeline}} />
+      </:body>
   </Section>
+  </div>
 {{/let}}
 
 <Section>

--- a/ui/app/templates/workspace/projects/project/app/deployment.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment.hbs
@@ -1,6 +1,6 @@
 {{page-title (concat @model.application.application "Deployments")}}
 {{#let (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployment.deployment-seq.resource') as |isNotResourcePage|}}
-  <div class={{if (and isNotResourcePage this.deploymentsByGeneration) "grid--menu-with-panel"}}>
+  <div class={{if (and isNotResourcePage this.deploymentsByGeneration) "grid grid--menu-with-panel"}}>
   {{#if isNotResourcePage}}
     {{#if this.deploymentsByGeneration}}
       <ul data-test-deployment-list class="sidebar list">

--- a/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
@@ -33,12 +33,14 @@
           </StatusReportMetaTable>
         </:body>
       </Section>
-      <Section @isExpandable={{false}}>
-        <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
-        <:body>
-          <Timeline @model={{@model.timeline}} />
-        </:body>
-      </Section>
+      {{#if @model.timeline}}
+        <Section @isExpandable={{false}}>
+          <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+          <:body>
+            <Timeline @model={{@model.timeline}} />
+          </:body>
+        </Section>
+      {{/if}}
   </div>
 
   {{#let

--- a/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployment/deployment-seq.hbs
@@ -16,19 +16,30 @@
     </:actions>
   </PanelHeader>
 
-  <Section @isExpandable={{false}}>
-    <:heading>{{t "page.deployment.overview.heading"}}</:heading>
-    <:body>
-      <StatusReportMetaTable @model={{@model}} @artifactType="Deployment">
-        <tr>
-          <th scope="row">{{t "page.deployment.overview.status"}}</th>
-          <td>
-            <OperationStatusIndicator::Deployment @operation={{@model}} />
-          </td>
-        </tr>
-      </StatusReportMetaTable>
-    </:body>
-  </Section>
+  <div class="grid grid--overview-timeline">
+    <Section @isExpandable={{false}}>
+        <:heading>{{t "page.artifact.overview.heading"}}</:heading>
+        <:body>
+          <StatusReportMetaTable @model={{@model}} @artifactType="Deployment">
+            <tr>
+              <th scope="row">{{t "page.artifact.overview.status"}}</th>
+              <td>
+                <Pds::Icon @type={{icon-for-component @model.component.name}} class="icon" />
+                <span>Deployed by <b>{{component-name @model.component.name}}</b>
+                  {{date-format-distance-to-now @model.status.startTime.seconds }}
+                </span>
+              </td>
+            </tr>
+          </StatusReportMetaTable>
+        </:body>
+      </Section>
+      <Section @isExpandable={{false}}>
+        <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+        <:body>
+          <Timeline @model={{@model.timeline}} />
+        </:body>
+      </Section>
+  </div>
 
   {{#let
     @model.statusReport.resourcesList

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -26,12 +26,14 @@
         </StatusReportMetaTable>
       </:body>
     </Section>
-    <Section @isExpandable={{false}}>
-      <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
-      <:body>
-        <Timeline @model={{@model.timeline}} />
-      </:body>
-    </Section>
+    {{#if @model.timeline}}
+      <Section @isExpandable={{false}}>
+        <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+        <:body>
+          <Timeline @model={{@model.timeline}} />
+        </:body>
+      </Section>
+    {{/if}}
   </div>
 
   {{#if @model.statusReport.resourcesList.length}}

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -12,19 +12,27 @@
     </:actions>
   </PanelHeader>
 
-  <Section @isExpandable={{false}}>
-    <:heading>{{t "page.release.overview.heading"}}</:heading>
-    <:body>
-      <StatusReportMetaTable @model={{@model}} @artifactType="Release">
-        <tr>
-          <th scope="row">{{t "page.release.overview.status"}}</th>
-          <td>
-            <OperationStatusIndicator::Release @operation={{@model}}/>
-          </td>
-        </tr>
-      </StatusReportMetaTable>
-    </:body>
-  </Section>
+  <div class="grid grid--overview-timeline">
+    <Section @isExpandable={{false}}>
+      <:heading>{{t "page.artifact.overview.heading"}}</:heading>
+      <:body>
+        <StatusReportMetaTable @model={{@model}} @artifactType="Release">
+          <tr>
+            <th scope="row">{{t "page.artifact.overview.status"}}</th>
+            <td>
+              <OperationStatusIndicator::Release @operation={{@model}}/>
+            </td>
+          </tr>
+        </StatusReportMetaTable>
+      </:body>
+    </Section>
+    <Section @isExpandable={{false}}>
+      <:heading>{{t "page.artifact.timeline.heading"}}</:heading>
+      <:body>
+        <Timeline @model={{@model.timeline}} />
+      </:body>
+    </Section>
+  </div>
 
   {{#if @model.statusReport.resourcesList.length}}
     <Section>

--- a/ui/tests/integration/components/timeline-test.ts
+++ b/ui/tests/integration/components/timeline-test.ts
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+class RouterStub extends Service {
+  currentRouteName = 'workspace.projects.project.app.release';
+}
+
+module('Integration | Component | timeline', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (_) {
+    this.owner.register('service:router', RouterStub);
+  });
+
+  test('happy path', async function (assert) {
+    this.set('timeline', {
+      build: {
+        sequence: 3,
+        status: {
+          state: 2,
+          completeTime: {
+            seconds: 1639166870,
+          },
+        },
+      },
+      deployment: {
+        sequence: 2,
+        status: {
+          state: 4,
+          completeTime: {
+            seconds: 1639166879,
+          },
+        },
+      },
+      release: {
+        sequence: 1,
+        status: {
+          state: 4,
+          completeTime: {
+            seconds: 1639166880,
+          },
+        },
+      },
+    });
+    await render(hbs`<Timeline @model={{this.timeline}}/>`);
+
+    let listItems = this.element.querySelectorAll('li');
+    assert.equal(listItems.length, 3);
+    assert.dom(listItems[0]).containsText('Build');
+    assert.dom(listItems[1]).containsText('Deployment');
+    assert.dom(listItems[2]).containsText('Release');
+    assert.dom(listItems[2]).containsText('You are here');
+  });
+
+  test('it does not render timestamps if status unavailable', async function (assert) {
+    this.set('timeline', {
+      build: { sequence: 4 },
+      deployment: { sequence: 3 },
+      release: { sequence: 2 },
+    });
+    await render(hbs`<Timeline @model={{this.timeline}}/>`);
+
+    let listItems = this.element.querySelectorAll('li');
+    assert.equal(listItems.length, 3);
+
+    for (let item of listItems) {
+      assert.dom('.timeline__li__timestamp', item).doesNotExist();
+    }
+  });
+
+  test('it does not render you are here badge if no router.currentRouteName value', async function (assert) {
+    this.set('timeline', {
+      build: { sequence: 4 },
+      deployment: { sequence: 3 },
+    });
+    await render(hbs`<Timeline @model={{this.timeline}}/>`);
+
+    let listItems = this.element.querySelectorAll('li');
+    assert.equal(listItems.length, 2);
+    assert.dom('.timeline__current-marker', this.element).doesNotExist();
+  });
+
+  test('it renders an empty ul with no model', async function (assert) {
+    await render(hbs`<Timeline />`);
+    assert.dom(this.element).hasNoText();
+    assert.dom('ul').exists();
+    assert.dom('li').doesNotExist();
+  });
+});

--- a/ui/tests/integration/components/timeline-test.ts
+++ b/ui/tests/integration/components/timeline-test.ts
@@ -11,11 +11,8 @@ class RouterStub extends Service {
 module('Integration | Component | timeline', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function (_) {
-    this.owner.register('service:router', RouterStub);
-  });
-
   test('happy path', async function (assert) {
+    this.owner.register('service:router', RouterStub);
     this.set('timeline', {
       build: {
         sequence: 3,
@@ -56,6 +53,7 @@ module('Integration | Component | timeline', function (hooks) {
   });
 
   test('it does not render timestamps if status unavailable', async function (assert) {
+    this.owner.register('service:router', RouterStub);
     this.set('timeline', {
       build: { sequence: 4 },
       deployment: { sequence: 3 },
@@ -72,6 +70,7 @@ module('Integration | Component | timeline', function (hooks) {
   });
 
   test('it does not render you are here badge if no router.currentRouteName value', async function (assert) {
+    this.owner.register('service:router', RouterStub);
     this.set('timeline', {
       build: { sequence: 4 },
       deployment: { sequence: 3 },

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -21,18 +21,23 @@ page:
     switching-workspace: Loading…
   artifact:
     overview:
+      heading: 'Overview'
+      status: 'Status'
       image: 'Image'
       health-check: 'Health'
       re-run-health-check: 'Re-run'
       unavailable: 'Currently unavailable'
       commit: 'Commit'
+    timeline:
+      heading: 'Timeline'
+      build: 'Build'
+      deployment: 'Deployment'
+      release: 'Release'
+      current-marker: 'You are here'
   builds:
     title: 'Builds'
   build:
     title: 'Build'
-    overview:
-      heading: 'Overview'
-      status: 'Status'
     logs:
       heading: Build Logs
   deployments:
@@ -52,9 +57,6 @@ page:
       heading: Resources
       deployment-table-caption: Resources created by <b>this deployment</b>
       release-table-caption-prefix: Resources created by <b>Release</b>
-    overview:
-      heading: 'Overview'
-      status: 'Status'
     logs:
       heading: Deployment Logs
   releases:
@@ -64,9 +66,6 @@ page:
     resources:
       heading: Resources
       table-caption: Resources created by <b>this release</b>
-    overview:
-      heading: 'Overview'
-      status: 'Status'
     logs:
       heading: Release Logs
   unavailable:


### PR DESCRIPTION
## Notes
Currently does not show destroyed deployments in the timeline, @almonk is still working on designs for the best way to show this

## How to test
1. Pull down the branch `git checkout ui/timeline-component`
2. `yarn start`
3. Check the build, deployment, and release details pages for the timelines
_Optional_
4. Spin up a Waypoint server + make some builds, deployments, and releases
5. `ember serve local`
6. Check the build, deployment, and release details pages for the timelines

## Screenshot
<img width="1436" alt="Screen Shot 2021-12-14 at 9 28 35 AM" src="https://user-images.githubusercontent.com/60155296/146020377-0a711374-add0-492d-8d31-6b3be742ff03.png">
