### PR TITLE
Docs: Minor update to upgrading with helm

### DIFF
--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -44,7 +44,7 @@ or steps you should take prior or following the upgrade.
 
 ```shell-session
 $ helm repo update
-$ helm upgrade waypoint
+$ helm upgrade waypoint hashicorp/waypoint
 ```
 
 -> Note that the "waypoint" value in `helm upgrade` refers to the


### PR DESCRIPTION
Missing just a few things on the CLI command to upgrade via helm. Tested by updating from 0.6.3 to 0.7.0.