### PR TITLE
ui: Ensure `<OperationLogs>` reacts correctly when `@jobId` updates

### DIFF
--- a/.changelog/2901.txt
+++ b/.changelog/2901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure logs update correctly when switching between deployments
+```

--- a/ui/app/components/operation-logs/index.hbs
+++ b/ui/app/components/operation-logs/index.hbs
@@ -1,8 +1,12 @@
-{{#if this.hasLogs}}
-  <RenderTerminal @terminal={{this.terminal}}/>
-{{else}}
-  <EmptyState>
-    <p>No output available</p>
-    <p>This could be because the operation did not render any output, or because it is no longer available</p>
-  </EmptyState>
-{{/if}}
+<div data-test-operation-logs
+  {{did-update this.changeJob @jobId}}
+>
+  {{#if this.hasLogs}}
+    <RenderTerminal @terminal={{this.terminal}}/>
+  {{else}}
+    <EmptyState>
+      <p>No output available</p>
+      <p>This could be because the operation did not render any output, or because it is no longer available</p>
+    </EmptyState>
+  {{/if}}
+</div>

--- a/ui/tests/helpers/xterm.ts
+++ b/ui/tests/helpers/xterm.ts
@@ -1,5 +1,17 @@
 import { triggerEvent, triggerKeyEvent, focus } from '@ember/test-helpers';
 
+// At the time of writing, xterm.js only implements the Macintosh “select all”
+// keyboard shortcut (cmd+a), not the Linux and Windows equivalent (ctrl+a).
+// What follows is a dreadful hack to make `getTerminalText` work in Linux CI.
+// Note: this needs to happen before xterm is required, so you’ll find an
+// import in `tests/test-helper.js`.
+Object.defineProperty(navigator, 'platform', {
+  value: 'Macintosh',
+  configurable: true,
+  enumerable: true,
+  writable: false,
+});
+
 /**
  * Returns the text from an xterm.js terminal element.
  *
@@ -10,9 +22,8 @@ import { triggerEvent, triggerKeyEvent, focus } from '@ember/test-helpers';
 export async function getTerminalText(): Promise<string> {
   await focus('.xterm-helper-textarea');
 
-  // Trigger cmd+a and ctrl+a to select all
+  // Trigger cmd+a to select all
   await triggerKeyEvent('.xterm-helper-textarea', 'keydown', 65, { metaKey: true });
-  await triggerKeyEvent('.xterm-helper-textarea', 'keydown', 65, { ctrlKey: true });
 
   let clipboardData = new DataTransfer();
   await triggerEvent('.xterm', 'copy', { clipboardData });

--- a/ui/tests/helpers/xterm.ts
+++ b/ui/tests/helpers/xterm.ts
@@ -1,0 +1,21 @@
+import { triggerEvent, triggerKeyEvent, focus } from '@ember/test-helpers';
+
+/**
+ * Returns the text from an xterm.js terminal element.
+ *
+ * Simulates select-all, then copy, then returns the resultant clipboard data.
+ *
+ * Assumes only one xterm instance is rendered.
+ */
+export async function getTerminalText(): Promise<string> {
+  await focus('.xterm-helper-textarea');
+
+  // Trigger cmd+a and ctrl+a to select all
+  await triggerKeyEvent('.xterm-helper-textarea', 'keydown', 65, { metaKey: true });
+  await triggerKeyEvent('.xterm-helper-textarea', 'keydown', 65, { ctrlKey: true });
+
+  let clipboardData = new DataTransfer();
+  await triggerEvent('.xterm', 'copy', { clipboardData });
+
+  return clipboardData.getData('text').trim();
+}

--- a/ui/tests/integration/components/operation-logs-test.ts
+++ b/ui/tests/integration/components/operation-logs-test.ts
@@ -1,0 +1,130 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import { render, settled } from '@ember/test-helpers';
+import { GetJobStreamRequest, GetJobStreamResponse } from 'waypoint-pb';
+import { getTerminalText } from '../../helpers/xterm';
+import Service from '@ember/service';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | operation-logs', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function (this: TestContext) {
+    this.owner.register('service:api', ApiStub);
+  });
+
+  test('happy path', async function (assert) {
+    let api: ApiStub = this.owner.lookup('service:api');
+
+    await render(hbs`
+      <OperationLogs @jobId="test-job-1" />
+    `);
+
+    api.sendLine('Test message');
+    await settled();
+
+    let text = await getTerminalText();
+
+    assert.equal(text, 'Test message');
+  });
+
+  test('changing @jobId', async function (assert) {
+    let api: ApiStub = this.owner.lookup('service:api');
+
+    // Render the component with test-job-1
+
+    this.set('jobId', 'test-job-1');
+    await render(hbs`
+      <OperationLogs @jobId={{this.jobId}} />
+    `);
+    api.sendLine('Message from test-job-1');
+    await settled();
+
+    let firstStream = api.client.stream;
+
+    // Send in a new job ID
+
+    this.set('jobId', 'test-job-2');
+    await settled();
+
+    api.sendLine('Message from test-job-2');
+    await settled();
+
+    let text = await getTerminalText();
+
+    assert.equal(api.currentRequest?.getJobId(), 'test-job-2', 'We requested the job stream for the new ID');
+    assert.equal(text, 'Message from test-job-2', 'We cleared the terminal');
+    assert.ok(firstStream?.cancelled, 'We cancelled the first stream');
+  });
+});
+
+// Stubs
+
+class ApiStub extends Service {
+  client = new ApiClientStub();
+
+  WithMeta() {
+    return {};
+  }
+
+  sendLine(message: string) {
+    this.client.sendLine(message);
+  }
+
+  get currentRequest() {
+    return this.client.currentRequest;
+  }
+}
+
+class ApiClientStub {
+  stream?: StreamStub;
+  currentRequest?: GetJobStreamRequest;
+
+  getJobStream(request: GetJobStreamRequest) {
+    this.currentRequest = request;
+    this.stream = new StreamStub();
+
+    return this.stream;
+  }
+
+  sendLine(message: string) {
+    this.stream?.sendLine(message);
+  }
+}
+
+type StreamEvent = 'data' | 'status';
+type StreamHandler = (response: GetJobStreamResponse) => void;
+
+class StreamStub {
+  cancelled = false;
+
+  handlers: Record<StreamEvent, StreamHandler[]> = {
+    data: [],
+    status: [],
+  };
+
+  on(event: StreamEvent, handler: StreamHandler): void {
+    this.handlers[event].push(handler);
+  }
+
+  cancel() {
+    this.cancelled = true;
+  }
+
+  sendLine(message: string) {
+    let response = new GetJobStreamResponse();
+    let terminal = new GetJobStreamResponse.Terminal();
+    let event = new GetJobStreamResponse.Terminal.Event();
+    let line = new GetJobStreamResponse.Terminal.Event.Line();
+
+    response.setTerminal(terminal);
+    terminal.setEventsList([event]);
+    event.setLine(line);
+    line.setMsg(message);
+
+    for (let handler of this.handlers.data) {
+      handler(response);
+    }
+  }
+}

--- a/ui/tests/test-helper.js
+++ b/ui/tests/test-helper.js
@@ -6,6 +6,7 @@ import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 import { setup as setupA11yTesting } from './helpers/a11y';
 import './helpers/flash-message';
+import './helpers/xterm';
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
## Why the change?

Closes #2855

## What’s the plan?

- [x] Figure out how to get current text from an xterm.js instance
- [x] Write a test for `<OperationLogs>`
- [x] Make the test pass
- [x] Make the xterm.js helper work on Linux (i.e. in CI)

## What does it look like?

### Before

https://user-images.githubusercontent.com/34030/149417773-8e4e1825-ada7-47a3-ba8a-e3e2d15af40c.mp4

### After

https://user-images.githubusercontent.com/34030/149417793-9369d4fb-b597-49b5-8783-e3ab4f59240b.mp4

## How do I test it?

1. Check out the branch `git checkout ui/operation-logs-attr-change`
2. [Boot the dev server against a waypoint server](https://github.com/hashicorp/waypoint/tree/main/ui#running-with-a-local-waypoint-server)
3. Try navigating between deployments
4. Verify that  the logs are correctly refreshed