### PR TITLE
builtin/aws: add `cpu_architecture` aws-ecs parameter

### DIFF
--- a/.changelog/3068.txt
+++ b/.changelog/3068.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+builtin/aws/ecs: Add `cpu_architecture` aws-ecs parameter
+to support deploying Docker images built by the Apple M1 chip on ECS
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -96,13 +96,14 @@ func (p *Platform) ConfigSet(config interface{}) error {
 		return err
 	}
 
-	if c.CpuArchitecture != "" {
+	if c.Architecture != "" {
+		c.Architecture = strings.ToUpper(c.Architecture)
 		cpuArchitectures := make([]interface{}, len(ecs.CPUArchitecture_Values()))
 		for i, ca := range ecs.CPUArchitecture_Values() {
 			cpuArchitectures[i] = ca
 		}
 		err := utils.Error(validation.ValidateStruct(c,
-			validation.Field(&c.CpuArchitecture,
+			validation.Field(&c.Architecture,
 				validation.In(cpuArchitectures...).Error("unsupported CPU architecture"),
 			),
 		))
@@ -1522,7 +1523,7 @@ func (p *Platform) resourceTaskDefinitionCreate(
 		Memory:           aws.String(mems),
 		Family:           aws.String(family),
 		RuntimePlatform: &ecs.RuntimePlatform{
-			CpuArchitecture: aws.String(p.config.CpuArchitecture),
+			CpuArchitecture: aws.String(p.config.Architecture),
 		},
 
 		NetworkMode:             aws.String("awsvpc"),
@@ -2721,7 +2722,7 @@ type Config struct {
 	// How much CPU to assign to the containers
 	CPU int `hcl:"cpu,optional"`
 
-	CpuArchitecture string `hcl:"cpu_architecture,optional"`
+	Architecture string `hcl:"architecture,optional"`
 
 	// The environment variables to pass to the main container
 	Environment map[string]string `hcl:"static_environment,optional"`
@@ -3092,13 +3093,8 @@ deploy {
 	)
 
 	doc.SetField(
-		"cpu_architecture",
-		"the CPU architecture",
-		docs.Summary(
-			"you can run your Linux tasks on an ARM-based platform by setting the value to `ARM64`.",
-			"this option is avaiable for tasks that run on Linuc Amazon EC2 instance",
-			"or Linux containers on Fargate.",
-		),
+		"architecture",
+		"the instruction set CPU architecture that the Amazon ECS supports. Valid values are: \"x86_64\", \"arm64\"",
 	)
 
 	return doc, nil

--- a/builtin/aws/ecs/platform_test.go
+++ b/builtin/aws/ecs/platform_test.go
@@ -205,4 +205,15 @@ func TestPlatformConfig(t *testing.T) {
 
 		require.Error(t, p.ConfigSet(cfg))
 	})
+
+	t.Run("disallows unsupported cpu_architecture", func(t *testing.T) {
+		var p Platform
+
+		cfg := &Config{
+			Memory:          512,
+			CpuArchitecture: "FOO",
+		}
+
+		require.Error(t, p.ConfigSet(cfg))
+	})
 }

--- a/builtin/aws/ecs/platform_test.go
+++ b/builtin/aws/ecs/platform_test.go
@@ -206,12 +206,12 @@ func TestPlatformConfig(t *testing.T) {
 		require.Error(t, p.ConfigSet(cfg))
 	})
 
-	t.Run("disallows unsupported cpu_architecture", func(t *testing.T) {
+	t.Run("disallows unsupported architecture", func(t *testing.T) {
 		var p Platform
 
 		cfg := &Config{
-			Memory:          512,
-			CpuArchitecture: "FOO",
+			Memory:       512,
+			Architecture: "foo",
 		}
 
 		require.Error(t, p.ConfigSet(cfg))

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -244,6 +244,15 @@ On Fargate, possible values for this are configured by the amount of memory the 
 - Type: **int**
 - **Optional**
 
+#### cpu_architecture
+
+The CPU architecture.
+
+You can run your Linux tasks on an ARM-based platform by setting the value to `ARM64`. this option is avaiable for tasks that run on Linuc Amazon EC2 instance or Linux containers on Fargate.
+
+- Type: **string**
+- **Optional**
+
 #### disable_alb
 
 Do not create a load balancer assigned to the service.

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -201,6 +201,13 @@ Environment variables to expose to this container.
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
+#### architecture
+
+The instruction set CPU architecture that the Amazon ECS supports. Valid values are: "x86_64", "arm64".
+
+- Type: **string**
+- **Optional**
+
 #### assign_public_ip
 
 Assign a public ip address to tasks. Defaults to true. Ignored if using an ec2 cluster.
@@ -242,15 +249,6 @@ On Fargate, possible values for this are configured by the amount of memory the 
 8192MB: 1024.
 
 - Type: **int**
-- **Optional**
-
-#### cpu_architecture
-
-The CPU architecture.
-
-You can run your Linux tasks on an ARM-based platform by setting the value to `ARM64`. this option is avaiable for tasks that run on Linuc Amazon EC2 instance or Linux containers on Fargate.
-
-- Type: **string**
 - **Optional**
 
 #### disable_alb


### PR DESCRIPTION
This is to support deploying Docker images built by the Apple M1 chip to ECS:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-arm64.html

Adding new `cpu_architecture` parameter (optional, no default value):

```hcl
app "example-nodejs" {
  labels = {
    "service" = "example-nodejs",
    "env"     = "dev"
  }

  build {
    use "docker" {}
    registry {
      use "aws-ecr" {
        region     = "ap-northeast-1"
        repository = "waypoint-example"
        tag        = "latest"
      }
    }
  }

  deploy {
    use "aws-ecs" {
      region = "ap-northeast-1"
      memory = "512"
      cpu_architecture = "ARM64"
    }
  }
}
```

NOTE: Currently, this only works with the `docker` build plugin, and not with the `pack` plugin. But I believe that's due to the upstream buildpacks issue with arm64, not coming from Waypoint itself.