### PR TITLE
docs: Fix typo for config source-set

### DIFF
--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -384,7 +384,7 @@ func (c *AppDocsCommand) mdxFormatConfigSourcer(name, ct string, doc *docs.Docum
 
 	if len(doc.Fields()) > 0 {
 		fmt.Fprintf(w, "\n\n### Source Parameters\n\n"+
-			"The parameters below are used with `waypoint config set-source` to configure\n"+
+			"The parameters below are used with `waypoint config source-set` to configure\n"+
 			"the behavior this plugin. These are _not_ used in `dynamic` calls. The\n"+
 			"parameters used for `dynamic` are in the previous section.\n\n")
 

--- a/website/content/partials/components/configsourcer-aws-ssm.mdx
+++ b/website/content/partials/components/configsourcer-aws-ssm.mdx
@@ -30,7 +30,7 @@ This plugin has no optional parameters.
 
 ### Source Parameters
 
-The parameters below are used with `waypoint config set-source` to configure
+The parameters below are used with `waypoint config source-set` to configure
 the behavior this plugin. These are _not_ used in `dynamic` calls. The
 parameters used for `dynamic` are in the previous section.
 

--- a/website/content/partials/components/configsourcer-null.mdx
+++ b/website/content/partials/components/configsourcer-null.mdx
@@ -46,7 +46,7 @@ This just returns the value given as the dynamic configuration. This isn't very 
 
 ### Source Parameters
 
-The parameters below are used with `waypoint config set-source` to configure
+The parameters below are used with `waypoint config source-set` to configure
 the behavior this plugin. These are _not_ used in `configdynamic` calls. The
 parameters used for `configdynamic` are in the previous section.
 

--- a/website/content/partials/components/configsourcer-terraform-cloud.mdx
+++ b/website/content/partials/components/configsourcer-terraform-cloud.mdx
@@ -60,7 +60,7 @@ This plugin has no optional parameters.
 
 ### Source Parameters
 
-The parameters below are used with `waypoint config set-source` to configure
+The parameters below are used with `waypoint config source-set` to configure
 the behavior this plugin. These are _not_ used in `dynamic` calls. The
 parameters used for `dynamic` are in the previous section.
 

--- a/website/content/partials/components/configsourcer-vault.mdx
+++ b/website/content/partials/components/configsourcer-vault.mdx
@@ -50,7 +50,7 @@ This plugin has no optional parameters.
 
 ### Source Parameters
 
-The parameters below are used with `waypoint config set-source` to configure
+The parameters below are used with `waypoint config source-set` to configure
 the behavior this plugin. These are _not_ used in `dynamic` calls. The
 parameters used for `dynamic` are in the previous section.
 


### PR DESCRIPTION
Maybe this was a problem introduced in #868?