### PR TITLE
cli: Requires `-app` flag if `config set -scope=app` is set.

### DIFF
--- a/.changelog/3040.txt
+++ b/.changelog/3040.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: requires -app flag if `config set -scope=app` is set
+```

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -116,6 +116,10 @@ func (c *ConfigSetCommand) Run(args []string) int {
 			}
 
 		case "app":
+			if c.flagApp == "" {
+				fmt.Fprintf(os.Stderr, "-scope requires -app set if scope is 'app'")
+				return 1
+			}
 			configVar.Target.AppScope = &pb.ConfigVar_Target_Application{
 				Application: &pb.Ref_Application{
 					Project:     projectRef.Project,


### PR DESCRIPTION
Currently, if the scope is set explicitly as "app" without an app provided, we set the scope with an empty app. We should return a helpful error message instead.

_Before:_

```
❯ waypoint-dev config set -scope=app tester=test

❯ waypoint-dev config get
   SCOPE  |  NAME  | VALUE | WORKSPACE | LABELS  
----------+--------+-------+-----------+---------
  project | test   | test  |           |         
  app:    | tester | test  |           |        
```

_After:_
```
❯ waypoint-dev config set -scope=app testt=test
-scope requires -app set if scope is 'app'
```