### PR TITLE
change runner adoption protobuf

### DIFF
--- a/internal/server/singleprocess/state/runner.go
+++ b/internal/server/singleprocess/state/runner.go
@@ -209,7 +209,7 @@ func (s *State) runnerCreate(dbTxn *bolt.Tx, memTxn *memdb.Txn, runnerpb *pb.Run
 	// replaced with real values if we have them.
 	runnerpb.FirstSeen = now
 	runnerpb.LastSeen = now
-	runnerpb.AdoptionState = pb.Runner_NEW
+	runnerpb.AdoptionState = pb.Runner_PENDING
 
 	// Look up the runner in our database. If it exists, override the
 	// values that are persistently stored.
@@ -242,7 +242,7 @@ func (s *State) runnerCreate(dbTxn *bolt.Tx, memTxn *memdb.Txn, runnerpb *pb.Run
 		// allows a runner to change their labels without affecting adoption.
 		// For now, we do not support this.
 		if hash1 != hash2 {
-			runnerpb.AdoptionState = pb.Runner_NEW
+			runnerpb.AdoptionState = pb.Runner_PENDING
 		}
 	}
 
@@ -333,7 +333,7 @@ func (s *State) runnerOffline(dbTxn *bolt.Tx, memTxn *memdb.Txn, id string) erro
 		//
 		// We also delete PREADOPTED because if the runner comes back, we expect
 		// it'll have a valid token to set it back to the PREADOPTED state.
-		del = r.AdoptionState == pb.Runner_NEW || r.AdoptionState == pb.Runner_PREADOPTED
+		del = r.AdoptionState == pb.Runner_PENDING || r.AdoptionState == pb.Runner_PREADOPTED
 
 	default:
 		// All other runner types like ODR and Local we don't keep records of.

--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -496,7 +496,7 @@ type Runner_AdoptionState int32
 const (
 	// New runner we've never seen before or has been forgotten.
 	// Runners in this state will wait for adoption.
-	Runner_NEW Runner_AdoptionState = 0
+	Runner_PENDING Runner_AdoptionState = 0
 	// Runner provided a valid runner token despite not being explicitly
 	// adopted. This type of runner can be forcibly rejected later such
 	// that pre-adoption doesn't work at all.
@@ -5007,7 +5007,7 @@ func (x *Runner) GetAdoptionState() Runner_AdoptionState {
 	if x != nil {
 		return x.AdoptionState
 	}
-	return Runner_NEW
+	return Runner_PENDING
 }
 
 type isRunner_Kind interface {

--- a/pkg/server/proto/server.proto
+++ b/pkg/server/proto/server.proto
@@ -2269,8 +2269,8 @@ message Runner {
   // be given work, but are also explicit about how they were adopted.
   enum AdoptionState {
     // New runner we've never seen before or has been forgotten.
-    // Runners in this state will wait for adoption.
-    NEW = 0;
+    // Runners in this state are pending adoption.
+    PENDING = 0;
 
     // Runner provided a valid runner token despite not being explicitly
     // adopted. This type of runner can be forcibly rejected later such
@@ -4386,7 +4386,7 @@ message GenerateRunnerTokenRequest {
   // The set of labels to restrict this runner token to work for. The runner
   // labels must match this label set exactly. If this is not set, then runners
   // with any labels may use the resulting token.
-  map<string,string> labels = 3;
+  map<string, string> labels = 3;
 }
 
 // Passed with GenerateInviteToken with the params on how the invite token should

--- a/pkg/serverstate/statetest/test_runner.go
+++ b/pkg/serverstate/statetest/test_runner.go
@@ -41,7 +41,7 @@ func TestRunner_crud(t *testing.T, factory Factory, restartF RestartFactory) {
 	found, err := s.RunnerById(rec.Id, nil)
 	require.NoError(err)
 	require.Equal(rec.Id, found.Id)
-	require.Equal(pb.Runner_NEW, found.AdoptionState)
+	require.Equal(pb.Runner_PENDING, found.AdoptionState)
 
 	// List should include it
 	list, err = s.RunnerList()
@@ -124,7 +124,7 @@ func TestRunnerAdopt(t *testing.T, factory Factory, restartF RestartFactory) {
 	ws := memdb.NewWatchSet()
 	found, err := s.RunnerById(rec.Id, ws)
 	require.NoError(err)
-	require.Equal(pb.Runner_NEW, found.AdoptionState)
+	require.Equal(pb.Runner_PENDING, found.AdoptionState)
 
 	// Watch should block
 	require.True(ws.Watch(time.After(10 * time.Millisecond)))
@@ -166,7 +166,7 @@ func TestRunnerAdopt(t *testing.T, factory Factory, restartF RestartFactory) {
 	{
 		found, err := s.RunnerById(rec.Id, nil)
 		require.NoError(err)
-		require.Equal(pb.Runner_NEW, found.AdoptionState)
+		require.Equal(pb.Runner_PENDING, found.AdoptionState)
 	}
 }
 
@@ -205,7 +205,7 @@ func TestRunnerAdopt_changeLabels(t *testing.T, factory Factory, restartF Restar
 		{
 			found, err := s.RunnerById(rec.Id, nil)
 			require.NoError(err)
-			require.Equal(pb.Runner_NEW, found.AdoptionState)
+			require.Equal(pb.Runner_PENDING, found.AdoptionState)
 		}
 	})
 
@@ -274,7 +274,7 @@ func TestRunnerAdopt_changeLabels(t *testing.T, factory Factory, restartF Restar
 		{
 			found, err := s.RunnerById(rec.Id, nil)
 			require.NoError(err)
-			require.Equal(pb.Runner_NEW, found.AdoptionState)
+			require.Equal(pb.Runner_PENDING, found.AdoptionState)
 		}
 	})
 }


### PR DESCRIPTION
Some [cleverness in modifying the `runner list` led to a change in output. ](https://hashicorp.slack.com/archives/C013QT1KG9W/p1646232325910549)This changes the protobuf to make the cleverness work.