### PR TITLE
UI/ember a11y refocus

### DIFF
--- a/.changelog/2837.txt
+++ b/.changelog/2837.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Improved UX of screen readers' transition between pages
+```

--- a/ui/app/components/header/index.hbs
+++ b/ui/app/components/header/index.hbs
@@ -1,4 +1,5 @@
 <header id="header">
+  {{yield}}
   <LinkTo @route="application" class="brand">
     <Pds::Icon @type="brand" class="logo" />
     <span class="pds--visuallyHidden">{{t "product.name"}}</span>

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -1,6 +1,8 @@
 {{page-title "Waypoint"}}
 <SvgPatterns />
-<Header />
+<Header>
+  <NavigationNarrator/>
+</Header>
 
 <Page>
   {{outlet}}

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "codemirror": "^5.62.2",
     "date-fns": "^2.15.0",
     "docker-parse-image": "^3.0.1",
-    "ember-a11y-refocus": "^2.0.0",
+    "ember-a11y-refocus": "^2.1.0",
     "ember-a11y-testing": "^4.3.0",
     "ember-auto-import": "^1.10.1",
     "ember-auto-import-typescript": "^0.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,6 +53,7 @@
     "codemirror": "^5.62.2",
     "date-fns": "^2.15.0",
     "docker-parse-image": "^3.0.1",
+    "ember-a11y-refocus": "^2.0.0",
     "ember-a11y-testing": "^4.3.0",
     "ember-auto-import": "^1.10.1",
     "ember-auto-import-typescript": "^0.4.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6105,6 +6105,14 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+ember-a11y-refocus@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-a11y-refocus/-/ember-a11y-refocus-2.0.0.tgz#fca7ab929bfd8cdc54ef22eea668123069d49602"
+  integrity sha512-o7TGB3/H4oT9I7i3sAs9YRQ6/chimaAeKUzdlJIMu3s45qauVtYv3OiV12UsI6zXMJw2kKXPzliWrGvEDWgdwQ==
+  dependencies:
+    ember-cli-babel "^7.26.3"
+    ember-cli-htmlbars "^5.7.1"
+
 ember-a11y-testing@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-4.3.0.tgz#30bd1f206998335d621b5138a5cdc12c729a50e9"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6105,10 +6105,10 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-refocus@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-a11y-refocus/-/ember-a11y-refocus-2.0.0.tgz#fca7ab929bfd8cdc54ef22eea668123069d49602"
-  integrity sha512-o7TGB3/H4oT9I7i3sAs9YRQ6/chimaAeKUzdlJIMu3s45qauVtYv3OiV12UsI6zXMJw2kKXPzliWrGvEDWgdwQ==
+ember-a11y-refocus@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-a11y-refocus/-/ember-a11y-refocus-2.1.0.tgz#cc0473d15c0eb0405d848b831afd78a49cae109f"
+  integrity sha512-jF9aOviA0T6d9P+4AmVtrMRcHVQcT4uBfq5OIGsx2rYrdP6LWj/7Tb+yNLLTDbPIdZDbluzofG7UU6HZYzkJIg==
   dependencies:
     ember-cli-babel "^7.26.3"
     ember-cli-htmlbars "^5.7.1"


### PR DESCRIPTION
_Note:_ should there be a changelog for this?

## Context
- This is work from horde programming time to implement `ember-a11y-refocus`
- Currently, there's still an issue where every time polling occurs, the transition element is refocused on
  - This will be addressed in a future PR (see branch: `ui/ember-a11y-refocus-model-refactor`)