### PR TITLE
Update to Go 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.16
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.17
     middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
     website: &WEBSITE_IMAGE docker.mirror.hashicorp.services/node:14

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # builder builds the Waypoint binaries
 #--------------------------------------------------------------------
 
-FROM docker.mirror.hashicorp.services/golang:1.16.5-alpine3.13 AS builder
+FROM docker.mirror.hashicorp.services/golang:1.17.5-alpine3.15 AS builder
 
 RUN apk add --no-cache git gcc libc-dev make
 
@@ -53,7 +53,7 @@ ENTRYPOINT ["/kaniko/waypoint"]
 # final image
 #--------------------------------------------------------------------
 
-FROM docker.mirror.hashicorp.services/alpine:3.13.5
+FROM docker.mirror.hashicorp.services/alpine:3.15.0
 
 # git is for gitrefpretty() and other calls for Waypoint
 RUN apk add --no-cache git


### PR DESCRIPTION
This is pretty long in the tooth probably since Go 1.18 now in beta, it just wasn't a priority for us, but I don't see any reason for us to not upgrade to the latest 1.17 version. This updates our CI and Dockerfile. We probably need to update our release repo too.

Don't think we should backport this, and just use it for the next minor.