### PR TITLE
cli: cleanup unused code path

### DIFF
--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -402,29 +402,8 @@ func (c *baseCommand) Init(opts ...Option) error {
 // the callback closure properties to cancel the passed in context. This
 // will stop any remaining callbacks and exit early.
 func (c *baseCommand) DoApp(ctx context.Context, f func(context.Context, *clientpkg.App) error) error {
-	var appTargets []string
-
-	// If the user specified a project flag, we want only the apps
-	// that are assigned to that project
-	if c.flagProject != "" {
-		client := c.project.Client()
-		projectTarget := &pb.Ref_Project{Project: c.flagProject}
-		resp, err := client.GetProject(c.Ctx, &pb.GetProjectRequest{
-			Project: &pb.Ref_Project{
-				Project: projectTarget.Project,
-			},
-		})
-		if err != nil {
-			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
-			return ErrSentinel
-		}
-		project := resp.Project
-
-		for _, a := range project.Applications {
-			appTargets = append(appTargets, a.Name)
-		}
-	}
-
+	// c.refApps is set in c.Init(), based on the project
+	// the command is running against
 	var apps []*clientpkg.App
 	for _, refApp := range c.refApps {
 		app := c.project.App(refApp.Application)

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -65,8 +66,13 @@ func SetupTestProject(templateDir string) (projectName string, projectDir string
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to create temp dir")
 	}
-
-	cmd := exec.Command("cp", "-r", templateDir+"/", tempDir)
+	templateDir = templateDir + "/"
+	var cmd *exec.Cmd
+	if runtime.GOOS == "linux" {
+		cmd = exec.Command("rsync", "-av", templateDir, tempDir)
+	} else {
+		cmd = exec.Command("cp", "-r", templateDir, tempDir)
+	}
 	err = cmd.Run()
 	if err != nil {
 		return "", "", errors.Wrapf(err, "failed to copy %s to %s", templateDir, tempDir)


### PR DESCRIPTION
This should have been removed in #2760 

I ran all the cli smoke tests against this also, which had the added benefit of learning that `cp` works differently on osx vs linux. So now our smoke tests will also work in CI whenever we add them. 🐧 

If anyone is curious:
`cp -r` with a trailing slash on the source dir is supposed to copy _only the contents of the dir_ and not the dir itself. But (at least some flavors, mine included) of linux ignore that rule.
Observe:
```
$ mkdir hey
$ mkdir yo
$ vi hey/ho.txt
$ cp -r hey/ yo
$ ls yo
hey
```
On osx, you'd get:
```
$ ls yo
ho.txt
```

Anyway, happy Friday!