### PR TITLE
Runner resilience part 1/N: startup resilience to server being down or going down

### DIFF
--- a/.changelog/3087.txt
+++ b/.changelog/3087.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+core: runners automatically reconnect on startup if the server is unavailable
+or becomes unavailable during the startup process
+```

--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -41,7 +41,7 @@ func (r *Runner) initConfigStream(ctx context.Context) error {
 	ch := make(chan *pb.RunnerConfig)
 	go r.watchConfig(ctx, log, ch)
 
-	// Start the config receiver. This will connect ot the RunnerConfig
+	// Start the config receiver. This will connect to the RunnerConfig
 	// endpoint and start receiving data. This will reconnect on failure.
 	go r.initConfigStreamReceiver(ctx, log, ch, false)
 

--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint/internal/appconfig"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -26,10 +29,80 @@ import (
 // this refresh.
 var appConfigRefreshPeriod = 15 * time.Second
 
+// initConfigStream starts the RunnerConfig stream in the background. This will
+// automatically retry if the server is currently unavailable or goes down
+// mid-stream.
+func (r *Runner) initConfigStream(ctx context.Context) error {
+	log := r.logger.Named("config")
+
+	// Start the watcher. This will do nothing until anything is sent on the
+	// channel so we can start it early. We share the same channel across
+	// config reconnects.
+	ch := make(chan *pb.RunnerConfig)
+	go r.watchConfig(ctx, log, ch)
+
+	// Start the config receiver. This will connect ot the RunnerConfig
+	// endpoint and start receiving data. This will reconnect on failure.
+	go r.initConfigStreamReceiver(ctx, log, ch, false)
+
+	return nil
+}
+
+func (r *Runner) initConfigStreamReceiver(
+	ctx context.Context,
+	log hclog.Logger,
+	ch chan<- *pb.RunnerConfig,
+	isRetry bool,
+) error {
+	// Open our log stream
+	log.Debug("registering instance, requesting config")
+	client, err := r.client.RunnerConfig(ctx, grpc.WaitForReady(isRetry))
+	if err != nil {
+		// If the connection failed, we'll just log that and retry in the
+		// background so the remainder of runner startup can continue.
+		if status.Code(err) == codes.Unavailable {
+			log.Error("error connecting to Waypoint server, will retry")
+			go r.initConfigStreamReceiver(ctx, log, ch, true)
+			return nil
+		}
+
+		return err
+	}
+
+	// Start the goroutine that receives messages from the stream.
+	// This will detect any stream disconections and perform a retry.
+	go r.recvConfig(ctx, client, ch, func() error {
+		return r.initConfigStreamReceiver(ctx, log, ch, true)
+	})
+
+	// Send our open request.
+	if err := client.Send(&pb.RunnerConfigRequest{
+		Event: &pb.RunnerConfigRequest_Open_{
+			Open: &pb.RunnerConfigRequest_Open{
+				Runner: r.runner,
+			},
+		},
+	}); err != nil {
+		if status.Code(err) == codes.Unavailable {
+			// Ignore this error, recvConfig will get it too and will
+			// trigger the reconnect.
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 // watchConfig sits in a goroutine receiving the new configurations from the
 // server.
-func (r *Runner) watchConfig(ctx context.Context, ch <-chan *pb.RunnerConfig) {
-	log := r.logger.Named("watch_config")
+func (r *Runner) watchConfig(
+	ctx context.Context,
+	log hclog.Logger,
+	ch <-chan *pb.RunnerConfig,
+) {
+	log = log.Named("watcher")
 	defer log.Trace("exiting goroutine")
 
 	// If we exit, the job is no longer ready since we can't be sure we're
@@ -196,17 +269,26 @@ func (r *Runner) recvConfig(
 	ctx context.Context,
 	client pb.Waypoint_RunnerConfigClient,
 	ch chan<- *pb.RunnerConfig,
+	reconnect func() error,
 ) {
 	log := r.logger.Named("config_recv")
 	defer log.Trace("exiting receive goroutine")
 
-	// On exit, we note that we're no longer connected to the config stream.
-	r.setState(&r.stateConfig, true)
-	defer r.setState(&r.stateConfig, false)
-	// On exit set the Runner state to stateExit to ensure the runner blocking
-	// on waitState is unblocked.
-	// See https://github.com/hashicorp/waypoint/pull/2571 for more information.
-	defer r.setState(&r.stateExit, true)
+	// Keep track of our first receive
+	first := true
+	reconnected := false
+
+	defer func() {
+		// Any reason we exit, this client is done so we mark we're done sending, too.
+		client.CloseSend()
+
+		// On exit, we note that we're no longer connected to the config stream.
+		// We only do this if we didn't reconnect, since reconnection will
+		// transfer ownership of stateConfig.
+		if !reconnected {
+			r.setState(&r.stateConfig, false)
+		}
+	}()
 
 	for {
 		// If the context is closed, exit
@@ -217,12 +299,39 @@ func (r *Runner) recvConfig(
 		// Wait for the next configuration
 		resp, err := client.Recv()
 		if err != nil {
+			// Note immediately that we have disconnected regardless of
+			// error type, since we've failed to receive. If we reconnect,
+			// it will reset this to true.
+			r.setState(&r.stateConfig, false)
+
+			// EOF means a graceful close, don't reconnect.
 			if err == io.EOF || clierrors.IsCanceled(err) {
+				log.Warn("EOF or cancellation received, graceful close of runner config stream")
 				return
+			}
+
+			// If we get the unavailable error then the connection died.
+			// We restablish the connection.
+			if status.Code(err) == codes.Unavailable {
+				log.Error("runner disconnected from server, attempting reconnect")
+				err = reconnect()
+
+				// If we successfully reconnected, then exit this.
+				if err == nil {
+					reconnected = true
+					return
+				}
 			}
 
 			log.Error("error receiving configuration, exiting", "err", err)
 			return
+		}
+
+		// If this is our first receive, then mark that we're connected.
+		if first {
+			log.Debug("first config received, switching config state to true")
+			first = false
+			r.setState(&r.stateConfig, true)
 		}
 
 		log.Info("new configuration received")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -301,29 +301,17 @@ func (r *Runner) Start(ctx context.Context) error {
 	// and runningCtx is tied to the full struct lifecycle rather than this
 	// single func call.
 
-	// Register
+	// Start our configuration
 	log.Debug("starting RunnerConfig stream")
-	client, err := r.client.RunnerConfig(r.runningCtx)
-	if err != nil {
-		return err
-	}
-	r.cleanup(func() { client.CloseSend() })
-
-	// Send request
-	if err := client.Send(&pb.RunnerConfigRequest{
-		Event: &pb.RunnerConfigRequest_Open_{
-			Open: &pb.RunnerConfigRequest_Open{
-				Runner: r.runner,
-			},
-		},
-	}); err != nil {
+	if err := r.initConfigStream(r.runningCtx); err != nil {
 		return err
 	}
 
-	// Start the watcher and the goroutine that receives configs
-	ch := make(chan *pb.RunnerConfig)
-	go r.watchConfig(r.runningCtx, ch)
-	go r.recvConfig(r.runningCtx, client, ch)
+	// Wait for initial registration
+	log.Debug("waiting for registration")
+	if r.waitState(&r.stateConfig, true) {
+		return status.Errorf(codes.Internal, "early exit while waiting for first config")
+	}
 
 	// Wait for the initial configuration to be set
 	log.Debug("runner registered, waiting for first config processing")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -276,7 +277,7 @@ func (r *Runner) Start(ctx context.Context) error {
 		log.Debug("requesting token with RunnerToken (initiates adoption)")
 		tokenResp, err := r.client.RunnerToken(tokenCtx, &pb.RunnerTokenRequest{
 			Runner: r.runner,
-		})
+		}, grpc.WaitForReady(true))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is the first body of work towards making runners more resilient to servers being down (and ultimately vice versa). This part focuses on the server going down or already being down during the runner startup process. 

This PR makes the runner able to tolerate the following conditions:

1. Server down prior to the runner ever starting - the runner blocks and attempts to reconnect
2. Server goes down while waiting on adoption - the runner reconnects and restarts the adoption (which is idempotent)
3. Server goes down after adoption but before the initial config stream - reconnect and re-establish initial config stream
4. Server goes down after start (adoption and config established) - reconnect to the config stream in the background

Prior to this PR, all four scenarios above would crash or exit the runner. 

All four scenarios are unit tested.

This PR _does not_ improve runner resilience with regards to job execution. That is a future PR.