### PR TITLE
Do not add ODR profile to job if profile is empty

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -245,8 +245,10 @@ func (c *Project) doJobMonitored(ctx context.Context, job *pb.Job, ui terminal.U
 		}
 		// If runner config is found, assign to job
 		if configRunner != nil {
-			job.OndemandRunner = &pb.Ref_OnDemandRunnerConfig{
-				Name: configRunner.Profile,
+			if configRunner.Profile != "" {
+				job.OndemandRunner = &pb.Ref_OnDemandRunnerConfig{
+					Name: configRunner.Profile,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently, if you have a default runner profile but no project-specific target, the waypoint server fails the job with the following error: `no runner profile name or id specified`. This is because the client's `waypointHCL.ConfigRunner()` is returning non-nil, but the profile field is an empty string, so the job is getting a runner profile assigned (but with an empty profile string).

The server is expecting a nil odr profile on a job to mean "no preference" [here](https://github.com/hashicorp/waypoint/blob/ff4406443d64d5f16812bef32d8b4428656aae6e/internal/server/singleprocess/service_job.go#L171), not an assigned profile with an empty string.

This fixes the problem by not assigning an odr profile to the job unless the profile name is actually set.