### PR TITLE
Hash labels as part of runner tokens and adoption

### DIFF
--- a/internal/cli/runner_token.go
+++ b/internal/cli/runner_token.go
@@ -18,6 +18,7 @@ type RunnerTokenCommand struct {
 
 	flagDuration time.Duration
 	flagId       string
+	flagLabels   map[string]string
 }
 
 func (c *RunnerTokenCommand) Run(args []string) int {
@@ -36,6 +37,7 @@ func (c *RunnerTokenCommand) Run(args []string) int {
 	resp, err := client.GenerateRunnerToken(c.Ctx, &pb.GenerateRunnerTokenRequest{
 		Duration: c.flagDuration.String(),
 		Id:       c.flagId,
+		Labels:   c.flagLabels,
 	})
 	if err != nil {
 		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
@@ -62,6 +64,15 @@ func (c *RunnerTokenCommand) Flags() *flag.Sets {
 			Name:   "id",
 			Target: &c.flagId,
 			Usage:  "Id to restrict this token to. If empty, all runner IDs are valid.",
+		})
+
+		f.StringMapVar(&flag.StringMapVar{
+			Name:   "label",
+			Target: &c.flagLabels,
+			Usage: "Labels that must match the runner for this token to be valid. " +
+				"These are set in 'k=v' format and this flag can be repeated to " +
+				"set multiple labels. If no labels are set, runners with any labels " +
+				"are valid.",
 		})
 	})
 }

--- a/internal/server/singleprocess/auth.go
+++ b/internal/server/singleprocess/auth.go
@@ -20,8 +20,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 	"github.com/hashicorp/waypoint/pkg/serverstate"
 )
 

--- a/internal/server/singleprocess/auth.go
+++ b/internal/server/singleprocess/auth.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/serverstate"
 )
@@ -233,6 +234,20 @@ func (s *service) authRunner(
 	if notAdopted {
 		return nil, status.Errorf(codes.PermissionDenied,
 			"runner is not adopted")
+	}
+
+	// If we have a label hash and it doesn't match the labels on the
+	// runner, then error.
+	if r != nil && tokenRunner.LabelHash > 0 {
+		hash, err := serverptypes.RunnerLabelHash(r.Labels)
+		if err != nil {
+			return nil, err
+		}
+
+		if tokenRunner.LabelHash != hash {
+			return nil, status.Errorf(codes.PermissionDenied,
+				"runner labels have changed since this token was issued")
+		}
 	}
 
 	return ctx, nil
@@ -496,13 +511,16 @@ func (s *service) GenerateRunnerToken(
 		}
 	}
 
-	// NOTE(mitchellh): label hash is currently ignored because runners
-	// don't have labels. We'll add support in a future PR.
+	hash, err := serverptypes.RunnerLabelHash(req.Labels)
+	if err != nil {
+		return nil, err
+	}
 
 	createToken := &pb.Token{
 		Kind: &pb.Token_Runner_{
 			Runner: &pb.Token_Runner{
-				Id: req.Id,
+				Id:        req.Id,
+				LabelHash: hash,
 			},
 		},
 	}

--- a/internal/server/singleprocess/auth.go
+++ b/internal/server/singleprocess/auth.go
@@ -511,9 +511,13 @@ func (s *service) GenerateRunnerToken(
 		}
 	}
 
-	hash, err := serverptypes.RunnerLabelHash(req.Labels)
-	if err != nil {
-		return nil, err
+	var hash uint64 = 0
+	if len(req.Labels) > 0 {
+		var err error
+		hash, err = serverptypes.RunnerLabelHash(req.Labels)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	createToken := &pb.Token{

--- a/internal/server/singleprocess/auth_test.go
+++ b/internal/server/singleprocess/auth_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 )
 
 func TestServiceAuth(t *testing.T) {

--- a/internal/server/singleprocess/auth_test.go
+++ b/internal/server/singleprocess/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
@@ -319,6 +320,68 @@ func TestServiceAuth(t *testing.T) {
 		// Auth should NOT work
 		_, err = s.Authenticate(context.Background(), token, "test", nil)
 		require.Error(err)
+	})
+
+	t.Run("validate a runner token with an ID set and label hash mismatch", func(t *testing.T) {
+		require := require.New(t)
+
+		labels := map[string]string{"foo": "bar"}
+
+		// Create a runner and adopt it.
+		require.NoError(s.state.RunnerCreate(&pb.Runner{
+			Id:     "A",
+			Labels: labels,
+			Kind: &pb.Runner_Remote_{
+				Remote: &pb.Runner_Remote{},
+			},
+		}))
+		defer s.state.RunnerDelete("A")
+		require.NoError(s.state.RunnerAdopt("A", false))
+
+		token, err := s.newToken(0, DefaultKeyId, nil, &pb.Token{
+			Kind: &pb.Token_Runner_{
+				Runner: &pb.Token_Runner{
+					Id:        "A",
+					LabelHash: 42,
+				},
+			},
+		})
+
+		// Auth should NOT work
+		_, err = s.Authenticate(context.Background(), token, "test", nil)
+		require.Error(err)
+	})
+
+	t.Run("validate a runner token with an ID set and label hash good match", func(t *testing.T) {
+		require := require.New(t)
+
+		labels := map[string]string{"foo": "bar"}
+		hash, err := serverptypes.RunnerLabelHash(labels)
+		require.NoError(err)
+
+		// Create a runner and adopt it.
+		require.NoError(s.state.RunnerCreate(&pb.Runner{
+			Id:     "A",
+			Labels: labels,
+			Kind: &pb.Runner_Remote_{
+				Remote: &pb.Runner_Remote{},
+			},
+		}))
+		defer s.state.RunnerDelete("A")
+		require.NoError(s.state.RunnerAdopt("A", false))
+
+		token, err := s.newToken(0, DefaultKeyId, nil, &pb.Token{
+			Kind: &pb.Token_Runner_{
+				Runner: &pb.Token_Runner{
+					Id:        "A",
+					LabelHash: hash,
+				},
+			},
+		})
+
+		// Auth should work
+		_, err = s.Authenticate(context.Background(), token, "test", nil)
+		require.NoError(err)
 	})
 }
 

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -197,6 +197,12 @@ func (s *service) RunnerToken(
 
 		case pb.Runner_ADOPTED:
 			// Runner explicitly adopted, create token and return!
+
+			hash, err := serverptypes.RunnerLabelHash(record.Labels)
+			if err != nil {
+				return nil, err
+			}
+
 			tok, err := s.newToken(
 				// Doesn't expire because we can expire it by unadopting.
 				// NOTE(mitchellh): At some point, we should make these
@@ -208,7 +214,8 @@ func (s *service) RunnerToken(
 				&pb.Token{
 					Kind: &pb.Token_Runner_{
 						Runner: &pb.Token_Runner{
-							Id: record.Id,
+							Id:        record.Id,
+							LabelHash: hash,
 						},
 					},
 				},

--- a/internal/server/singleprocess/service_runner.go
+++ b/internal/server/singleprocess/service_runner.go
@@ -126,6 +126,21 @@ func (s *service) RunnerToken(
 				break
 			}
 
+			// If the token has a label hash, then we need to validate it.
+			// If the label hash does not match what we know about the runner,
+			// we need to trigger adoption.
+			if expected := k.Runner.LabelHash; expected > 0 {
+				actual, err := serverptypes.RunnerLabelHash(record.Labels)
+				if err != nil {
+					return nil, err
+				}
+
+				if expected != actual {
+					log.Info("runner token has invalid label hash, restarting adoption")
+					break
+				}
+			}
+
 			// Seemingly valid runner token. If our logic is wrong its okay
 			// because RunnerConfig will reject them.
 			log.Debug("valid runner token provided, adoption will be skipped")

--- a/internal/server/singleprocess/service_runner_test.go
+++ b/internal/server/singleprocess/service_runner_test.go
@@ -324,6 +324,89 @@ func TestServiceRunnerToken_invalidRunnerToken(t *testing.T) {
 	}
 }
 
+func TestServiceRunnerToken_zeroToLabels(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+
+	// Create our server
+	impl, err := New(WithDB(testDB(t)))
+	require.NoError(err)
+	client := server.TestServer(t, impl)
+
+	// Get our cookied context
+	ctx = server.TestCookieContext(ctx, t, client)
+
+	// Get the runner id
+	id, err := server.Id()
+	require.NoError(err)
+	r := &pb.Runner{
+		Id: id,
+		Kind: &pb.Runner_Remote_{
+			Remote: &pb.Runner_Remote{},
+		},
+	}
+
+	// Reconnect with no token
+	anonClient := server.TestServer(t, impl, server.TestWithToken(""))
+
+	// Start getting the resp
+	var resp *pb.RunnerTokenResponse
+	var respErr error
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		resp, respErr = anonClient.RunnerToken(ctx, &pb.RunnerTokenRequest{
+			Runner: r,
+		})
+	}()
+
+	// Should block
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-doneCh:
+		t.Fatal("should block")
+	}
+
+	// Adopt it
+	_, err = client.AdoptRunner(ctx, &pb.AdoptRunnerRequest{
+		RunnerId: id,
+		Adopt:    true,
+	})
+	require.NoError(err)
+
+	// Should be done
+	select {
+	case <-doneCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("should return")
+	}
+
+	// Verify token resp
+	require.NoError(respErr)
+	require.NotNil(resp)
+	require.NotEmpty(resp.Token)
+
+	// Reconnect with the token
+	client = server.TestServer(t, impl, server.TestWithToken(resp.Token))
+
+	// Change the labels, and then re-request a token
+	r.Labels = map[string]string{"A": "B"}
+	doneCh = make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		resp, respErr = client.RunnerToken(ctx, &pb.RunnerTokenRequest{
+			Runner: r,
+		})
+	}()
+
+	// Should block
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-doneCh:
+		t.Fatal("should block")
+	}
+}
+
 func TestServiceRunnerToken_changedLabels(t *testing.T) {
 	ctx := context.Background()
 	require := require.New(t)

--- a/internal/server/singleprocess/state/runner.go
+++ b/internal/server/singleprocess/state/runner.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	serverptypes "github.com/hashicorp/waypoint/internal/server/ptypes"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 )
 
 var (

--- a/pkg/server/ptypes/runner.go
+++ b/pkg/server/ptypes/runner.go
@@ -13,11 +13,17 @@ import (
 )
 
 // RunnerLabelHash calculates a unique hash for the set of labels on the
-// runner. If there are no labels, the hash value is always zero.
+// runner. This generates a consistent hash value for an empty set of labels.
+// The result is never 0.
 func RunnerLabelHash(v map[string]string) (uint64, error) {
-	if len(v) == 0 {
-		return 0, nil
+	if v == nil {
+		v = map[string]string{}
 	}
+
+	// We always set this special key so that even empty label sets have
+	// a non-zero hash value. This MUST NEVER BE CHANGED otherwise the
+	// hash values for all previously issued tokens will be invalidated.
+	v["waypoint.hashicorp.com/runner-hash"] = "1"
 
 	return hashstructure.Hash(v, hashstructure.FormatV2, nil)
 }

--- a/pkg/server/ptypes/runner.go
+++ b/pkg/server/ptypes/runner.go
@@ -4,12 +4,23 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/go-testing-interface"
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/waypoint/internal/pkg/validationext"
 	serverpkg "github.com/hashicorp/waypoint/pkg/server"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
+
+// RunnerLabelHash calculates a unique hash for the set of labels on the
+// runner. If there are no labels, the hash value is always zero.
+func RunnerLabelHash(v map[string]string) (uint64, error) {
+	if len(v) == 0 {
+		return 0, nil
+	}
+
+	return hashstructure.Hash(v, hashstructure.FormatV2, nil)
+}
 
 func TestRunner(t testing.T, src *pb.Runner) *pb.Runner {
 	t.Helper()

--- a/pkg/server/ptypes/runner_test.go
+++ b/pkg/server/ptypes/runner_test.go
@@ -1,0 +1,24 @@
+package ptypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test ensures that empty hashes return the expected value. This
+// is important because we set a base key to ensure empty maps don't hash
+// to 0.
+func TestRunnerLabelHash_empty(t *testing.T) {
+	{
+		h, err := RunnerLabelHash(nil)
+		require.NoError(t, err)
+		require.Equal(t, h, uint64(0x85d03bbbdf8bbf66))
+	}
+
+	{
+		h, err := RunnerLabelHash(map[string]string{})
+		require.NoError(t, err)
+		require.Equal(t, h, uint64(0x85d03bbbdf8bbf66))
+	}
+}

--- a/website/content/commands/runner-token.mdx
+++ b/website/content/commands/runner-token.mdx
@@ -38,5 +38,6 @@ level of security to transfer a token around.
 
 - `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'.
 - `-id=<string>` - Id to restrict this token to. If empty, all runner IDs are valid.
+- `-label=<key=value>` - Labels that must match the runner for this token to be valid. These are set in 'k=v' format and this flag can be repeated to set multiple labels. If no labels are set, runners with any labels are valid.
 
 @include "commands/runner-token_more.mdx"


### PR DESCRIPTION
This improves #2935 by making adoption label-aware. If a label set changes, the adoption state of a runner is reset. Additionally, runner tokens include a hash of the labels they're minted for, so if the label changes, tokens are invalidated.

This prevents the following insecure scenario: a runner registers and is adopted with a set of labels for development targeting. After adoption, the runner restarts with a set of labels for production targeting. With this PR, this scenario would result in the runner reseting to the un-adopted state and the previously distributed tokens becoming invalid.

For pre-adoption, users can specify the `-label` flag to the `waypoint runner token` command to create a token for a specific set of labels.