### PR TITLE
Rename "cookie" metadata to "wpcookie"

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -180,7 +180,7 @@ func New(opts ...Option) (*Runner, error) {
 		runner.runningCtx = metadata.NewOutgoingContext(
 			runner.runningCtx,
 			metadata.New(map[string]string{
-				"cookie": v,
+				"wpcookie": v,
 			}),
 		)
 	}
@@ -263,7 +263,7 @@ func (r *Runner) Start(ctx context.Context) error {
 		tokenCtx = metadata.NewOutgoingContext(
 			tokenCtx,
 			metadata.New(map[string]string{
-				"cookie": r.cookie,
+				"wpcookie": r.cookie,
 			}),
 		)
 	} else if !adopt {

--- a/internal/server/singleprocess/auth.go
+++ b/internal/server/singleprocess/auth.go
@@ -126,7 +126,7 @@ func (s *service) tokenFromContext(ctx context.Context) *pb.Token {
 // or blank if none (or a blank cookie) is provided.
 func (s *service) cookieFromRequest(ctx context.Context) string {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if c, ok := md["cookie"]; ok && len(c) > 0 {
+		if c, ok := md["wpcookie"]; ok && len(c) > 0 {
 			return c[0]
 		}
 	}

--- a/pkg/server/testing.go
+++ b/pkg/server/testing.go
@@ -236,6 +236,6 @@ func TestVersionInfoResponse() *pb.GetVersionInfoResponse {
 func TestCookieContext(ctx context.Context, t testing.T, c pb.WaypointClient) context.Context {
 	resp, err := c.GetServerConfig(ctx, &empty.Empty{})
 	require.NoError(t, err)
-	md := metadata.New(map[string]string{"cookie": resp.Config.Cookie})
+	md := metadata.New(map[string]string{"wpcookie": resp.Config.Cookie})
 	return metadata.NewOutgoingContext(ctx, md)
 }


### PR DESCRIPTION
The gRPC web client will send browser cookies automatically using the
"cookie" metadata. We don't want to conflict with anything because
invalid cookie values cause API requests to fail. This commit replaces
"cookie" with "wpcookie" but is otherwise functionally identical.