### PR TITLE
ui: use alternative method to support icons in Percy

### DIFF
--- a/ui/tests/index.html
+++ b/ui/tests/index.html
@@ -21,10 +21,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture">
       <div id="ember-testing-container">
-        <div id="ember-testing">
-          <!-- this is used to inject the SVG sprite -->
-          {{content-for "ember-testing-sprite-embed"}}
-        </div>
+        <div id="ember-testing"></div>
       </div>
     </div>
 


### PR DESCRIPTION
## Why the change?

Closes #2934 

Our previous solution caused a11yAudit to take noticeable longer, due to the presence of a duplicate spritesheet in the page for every single test (documented in #2934).

This patch achieves the same ends, but does the work to include the spritesheet during Percy’s snapshotting procedure. It’s a little more complex, but only applies to the Percy tests and avoids adding redundant sprite sheets to the rest of the suite.

## What’s the plan?

- [x] Implement fix
- [x] Check timings in CI
- [x] Check Percy build works

## What does it look like?

[The last `ember-test` on main](https://app.circleci.com/pipelines/github/hashicorp/waypoint/13881/workflows/b0d606bf-74d7-4804-b920-44f85fee2e64/jobs/139230) took **4m 6s**
[The last `ember-test` on this branch](https://app.circleci.com/pipelines/github/hashicorp/waypoint/13898/workflows/2cf1c27d-ede0-48f5-85d9-f06959faea58/jobs/139483) took **1m 39s**

## How do I test it?

Check the build in Percy and ensure that icons are rendered correctly (Percy seems to think they are).