### PR TITLE
CLI: emit dirty vcs warning for remote operations.

### DIFF
--- a/.changelog/2799.txt
+++ b/.changelog/2799.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli: Warn if about to perform a remote operation with a dirty local git state 
+```
+

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -296,22 +296,21 @@ func (c *baseCommand) Init(opts ...Option) error {
 	//     required
 
 	// 1. Parse the configuration
-	c.cfg = &config.Config{}
 
 	if !baseCfg.NoConfig {
 		// Try parsing config
-		cfg, err := c.initConfig("")
+		c.cfg, err = c.initConfig("")
 		if err != nil {
 			c.logError(c.Log, "failed to load config", err)
 			return err
 		}
 
 		// If that worked, set our refs
-		if cfg != nil {
-			c.refProject = &pb.Ref_Project{Project: cfg.Project}
-			for _, app := range cfg.Apps() {
+		if c.cfg != nil {
+			c.refProject = &pb.Ref_Project{Project: c.cfg.Project}
+			for _, app := range c.cfg.Apps() {
 				c.refApps = append(c.refApps, &pb.Ref_Application{
-					Project:     cfg.Project,
+					Project:     c.cfg.Project,
 					Application: app,
 				})
 			}

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -114,6 +114,10 @@ func (c *baseCommand) initClient(
 		opts = append(opts, clientpkg.WithUI(c.ui))
 	}
 
+	if c.cfg != nil {
+		opts = append(opts, clientpkg.WithConfigPath(c.cfg.GetConfigPath()))
+	}
+
 	if ctx == nil {
 		ctx = c.Ctx
 	}

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -115,7 +115,7 @@ func (c *baseCommand) initClient(
 	}
 
 	if c.cfg != nil {
-		opts = append(opts, clientpkg.WithConfigPath(c.cfg.GetConfigPath()))
+		opts = append(opts, clientpkg.WithConfigPath(c.cfg.ConfigPath()))
 	}
 
 	if ctx == nil {

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -501,10 +501,10 @@ const stateEventPause = 3000 * time.Millisecond
 
 var (
 	warnGitDirty = strings.TrimSpace(`
-       There are local changes that do not match the remote repository. By default, 
-       Waypoint will perform this operation using a remote runner that will use the 
-       remote repository’s git ref and not these local changes. For these changes 
-       to be used for future operations, either commit and push, or run the operation 
-       locally with the -local flag.
-	`)
+There are local changes that do not match the remote repository. By default, 
+Waypoint will perform this operation using a remote runner that will use the 
+remote repository’s git ref and not these local changes. For these changes 
+to be used for future operations, either commit and push, or run the operation 
+locally with the -local flag.
+`)
 )

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -41,6 +41,10 @@ type Project struct {
 
 	localServer bool // True when a local server is created
 
+	// configPath is the path to the local directory that contains our config file (waypoint.hcl)
+	// May not be present.
+	configPath string
+
 	// These are used to manage a local runner and its job processing
 	// in a goroutine.
 	wg           sync.WaitGroup
@@ -269,6 +273,15 @@ func WithNoLocalServer() Option {
 func WithUseLocalRunner(useLocalRunner bool) Option {
 	return func(c *Project, cfg *config) error {
 		c.useLocalRunner = &useLocalRunner
+		return nil
+	}
+}
+
+// WithConfigPath sets the path to the local directory that contains our config
+// file (waypoint.hcl).
+func WithConfigPath(configPath string) Option {
+	return func(c *Project, cfg *config) error {
+		c.configPath = configPath
 		return nil
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,3 +161,8 @@ func Load(path string, opts *LoadOptions) (*Config, error) {
 func (c *Config) HCLContext() *hcl.EvalContext {
 	return c.ctx.NewChild()
 }
+
+// GetConfigPath returns the path to the directory that contains the config file (waypoint.hcl)
+func (c *Config) GetConfigPath() string {
+	return c.path
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,7 @@ func (c *Config) HCLContext() *hcl.EvalContext {
 	return c.ctx.NewChild()
 }
 
-// GetConfigPath returns the path to the directory that contains the config file (waypoint.hcl)
-func (c *Config) GetConfigPath() string {
+// ConfigPath returns the path to the directory that contains the config file (waypoint.hcl)
+func (c *Config) ConfigPath() string {
 	return c.path
 }

--- a/internal/pkg/gitdirty/gitdirty.go
+++ b/internal/pkg/gitdirty/gitdirty.go
@@ -23,6 +23,24 @@ func init() {
 	githubStyleHttpRemoteRegexp = regexp.MustCompile(`http[s]?:\/\/(.*?\..*?)\/(.*)`) // Example: https://git.test/testorg/testrepo.git
 }
 
+// GitInstalled checks if the command-line tool `git` is installed
+func GitInstalled() bool {
+	if _, err := exec.LookPath("git"); err == nil {
+		return true
+	}
+	return false
+}
+
+// GetRepoTopLevel returns the path to the root of the repository that contains pathWithinVcs.
+// Equivalent to git rev-parse --show-toplevel
+func GetRepoTopLevel(log hclog.Logger, pathWithinVcs string) (string, error) {
+	out, err := runGitCommand(log, pathWithinVcs, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(strings.TrimRight(out, "\n")), nil
+}
+
 // RepoIsDirty looks for unstaged, staged, and committed (but not pushed)
 // changes on the local GitDirty.path repo not on the specified remote
 // url and branch.

--- a/internal/pkg/gitdirty/gitdirty.go
+++ b/internal/pkg/gitdirty/gitdirty.go
@@ -25,15 +25,13 @@ func init() {
 
 // GitInstalled checks if the command-line tool `git` is installed
 func GitInstalled() bool {
-	if _, err := exec.LookPath("git"); err == nil {
-		return true
-	}
-	return false
+	_, err := exec.LookPath("git")
+	return err == nil
 }
 
-// GetRepoTopLevel returns the path to the root of the repository that contains pathWithinVcs.
+// RepoTopLevelPath returns the path to the root of the repository that contains pathWithinVcs.
 // Equivalent to git rev-parse --show-toplevel
-func GetRepoTopLevel(log hclog.Logger, pathWithinVcs string) (string, error) {
+func RepoTopLevelPath(log hclog.Logger, pathWithinVcs string) (string, error) {
 	out, err := runGitCommand(log, pathWithinVcs, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Merge after https://github.com/hashicorp/waypoint/pull/2779

This change wires in the vcs detection library introduced in https://github.com/hashicorp/waypoint/pull/2772.

## What problem is this solving

Now that waypoint runs operations remotely wherever possible, users who were previously used to local operations will be exposed to remote ops. They may be used to modifying their `waypoint.hcl` file, running something like `waypoint up`, and expecting the runner to take the change. The remote runner will run off a fresh clone of their repo though, and won't see the change.

We can't _just_ look at the waypoint.hcl file though, because they may have template file directives in there, and some plugins read other files (e.x. docker reads the Dockerfile). There's no good way to detect which files we need to be clean to run a safe operation, so we need to warn if anything is dirty.

## What changed

If we're going to execute an operation remotely, and we're in a project directory, and there is any difference detected between that project dir and the vcs state the remote runner will use, we emit a big warning.

## How to verify

Set up a project for remote ops, dirty the project repo by modifying the `waypoint.hcl` file, run an op, and observe the warning:

```
$ waypoint build

» Building learn-waypoint-lambda...
There are local changes that do not match the remote repository. By default, 
       Waypoint will perform this operation using a remote runner that will use the 
       remote repository’s git ref and not these local changes. For these changes 
       to be used for future operations, either commit and push, or run the operation 
       locally with the -local flag.

» Cloning data from Git
  URL: https://github.com/hashicorp/waypoint-examples
  Ref: us-east-1
...
```

