### PR TITLE
lock ember-cli-flash to 2.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -66,7 +66,7 @@
     "ember-cli-clipboard": "^0.15.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-favicon": "^3.0.0",
-    "ember-cli-flash": "^2.1.1",
+    "ember-cli-flash": "~2.1.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mirage": "^2.2.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6347,11 +6347,12 @@ ember-cli-favicon@^3.0.0:
     ember-cli-babel "^7.26.6"
     lodash.merge "^4.6.2"
 
-ember-cli-flash@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-flash/-/ember-cli-flash-2.1.1.tgz#a1547676d20a8d6f5d0f523228d3e7c8a76486ee"
-  integrity sha512-JLqrc2gOwCFI8dB1hUV537Iv+yzplsgfVG3u4JSp8QAsQHPCGAT0XZR1yQDlXfoLwFGr1Akw8y72/TwN9jBW9w==
+ember-cli-flash@~2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-flash/-/ember-cli-flash-2.1.3.tgz#b193c42e13cd934964ba0fa01720ac6ddbffc131"
+  integrity sha512-pwwZzqGXBmbDg67yDxh6KbMGEp6s4CQJUDoUgRtuA6QTm01Us39obdma6DLDokyLs2iuS8Z39VNharJbOIj3sQ==
   dependencies:
+    "@ember/render-modifiers" "^1.0.2"
     ember-cli-babel "^7.18.0"
     ember-cli-htmlbars "^4.2.3"
     ember-runtime-enumerable-includes-polyfill "^2.1.0"


### PR DESCRIPTION
the latest upgrade (2.2.x) seemed to be causing some issues: 
<img width="637" alt="Screen Shot 2022-01-05 at 18 53 53" src="https://user-images.githubusercontent.com/1416421/148272009-fbcf7b24-9397-475f-96bd-425fc59d5e99.png">

