### PR TITLE
internal/server: Cache Horizon URL Name and Host for Deploy Bundle

### DIFF
--- a/.changelog/2950.txt
+++ b/.changelog/2950.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+server: Cache Horizon hostname URL lookup when listing deployments in the
+UI_ListDeployments bundle. Now we look up the deployment URL once, and craft
+the deployment URLs based on the original hostname lookup.
+```

--- a/internal/server/singleprocess/service_ui_deploy.go
+++ b/internal/server/singleprocess/service_ui_deploy.go
@@ -39,7 +39,12 @@ func (s *service) UI_ListDeployments(
 		return nil, err
 	}
 
-	var deployBundles []*pb.UI_DeploymentBundle
+	var (
+		deployBundles []*pb.UI_DeploymentBundle
+
+		deployURLName string
+		deployURLHost string
+	)
 
 	for _, deploy := range deployList {
 
@@ -84,9 +89,17 @@ func (s *service) UI_ListDeployments(
 			}
 		}
 
+		// NOTE(briancain): Look up horizon URL ONCE, then for each deployment, append the deploy sequence
+		// This assumes every app deployment has the same URL, which it generally always does. We don't
+		// need to look up the hostname for every deployment for an application.
+		// We do this because `ListHostnames` service makes an HTTP request to Horizon. Doing
+		// this here means _for each_ deployment, we'd query Horizon for the same data, the horizon URL
+		// and vanity handle. We can grab it once off the first deployment, and use it for the rest of
+		// the bundle instead.
+
 		// Find deployment url
 		// If we had no entrypoint config it is not possible for the preload URL to work.
-		if deploy.HasEntrypointConfig {
+		if deploy.HasEntrypointConfig && deployURLName == "" {
 			resp, err := s.ListHostnames(ctx, &pb.ListHostnamesRequest{
 				Target: &pb.Hostname_Target{
 					Target: &pb.Hostname_Target_Application{
@@ -106,7 +119,16 @@ func (s *service) UI_ListDeployments(
 					(&ptypes.Deployment{Deployment: deploy}).URLFragment(),
 					strings.TrimPrefix(hostname.Fqdn, hostname.Hostname),
 				)
+
+				deployURLName = hostname.Hostname
+				deployURLHost = strings.TrimPrefix(hostname.Fqdn, hostname.Hostname)
 			}
+		} else {
+			bundle.DeployUrl = fmt.Sprintf(
+				"%s--%s%s",
+				deployURLName,
+				(&ptypes.Deployment{Deployment: deploy}).URLFragment(), // Deployment Sequence Number
+				deployURLHost)
 		}
 
 		deployBundles = append(deployBundles, &bundle)


### PR DESCRIPTION
Prior to this commit, when crafting a Deploy bundle, we would include
the applications deployment URL for each deployment in the bundle.
Looking up this hostname requires making an HTTP request to Horizon. The
way this was originally written, we would look up that URL for all
requested deployments. If a user had 80+ deployments in the bolt db,
this request would take quite some time.

Given that each applications deployment vanity name and hostname should
be the same, and only differs by the deployment sequence, we don't need
to get the hostname for each requested deployment. Instead we can grab
it once, and use it for the remaining deployments in the bundle.

Fixes #2304

In my testing, I had around 180 deployments and the request took about 5 seconds to process.
Now with this fix, the same number of deployments only takes ~30-50 ms. For reference, it only
takes about 20 ms to list a single deployment.