### PR TITLE
Add tooling to generate protos with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,13 @@ tools: # install dependencies and tools required to build
 	$(GO_CMD) generate -tags tools tools/tools.go
 	@echo
 	@echo "Done!"
+
+.PHONY: docker/tools
+docker/tools:
+	@ echo "Building docker tools image"
+	docker build -f tools.Dockerfile -t waypoint-tools:dev .
+
+.PHONY: docker/gen/server
+docker/gen/server:
+	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
+	docker run -v `pwd`:/waypoint -it docker.io/library/waypoint-tools:dev make gen/server

--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.17.6
+
+RUN apt-get update; apt-get install unzip
+
+# Protoc
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip -O /tmp/protoc.zip && \
+    unzip /tmp/protoc.zip -d /tmp && \
+    mv /tmp/bin/protoc /usr/local/bin/ && \
+    chmod +x /usr/local/bin/protoc && \
+    mv /tmp/include/* /usr/local/include/
+
+# Copy files required to update tooling
+RUN mkdir -p /tools/tools
+COPY ./tools/tools.go /tools/tools
+COPY ./Makefile /tools
+COPY go.mod /tools
+COPY go.sum /tools
+
+RUN make -C /tools tools
+
+WORKDIR /waypoint

--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.17.6
 
+ARG PROTOC_VERSION="3.15.8"
+
 RUN apt-get update; apt-get install unzip
 
 # Protoc
 # TODO(izaak): discover the protoc version from the nix files
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip -O /tmp/protoc.zip && \
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip -O /tmp/protoc.zip && \
     unzip /tmp/protoc.zip -d /tmp && \
     mv /tmp/bin/protoc /usr/local/bin/ && \
     chmod +x /usr/local/bin/protoc && \

--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.17.6
 RUN apt-get update; apt-get install unzip
 
 # Protoc
+# TODO(izaak): discover the protoc version from the nix files
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip -O /tmp/protoc.zip && \
     unzip /tmp/protoc.zip -d /tmp && \
     mv /tmp/bin/protoc /usr/local/bin/ && \


### PR DESCRIPTION
This introduces a new method to generate protos. You can run `make docker/tools` go create a new local docker container that contains all the tools in `tools/tools.go` and the correct version of protoc, then run `make docker/gen/server` to regenerate protobufs using that container.

This is an alternative to:

- Building protos locally by downloading the correct version of `protoc` locally and installing it (and its includes), and running `make tools; make gen/server`. 

- Building protos in nix with `nix-shell; make gen/server`

The downside here is that we're pinning the protoc version in the dockerfile, so if we upgrade protoc we'll need to update both here and in nix. I don't know of a great way to extract the `v3.15.8` from the nix definitions.