### PR TITLE
cli: Enable context create to set the server platform

### DIFF
--- a/.changelog/3055.txt
+++ b/.changelog/3055.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Add a way to `waypoint context create` to set the Waypoint server platform
+cli: Add a way for `waypoint context create` to set the Waypoint server platform
 ```

--- a/.changelog/3055.txt
+++ b/.changelog/3055.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add a way to `waypoint context create` to set the Waypoint server platform
+```

--- a/internal/cli/context_create.go
+++ b/internal/cli/context_create.go
@@ -73,6 +73,12 @@ func (c *ContextCreateCommand) Flags() *flag.Sets {
 			Target: &c.flagConfig.Server.AuthToken,
 			Usage:  "Authentication token to use to connect to the server.",
 		})
+		f.StringVar(&flag.StringVar{
+			Name:    "server-platform",
+			Target:  &c.flagConfig.Server.Platform,
+			Default: "n/a",
+			Usage:   "The current platform that Waypoint server is running on.",
+		})
 		f.BoolVar(&flag.BoolVar{
 			Name:    "server-tls",
 			Target:  &c.flagConfig.Server.Tls,

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -31,6 +31,7 @@ Creates a new context.
 - `-set-default` - Set this context as the new default for the CLI.
 - `-server-addr=<string>` - Address for the server.
 - `-server-auth-token=<string>` - Authentication token to use to connect to the server.
+- `-server-platform=<string>` - The current platform that Waypoint server is running on.
 - `-server-tls` - If true, will connect to the server over TLS.
 - `-server-tls-skip-verify` - If true, will not validate TLS cert presented by the server.
 - `-server-require-auth` - If true, will send authentication details.


### PR DESCRIPTION
Prior to this commit, there was no way for the CLI to set the server
platform when creating a context. This commit enables that flow by
introducing a string var flag so it can be set on creation.