### PR TITLE
feat(nix): support nix on aarch64-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643045099,
-        "narHash": "sha256-6foSoXu02jzU13VWCRlgrI53mQT1gfCA3FkPTLml95I=",
+        "lastModified": 1639584099,
+        "narHash": "sha256-3UioSxWXcXMoq3YV6i7nl3DWpKX2xA3ogYnqynPBk2w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b1f2623e3cfbf5d944c63b16820333165f302c3b",
+        "rev": "9367ef512d32a3c8b9e1d2b75ba5134de48d86ed",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639584099,
-        "narHash": "sha256-3UioSxWXcXMoq3YV6i7nl3DWpKX2xA3ogYnqynPBk2w=",
+        "lastModified": 1643045099,
+        "narHash": "sha256-6foSoXu02jzU13VWCRlgrI53mQT1gfCA3FkPTLml95I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9367ef512d32a3c8b9e1d2b75ba5134de48d86ed",
+        "rev": "b1f2623e3cfbf5d944c63b16820333165f302c3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates `flake-utils` to HEAD as of time of writing with the goal of adding support for `aarch64-darwin` from https://github.com/numtide/flake-utils/commit/c5d161cc0af116a2e17f54316f0bf43f0819785c to support anyone that might be using Nix from an Apple M1 host.  The couple additional changes since seemed reasonable to include.
* `nix flake lock --update-input flake-utils`

I believe this will take at least a couple minutes to rebuild your shell for anyone already using nix.  Be forewarned.

Initially I had updated `nixpkgs` as well by blindly running `nix flake update`, however it was not necessary to update `nixpkgs` to get `aarch64-darwin` support and given the rate of change in that repo it seemed inappropriate.  If there's a need for `nixpkgs` to be updated in the future it might be better to pin to a release branch, e.g.
* `nix flake lock --override-input nixpkgs github:NixOS/nixpkgs/21.11`

I am seeing `buildFlagsArray` warnings from `nix/go-mockery.nix` similar to those referenced in https://github.com/NixOS/nixpkgs/issues/152812, but otherwise after building with `nix develop`, `nix shell` and `direnv` support appear to be working as intended on an M1 host.