### PR TITLE
Fix broken link to remote-runners

### DIFF
--- a/website/content/docs/waypoint-hcl/registry.mdx
+++ b/website/content/docs/waypoint-hcl/registry.mdx
@@ -13,7 +13,7 @@ The `registry` stanza configures the result of a build to be pushed
 to a registry such as a Docker Registry, Amazon ECR, Artifactory, etc. A registry
 is used to make the result of a build available to the deployment platform.
 
-A `registry` is required when using a [remote runner](docs/runner#remote-runner)
+A `registry` is required when using a [remote runner](/docs/runner#remote-runner)
 with GitOps. The remote runner will build your image and push the artifact to
 this registery.
 


### PR DESCRIPTION
Broken link on the [Registry docs](https://www.waypointproject.io/docs/waypoint-hcl/registry). Without the `/` here the url ends up being `/docs/waypoint-hcl/docs/runner#remote-runner` which is a no-fun [`404`](https://www.waypointproject.io/docs/waypoint-hcl/docs/runner#remote-runner). The page we want is [`/docs/runner#remote-runner`](https://www.waypointproject.io/docs/runner#remote-runner)