### PR TITLE
Start runner liveness check _before_ starting the runner.

### DIFF
--- a/.changelog/3052.txt
+++ b/.changelog/3052.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-runner: start health check before blocking on adoption
-```

--- a/.changelog/3052.txt
+++ b/.changelog/3052.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+runner: start health check before blocking on adoption
+```


### PR DESCRIPTION
Without this, with the helm runner-only install using the adoption flow, the runner pauses
waiting to be adopted before starting it's health check. It sits in that state for 10 seconds,
then k8s gives up on it and terminates it becasue it's failed too many health checks.

Verified through local testing