### PR TITLE
ui: limit number of deployments requested

### DIFF
--- a/.changelog/2930.txt
+++ b/.changelog/2930.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Limit number of deployments requested
+```

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -104,6 +104,8 @@ export default class ApiService extends Service {
 
     let order = new OperationOrder();
     order.setDesc(true);
+    // See https://github.com/hashicorp/waypoint/issues/2919 for more context on this limit
+    order.setLimit(10);
     req.setOrder(order);
 
     let resp = await this.client.uI_ListDeployments(req, this.WithMeta());


### PR DESCRIPTION
## Why the change?

Closes #2919

## What’s the plan?

- [x] Set `limit` on `OperationOrder` in `UI_ListDeployments` request
- [x] Document the results in this PR

## What does it look like?

### Before

~10s for ~50 deployments

<img width="1360" alt="CleanShot 2022-01-21 at 13 17 21@2x" src="https://user-images.githubusercontent.com/34030/150525854-49269cf4-fbea-4eeb-88ea-300f9dcb731b.png">

### After

~2s for the latest 10 of ~50 deployments (still pretty slow, but tolerable)

<img width="1360" alt="CleanShot 2022-01-21 at 13 17 42@2x" src="https://user-images.githubusercontent.com/34030/150525868-e559e163-4999-4c91-9b29-2dfbb1b5cfc2.png">

## How do I test it?

1. Generate lots of deployments on a Waypoint server of your choosing
2. `git checkout ui/deployments-limit`
3. `cd ui && yarn start local`
4. [Visit http://localhost:4200](http://localhost:4200)
5. Navigate to the app in question
6. Verify that the loading time is tolerable