### PR TITLE
Fix the -set-default flag for `context create`.

### DIFF
--- a/.changelog/3044.txt
+++ b/.changelog/3044.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix the -set-default flag on `waypoint context create`
+```

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -61,7 +61,7 @@ func (c *ContextCreateCommand) Flags() *flag.Sets {
 			Name:    "set-default",
 			Target:  &c.flagSetDefault,
 			Default: true,
-			Usage:   "Set this context as the new default for the CLI.",
+			Usage:   "Set this context as the new default for the CLI. Defaults to true.",
 		})
 		f.StringVar(&flag.StringVar{
 			Name:   "server-addr",

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -43,6 +43,13 @@ func (c *ContextCreateCommand) Run(args []string) int {
 		return 1
 	}
 
+	if c.flagSetDefault {
+		if err := c.contextStorage.SetDefault(name); err != nil {
+			c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+			return 1
+		}
+	}
+
 	c.ui.Output("Context %q created.", name, terminal.WithSuccessStyle())
 	return 0
 }
@@ -51,9 +58,10 @@ func (c *ContextCreateCommand) Flags() *flag.Sets {
 	return c.flagSet(0, func(set *flag.Sets) {
 		f := set.NewSet("Command Options")
 		f.BoolVar(&flag.BoolVar{
-			Name:   "set-default",
-			Target: &c.flagSetDefault,
-			Usage:  "Set this context as the new default for the CLI.",
+			Name:    "set-default",
+			Target:  &c.flagSetDefault,
+			Default: true,
+			Usage:   "Set this context as the new default for the CLI.",
 		})
 		f.StringVar(&flag.StringVar{
 			Name:   "server-addr",

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -28,7 +28,7 @@ Creates a new context.
 
 #### Command Options
 
-- `-set-default` - Set this context as the new default for the CLI.
+- `-set-default` - Set this context as the new default for the CLI. Defaults to true.
 - `-server-addr=<string>` - Address for the server.
 - `-server-auth-token=<string>` - Authentication token to use to connect to the server.
 - `-server-tls` - If true, will connect to the server over TLS.


### PR DESCRIPTION
The flag was unused before this point. This also sets the default state to "true", which is what I think most users would expect.

## How to verify
```
$ waypoint context create is-default
$ waypoint context list
    |         NAME         |  PLATFORM  |                                    SERVER ADDRESS
----+----------------------+------------+----------------------------------------------------------------------------------------
  * | is-default           | n/a        |

$ waypoint context create -set-default=false not-default

Context "not-default" created.
$ waypoint context list
    |         NAME         |  PLATFORM  |                                    SERVER ADDRESS
----+----------------------+------------+----------------------------------------------------------------------------------------
  * | is-default           | n/a        |
    | not-default          | n/a        |
```