### PR TITLE
ci: remove memory usage trace from ember-build-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,11 +328,6 @@ jobs:
           key: *YARN_CACHE_KEY
       - run: cd ui && yarn build:test
 
-      # Emits the maximum memory usage by the container up to this point
-      - run:
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-          when: always
-
       # saves the build to a workspace to be passed to a downstream job
       - persist_to_workspace:
           root: ui


### PR DESCRIPTION
## Why the change?

[CircleCI now has this feature built in](https://circleci.com/changelog/#docker-resource-utilization-graphs).