### PR TITLE
Allow hyphens in workspace names

### DIFF
--- a/internal/server/ptypes/workspace.go
+++ b/internal/server/ptypes/workspace.go
@@ -14,7 +14,7 @@ import (
 
 // WorkspaceNameRegexp is the valid Workspace name regular expression. At this
 // time the only restriction is to not allow spaces.
-var WorkspaceNameRegexp = regexp.MustCompile(`^[\p{L}\p{N}_]*$`)
+var WorkspaceNameRegexp = regexp.MustCompile(`^[\p{L}\p{N}_-]*$`)
 
 // TestWorkspace returns a valid workspace for tests.
 func TestWorkspace(t testing.T, src *pb.Workspace) *pb.Workspace {

--- a/internal/server/ptypes/workspace.go
+++ b/internal/server/ptypes/workspace.go
@@ -14,7 +14,7 @@ import (
 
 // WorkspaceNameRegexp is the valid Workspace name regular expression. At this
 // time the only restriction is to not allow spaces.
-var WorkspaceNameRegexp = regexp.MustCompile(`^[\p{L}\p{N}_-]*$`)
+var WorkspaceNameRegexp = regexp.MustCompile(`^[\p{L}\p{N}]+[\p{L}\p{N}\-_]*[^\-_]$`)
 
 // TestWorkspace returns a valid workspace for tests.
 func TestWorkspace(t testing.T, src *pb.Workspace) *pb.Workspace {

--- a/internal/serverstate/statetest/test_workspace.go
+++ b/internal/serverstate/statetest/test_workspace.go
@@ -126,6 +126,19 @@ func TestWorkspacePut(t *testing.T, factory Factory, _ RestartFactory) {
 		require.Error(err)
 	})
 
+	t.Run("Allow underscores and hyphens", func(t *testing.T) {
+		require := require.New(t)
+
+		s := factory(t)
+		defer s.Close()
+
+		// Underscores and hyphens are fine
+		err := s.WorkspacePut(serverptypes.TestWorkspace(t, &pb.Workspace{
+			Name: "special_and-allowed-_",
+		}))
+		require.NoError(err)
+	})
+
 	t.Run("Multi List", func(t *testing.T) {
 		require := require.New(t)
 

--- a/internal/serverstate/statetest/test_workspace.go
+++ b/internal/serverstate/statetest/test_workspace.go
@@ -134,7 +134,7 @@ func TestWorkspacePut(t *testing.T, factory Factory, _ RestartFactory) {
 
 		// Underscores and hyphens are fine
 		err := s.WorkspacePut(serverptypes.TestWorkspace(t, &pb.Workspace{
-			Name: "special_and-allowed-_",
+			Name: "special_and-allowed",
 		}))
 		require.NoError(err)
 	})
@@ -203,6 +203,33 @@ func TestWorkspacePut(t *testing.T, factory Factory, _ RestartFactory) {
 			require.Len(workspace.Projects, 1)
 		}
 	})
+
+	// Enforce that workspaces cannot start or end with either hyphens and
+	// underscores, or contain spaces
+	invalidNames := []string{
+		"cannot contain spaces",
+		" cannot start with spaces",
+		"-starts_with-hyphen",
+		"_starts-with_underscore",
+		"_ends-with_underscore-_",
+		"_ends-with_underscore-_",
+	}
+
+	for _, invalidName := range invalidNames {
+		// hyphens and underscores are allowed, but names cannot start with them
+		t.Run("Invalid_"+invalidName, func(t *testing.T) {
+			require := require.New(t)
+
+			s := factory(t)
+			defer s.Close()
+
+			// Workspace names cannot start with underscore or hyphens
+			err := s.WorkspacePut(serverptypes.TestWorkspace(t, &pb.Workspace{
+				Name: invalidName,
+			}))
+			require.Error(err)
+		})
+	}
 }
 
 func TestWorkspaceProject(t *testing.T, factory Factory, restartF RestartFactory) {


### PR DESCRIPTION
The current regex to validate names used in the `UpsertWorkspace` endpoint does not allow hyphens, which I do not believe were meant to be excluded in valid names in https://github.com/hashicorp/waypoint/pull/2758


Note: no changelog entry because at this time this endpoint is not yet released