### PR TITLE
ui: automatic workspace selection

### DIFF
--- a/.changelog/2835.txt
+++ b/.changelog/2835.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Automatically select the appropriate workspace
+```

--- a/ui/app/components/logout/index.hbs
+++ b/ui/app/components/logout/index.hbs
@@ -1,5 +1,5 @@
 {{#if @canLogout}}
-  <button class="auth-link" type="button" {{on "click" this.logout}}>
+  <button data-test-logout-button class="auth-link" type="button" {{on "click" this.logout}}>
     <FlightIcon @name="sign-out" class="nav-icon" />
     Logout
   </button>

--- a/ui/app/instance-initializers/session-workspace-storage.ts
+++ b/ui/app/instance-initializers/session-workspace-storage.ts
@@ -1,0 +1,15 @@
+import ApplicationInstance from '@ember/application/instance';
+
+export function initialize(appInstance: ApplicationInstance): void {
+  let session = appInstance.lookup('service:session');
+
+  session.on('invalidationSucceeded', () => {
+    // Clear workspace on logout
+    session.set('data.workspace', undefined);
+  });
+}
+
+export default {
+  name: 'session-workspace-storage',
+  initialize,
+};

--- a/ui/app/routes/workspace.ts
+++ b/ui/app/routes/workspace.ts
@@ -1,15 +1,27 @@
 import Route from '@ember/routing/route';
 import { Ref } from 'waypoint-pb';
+import SessionService from 'ember-simple-auth/services/session';
+import { inject as service } from '@ember/service';
 
 export type Params = { workspace_id: string };
 export type Model = Ref.Workspace.AsObject;
 
 export default class Workspace extends Route {
+  @service session!: SessionService;
+
   async model(params: Params): Promise<Model> {
     // Workspace "id" which is a name, based on URL param
     let ws = new Ref.Workspace();
     ws.setWorkspace(params.workspace_id);
 
     return ws.toObject();
+  }
+
+  afterModel(model: Model): void {
+    this.storeWorkspace(model.workspace);
+  }
+
+  storeWorkspace(workspace: string): void {
+    this.session.set('data.workspace', workspace);
   }
 }

--- a/ui/app/routes/workspaces.ts
+++ b/ui/app/routes/workspaces.ts
@@ -1,12 +1,32 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
+import SessionService from 'ember-simple-auth/services/session';
 
 export default class Workspaces extends Route {
   @service api!: ApiService;
+  @service session!: SessionService;
 
-  redirect(): void {
-    // For now, we just support the default workspace
+  async redirect(): Promise<void> {
+    let workspaces = await this.api.listWorkspaces();
+    let workspaceNames = workspaces.map((w) => w.name).sort();
+    let storedWorkspaceName = this.session.data.workspace;
+
+    if (storedWorkspaceName && workspaceNames.includes(storedWorkspaceName)) {
+      this.transitionTo('workspace', storedWorkspaceName);
+      return;
+    }
+
+    if (workspaceNames.includes('default')) {
+      this.transitionTo('workspace', 'default');
+      return;
+    }
+
+    if (workspaceNames.length) {
+      this.transitionTo('workspace', workspaceNames[0]);
+      return;
+    }
+
     this.transitionTo('workspace', 'default');
   }
 }

--- a/ui/mirage/helpers/login.ts
+++ b/ui/mirage/helpers/login.ts
@@ -1,3 +1,0 @@
-export default function login(token?: string): void {
-  window.localStorage.waypointAuthToken = token || 'default-test-token-value';
-}

--- a/ui/mirage/scenarios/default.ts
+++ b/ui/mirage/scenarios/default.ts
@@ -1,9 +1,7 @@
 import { Server } from 'ember-cli-mirage';
-import login from '../helpers/login';
 
 export default function (server: Server): void {
   server.create('project', 'marketing-public');
   server.create('project', 'mutable-deployments');
   server.create('project', 'example-nodejs');
-  login();
 }

--- a/ui/types/ember-simple-auth/services/session.d.ts
+++ b/ui/types/ember-simple-auth/services/session.d.ts
@@ -2,15 +2,21 @@ import type RouterService from '@ember/routing/router-service';
 type Transition = ReturnType<RouterService['transitionTo']>;
 
 declare module 'ember-simple-auth/services/session' {
+  type SessionEvent = 'authenticationSucceeded' | 'invalidationSucceeded';
+
   export default interface SessionService {
     authenticate(authenticator: string, params: unknown): Promise<void>;
     isAuthenticated: boolean;
     invalidate(): Promise<void>;
     attemptedTransition: Transition;
     data: SessionData;
+
+    on(event: SessionEvent, callback: () => void): void;
+    set(key: string, value: unknown): void;
   }
 
   interface SessionData {
     authenticated?: Record<string, unknown>;
+    workspace?: string;
   }
 }


### PR DESCRIPTION
## Why the change?

Closes #2662 

## What’s the plan?

- [x] Capture the logic from #2662 in some tests
- [x] Figure out how to do storage properly with ember-simple-auth
- [x] Figure out the slightly surprising way that the presence of `login()` in our default mirage scenario interferes with this behavior
- [x] PR description

## What does it look like?

### Before

Notice:

1. We land in the `default` workspace, even though it’s not in use (or doesn’t exist at all)
2. If we switch workspace and revisit the UI, we end up back at `default`

https://user-images.githubusercontent.com/34030/150109628-f12ab897-15af-4ea0-9d64-985926f7a015.mp4

### After

Notice:

1. We land in the `production` workspace, because it’s alphabetically first of the workspaces that exist
2. When we switch workspace and revisit the UI, we end up back at the last workspace we saw (`staging` in this case)

https://user-images.githubusercontent.com/34030/150109657-8236a454-f23b-4d8c-9ecc-d90786b45e73.mp4

## How do I test it?

1. `git checkout ui/automatic-workspace-selection`
2. Pre-populate a Waypoint server with a variety of workspaces
3. [Boot the dev server against that Waypoint server](https://github.com/hashicorp/waypoint/blob/main/ui/README.md#running-with-a-local-waypoint-server)
4. Try navigating in various ways
5. Verify workspace selection behaves in a sensible manner