### PR TITLE
Adding -from-kubernetes-config and -from-kubernetes-kubeconfig to login

### DIFF
--- a/.changelog/2995.txt
+++ b/.changelog/2995.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add -from-kubernetes-context and -from-kubernetes-kubeconfig flags to login command
+```

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -34,6 +34,8 @@ type LoginCommand struct {
 	flagK8SService     string
 	flagK8STokenSecret string
 	flagK8SNamespace   string
+	flagK8SContext     string
+	flagK8SKubeconfig  string
 }
 
 func (c *LoginCommand) Run(args []string) int {
@@ -322,7 +324,7 @@ func (c *LoginCommand) loginOIDC(ctx context.Context) (string, int) {
 
 func (c *LoginCommand) loginK8S(ctx context.Context) (string, int) {
 	// Get our Kubernetes client
-	clientset, ns, _, err := k8sauth.Clientset("", "")
+	clientset, ns, _, err := k8sauth.Clientset(c.flagK8SKubeconfig, c.flagK8SContext)
 	if err != nil {
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return "", 1
@@ -353,7 +355,7 @@ func (c *LoginCommand) loginK8S(ctx context.Context) (string, int) {
 
 func (c *LoginCommand) k8sServerAddr(ctx context.Context) (string, error) {
 	// Get our Kubernetes client
-	clientset, ns, _, err := k8sauth.Clientset("", "")
+	clientset, ns, _, err := k8sauth.Clientset(c.flagK8SKubeconfig, c.flagK8SContext)
 	if err != nil {
 		return "", err
 	}
@@ -462,6 +464,20 @@ func (c *LoginCommand) Flags() *flag.Sets {
 			Name:   "from-kubernetes-namespace",
 			Target: &c.flagK8SNamespace,
 			Usage: "The name of the Kubernetes namespace that has the Waypoint token " +
+				"when using the -from-kubernetes flag.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "from-kubernetes-kubeconfig",
+			Target: &c.flagK8SKubeconfig,
+			Usage: "Path to the kubeconfig file for the cluster Waypoint was installed into " +
+				"when using the -from-kubernetes flag.",
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:   "from-kubernetes-context",
+			Target: &c.flagK8SContext,
+			Usage: "The name of the Kubernetes context that Waypoint was installed into " +
 				"when using the -from-kubernetes flag.",
 		})
 	})

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -56,5 +56,7 @@ or file.
 - `-from-kubernetes-service=<string>` - The name of the Kubernetes service to get the server address from when using the -from-kubernetes flag.
 - `-from-kubernetes-secret=<string>` - The name of the Kubernetes secret that has the Waypoint token when using the -from-kubernetes flag.
 - `-from-kubernetes-namespace=<string>` - The name of the Kubernetes namespace that has the Waypoint token when using the -from-kubernetes flag.
+- `-from-kubernetes-kubeconfig=<string>` - Path to the kubeconfig file for the cluster Waypoint was installed into when using the -from-kubernetes flag.
+- `-from-kubernetes-context=<string>` - The name of the Kubernetes context that Waypoint was installed into when using the -from-kubernetes flag.
 
 @include "commands/login_more.mdx"


### PR DESCRIPTION
It's not uncommon for me to have many contexts live, and always set it when invoking kubectl
rather than rely on the default. It's also not uncommon to have multiple kubeconfig files, and
specify that path on the command line rather than move it to the default location.

Example of using these flags:
```
$ waypoint login -from-kubernetes -from-kubernetes-namespace=waypoint -from-kubernetes-context=arn:aws:eks:us-east-2:999999999999:cluster/prod -from-kubernetes-kubeconfig=~/kube/prod-config
```