### PR TITLE
ui: fix workspace switcher issues on deployment master-detail pages

### DIFF
--- a/ui/app/components/workspace-switcher.hbs
+++ b/ui/app/components/workspace-switcher.hbs
@@ -34,6 +34,7 @@
                 @models={{array-concat workspace.name @models}}
                 aria-current={{if (eq workspace.name @current) "page" false}}
                 {{on "click" D.close}}
+                data-test-workspace-link={{workspace.name}}
               >
                 <span class="workspace-switcher__link-contents">
                   {{#if (eq workspace.name @current)}}

--- a/ui/app/controllers/workspace/projects/project/app.ts
+++ b/ui/app/controllers/workspace/projects/project/app.ts
@@ -6,4 +6,39 @@ import { tracked } from '@glimmer/tracking';
 export default class extends Controller {
   @tracked isSwitchingWorkspace = false;
   @service router!: RouterService;
+
+  /**
+   * Returns a suitable “pivot” route when switching between workspaces.
+   * For example, if you’re looking at a list of builds for production
+   * then it makes sense to switch to the list of builds for staging.
+   * However, if you’re looking at an individual deployment in production
+   * then it wouldn’t make sense to switch to that same deployment in staging,
+   * because it won’t be there. Instead, you want to jump up a level to see
+   * the list of all deployments for production.
+   */
+  get workspaceSwitcherTargetRoute(): RouterService['currentRoute'] {
+    let result = this.router.currentRoute;
+
+    while (result.parent && result.parent.localName !== 'app') {
+      result = result.parent;
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the array of models to go with `workspaceSwitcherTargetRoute`,
+   * except without the leading workspace model (which the switcher will provide).
+   */
+  get workspaceSwitcherTargetModels(): unknown[] {
+    let result: unknown[] = [];
+    let route = this.workspaceSwitcherTargetRoute;
+
+    while (route.parent && route.parent.localName !== 'workspace') {
+      result = [...Object.values(route.params), ...result];
+      route = route.parent;
+    }
+
+    return result;
+  }
 }

--- a/ui/app/templates/workspace/projects/project/app.hbs
+++ b/ui/app/templates/workspace/projects/project/app.hbs
@@ -10,8 +10,8 @@
       <h1>{{@model.application.application}}</h1>
       <WorkspaceSwitcher
         @current={{@model.workspaceName}}
-        @route={{this.router.currentRoute.name}}
-        @models={{array @model.project.name @model.application.application}}
+        @route={{this.workspaceSwitcherTargetRoute.name}}
+        @models={{this.workspaceSwitcherTargetModels}}
       />
       {{#if this.isSwitchingWorkspace}}
         <span class="workspace-switching-indicator">

--- a/ui/tests/acceptance/workspaces-test.ts
+++ b/ui/tests/acceptance/workspaces-test.ts
@@ -1,4 +1,4 @@
-import { click, visit } from '@ember/test-helpers';
+import { click, visit, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -9,23 +9,43 @@ module('Acceptance | workspaces', function (hooks) {
   setupSession(hooks);
   setupMirage(hooks);
 
-  test('switching workspaces', async function (assert) {
+  test('switching between workspaces while looking at deployments', async function (assert) {
     let staging = this.server.create('workspace', { name: 'staging' });
     let production = this.server.create('workspace', { name: 'production' });
     let project = this.server.create('project', { name: 'test-project' });
-    let application = this.server.create('application', { name: 'test-project', project });
-    this.server.create('build', 'random', { application, workspace: staging });
-    this.server.create('build', 'random', { application, workspace: production });
+    let application = this.server.create('application', { name: 'test-app', project });
 
-    await visit(`/${staging.name}/${project.name}/app/${application.name}/builds`);
+    this.server.create('deployment', 'random', { application, seq: 1, workspace: staging });
+    this.server.create('deployment', 'random', { application, seq: 2, workspace: production });
+
+    await visit(`/staging/test-project/app/test-app`);
 
     assert.dom('[data-test-workspace-switcher]').containsText('staging');
-    assert.dom('[data-test-app-item-build]').containsText('v1');
 
-    await click('[data-test-dropdown-trigger]');
-    await click(`a[href="/${production.name}/${project.name}/app/${application.name}/builds"]`);
+    await click('[data-test-workspace-switcher] [data-test-dropdown-trigger]');
+    await click(`[data-test-workspace-link="production"]`);
 
+    assert.equal(currentURL(), `/production/test-project/app/test-app/deployment/seq/2`);
     assert.dom('[data-test-workspace-switcher]').containsText('production');
-    assert.dom('[data-test-app-item-build]').containsText('v2');
+  });
+
+  test('switching between workspaces while looking at builds', async function (assert) {
+    let staging = this.server.create('workspace', { name: 'staging' });
+    let production = this.server.create('workspace', { name: 'production' });
+    let project = this.server.create('project', { name: 'test-project' });
+    let application = this.server.create('application', { name: 'test-app', project });
+
+    this.server.create('build', 'random', { application, seq: 1, workspace: staging });
+    this.server.create('build', 'random', { application, seq: 2, workspace: production });
+
+    await visit(`/staging/test-project/app/test-app/builds`);
+
+    assert.dom('[data-test-workspace-switcher]').containsText('staging');
+
+    await click('[data-test-workspace-switcher] [data-test-dropdown-trigger]');
+    await click(`[data-test-workspace-link="production"]`);
+
+    assert.equal(currentURL(), `/production/test-project/app/test-app/builds`);
+    assert.dom('[data-test-workspace-switcher]').containsText('production');
   });
 });


### PR DESCRIPTION
## Why the change?

Originally, the workspace switcher appeared on the `app` page and its immediate child pages (builds, deployments, releases, etc). None of these pages included additional dynamic URL segments beyond `:app_id`. The workspace switcher was implemented with the faulty assumption that this would always be the case.

Why does this matter? Well, the workspace switcher renders links with fully-qualified paths, which need to be fed the correct params (dynamic segments) in order to function correctly. Let’s work through an example to see where this can break down:

Given this path:
```
/:workspace_id/:project_id/app/:app_id/deployments/seq/:deployment_seq
```

And this invocation of `LinkTo`:
```hbs
<LinkTo
  @route="workspace.projects.project.app.deployment.deployment-seq"
  @models={{array "my-workspace" "my-project" "my-app" "1"}}
>
```
Then `@models` will be plumbed into the path as follows:
```
@models={{array "my-workspace" "my-project" "my-app" "1"}}
                └──────┬─────┘ └─────┬────┘ └──┬───┘ └┬┘
       ┌───────────────┘             │         │      │
       │            ┌────────────────┘         │      │
       │            │             ┌────────────┘      └───────┐
 ┌─────┴─────┐ ┌────┴────┐     ┌──┴──┐                 ┌──────┴──────┐
/:workspace_id/:project_id/app/:app_id/deployments/seq/:deployment_seq
```

`@models` are fed in *from the right* (from least significant, if you like). Ember assumes any model you haven’t specified should remain unchanged. So let’s see what happens if a model is missing from the right hand side, let’s remove the sequence param:

```
@models={{array "my-workspace" "my-project" "my-app"}}
                └──────┬─────┘ └─────┬────┘ └──┬───┘
                       │             │         │
                    ┌──┘          ┌──┘         └──────────────┐
                    │             │                           │
               ┌────┴────┐     ┌──┴──┐                 ┌──────┴──────┐
/:workspace_id/:project_id/app/:app_id/deployments/seq/:deployment_seq
```

Which gives us a nonsense path, like this:

```
/previous-workspace/my-workspace/app/my-project/deployments/seq/my-app
```

This is the situation we found ourselves in with the workspace switcher, because we were only ever feeding in `@models` up to the `:app_id`, assuming there would be no further dynamic segments for pages on which the switcher appears.

Phew!

The fix is threefold:

1. Rather than linking to simply `currentRoute`, calculate a suitable “pivot route” which makes sense when switching between workspaces. At present, this is the immediate child route of the `app` route, but this may change in future if the app route gains immediate children with dynamic segments that don’t apply cleanly between workspaces. For example, if `deployment-seq` with it’s `:deployment_seq` dynamic segment were to become a direct child of `app`, then we’d have to tweak the behavior, but at least it’ll be more obvious what’s happening rather than seeing a bizarre nonsense path.
2. Calculate the `@models` array in a generic manner, so it’s more robust to additional dynamic segments.
3. Expand test coverage to catch regressions

## What’s the plan?

- [x] Improve test coverage so it actually catches this issue
- [x] Fix the issue 🦉 
- [x] PR description

## What does it look like?

### Before

https://user-images.githubusercontent.com/34030/146375921-b072e730-8518-47dc-83e6-7153c8fd8045.mp4

### After

https://user-images.githubusercontent.com/34030/146375949-a1dcc538-80ef-4e62-b5c4-05fef85384ca.mp4

## How do I test it?

1. `git checkout ui/workspace-switcher-fixes`
2. `cd ui && yarn start`
3. `open http://localhost:4200/default/marketing-public/app/wp-matrix`
4. Try switching between workspaces on the deployments, builds, and releases pages
5. Verify everything works as you’d expect