### PR TITLE
More HDS hack spike: swap out components and bump ember-flight-icons

### DIFF
--- a/ui/app/components/app-item/deployment.hbs
+++ b/ui/app/components/app-item/deployment.hbs
@@ -11,7 +11,7 @@
     @route="workspace.projects.project.app.deployments.deployment"
     @models={{array @deployment.sequence}}
   >
-    <b class="badge badge--version">v{{@deployment.sequence}}</b>
+    <Hds::Badge @text="v{{@deployment.sequence}}" @size="small" @color="neutral-dark-mode" />
     <div class="app-item__deployment-state">
       {{!-- ROW: health check + deployment URL --}}
       {{#if @deployment.statusReport.health}}

--- a/ui/app/components/login-token/index.hbs
+++ b/ui/app/components/login-token/index.hbs
@@ -17,10 +17,8 @@
       placeholder={{t 'login.input.placeholder'}} />
   </fieldset>
 
-  <button
-    data-test-login-submit
-    type="submit"
-    class="button button--primary">
-    {{t 'login.button'}}
-  </button>
+  {{!-- Note: Because Hds::Button and Hds::LinkTo::Standalone's require an icon and text, the text 
+  isn't centered in the component container, but in the space not including the icon. So 
+  this swap out makes the centered text uneven with the "Authenticate with OIDC" LinkTo below --}}
+  <Hds::Button @text={{t 'login.button'}} @icon="clipboard-copy" data-test-login-submit />
 </form>

--- a/ui/app/styles/pages/auth-page.scss
+++ b/ui/app/styles/pages/auth-page.scss
@@ -80,3 +80,8 @@
     }
   }
 }
+
+.hds-linkto-parent {
+  display: flex;
+  justify-content: center;
+}

--- a/ui/app/templates/auth/index.hbs
+++ b/ui/app/templates/auth/index.hbs
@@ -3,10 +3,8 @@
 {{#if @model.authMethodsList}}
   <OidcAuthButtons @model={{@model}}/>
 {{else}}
-  <p>
-    <LinkTo @route="auth.token" class="button button--primary">
-      {{t 'auth.button'}}
-    </LinkTo>
+  <p class="hds-linkto-parent">
+    <Hds::LinkTo::Standalone @text='Authenticate' @icon="arrow-right" @iconPosition="trailing" @route="auth.token" />
   </p>
   <hr />
   <p>

--- a/ui/app/templates/auth/token.hbs
+++ b/ui/app/templates/auth/token.hbs
@@ -5,11 +5,13 @@
 
 <hr />
 <small>
+  {{!-- Did not swap out for Hds::LinkTo::Standalone because component requires an icon --}}
   <LinkTo @route="auth">{{t 'login.oidc_link'}}</LinkTo>
 </small>
 <hr />
 <small>
   Received an invite?
+  {{!-- Did not swap out for Hds::LinkTo::Standalone because component requires an icon --}}
   <LinkTo @route="auth.invite">Redeem invite</LinkTo>
 </small>
 

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -20,10 +20,7 @@
       {{/if}}
     </small>
   </div>
-  <Pds::CtaLink @route="workspace.projects.new" @variant="secondary "class="pds--iconStart">
-    <FlightIcon @name="plus" class="pds-button__iconStart"/>
-    &nbsp;{{t "form.project_new.title"}}
-  </Pds::CtaLink>
+  <Hds::LinkTo::Standalone @text={{t "form.project_new.title"}} @icon="plus" @iconPosition="leading" @route="workspace.projects.new" />
 </PageHeader>
 
 <div data-test-project-list>

--- a/ui/package.json
+++ b/ui/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "@hashicorp/design-system-components": "^0.1.1",
-    "@hashicorp/ember-flight-icons": "^2.0.0",
+    "@hashicorp/ember-flight-icons": "^2.0.2",
     "@types/google-protobuf": "^3.7.2",
     "api-common-protos": "link:./lib/api-common-protos",
     "ember-cli-typescript-blueprints": "^3.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2348,16 +2348,7 @@
   resolved "https://registry.yarnpkg.com/@hashicorp/design-system-tokens/-/design-system-tokens-0.5.1.tgz#5030214f4f94187733a782b4d0d25a4bf806b297"
   integrity sha512-Sw4MK6pRTuHoX+xsrwUROhPxTqxWAlyTDrxkPY347+HZwHf7uSi+BspXotFeNoZKyojM5JGX7F1IfbjDIxnc/g==
 
-"@hashicorp/ember-flight-icons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.0.tgz#d4eb9082fe6579c54d481de4f1644f0c3188f37c"
-  integrity sha512-mCOyha0YnZjQcEomm2FKKL74BBvTrVJVjicxh+P5yu+Yo8hmiFOr0PbaoOuLrFOxsHsd33VW6Y5uskcZivR1tQ==
-  dependencies:
-    "@hashicorp/flight-icons" "^2.0.0"
-    ember-cli-babel "^7.26.6"
-    ember-cli-htmlbars "^5.7.1"
-
-"@hashicorp/ember-flight-icons@^2.0.1":
+"@hashicorp/ember-flight-icons@^2.0.1", "@hashicorp/ember-flight-icons@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-2.0.2.tgz#05aded9992922d00e62bdf95d99e188905494095"
   integrity sha512-OBye+O1RdHNXUcy3W+WEHyORY45E5QUVZrKH7wDCN1qxcuUkQTIN1DRn41W+s9B7S+N+Xyg7YNdrfZbRmZPUuA==
@@ -2365,11 +2356,6 @@
     "@hashicorp/flight-icons" "^2.1.1"
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.0.1"
-
-"@hashicorp/flight-icons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.0.0.tgz#84910c97f2bc643a6ca039ca7ed9be0bf14f8ee2"
-  integrity sha512-jNRHHCFvptOHLXPIlnZ4A1LIFtS6m+Bv72NsE3Pl7KHMwcqkLHDN8gNa6AHf80cvFE+pR3sEx6Yjxu79jWJczQ==
 
 "@hashicorp/flight-icons@^2.1.1":
   version "2.1.1"


### PR DESCRIPTION
Bump ember-flight-icons
  - Have same versions in the yarn.lock, one comes from design-system-components (re: https://github.com/hashicorp/waypoint/pull/3084#discussion_r824113529)
  
Swap `Hds::LinkTo::Standalone` for `Pds::CtaLink`
  - The `Hds::LinkTo::Standalone` is intentionally not styled like a button
<img width="486" alt="image" src="https://user-images.githubusercontent.com/1372946/157779125-a2cb832e-8842-445b-94a6-395d3db945d7.png">

Swap `Hds::Button` for button
  - Left some notes about the LinkTo's on the same screen. I did not swap them out here since the `Hds::Link (Standalone)` / `HDS::LinkTo (Standalone)` component requires an icon (is why looks off center with the below link)

<img width="467" alt="image" src="https://user-images.githubusercontent.com/1372946/157779284-b17d42c2-cc59-4022-8f1a-ad2645569e2a.png">

Swap `Hds::Badge` for class="badge badge--version"
  - Went with @color="neutral-dark-mode" because of the existing grey background row select

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/1372946/157778559-a11bc4c8-435c-41f2-bb2e-c2654283dceb.png">

Replaces: https://github.com/hashicorp/waypoint/pull/3084

Note: Since the HDS components do not have dark mode by default, that would be a blocker for production
