### PR TITLE
internal/config/dynamic: rename configdynamic() to dynamic()

### DIFF
--- a/.changelog/2892.txt
+++ b/.changelog/2892.txt
@@ -1,0 +1,4 @@
+```release-note:breaking-change
+core: `configdynamic` has been renamed to `dynamic`. The existing function
+name continues to work but is deprecated and may be removed in a future version.
+```

--- a/internal/config/dynamic/func.go
+++ b/internal/config/dynamic/func.go
@@ -19,7 +19,11 @@ import (
 // This function ensures that we can change the function name easily
 // and consistently or add new dynamic-related functions.
 func Register(m map[string]function.Function) map[string]function.Function {
+	m["dynamic"] = Func
+
+	// This is deprecated, but we keep this form working cause it costs nothing.
 	m["configdynamic"] = Func
+
 	return m
 }
 


### PR DESCRIPTION
This was discussed heavily in Slack and Google Docs.

`configdynamic` remains functionality indefinitely, its harmless to keep it working for now as long as we note its deprecated and do not document that form.