### PR TITLE
Feat/nomad odr namespace fix

### DIFF
--- a/.changelog/2896.txt
+++ b/.changelog/2896.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/nomad: Fix Nomad job namespace when using ODRs
+```

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -83,6 +83,9 @@ func (p *Platform) Deploy(
 	// Set our deployment ID on the meta.
 	job.SetMeta(metaId, result.Id)
 
+	// Update our client to use the Namespace set in the jobspec
+	client.SetNamespace(*job.Namespace)
+
 	// Register job
 	s.Update("Registering job %q...", *job.Name)
 	regResult, _, err := jobclient.Register(job, nil)


### PR DESCRIPTION
Addresses #2791.

The Nomad API client's namespace configuration will be set equal to the namespace in the jobspec, for Nomad jobspec deployments. The image below showcases the desired result of a jobspec deployment with `namespace = "dev"` set in its jobspec, where the Waypoint server & static runner are deployed to a namespace (in this case, default), the ODR is deployed to a namespace (in this case, default), and the actual application (in this case, nomad-test) is deployed to a separate namespace, dev, by the ODR.

![image](https://user-images.githubusercontent.com/83741749/149073647-f396a77c-b07c-4195-a657-e3670f252f64.png)

My ODR profile, for reference:
```json
{
	"datacenter": "dc1",
	"namespace": "default",
	"nomad_host": "http://my-nomad-host:4646",
	"region": "global",
	"resources_cpu": "200",
	"resources_memory": "600"
}
```
Excerpt from my jobspec, for reference:
```hcl
job "nomad-test" {
  type = "service"
  namespace = "dev"
```