### PR TITLE
internal/server: Ensure on-demand runner config exists before start job

### DIFF
--- a/.changelog/3054.txt
+++ b/.changelog/3054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic where on-demand runner config was nil before starting task
+```

--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -279,6 +279,12 @@ func (s *service) onDemandRunnerStartJob(
 ) (*pb.Job, string, error) {
 	log := hclog.FromContext(ctx)
 
+	if od == nil {
+		return nil, "", status.Errorf(codes.FailedPrecondition,
+			"the on-demand runner config for id %q and job %q was nil",
+			source.OndemandRunner.Id, source.Id)
+	}
+
 	// Generate a unique ID for the runner
 	runnerId, err := server.Id()
 	if err != nil {

--- a/internal/server/singleprocess/service_job.go
+++ b/internal/server/singleprocess/service_job.go
@@ -232,6 +232,11 @@ func (s *service) wrapJobWithRunner(
 	if err != nil {
 		return nil, err
 	}
+	if od == nil {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"the on-demand runner config for id %q and job %q was nil",
+			source.OndemandRunner.Id, source.Id)
+	}
 
 	// Generate our job to start the ODR
 	startJob, runnerId, err := s.onDemandRunnerStartJob(ctx, source, od)

--- a/internal/server/singleprocess/service_job_test.go
+++ b/internal/server/singleprocess/service_job_test.go
@@ -480,6 +480,21 @@ func TestServiceQueueJob_odr(t *testing.T) {
 	// Simplify writing tests
 	type Req = pb.QueueJobRequest
 
+	// Create with no ODR should error
+	queueResp, err := client.QueueJob(ctx, &Req{
+		Job: serverptypes.TestJobNew(t, &pb.Job{
+			Application: &pb.Ref_Application{
+				Application: "app",
+				Project:     "proj",
+			},
+			OndemandRunner: &pb.Ref_OnDemandRunnerConfig{
+				Name: "fake",
+			},
+		}),
+	})
+	require.Error(err)
+	require.Empty(queueResp)
+
 	// Create an ODR profile
 	odr := serverptypes.TestOnDemandRunnerConfig(t, &pb.OnDemandRunnerConfig{
 		PluginType:   "magic-carpet",
@@ -502,7 +517,7 @@ func TestServiceQueueJob_odr(t *testing.T) {
 	require.NoError(err)
 
 	// Create, should get an ID back
-	queueResp, err := client.QueueJob(ctx, &Req{
+	queueResp, err = client.QueueJob(ctx, &Req{
 		Job: serverptypes.TestJobNew(t, &pb.Job{
 			Application: &pb.Ref_Application{
 				Application: "app",


### PR DESCRIPTION
Prior to this commit, if the state package returned nil or nothing for
an on-demand runner config based on the id set for a job, Waypoint would
still attempt to queue the job with a nil ODR config. This leads to a
panic immediately after when we attempt to set environment variables
from the ODR config for the job on a nil config. This commit fixes that
by returning an error if the requested ODR config does not exist in the
state database.

This is related to https://github.com/hashicorp/waypoint/issues/3051 but
mainly fixes the bad behavior with the panic, not the core bug of a invalid
or missing ODR config set on a job.