### PR TITLE
CLI display improvements to operations

### DIFF
--- a/.changelog/3081.txt
+++ b/.changelog/3081.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Print operation sequence ids and pushed artifact id
+```

--- a/internal/cli/artifact_build.go
+++ b/internal/cli/artifact_build.go
@@ -30,12 +30,15 @@ func (c *ArtifactBuildCommand) Run(args []string) int {
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		app.UI.Output("Building %s...", app.Ref().Application, terminal.WithHeaderStyle())
-		_, err := app.Build(ctx, &pb.Job_BuildOp{
+		buildResult, err := app.Build(ctx, &pb.Job_BuildOp{
 			DisablePush: !c.flagPush,
 		})
 		if err != nil {
 			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
+		}
+		if buildResult.Push != nil {
+			app.UI.Output("\nCreated artifact v%d", buildResult.Push.Sequence)
 		}
 
 		return nil

--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -71,6 +71,11 @@ func (a *App) Build(ctx context.Context, optFuncs ...BuildOption) (
 	return build, artifact, err
 }
 
+// Name returns the name of the operation
+func (op *buildOperation) Name() string {
+	return "build"
+}
+
 // BuildOption is used to configure a Build
 type BuildOption func(*buildOptions) error
 

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -155,6 +155,11 @@ type deployOperation struct {
 	result interface{}
 }
 
+// Name returns the name of the operation
+func (op *deployOperation) Name() string {
+	return "deploy"
+}
+
 func (op *deployOperation) Close() error {
 	if op.component != nil {
 		return op.component.Close()

--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -193,6 +193,11 @@ type deployDestroyOperation struct {
 	Deployment *pb.Deployment
 }
 
+// Name returns the name of the operation
+func (op *deployDestroyOperation) Name() string {
+	return "deployment destroy"
+}
+
 func (op *deployDestroyOperation) Init(app *App) (proto.Message, error) {
 	return op.Deployment, nil
 }

--- a/internal/core/app_push.go
+++ b/internal/core/app_push.go
@@ -154,6 +154,11 @@ func (op *pushBuildOperation) Upsert(
 	return resp.Artifact, nil
 }
 
+// Name returns the name of the operation
+func (op *pushBuildOperation) Name() string {
+	return "push build"
+}
+
 func (op *pushBuildOperation) Do(ctx context.Context, log hclog.Logger, app *App, _ proto.Message) (interface{}, error) {
 	// If we have no registry, we just push the local build.
 	if op.ComponentRegistry == nil {

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -211,6 +211,11 @@ func (op *releaseOperation) Upsert(
 	return resp.Release, nil
 }
 
+// Name returns the name of the operation
+func (op *releaseOperation) Name() string {
+	return "release"
+}
+
 func (op *releaseOperation) Do(ctx context.Context, log hclog.Logger, app *App, msg proto.Message) (interface{}, error) {
 	// If we have no releaser, we do nothing since we just update the
 	// blank release metadata.

--- a/internal/core/app_release_destroy.go
+++ b/internal/core/app_release_destroy.go
@@ -236,6 +236,11 @@ func (op *releaseDestroyOperation) Upsert(
 	return resp.Release, nil
 }
 
+// Name returns the name of the operation
+func (op *releaseDestroyOperation) Name() string {
+	return "release destroy"
+}
+
 func (op *releaseDestroyOperation) Do(ctx context.Context, log hclog.Logger, app *App, _ proto.Message) (interface{}, error) {
 	// If we have no releaser then we're done.
 	if op.Component == nil {

--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -308,6 +308,11 @@ func (op *statusReportOperation) Upsert(
 	return resp.StatusReport, nil
 }
 
+// Name returns the name of the operation
+func (op *statusReportOperation) Name() string {
+	return "status report"
+}
+
 func (op *statusReportOperation) Do(
 	ctx context.Context,
 	log hclog.Logger,


### PR DESCRIPTION
Currently, when you run an operation on the CLI, there's no great way to know later which operation you just ran. I.e. you can run `waypoint build`, and later run `waypoint artifact list-builds` and assume the highest-numbered build is the one you just created, but you can't really know for sure. This also makes it hard to correlate between the CLI and the UI.

This change adds a new step group, printing `⠏ Running build v18`, or `⠏ Running deploy v3`, or equivalent, to every operation. It completes when the full op completes.

For artifacts in particular, this also prints the id of the produced artifact, if any (which is distinct from the build)

Example:

<img width="1064" alt="Screen Shot 2022-03-08 at 3 56 31 PM" src="https://user-images.githubusercontent.com/8404559/157323842-440f05c5-7a36-4d59-85e5-74b120532a33.png">
<img width="1064" alt="Screen Shot 2022-03-08 at 3 56 50 PM" src="https://user-images.githubusercontent.com/8404559/157323847-fbca58b8-76ae-42d9-a478-3e0bae2715af.png">

