### PR TITLE
website: upgrade downloads page

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -24,7 +24,7 @@
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-image": "^4.0.3",
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@hashicorp/react-product-downloads-page": "^2.5.3",
+        "@hashicorp/react-product-downloads-page": "^2.7.0",
         "@hashicorp/react-search": "^6.1.1",
         "@hashicorp/react-section-header": "^5.0.4",
         "@hashicorp/react-stepped-feature-list": "^4.0.3",
@@ -1782,9 +1782,9 @@
       }
     },
     "node_modules/@hashicorp/react-product-downloads-page": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.5.3.tgz",
-      "integrity": "sha512-SY3sEM/xYZDbd7XSDaqkT4L+DVRdGJYPpF/0WRDHfR0PObf2zE+iqRjm2APaIACg32sAM1NIZPuc+oQv6vKq5A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.7.0.tgz",
+      "integrity": "sha512-GAw+Ztq4Cr/GJ5kyL3HvpLzs2wtpTFrs0FGDp6TRXjAVgqgfqrQU3cJzthtwkvKAZBmgGmubpQf84bhtfgtvLA==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.0",
@@ -21010,9 +21010,9 @@
       "requires": {}
     },
     "@hashicorp/react-product-downloads-page": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.5.3.tgz",
-      "integrity": "sha512-SY3sEM/xYZDbd7XSDaqkT4L+DVRdGJYPpF/0WRDHfR0PObf2zE+iqRjm2APaIACg32sAM1NIZPuc+oQv6vKq5A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.7.0.tgz",
+      "integrity": "sha512-GAw+Ztq4Cr/GJ5kyL3HvpLzs2wtpTFrs0FGDp6TRXjAVgqgfqrQU3cJzthtwkvKAZBmgGmubpQf84bhtfgtvLA==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-image": "^4.0.3",
     "@hashicorp/react-inline-svg": "^6.0.3",
-    "@hashicorp/react-product-downloads-page": "^2.5.3",
+    "@hashicorp/react-product-downloads-page": "^2.7.0",
     "@hashicorp/react-search": "^6.1.1",
     "@hashicorp/react-section-header": "^5.0.4",
     "@hashicorp/react-stepped-feature-list": "^4.0.3",


### PR DESCRIPTION
Upgrading the downloads page package, which includes some retry logic when fetching release data from releases.hashicorp.com. This should hopefully reduce the likelihood of a failed site deployment immediately after a product release.