### PR TITLE
Allow more time for grpc connection

### DIFF
--- a/internal/serverclient/client.go
+++ b/internal/serverclient/client.go
@@ -34,7 +34,7 @@ type ConnectOption func(*connectConfig) error
 func Connect(ctx context.Context, opts ...ConnectOption) (*grpc.ClientConn, error) {
 	// Defaults
 	var cfg connectConfig
-	cfg.Timeout = 5 * time.Second
+	cfg.Timeout = 10 * time.Second
 	cfg.Log = hclog.NewNullLogger()
 
 	// Set config


### PR DESCRIPTION
Extend the dial timeout for our gRPC connection to be 10 seconds, up from 5. I found with Waypoint on ECS the `grpc.DialContext()` call (around line 107 at time of writing) was taking around 6 seconds. Doubled the timeout to be safe. I'm not entirely sure why this method takes so long _sometimes_. For now though this change will greatly reduce the number of `context exceeded` errors from the CLI when talking to Waypoint on ECS