### PR TITLE
Add Exec Terminal to the browser UI

### DIFF
--- a/.changelog/2849.txt
+++ b/.changelog/2849.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Add Exec Terminal to the web UI 
+```

--- a/ui/app/components/exec/index.hbs
+++ b/ui/app/components/exec/index.hbs
@@ -1,0 +1,2 @@
+<RenderTerminal @terminal={{this.terminal}}/>
+

--- a/ui/app/components/exec/index.ts
+++ b/ui/app/components/exec/index.ts
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
+import { ExecStreamRequest } from 'waypoint-pb';
+import { ExecWebSocketAddon } from 'waypoint/utils/exec-websocket-addon';
+import SessionService from 'ember-simple-auth/services/session';
+import { Terminal } from 'xterm';
+import { createTerminal } from 'waypoint/utils/create-terminal';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+interface ExecComponentArgs {
+  deploymentId: string;
+}
+
+export default class ExecComponent extends Component<ExecComponentArgs> {
+  @service session!: SessionService;
+
+  @tracked deploymentId: string;
+  @tracked terminal!: Terminal;
+  @tracked socket!: WebSocket;
+
+  constructor(owner: unknown, args: ExecComponentArgs) {
+    super(owner, args);
+    let { deploymentId } = this.args;
+    this.deploymentId = deploymentId;
+    this.terminal = createTerminal({ inputDisabled: false });
+    this.terminal.focus();
+    this.startExecStream(deploymentId);
+  }
+
+  async startExecStream(deploymentId: string): Promise<void> {
+    let token = this.session.data.authenticated?.token;
+    let apiHost = window.location.hostname;
+    let socket = new WebSocket(`wss://${apiHost}:9702/v1/exec?token=${token}`);
+    socket.binaryType = 'arraybuffer';
+    this.socket = socket;
+    // The socket addon handles all terminal input/output
+    let socketAddon = new ExecWebSocketAddon(socket, { bidirectional: true, deploymentId });
+    this.terminal.loadAddon(socketAddon);
+  }
+
+  disconnect(): void {
+    let execStreamRequest = new ExecStreamRequest();
+    execStreamRequest.setInputEof(new Empty());
+    this.socket.send(execStreamRequest.serializeBinary());
+  }
+
+  willDestroy(): void {
+    this.disconnect();
+    super.willDestroy();
+  }
+}

--- a/ui/app/components/exec/index.ts
+++ b/ui/app/components/exec/index.ts
@@ -40,9 +40,11 @@ export default class ExecComponent extends Component<ExecComponentArgs> {
   }
 
   disconnect(): void {
+    // send EOF message then close socket connection
     let execStreamRequest = new ExecStreamRequest();
     execStreamRequest.setInputEof(new Empty());
     this.socket.send(execStreamRequest.serializeBinary());
+    this.socket.close();
   }
 
   willDestroy(): void {

--- a/ui/app/components/exec/index.ts
+++ b/ui/app/components/exec/index.ts
@@ -7,6 +7,7 @@ import { Terminal } from 'xterm';
 import { createTerminal } from 'waypoint/utils/create-terminal';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import config from 'waypoint/config/environment';
 
 interface ExecComponentArgs {
   deploymentId: string;
@@ -29,9 +30,12 @@ export default class ExecComponent extends Component<ExecComponentArgs> {
   }
 
   async startExecStream(deploymentId: string): Promise<void> {
-    let token = this.session.data.authenticated?.token;
-    let apiHost = window.location.hostname;
-    let socket = new WebSocket(`wss://${apiHost}:9702/v1/exec?token=${token}`);
+    let token = this.session.data.authenticated?.token as string;
+    let url = new URL(config.apiAddress);
+    url.protocol = 'wss:';
+    url.pathname = '/v1/exec';
+    url.searchParams.append('token', token);
+    let socket = new WebSocket(url);
     socket.binaryType = 'arraybuffer';
     this.socket = socket;
     // The socket addon handles all terminal input/output

--- a/ui/app/routes/workspace/projects/project/app/exec.ts
+++ b/ui/app/routes/workspace/projects/project/app/exec.ts
@@ -1,11 +1,13 @@
+import ApiService from 'waypoint/services/api';
+import { Model as AppRouteModel } from '../app';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ApiService from 'waypoint/services/api';
 
 export default class Exec extends Route {
   @service api!: ApiService;
 
-  async model(): Promise<void> {
-    // todo(pearkes): construct GetExecStreamRequest
+  async model(): Promise<AppRouteModel> {
+    let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
+    return app;
   }
 }

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -2,25 +2,4 @@
 
 <h3>Exec</h3>
 
-<div class="output-pane">
-  {{#if this.hasExec}}
-  <div class="output">
-    <code>A line of output</code>
-    <code>Another line of output</code>
-  </div>
-  {{else}}
-  <EmptyState>
-    <p>This functionality is not available yet.</p>
-    <p>You can run exec in the CLI with <code class="inline">waypoint exec &lt;command&gt;</code></p>
-  </EmptyState>
-  {{/if}}
-
-  <div class="run-prompt">
-    <FlightIcon @name="chevron-right" @size='24' class="prompt-icon" />
-    <input type="text" class="run-prompt-input" disabled aria-label="Command" />
-    <button type="button" class="button button--primary" disabled>
-      <FlightIcon @name="corner-down-right" class="icon" />
-      <span>Run</span>
-    </button>
-  </div>
-</div>
+<Exec @deploymentId={{@model.releases.firstObject.deploymentId}}/>

--- a/ui/app/utils/create-terminal.ts
+++ b/ui/app/utils/create-terminal.ts
@@ -34,6 +34,11 @@ export function createTerminal(options: TerminalOptions): Terminal {
     terminalOptions.cursorBlink = false;
     terminalOptions.cursorStyle = 'bar';
     terminalOptions.cursorWidth = 1;
+    terminalOptions.theme.cursor = terminalOptions.theme.background;
+  } else {
+    terminalOptions.cursorBlink = true;
+    terminalOptions.cursorStyle = 'bar';
+    terminalOptions.cursorWidth = 2;
   }
 
   let terminal = new Terminal(terminalOptions);

--- a/ui/app/utils/exec-websocket-addon.ts
+++ b/ui/app/utils/exec-websocket-addon.ts
@@ -1,0 +1,226 @@
+import * as AnsiColors from 'ansi-colors';
+
+import { ExecStreamRequest, ExecStreamResponse } from 'waypoint-pb';
+import { IDisposable, Terminal } from 'xterm';
+
+import { AttachAddon } from 'xterm-addon-attach';
+import KEYS from 'waypoint/utils/keys';
+import { tracked } from '@glimmer/tracking';
+
+const BACKSPACE_ONE_CHARACTER = '\x08 \x08';
+
+// eslint-disable-next-line no-control-regex
+const UNPRINTABLE_CHARACTERS_REGEX = /[\x00-\x1F]/g;
+interface IAttachOptions {
+  bidirectional?: boolean;
+  deploymentId?: string;
+}
+
+type WaypointCloseEvent = CloseEvent & MessageEvent;
+
+export class ExecWebSocketAddon extends AttachAddon {
+  private _socket: WebSocket;
+  private _deploymentId?: string;
+  private _bidirectional: boolean;
+  private _disposables: IDisposable[] = [];
+  encoder: TextEncoder;
+  @tracked terminal!: Terminal;
+  @tracked command!: string;
+
+  constructor(socket: WebSocket, options?: IAttachOptions) {
+    super(socket, options);
+    this._socket = socket;
+    this._deploymentId = options?.deploymentId;
+    this.command = '';
+    // always set binary type to arraybuffer, we do not handle blobs
+    this._socket.binaryType = 'arraybuffer';
+    this._bidirectional = !(options && options.bidirectional === false);
+    this.encoder = new TextEncoder();
+  }
+
+  activate(terminal: Terminal): void {
+    this.terminal = terminal;
+    if (!this._deploymentId) {
+      // If there is no deployment ID to connect to, warn the user.
+      terminal.clear();
+      terminal.writeln(AnsiColors.yellow('No deployment available'));
+      return;
+    }
+
+    this._disposables.push(
+      addSocketListener(this._socket, 'open', () => {
+        terminal.writeln(AnsiColors.bold.cyan('Connecting...'));
+        if (this._deploymentId) {
+          this.sendStart(this._deploymentId, terminal);
+          this.setupWinch(terminal);
+        }
+      }),
+      addSocketListener(this._socket, 'message', (event: MessageEvent) => {
+        let output = event.data;
+        let resp = ExecStreamResponse.deserializeBinary(output);
+        if (resp.hasOpen()) {
+          terminal.clear();
+          terminal.writeln(AnsiColors.bold.cyan(`Connected to deployment: ${this._deploymentId}`));
+        }
+        if (resp.getEventCase() === 2 && resp.getExit()) {
+          let exitCode = resp.getExit() || 'unknown';
+          terminal.writeln(AnsiColors.yellow(`Exit code: ${exitCode}`));
+          terminal.writeln(AnsiColors.yellow('Connection closed...'));
+        }
+        // Output
+        if (resp.getEventCase() === 1 && resp.getOutput()) {
+          let uint8data = resp.getOutput()?.getData_asU8() as Uint8Array;
+          terminal.write(uint8data);
+        }
+        // Event not set
+        if (resp.getEventCase() === 0) {
+          terminal.writeln(AnsiColors.yellow('Connection closed...'));
+        }
+      }),
+      addSocketListener(this._socket, 'close', (event: WaypointCloseEvent) => {
+        let output = event.data;
+        if (output) {
+          let resp = ExecStreamResponse.deserializeBinary(output);
+          let uint8data = resp.getOutput()?.getData_asU8() as Uint8Array;
+          terminal.write(uint8data);
+          terminal.writeln(AnsiColors.yellow('Connection closed...'));
+        }
+      }),
+      addSocketListener(this._socket, 'error', (event: MessageEvent) => {
+        let output = event.data;
+        if (output) {
+          let resp = ExecStreamResponse.deserializeBinary(output);
+          let uint8data = resp.getOutput()?.getData_asU8() as Uint8Array;
+          terminal.write(uint8data);
+        }
+      })
+    );
+
+    if (this._bidirectional) {
+      this._disposables.push(terminal.onData((data) => this.handleOnData(data)));
+      this._disposables.push(terminal.onBinary((data) => this.handleOnBinary(data)));
+    }
+  }
+
+  handleOnData(data: string): void {
+    if (
+      data === KEYS.LEFT_ARROW ||
+      data === KEYS.UP_ARROW ||
+      data === KEYS.RIGHT_ARROW ||
+      data === KEYS.DOWN_ARROW
+    ) {
+      // Ignore arrow keys
+    } else if (data === KEYS.CONTROL_U) {
+      this.terminal.write(BACKSPACE_ONE_CHARACTER.repeat(this.command.length));
+      this.command = '';
+    } else if (data === KEYS.ENTER) {
+      this.terminal.write(BACKSPACE_ONE_CHARACTER.repeat(this.command.length));
+      this.command += KEYS.ENTER;
+      this._sendData(this.command);
+      this.command = '';
+    } else if (data === KEYS.DELETE) {
+      if (this.command.length > 0) {
+        this.terminal.write(BACKSPACE_ONE_CHARACTER);
+        this.command = this.command.slice(0, -1);
+      }
+    } else if (data.length > 0) {
+      let strippedData = data.replace(UNPRINTABLE_CHARACTERS_REGEX, '');
+      this.terminal.write(strippedData);
+      this.command = `${this.command}${strippedData}`;
+    }
+  }
+
+  handleOnBinary(data: string): void {
+    this._sendBinary(data);
+  }
+
+  dispose(): void {
+    this._disposables.forEach((d) => d.dispose());
+    this._disposables.length = 0;
+  }
+
+  private _sendData(data: string): void {
+    // TODO: do something better than just swallowing
+    // the data if the socket is not in a working condition
+    if (this._socket.readyState !== 1) {
+      return;
+    }
+
+    let execStreamRequest = new ExecStreamRequest();
+    let input = new ExecStreamRequest.Input();
+    input.setData(this.encoder.encode(data));
+    execStreamRequest.setInput(input);
+    this._socket.send(execStreamRequest.serializeBinary());
+  }
+
+  private _sendBinary(data: string): void {
+    if (this._socket.readyState !== 1) {
+      return;
+    }
+    let buffer = new Uint8Array(data.length);
+    for (let i = 0; i < data.length; ++i) {
+      buffer[i] = data.charCodeAt(i) & 255;
+    }
+    let execStreamRequest = new ExecStreamRequest();
+    let input = new ExecStreamRequest.Input();
+    input.setData(buffer);
+    execStreamRequest.setInput(input);
+    this._socket.send(execStreamRequest.serializeBinary());
+  }
+
+  sendStart(deploymentId: string, terminal: Terminal): void {
+    let execStreamStartRequest = new ExecStreamRequest();
+    let start = new ExecStreamRequest.Start();
+    // Important: ArgsList can't be empty
+    start.setArgsList(['/bin/bash']);
+    let streaminput = new ExecStreamRequest.Input();
+    execStreamStartRequest.setInput(streaminput);
+    start.setDeploymentId(deploymentId);
+    let pty = new ExecStreamRequest.PTY();
+    pty.setTerm('bash');
+    if (terminal.element) {
+      let windowSize = new ExecStreamRequest.WindowSize();
+      windowSize.setCols(terminal.cols);
+      windowSize.setRows(terminal.rows);
+      windowSize.setHeight(terminal.element.offsetHeight);
+      windowSize.setWidth(terminal.element.offsetWidth);
+      pty.setWindowSize(windowSize);
+    }
+    pty.setEnable(true);
+    start.setPty(pty);
+    execStreamStartRequest.setStart(start);
+    // Send start message
+    this._socket.send(execStreamStartRequest.serializeBinary());
+  }
+
+  setupWinch(terminal: Terminal): void {
+    if (terminal.element) {
+      // setup winch
+      let execStreamWinchRequest = new ExecStreamRequest();
+      let windowSize = new ExecStreamRequest.WindowSize();
+      windowSize.setCols(terminal.cols);
+      windowSize.setRows(terminal.rows);
+      windowSize.setHeight(terminal.element?.offsetHeight);
+      windowSize.setWidth(terminal.element?.offsetWidth);
+      execStreamWinchRequest.setWinch(windowSize);
+      this._socket.send(execStreamWinchRequest.serializeBinary());
+    }
+  }
+}
+
+function addSocketListener<K extends keyof WebSocketEventMap>(
+  socket: WebSocket,
+  type: K,
+  handler: (this: WebSocket, ev: WebSocketEventMap[K]) => unknown
+): IDisposable {
+  socket.addEventListener(type, handler);
+  return {
+    dispose: () => {
+      if (!handler) {
+        // Already disposed
+        return;
+      }
+      socket.removeEventListener(type, handler);
+    },
+  };
+}

--- a/ui/app/utils/exec-websocket-addon.ts
+++ b/ui/app/utils/exec-websocket-addon.ts
@@ -25,6 +25,7 @@ export class ExecWebSocketAddon extends AttachAddon {
   private _disposables: IDisposable[] = [];
   encoder: TextEncoder;
   @tracked terminal!: Terminal;
+  // Command is used to store the current command until it gets sent over WS
   @tracked command!: string;
 
   constructor(socket: WebSocket, options?: IAttachOptions) {
@@ -59,6 +60,7 @@ export class ExecWebSocketAddon extends AttachAddon {
         let output = event.data;
         let resp = ExecStreamResponse.deserializeBinary(output);
         if (resp.hasOpen()) {
+          // remove "Connecting..." message
           terminal.clear();
           terminal.writeln(AnsiColors.bold.cyan(`Connected to deployment: ${this._deploymentId}`));
         }
@@ -114,6 +116,7 @@ export class ExecWebSocketAddon extends AttachAddon {
       this.terminal.write(BACKSPACE_ONE_CHARACTER.repeat(this.command.length));
       this.command = '';
     } else if (data === KEYS.ENTER) {
+      // We remove the characters here because since the response already contains those
       this.terminal.write(BACKSPACE_ONE_CHARACTER.repeat(this.command.length));
       this.command += KEYS.ENTER;
       this._sendData(this.command);
@@ -134,6 +137,7 @@ export class ExecWebSocketAddon extends AttachAddon {
     this._sendBinary(data);
   }
 
+  // dispose is called by the RenderTerminal component when it gets removed
   dispose(): void {
     this._disposables.forEach((d) => d.dispose());
     this._disposables.length = 0;

--- a/ui/app/utils/keys.ts
+++ b/ui/app/utils/keys.ts
@@ -1,0 +1,10 @@
+export default {
+  LEFT_ARROW: '\x1b[D',
+  UP_ARROW: '\x1b[A',
+  RIGHT_ARROW: '\x1b[C',
+  DOWN_ARROW: '\x1b[B',
+  CONTROL_A: '\x01',
+  CONTROL_U: '\x15',
+  ENTER: '\r',
+  DELETE: '\x7F',
+};

--- a/ui/app/utils/terminal-theme.ts
+++ b/ui/app/utils/terminal-theme.ts
@@ -3,6 +3,7 @@ import { ITheme } from 'xterm';
 const lightTheme: ITheme = {
   foreground: 'rgb(0,0,0)',
   background: 'rgb(247,250,252)',
+  cursor: 'rgb(0, 187, 187)',
   cyan: 'rgb(0, 187, 187)',
   brightBlue: 'rgb(85, 85, 255)',
   green: 'rgb(0, 187, 0)',
@@ -18,6 +19,7 @@ const lightTheme: ITheme = {
 const darkTheme: ITheme = {
   foreground: 'rgb(247,250,252)',
   background: 'rgb(29,33,38)',
+  cursor: 'rgb(0, 187, 187)',
   cyan: 'rgb(0, 187, 187)',
   brightBlue: 'rgb(85, 85, 255)',
   green: 'rgb(0, 187, 0)',

--- a/ui/package.json
+++ b/ui/package.json
@@ -120,6 +120,7 @@
     "ua-parser-js": "^0.7.24",
     "webpack-bundle-analyzer": "^3.8.0",
     "xterm": "^4.13.0",
+    "xterm-addon-attach": "^0.6.0",
     "xterm-addon-fit": "^0.5.0"
   },
   "engines": {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14581,6 +14581,11 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-attach@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-attach/-/xterm-addon-attach-0.6.0.tgz#220c23addd62ab88c9914e2d4c06f7407e44680e"
+  integrity sha512-Mo8r3HTjI/EZfczVCwRU6jh438B4WLXxdFO86OB7bx0jGhwh2GdF4ifx/rP+OB+Cb2vmLhhVIZ00/7x3YSP3dg==
+
 xterm-addon-fit@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"


### PR DESCRIPTION
Closes #1240 

This PR adds an Exec Terminal to the browser UI. It connects to the latest available deployment. 

**Note**: I have spent a lot of time attempting to get the terminal working in raw (or quasi-raw, rare, etc.) mode and got pretty close, but we've decided to ship this in cooked mode because of time constraints. There is opportunity to resume that work later.  

How it works:
- the `Exec` component renders the terminal with the `RenderTerminal`
- it sets up the Websocket connection to the `/exec` endpoint 
- it then sets up the input/output handling by attaching the `exec-websocket-addon` to the terminal (more on `xterm.js` addons here: https://xtermjs.org/docs/guides/using-addons/#creating-an-addon ) 

Because a lot of the functionality is handled/abstracted by xterm.js, it is worth pulling the branch and trying this feature locally to get a feel for how it works. 
