### PR TITLE
ci: remove ember-test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,6 @@ jobs:
     environment:
       EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
       EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
-    parallelism: 2
     steps:
       - checkout
       - md5uilib


### PR DESCRIPTION
## Why the change?

Closes #2923

Turns out we don’t actually have ember-exam installed, so we were just running exactly the same set of tests twice. We might want to try out ember-exam again in future, but for now our test suite is reasonably quick (~2m) so it’s probably not worth the bother.

## How do I test it?

Check CI output to ensure all tests were run and the timings are reasonable.