### PR TITLE
cli: Sort jobs by timestamp completetime before format

### DIFF
--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -54,8 +54,9 @@ func (c *JobListCommand) Run(args []string) int {
 		})
 	}
 
+	// limit to the first n jobs
 	if c.flagLimit > 0 && c.flagLimit <= len(jobs) {
-		jobs = jobs[len(jobs)-c.flagLimit:]
+		jobs = jobs[:c.flagLimit]
 	}
 
 	if c.flagJson {

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/dustin/go-humanize"
 	"github.com/golang/protobuf/jsonpb"
@@ -41,6 +42,11 @@ func (c *JobListCommand) Run(args []string) int {
 	}
 
 	jobs := resp.Jobs
+
+	// sort by complete time
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].CompleteTime.AsTime().Before(jobs[j].CompleteTime.AsTime())
+	})
 
 	if c.flagDesc {
 		var reverse []*pb.Job

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -44,16 +44,14 @@ func (c *JobListCommand) Run(args []string) int {
 	jobs := resp.Jobs
 
 	// sort by complete time
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].CompleteTime.AsTime().Before(jobs[j].CompleteTime.AsTime())
-	})
-
 	if c.flagDesc {
-		var reverse []*pb.Job
-		for i := len(jobs) - 1; i >= 0; i-- {
-			reverse = append(reverse, jobs[i])
-		}
-		jobs = reverse
+		sort.Slice(jobs, func(i, j int) bool {
+			return jobs[i].CompleteTime.AsTime().Before(jobs[j].CompleteTime.AsTime())
+		})
+	} else {
+		sort.Slice(jobs, func(i, j int) bool {
+			return jobs[i].CompleteTime.AsTime().After(jobs[j].CompleteTime.AsTime())
+		})
 	}
 
 	if c.flagLimit > 0 && c.flagLimit <= len(jobs) {


### PR DESCRIPTION
Prior to this commit, we relied on the job list being in order from the
database. This is fragile, so instead we first sort by compeltion time
before formatting the job list table.

Fixes #3078