### PR TITLE
ui: extract `<Table>`

### DIFF
--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -1,46 +1,41 @@
-<div
+<Table
   data-test-resources-table
-  class="
-    resources-table
-    {{if @withMargin "resources-table--with-margin"}}
-  "
+  @withMargin={{@withMargin}}
 >
-  <table>
-    <caption>{{yield to="caption"}}</caption>
+  <caption>{{yield to="caption"}}</caption>
 
-    <colgroup>
-      <col class="w-2/5">
-      <col>
-      <col>
-      <col>
-    </colgroup>
+  <colgroup>
+    <col class="w-2/5">
+    <col>
+    <col>
+    <col>
+  </colgroup>
 
-    <thead>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Age</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    {{#each @resources key="id" as |resource|}}
       <tr>
-        <th>Name</th>
-        <th>Type</th>
-        <th>Age</th>
-        <th>Status</th>
+        <th scope="row">
+          <LinkTo
+            title={{resource.name}}
+            @route={{@route}}
+            @models={{append (or @models (array)) resource.id}}
+          >
+            {{resource.name}}
+          </LinkTo>
+        </th>
+        <td><Pds::Icon @type={{icon-for-component resource.platform}} /> {{resource.type}}</td>
+        <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
+        <td><ResourceHealthIndicator @resource={{resource}} /></td>
       </tr>
-    </thead>
-
-    <tbody>
-      {{#each @resources key="id" as |resource|}}
-        <tr>
-          <th scope="row">
-            <LinkTo
-              title={{resource.name}}
-              @route={{@route}}
-              @models={{append (or @models (array)) resource.id}}
-            >
-              {{resource.name}}
-            </LinkTo>
-          </th>
-          <td><Pds::Icon @type={{icon-for-component resource.platform}} /> {{resource.type}}</td>
-          <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
-          <td><ResourceHealthIndicator @resource={{resource}} /></td>
-        </tr>
-      {{/each}}
-    </tbody>
-  </table>
-</div>
+    {{/each}}
+  </tbody>
+</Table>

--- a/ui/app/components/table.hbs
+++ b/ui/app/components/table.hbs
@@ -1,0 +1,47 @@
+{{!--
+
+This component is designed to be a drop-in replacement for `<table>`. It applies
+some styles and adds an extra wrapping element, but apart from that it’s a plain
+old HTML table so feel free to use all your favorite HTML table features.
+
+Usage:
+
+    <Table>
+      <caption>My very nice table</caption>
+
+      <colgroup>
+        <col class="w-1/2">
+        <col>
+        <col>
+      </colgroup>
+
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Location</th>
+          <th>Role</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <th scope="row">Alice Example</th>
+          <td>Minneapolis</td>
+          <td>Engineer</td>
+        </tr>
+      </tbody>
+    </Table>
+
+--}}
+
+<div
+  data-test-table
+  class="
+    table
+    {{if @withMargin "table--with-margin"}}
+  "
+>
+  <table ...attributes>
+    {{yield}}
+  </table>
+</div>

--- a/ui/app/styles/components/_index.scss
+++ b/ui/app/styles/components/_index.scss
@@ -24,13 +24,13 @@
 @import 'output-pane';
 @import 'project-init-error';
 @import 'resource-detail';
-@import 'resources-table';
 @import 'section';
 @import 'spinner';
 @import 'status-report-indicator';
 @import 'structure/pds-form';
 @import 'structure/pds-tabnav';
 @import 'terminal';
+@import 'table';
 @import 'tooltip';
 @import 'up-button';
 @import 'variables-list';

--- a/ui/app/styles/components/table.scss
+++ b/ui/app/styles/components/table.scss
@@ -1,4 +1,4 @@
-.resources-table {
+.table {
   background: rgb(var(--panel));
   border-radius: 8px;
   padding: 10px;
@@ -55,7 +55,22 @@
     }
   }
 
+  .w-1\/2 {
+    width: 50%;
+  }
+  .w-1\/3 {
+    width: 33.333%;
+  }
+  .w-1\/4 {
+    width: 25%;
+  }
+  .w-1\/5 {
+    width: 20%;
+  }
   .w-2\/5 {
     width: 40%;
+  }
+  .w-3\/5 {
+    width: 60%;
   }
 }


### PR DESCRIPTION
## Why the change?

We’re going to start using this new table style in other places for #2391.

## What’s the plan?

- [x] Extract `<Table>` from `<ResourcesTable>`

## What does it look like?

Hopefully identical!

### Before

<img width="1360" alt="CleanShot 2021-12-06 at 16 14 24@2x" src="https://user-images.githubusercontent.com/34030/144881747-1aa9ca5c-389f-4747-af6d-134c3aa5effb.png">

### After

<img width="1360" alt="CleanShot 2021-12-06 at 16 14 11@2x" src="https://user-images.githubusercontent.com/34030/144881777-b5050bbb-2112-478b-bdab-2bc9de634cba.png">

### How do I test it?

1. `git checkout ui/table`
2. `cd ui && yarn start`
3. [Visit localhost:4200](http://localhost:4200)
4. Browse around
5. Verify tables look decent
6. Try adding some new tables using `<Table>`
7. Verify the API isn’t too terrible 🙃