### PR TITLE
ui: ember-a11y-refocus@^2.3.0

### DIFF
--- a/.changelog/3019.txt
+++ b/.changelog/3019.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixed issue with focus jumping back to the skip link on automatic refresh
+```

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "codemirror": "^5.62.2",
     "date-fns": "^2.15.0",
     "docker-parse-image": "^3.0.1",
-    "ember-a11y-refocus": "^2.1.0",
+    "ember-a11y-refocus": "^2.3.0",
     "ember-a11y-testing": "^4.3.0",
     "ember-auto-import": "^2.2.4",
     "ember-auto-import-typescript": "^0.6.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7264,13 +7264,13 @@ elliptic@^6.0.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-ember-a11y-refocus@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-a11y-refocus/-/ember-a11y-refocus-2.1.0.tgz#cc0473d15c0eb0405d848b831afd78a49cae109f"
-  integrity sha512-jF9aOviA0T6d9P+4AmVtrMRcHVQcT4uBfq5OIGsx2rYrdP6LWj/7Tb+yNLLTDbPIdZDbluzofG7UU6HZYzkJIg==
+ember-a11y-refocus@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ember-a11y-refocus/-/ember-a11y-refocus-2.3.0.tgz#c7c0b00506ca55d2670c028683fdd952e5d76a76"
+  integrity sha512-gbD9IiSPSbXnCh6YFQ5iJUwbsFvvI/0rwQy+tXrH2d/5dfOnBT3rV2XhCmCrWsK1UTBL8HNYhuKNN74vllSQDA==
   dependencies:
-    ember-cli-babel "^7.26.3"
-    ember-cli-htmlbars "^5.7.1"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.0.1"
 
 ember-a11y-testing@^4.3.0:
   version "4.3.0"
@@ -7486,7 +7486,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.26.10:
+ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==


### PR DESCRIPTION
## Why the change?

Closes #2882

Thanks to ember-a11y-refocus#334

## How do I test it?

1. `git checkout ui/ember-a11y-refocus@2.3.0`
2. `cd ui && yarn start`
3. [Visit a deployment](http://localhost:4200/default/marketing-public/app/wp-matrix/deployments/4)
4. Move focus to some element other than the skip link
5. Wait 15 seconds for the automatic refresh
6. Verify focus does not jump back to the skip link
7. Try navigating to a different page
8. Verify focus has jumped back to the skip link