### PR TITLE
ui: spacing adjustments

### DIFF
--- a/.changelog/2898.txt
+++ b/.changelog/2898.txt
@@ -1,0 +1,4 @@
+```release-note:improvements
+ui: Fixed spacing issues in the Overview sections
+```
+

--- a/ui/app/components/image-ref.hbs
+++ b/ui/app/components/image-ref.hbs
@@ -4,7 +4,7 @@
   </span>
 
   {{#if this.hasTag}}
-    <span class="image-ref__tag badge badge--info" data-test-image-ref-tag>
+    <span class="image-ref__tag badge badge--info" data-test-image-ref-tag title={{this.presentableTag}}>
       {{this.presentableTag}}
     </span>
   {{/if}}

--- a/ui/app/components/operation-status-indicator/release.hbs
+++ b/ui/app/components/operation-status-indicator/release.hbs
@@ -1,4 +1,4 @@
-<OperationStatusIndicator @operation={{@operation}} @isDetailed={{false}}>
+<OperationStatusIndicator @operation={{@operation}} @isDetailed={{true}}>
   <:status-text>
     {{if (eq @operation.status.state 1) 'Releasing' 'Released'}} on
   </:status-text>

--- a/ui/app/styles/components/navigation/artifact-overview.scss
+++ b/ui/app/styles/components/navigation/artifact-overview.scss
@@ -1,15 +1,27 @@
 .artifact-overview {
   padding-bottom: 0.5rem;
+  overflow: hidden;
 
   h2 {
     border-bottom: 1px solid rgb(var(--border));
     padding-bottom: 0.5rem;
   }
 
+  table, table > tbody, tr {
+    width: 100%;
+    overflow: hidden;
+  }
+
   table {
+    display: table;
+    table-layout: fixed;
     padding: 0;
     font-size: 0.875rem;
     line-height: 17px;
+
+    :first-child > * {
+      padding-top: 0;
+    }
 
     th,
     td {
@@ -17,6 +29,11 @@
       padding-top: scale.$sm--2;
       padding-bottom: scale.$sm--2;
       vertical-align: top;
+
+      > * {
+        overflow: hidden;
+        white-space: nowrap;
+      }
     }
 
     th {
@@ -27,7 +44,7 @@
     }
 
     .status-indicator {
-      display: flex;
+      display: inline-flex;
       align-items: center;
       padding-bottom: 0.25rem;
     }

--- a/ui/app/styles/components/navigation/page-header.scss
+++ b/ui/app/styles/components/navigation/page-header.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  padding-bottom: scale.$base;
 
   .icon-tile {
     margin-right: scale.$base;

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -26,6 +26,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+      margin-right: scale.$sm-4;
     }
   }
 
@@ -37,6 +38,10 @@
     cursor: default;
     font-size: inherit;
     font-weight: inherit;
+
+    svg {
+      margin-left: scale.$sm-4;
+    }
 
     &--error {
       color: rgb(var(--error-text));

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -1,5 +1,3 @@
 {{page-title (concat @model.application.application "Exec")}}
 
-<h3>Exec</h3>
-
 <Exec @deploymentId={{@model.releases.firstObject.deploymentId}}/>

--- a/ui/app/templates/workspace/projects/project/app/logs.hbs
+++ b/ui/app/templates/workspace/projects/project/app/logs.hbs
@@ -1,4 +1,3 @@
 {{page-title (concat @model.application.application "Logs")}}
 
-<h3>Application logs</h3>
 <LogStream @req={{@model.request}}></LogStream>


### PR DESCRIPTION
## Fixed by this PR
- [x] Overview + timeline are not aligned (baseline of `Status` row should match baseline of `Build` timeline element)
- [x] Overview: commit information misaligned horizontally
- [x] Alignment of rows in Overview table slightly off (https://github.com/hashicorp/waypoint/issues/2539)
- [x] [Missing spacing in build status](https://github.com/hashicorp/waypoint/issues/2883#issuecomment-1011083872)
- [x] [Tight spacing between header and list on apps list page](https://github.com/hashicorp/waypoint/issues/2883#issuecomment-1011088800)
- [x] [Logs and Exec pages have headings but Deployments, Builds, and Releases pages do not](https://github.com/hashicorp/waypoint/issues/2883#issuecomment-1011105711)
- [x] [Release status is missing some spacing and an icon](https://github.com/hashicorp/waypoint/issues/2883#issuecomment-1011132453)

## Screenshots
<img width="1440" alt="Screen Shot 2022-01-13 at 10 30 15 AM" src="https://user-images.githubusercontent.com/60155296/149359488-84116951-3aad-4c53-b5d3-28aead6c6063.png">

### With rulers to highlight Overview alignment fixes
<img width="1064" alt="Screen Shot 2022-01-13 at 10 31 46 AM" src="https://user-images.githubusercontent.com/60155296/149359692-5e379f03-d187-4ab4-8a94-2c26f322c307.png">

### Release Overview (status timestamp now has icon + tooltip)
<img width="787" alt="Screen Shot 2022-01-13 at 10 45 01 AM" src="https://user-images.githubusercontent.com/60155296/149361968-1cd9e689-7a33-40fd-b126-e9cc424644c5.png">
