### PR TITLE
Fix some broken links in website documentation

### DIFF
--- a/website/content/docs/exec.mdx
+++ b/website/content/docs/exec.mdx
@@ -57,7 +57,7 @@ instance so resources aren't shared.
 ## Disabling Exec
 
 Currently, exec can only be disabled by
-[disabling the Waypoint entrypoint](docs/entrypoint/disable) completely
+[disabling the Waypoint entrypoint](/docs/entrypoint/disable) completely
 or by disabling only the exec functionality of the entrypoint. Please see
 the linked documentation for more information.
 

--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -130,7 +130,7 @@ ENTRYPOINT ["/app"]
 ```
 
 To invoke this, you can set the `github_token` input variable
-[many different ways](docs/waypoint-hcl/variables/input#assigning-values-to-custom-input-variables). For long term use, the recommended location to set the variable
+[many different ways](/docs/waypoint-hcl/variables/input#assigning-values-to-custom-input-variables). For long term use, the recommended location to set the variable
 is via the web UI. However, for testing, you can use the CLI:
 
 ```shell-session

--- a/website/content/docs/triggers.mdx
+++ b/website/content/docs/triggers.mdx
@@ -32,7 +32,7 @@ Check out our CLI docs for the `waypoint trigger` command, such as
 
 As an example, you can create a Trigger URL config that deploys the latest artifact
 to the production workspace. First, configure the Trigger to use the
-right project, application, and workspace. Then, specify which [lifecycle operation](docs/lifecycle)
+right project, application, and workspace. Then, specify which [lifecycle operation](/docs/lifecycle)
 you want the trigger to execute when run. You can also include a `description` or
 `tags` for extra information for the user.
 


### PR DESCRIPTION
Found 3 broken links with `$ ack "]\(docs" website/content`. I did not find any for `commands` or `plugins`, the other two main sections of the site