### PR TITLE
ui/mirage: fix `UpsertProject` handler

### DIFF
--- a/ui/mirage/services/project.ts
+++ b/ui/mirage/services/project.ts
@@ -52,7 +52,7 @@ export function update(this: RouteHandler, schema: any, { requestBody }: Request
     .map((v) => v.toObject());
   let dataSource = requestMsg.getProject()?.getDataSource();
   let poll = requestMsg.getProject()?.getDataSourcePoll();
-  let model = schema.projects.findBy({ name });
+  let model = schema.projects.findOrCreateBy({ name });
 
   model.variables = variablesList?.map((v) => model.newVariable(v));
   model.dataSource = dataSourceFromProto(schema, dataSource);


### PR DESCRIPTION
## Why the change?

Previously this would fail to create a brand new project.

## How do I test it?

1. `git checkout ui/mirage-upsert-project-fix`
2. `cd ui && yarn start`
3. [Try making a new project](http://localhost:4200/default/new)
4. Observe it doesn’t work
5. `git checkout ui/mirage-upsert-project-fix`
6. [Try making a new project](http://localhost:4200/default/new)
7. Verify it now works