### PR TITLE
fix(docs): aws-lambda typo

### DIFF
--- a/website/content/plugins/aws-lambda.mdx
+++ b/website/content/plugins/aws-lambda.mdx
@@ -35,7 +35,7 @@ def handler(event:, context:)
         "headers": {
             "Content-Type": "text/html"
         },
-        "body": "<html><body><h1>Hello there #{name} from Lambda!</h1></html></body>"
+        "body": "<html><body><h1>Hello there #{name} from Lambda!</h1></body></html>"
     }
 end
 ```


### PR DESCRIPTION
# Description

Fix html string in lambda docs