### PR TITLE
fixup: Don't include default value

### DIFF
--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -61,7 +61,7 @@ func (c *ContextCreateCommand) Flags() *flag.Sets {
 			Name:    "set-default",
 			Target:  &c.flagSetDefault,
 			Default: true,
-			Usage:   "Set this context as the new default for the CLI. Defaults to true.",
+			Usage:   "Set this context as the new default for the CLI.",
 		})
 		f.StringVar(&flag.StringVar{
 			Name:   "server-addr",

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -28,7 +28,7 @@ Creates a new context.
 
 #### Command Options
 
-- `-set-default` - Set this context as the new default for the CLI. Defaults to true.
+- `-set-default` - Set this context as the new default for the CLI.
 - `-server-addr=<string>` - Address for the server.
 - `-server-auth-token=<string>` - Authentication token to use to connect to the server.
 - `-server-tls` - If true, will connect to the server over TLS.


### PR DESCRIPTION
The CLI package will append the default value of a flag automatically so
no need to include it ourselves.