### PR TITLE
plugin/docker: add no-cache option

### DIFF
--- a/.changelog/2953.txt
+++ b/.changelog/2953.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/docker: Add parameter to disable the build cache
+```

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -101,6 +101,15 @@ If buildkit is enabled unused stages will be skipped.
 - Type: **string**
 - **Optional**
 
+#### no_cache
+
+Do not use cache when building the image
+
+Ensures a clean image build.
+
+- Type: **bool**
+- **Optional**
+
 ### Output Attributes
 
 Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -83,6 +83,15 @@ Set this when the Dockerfile is not APP-PATH/Dockerfile.
 - Type: **string**
 - **Optional**
 
+#### no_cache
+
+Do not use cache when building the image.
+
+Ensures a clean image build.
+
+- Type: **bool**
+- **Optional**
+
 #### platform
 
 Set target platform to build container if server is multi-platform capable.
@@ -99,15 +108,6 @@ The target build stage in a multi-stage Dockerfile.
 If buildkit is enabled unused stages will be skipped.
 
 - Type: **string**
-- **Optional**
-
-#### no_cache
-
-Do not use cache when building the image
-
-Ensures a clean image build.
-
-- Type: **bool**
 - **Optional**
 
 ### Output Attributes


### PR DESCRIPTION
Allow to pass through the no-cache flag to disable the build cache.

This is useful in cases where you want to make sure you're doing a clean build or to mitigate issues with the build cache that arise from time to time.