### PR TITLE
ui: fix build logs heading

### DIFF
--- a/ui/app/templates/workspace/projects/project/app/build.hbs
+++ b/ui/app/templates/workspace/projects/project/app/build.hbs
@@ -23,7 +23,7 @@
 {{/let}}
 
 <Section>
-    <:heading>{{t "page.deployment.logs.heading"}}</:heading>
+    <:heading>{{t "page.build.logs.heading"}}</:heading>
     <:body>
       <OperationLogs @jobId={{@model.jobId}} />
     </:body>

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -33,6 +33,8 @@ page:
     overview:
       heading: 'Overview'
       status: 'Status'
+    logs:
+      heading: Build Logs
   deployments:
     title: 'Deployments'
     destroyed_label: 'Destroyed'


### PR DESCRIPTION
## Why the change?

The heading for the logs on the build page was “Deployment Logs”.

## How do I test it?

1. `git checkout ui/fix-build-logs-heading`
2. `cd ui && yarn start`
3. [Visit a build page](http://localhost:4200/default/marketing-public/app/wp-matrix/build/seq/4)
4. Verify the heading for the logs is “Build Logs”