### PR TITLE
Make runner profile optional in waypoint HCL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ type hclConfig struct {
 // Runner is the configuration for supporting runners in this project.
 type Runner struct {
 	// Profile is the name of the on-demand runner configuration.
-	Profile string `hcl:"profile"`
+	Profile string `hcl:"profile,optional"`
 
 	// Note (XX): The other properties in this struct are only used on init,
 	// and don't really make sense being here.


### PR DESCRIPTION
^ yup!

Original idea was to have `profile = ""` even if the user doesn't want to define any profile and have the server choose a default, but after considerations this is redundant and will bug out if the user omits this field.