### PR TITLE
K8s: Don't error build/deploy/release because a previous deployment isn't found

### DIFF
--- a/.changelog/3070.txt
+++ b/.changelog/3070.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/k8s: don't error if previous deployment is not found during cleanup
+```


### PR DESCRIPTION
If for some reason a previous deployment is not found and on `waypoint up` we try to remove it, the entire operation will be reported as a failure even if we successfully deployed a new version.

Here we check for not found, and simply continue 