### PR TITLE
internal/serverinstall: fix dropped error

### DIFF
--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -592,6 +592,9 @@ func (i *NomadInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error
 	s.Update("Waypoint job and allocations purged")
 
 	vols, _, err := client.CSIVolumes().List(&api.QueryOptions{Prefix: "waypoint"})
+	if err != nil {
+		return err
+	}
 	for _, vol := range vols {
 		if vol.ID == "waypoint" {
 			s.Update("Destroying persistent CSI volume")


### PR DESCRIPTION
This fixes a dropped `err` variable in `internal/serverinstall`.
