### PR TITLE
cli: Fix panic in `waypoint plugin` cli

### DIFF
--- a/.changelog/3095.txt
+++ b/.changelog/3095.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix panic in `waypoint plugin` CLI
+```

--- a/website/content/commands/plugin.mdx
+++ b/website/content/commands/plugin.mdx
@@ -15,7 +15,9 @@ Execute a built-in plugin.
 
 ## Usage
 
-Usage: `waypoint plugin [options]`
+Usage: `waypoint plugin [options] <plugin>`
+
+Runs a specified plugin directly.
 
 #### Global Options
 
@@ -26,6 +28,6 @@ Usage: `waypoint plugin [options]`
 
 #### Command Options
 
-- `-debug` - set to true to run the plugin with support for debuggers like delve
+- `-debug` - Set to true to run the plugin with support for debuggers like delve.
 
 @include "commands/plugin_more.mdx"


### PR DESCRIPTION
Prior to this commit, if a user just ran `waypoint plugin` with no
arguments, the CLI would panic assuming that an argument was passed in.
This commit fixes that by looking at the argument slice and printing an
error if none was passed in. It fixes up some of the other panics to
print errors and return 1.