### PR TITLE
CLI: Warn if project from flags mismatches project from config

### DIFF
--- a/.changelog/2815.txt
+++ b/.changelog/2815.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Enhance warning project flag mismatches project parsed from config
+cli: Enhance warning for project flag mismatches when project parsed from config
 ```

--- a/.changelog/2815.txt
+++ b/.changelog/2815.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Enhance warning project flag mismatches project parsed from config
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -332,7 +332,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 			// NOTE(izaak): unless we force remoteness, we may spawn a local runner which will operate against
 			// the current config (which isn't relevant)
-			c.Log.Debug("Forcing any future operations to occur remotely because we don't have the relevant waypoint.hcl present.")
+			c.Log.Debug("Forcing any future operations to occur remotely because the relevant waypoint.hcl is not present.")
 			flagLocal := false
 			c.flagLocal = &flagLocal
 		}

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -307,12 +307,24 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 		// If that worked, set our refs
 		if c.cfg != nil {
-			c.refProject = &pb.Ref_Project{Project: c.cfg.Project}
-			for _, app := range c.cfg.Apps() {
-				c.refApps = append(c.refApps, &pb.Ref_Application{
-					Project:     c.cfg.Project,
-					Application: app,
-				})
+			// Warn if the project from config and the project from flags conflict
+			if c.flagProject != "" && c.flagProject != c.cfg.Project {
+				c.ui.Output(warnProjectFlagMismatch, c.refProject.Project, c.flagProject, terminal.WithWarningStyle())
+
+				// NOTE(izaak): unless we force remoteness, we may spawn a local runner which will operate against
+				// the current config (which isn't relevant)
+				c.Log.Debug("Forcing any future operations to occur remotely because the relevant waypoint.hcl is not present.")
+				flagLocal := false
+				c.flagLocal = &flagLocal
+			} else {
+				// This config is good - use it to obtain our refs.
+				c.refProject = &pb.Ref_Project{Project: c.cfg.Project}
+				for _, app := range c.cfg.Apps() {
+					c.refApps = append(c.refApps, &pb.Ref_Application{
+						Project:     c.cfg.Project,
+						Application: app,
+					})
+				}
 			}
 		}
 	}
@@ -321,22 +333,6 @@ func (c *baseCommand) Init(opts ...Option) error {
 	// config parsing, as precedence order means we take the most specific value
 	// which is the -project flag
 	if c.flagProject != "" {
-		// Warn if the project from config and the project from flags conflict
-		if c.refProject != nil && c.flagProject != c.refProject.Project {
-			c.ui.Output(warnProjectFlagMismatch, c.refProject.Project, c.flagProject, terminal.WithWarningStyle())
-
-			// The config we parsed is for some other project, so we don't want to use it
-			c.cfg = nil
-			c.refProject = nil
-			c.refApps = nil
-
-			// NOTE(izaak): unless we force remoteness, we may spawn a local runner which will operate against
-			// the current config (which isn't relevant)
-			c.Log.Debug("Forcing any future operations to occur remotely because the relevant waypoint.hcl is not present.")
-			flagLocal := false
-			c.flagLocal = &flagLocal
-		}
-
 		c.refProject = &pb.Ref_Project{Project: c.flagProject}
 	}
 


### PR DESCRIPTION
## What changed

A user can add the `-project` flag when they're in some other project's directory:

Example:

```
$ cd ~/projects/project-a
$ cat waypoint.hcl # it exists
$ waypoint deploy -project=project-b
```

This means one of two things:

1: They added the flag explicitly, and they want to operate against `project-b`.

2: The user wants to operate against the project that matches the directory they're in, but they've copied the `-project` flag from some other command/example.

We could just error here, but it feels onerous to force the user from scenario 1 to `cd` into some safe directory before running their command.

The middle ground here is to continue to allow flags to override config, but issue a warning to help the user from scenario 2. We also force the operation to happen remotely, as the local runner doesn't currently support cloning down some other project's vcs source.

## What this looks like

```
$ waypoint build -project=learn-waypoint-lambda
Warning: Currently in project directory for "example-nginx-ami", but will operate 
against specified project "learn-waypoint-lambda"

» Building learn-waypoint-lambda...

» Cloning data from Git
  URL: https://github.com/hashicorp/waypoint-examples
  Ref: us-east-1
...
```