### PR TITLE
Don't panic if autocomplete has already been installed

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/hashicorp/go-hclog"
@@ -125,6 +126,10 @@ func Main(args []string) int {
 	// Run the CLI
 	exitCode, err := cli.Run()
 	if err != nil {
+		if strings.Contains(err.Error(), "already installed") {
+			fmt.Println(err)
+			return 1
+		}
 		panic(err)
 	}
 


### PR DESCRIPTION
If run `$ waypoint -autocomplete-install` successfully at least once, any time after that will result in a panic:

```
$ waypoint -autocomplete-install
panic: 1 error occurred:
        * already installed in /Users/clint/.zshrc



goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.Main({0xc00021c000, 0x3711720, 0xc0000001a0})
        /Users/clint/go-src/github.com/hashicorp/waypoint/internal/cli/main.go:128 +0x596
main.main()
        /Users/clint/go-src/github.com/hashicorp/waypoint/cmd/waypoint/main.go:14 +0x7f
```

This error comes from [mitchellh/cli](https://github.com/mitchellh/cli) but originates in [posener/complete](https://github.com/posener/complete/blob/9a4745ac49b29530e07dc2581745a218b646b7a3/cmd/install/zsh.go#L21). It's not using an error type so here I just try to check for matching string. 

It's not a huge improvement but it prevents us outputting panic info when I don't think it's necessary:

```
$ waypoint -autocomplete-install
1 error occurred:
        * already installed in /Users/clint/.zshrc
```