### PR TITLE
builtin/vault(docs) clarify `key` value format difference

### DIFF
--- a/builtin/vault/config_sourcer.go
+++ b/builtin/vault/config_sourcer.go
@@ -333,8 +333,16 @@ config {
       key = "password"
     })
 
-    "DATABASE_HOST" = dynamic("vault", {
-      path = "kv/database-host"
+    # KV Version 2
+    "PASSWORD_FOO" = dynamic("vault", {
+      path = "secret/data/my-secret
+      key = "/data/password"  # key must be prefixed with "/data" (see below)
+    })
+
+    # KV Version 1
+    "PASSWORD_BAR" = dynamic("vault", {
+      path = "kv1/my-secret
+      key = "password"
     })
   }
 }
@@ -360,14 +368,16 @@ config {
 		"key",
 		"The key name that exists at the specified Vault `path` parameter.",
 		docs.Summary(
-			"When using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1)",
-			"secret backend, the key can be a direct key name such as `password`.",
-			"\n\nHowever, when using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2)",
+			"The value can be a direct key such as `password` or it can be a",
+			"[JSON pointer](https://tools.ietf.org/html/rfc6901) string to retrieve a nested value.",
+			"\n\nWhen using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2)",
 			"secret backend, the key must be prefixed with an additional string of `/data`. For example, `/data/password`.",
+			"\n\nWhen using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1)",
+			"secret backend, the key can be a direct key name such as `password`.",
 			"\n\nThis is because the Vault KV API returns different data structures in its response depending on",
 			"the Vault KV version the key is stored in. Therefore, the `/data` prefix is required for keys stored in",
 			"the Vault KV `Version 2` secret backend in order to retrieve its nested value using",
-			"[JSON pointer](https://tools.ietf.org/html/rfc6901) string.",
+			"JSON pointer string.",
 		),
 	)
 

--- a/builtin/vault/config_sourcer.go
+++ b/builtin/vault/config_sourcer.go
@@ -358,16 +358,16 @@ config {
 
 	doc.SetRequestField(
 		"key",
-		"The key in the structured response from the secret to read the value.",
+		"The key name that exists at the specified Vault `path` parameter.",
 		docs.Summary(
-			"This value can be a direct key such as `password` or it can be a",
-			"[JSON pointer](https://tools.ietf.org/html/rfc6901) string to retrieve",
-			"a nested value. This is because Vault secrets can be any arbitrary",
-			"structure, not just simple key/value mappings. An example of a JSON pointer",
-			"value would be `/data/username/`.",
-			"\n\nWhen using the Vault KV secret backend, the key typically has to be",
-			"prefixed with `/data` because the Vault KV API returns the data nested under",
-			"the `data` key. For example: `/data/username`.",
+			"When using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1)",
+			"secret backend, the key can be a direct key name such as `password`.",
+			"\n\nHowever, when using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2)",
+			"secret backend, the key must be prefixed with an additional string of `/data`. For example, `/data/password`.",
+			"\n\nThis is because the Vault KV API returns different data structures in its response depending on",
+			"the Vault KV version the key is stored in. Therefore, the `/data` prefix is required for keys stored in",
+			"the Vault KV `Version 2` secret backend in order to retrieve its nested value using",
+			"[JSON pointer](https://tools.ietf.org/html/rfc6901) string.",
 		),
 	)
 

--- a/website/content/partials/components/configsourcer-vault.mdx
+++ b/website/content/partials/components/configsourcer-vault.mdx
@@ -30,9 +30,9 @@ These parameters are used in `dynamic` for sourcing [configuration values](/docs
 
 #### key
 
-The key in the structured response from the secret to read the value.
+The key name that exists at the specified Vault `path` parameter.
 
-This value can be a direct key such as `password` or it can be a [JSON pointer](https://tools.ietf.org/html/rfc6901) string to retrieve a nested value. This is because Vault secrets can be any arbitrary structure, not just simple key/value mappings. An example of a JSON pointer value would be `/data/username/`. When using the Vault KV secret backend, the key typically has to be prefixed with `/data` because the Vault KV API returns the data nested under the `data` key. For example: `/data/username`.
+When using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1) secret backend, the key can be a direct key name such as `password`. However, when using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) secret backend, the key must be prefixed with an additional string of `/data`. For example, `/data/password`. This is because the Vault KV API returns different data structures in its response depending on the Vault KV version the key is stored in. Therefore, the `/data` prefix is required for keys stored in the Vault KV `Version 2` secret backend in order to retrieve its nested value using [JSON pointer](https://tools.ietf.org/html/rfc6901) string.
 
 - Type: **string**
 

--- a/website/content/partials/components/configsourcer-vault.mdx
+++ b/website/content/partials/components/configsourcer-vault.mdx
@@ -17,8 +17,16 @@ config {
       key = "password"
     })
 
-    "DATABASE_HOST" = dynamic("vault", {
-      path = "kv/database-host"
+    # KV Version 2
+    "PASSWORD_FOO" = dynamic("vault", {
+      path = "secret/data/my-secret
+      key = "/data/password"  # key must be prefixed with "/data" (see below)
+    })
+
+    # KV Version 1
+    "PASSWORD_BAR" = dynamic("vault", {
+      path = "kv1/my-secret
+      key = "password"
     })
   }
 }
@@ -32,7 +40,7 @@ These parameters are used in `dynamic` for sourcing [configuration values](/docs
 
 The key name that exists at the specified Vault `path` parameter.
 
-When using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1) secret backend, the key can be a direct key name such as `password`. However, when using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) secret backend, the key must be prefixed with an additional string of `/data`. For example, `/data/password`. This is because the Vault KV API returns different data structures in its response depending on the Vault KV version the key is stored in. Therefore, the `/data` prefix is required for keys stored in the Vault KV `Version 2` secret backend in order to retrieve its nested value using [JSON pointer](https://tools.ietf.org/html/rfc6901) string.
+The value can be a direct key such as `password` or it can be a [JSON pointer](https://tools.ietf.org/html/rfc6901) string to retrieve a nested value. When using the Vault KV [Version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) secret backend, the key must be prefixed with an additional string of `/data`. For example, `/data/password`. When using the Vault KV [Version 1](https://www.vaultproject.io/docs/secrets/kv/kv-v1) secret backend, the key can be a direct key name such as `password`. This is because the Vault KV API returns different data structures in its response depending on the Vault KV version the key is stored in. Therefore, the `/data` prefix is required for keys stored in the Vault KV `Version 2` secret backend in order to retrieve its nested value using JSON pointer string.
 
 - Type: **string**
 


### PR DESCRIPTION
This PR attempts to improve the current ambiguous description of the `key` parameter in the `vault` configsourcer doc:
https://www.waypointproject.io/plugins/vault#key

Basically, keys stored in the "KV2" (KV version 2) secret engine must be prefixed with `/data`.

```hcl
    PASSWORD_KV1 = dynamic("vault", {
      path = "kv1/my-secret"
      key = "password"
    })
    PASSWORD_KV2 = dynamic("vault", {
      path = "kv2/data/my-secret"
      key = "/data/password"  # super confusing
    })
```

ref. https://github.com/hashicorp/waypoint/blob/v0.7.2/builtin/vault/config_sourcer.go#L188

This is how `cachedSecretVal.Secret.Data` looks different between KV and KV2:

KV:
> map[string]interface {}{“password”:“foobar”}

KV2:
> map[string]interface {}{“data”:map[string]interface {}{“password”:“foobar”}, “metadata”:map[string]interface {}{“created_time”:“2022-03-10T18:14:10.883066333Z”, “custom_metadata”:interface {}(nil), “deletion_time”:“”, “destroyed”:false, “version”:“1"}}