### PR TITLE
fix(aws-alb): DuplicateListener on 2nd `up`

### DIFF
--- a/.changelog/3035.txt
+++ b/.changelog/3035.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/alb: Handle DuplicateListener errors from aws-alb releaser
+```


### PR DESCRIPTION
# Description

This fixes a `DuplicateListener` error on subsequent `waypoint up`'s, after the first.

The error occurs with both the [`aws/ec2`](https://github.com/hashicorp/waypoint-examples/blob/main/aws/ec2/waypoint.hcl#L28-L32) and [`aws/lambda/ruby`](https://github.com/hashicorp/waypoint-examples/blob/main/aws/lambda/ruby/waypoint.hcl#L23-L24) examples which both use the `aws-alb` releaser

Closes https://github.com/hashicorp/waypoint/issues/2066