### PR TITLE
builtin/docker: fix crash during stop task with ODR

### DIFF
--- a/builtin/docker/task.go
+++ b/builtin/docker/task.go
@@ -292,15 +292,13 @@ func (b *TaskLauncher) StopTask(
 	if err := cli.ContainerRemove(ctx, ti.Id, types.ContainerRemoveOptions{
 		Force: true,
 	}); err != nil {
-		// "removal of container already in progress" is the error when
-		// the daemon is removing this for some reason (auto remove or
-		// other). This is not an error.
 		if strings.Contains(err.Error(), "already in progress") {
+			// "removal of container already in progress" is the error when
+			// the daemon is removing this for some reason (auto remove or
+			// other). This is not an error.
 			err = nil
-		}
-
-		// Container is already removed
-		if strings.Contains(strings.ToLower(err.Error()), "no such container") {
+		} else if strings.Contains(strings.ToLower(err.Error()), "no such container") {
+			// Container is already removed
 			err = nil
 		}
 
@@ -358,6 +356,7 @@ func (b *TaskLauncher) StartTask(
 		"oci-url", tli.OciUrl,
 		"arguments", tli.Arguments,
 		"environment", env,
+		"autoremove", !b.config.DebugContainers,
 	)
 
 	var memory int64


### PR DESCRIPTION
A crash could occur if a container is already removing, since we set err
to nil and then later check `err.Error()`. This crash causes no actual
problems cause the container is already auto-removing, but it makes the
logs noisier than they need to be.