### PR TITLE
replace nil value with non-nil value

### DIFF
--- a/.changelog/2968.txt
+++ b/.changelog/2968.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix panic on nil value for project
+```

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -309,7 +309,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 		if c.cfg != nil {
 			// Warn if the project from config and the project from flags conflict
 			if c.flagProject != "" && c.flagProject != c.cfg.Project {
-				c.ui.Output(warnProjectFlagMismatch, c.refProject.Project, c.flagProject, terminal.WithWarningStyle())
+				c.ui.Output(warnProjectFlagMismatch, c.cfg.Project, c.flagProject, terminal.WithWarningStyle())
 
 				// NOTE(izaak): unless we force remoteness, we may spawn a local runner which will operate against
 				// the current config (which isn't relevant)


### PR DESCRIPTION
Fix a panic

Before:
```
$ waypoint build -project=example-go1

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x10248db40]

goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.(*baseCommand).Init(0x14000d3ce00, {0x14000e1fc60, 0x3, 0x3})
	/Users/raekrantz/wp/waypoint/internal/cli/base.go:312 +0x820
github.com/hashicorp/waypoint/internal/cli.(*ArtifactBuildCommand).Run(0x140002b8be0, {0x140001a6860, 0x1, 0x2})
	/Users/raekrantz/wp/waypoint/internal/cli/artifact_build.go:23 +0xb4
github.com/mitchellh/cli.(*CLI).Run(0x14000c0a000)
	/Users/raekrantz/go/bin/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5c4
github.com/hashicorp/waypoint/internal/cli.Main({0x14000186090, 0x3, 0x3})
	/Users/raekrantz/wp/waypoint/internal/cli/main.go:126 +0x5d4
main.main()
	/Users/raekrantz/wp/waypoint/cmd/waypoint/main.go:14 +0xb4
```

After:
```
$ waypoint build -project=example-go1
Warning: Currently in project directory for "example-go", but will operate
against specified project "example-go1"
! Failed to get project example-go1: rpc error: code = NotFound desc = record not found for ID: example-go1

$ waypoint build -project=example-python
Warning: Currently in project directory for "example-go", but will operate
against specified project "example-python"

» Building example-python...
! Project example-python does not have a data source configured. Remote jobs
  require a data source such as Git to be configured with the project. Data
  sources can be configured via the CLI or UI. For help, see :
  https://www.waypointproject.io/docs/projects/git#configuring-the-project
```