### PR TITLE
ui: readded lost translations

### DIFF
--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -69,6 +69,13 @@ page:
       release-table-caption-prefix: Resources created by <b>Release</b>
     logs:
       heading: Deployment Logs
+  release:
+    title: 'Release'
+    resources:
+      heading: Resources
+      table-caption: Resources created by <b>this release</b>
+    logs:
+      heading: Release Logs
   releases:
     title: 'Releases'
     table:
@@ -95,11 +102,6 @@ page:
       release: 'Release'
       deployment: 'Deployment'
     title: 'Release'
-    resources:
-      heading: Resources
-      table-caption: Resources created by <b>this release</b>
-    logs:
-      heading: Release Logs
   unavailable:
     title: ''
 


### PR DESCRIPTION
Somehow in the shuffle of things the `release` details page translations got removed and placed into the `releases` page.