### PR TITLE
Add link to the entrypoint download page

### DIFF
--- a/website/content/docs/entrypoint/index.mdx
+++ b/website/content/docs/entrypoint/index.mdx
@@ -27,7 +27,7 @@ injected into the container image.**
 For other types of builds, the entrypoint must be manually installed.
 To manually install the entrypoint:
 
-1. Download the appropriate `waypoint-entrypoint` binary for the
+1. [Download](https://releases.hashicorp.com/waypoint-entrypoint/) the appropriate `waypoint-entrypoint` binary for the
    platform your application will run on. This is _not_ your desktop operating
    system but the operating system your app will be deployed _to_.
 


### PR DESCRIPTION
This adds a link to our docs that takes you to the waypoint entrypoint binary download page