### PR TITLE
Handle auth error in workspaces route

### DIFF
--- a/.changelog/2971.txt
+++ b/.changelog/2971.txt
@@ -1,0 +1,3 @@
+```release-note:ui
+ui: Fix unauthenticated UI state with expired/wrong token
+```

--- a/ui/app/routes/workspaces.ts
+++ b/ui/app/routes/workspaces.ts
@@ -1,14 +1,21 @@
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
+import Route from '@ember/routing/route';
 import SessionService from 'ember-simple-auth/services/session';
+import { Workspace } from 'waypoint-pb';
+import { inject as service } from '@ember/service';
 
 export default class Workspaces extends Route {
   @service api!: ApiService;
   @service session!: SessionService;
 
   async redirect(): Promise<void> {
-    let workspaces = await this.api.listWorkspaces();
+    let workspaces: Workspace.AsObject[] = [];
+    try {
+      workspaces = await this.api.listWorkspaces();
+    } catch (error) {
+      // Send Authentication or other error if it exists
+      this.send('error', error);
+    }
     let workspaceNames = workspaces.map((w) => w.name).sort();
     let storedWorkspaceName = this.session.data.workspace;
 

--- a/ui/tests/acceptance/auth-test.ts
+++ b/ui/tests/acceptance/auth-test.ts
@@ -9,6 +9,11 @@ module('Acceptance | auth', function (hooks: NestedHooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  test('redirects to /auth from index route when logged out', async function (assert) {
+    await visit(`/`);
+    assert.equal(currentURL(), `/auth`);
+  });
+
   test('redirects to /auth from authenticated routes when logged out', async function (assert) {
     await visit(`/default`);
     assert.equal(currentURL(), `/auth`);


### PR DESCRIPTION
Because of the `redirect` hook added in https://github.com/hashicorp/waypoint/pull/2835, a user with an invalid auth token would hit the workspaces route, trigger an error from the api, and be stuck in a weird state (not logged out, not logged in), with a cryptic button in the UI.
<img width="2474" alt="Screen Shot 2022-01-31 at 19 14 44" src="https://user-images.githubusercontent.com/1416421/152179480-b81f05a2-200e-4f7c-b84d-532311d97e91.png">

