### PR TITLE
internal/runner: make Accept resilient to the server going down

### DIFF
--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -132,7 +132,7 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 				// RunnerConfig stream to re-establish. We wait for the config
 				// generation to increment.
 				if r.waitStateGreater(&r.stateConfig, stateGen) {
-					return status.Errorf(codes.Internal, "early exit while waiting for reconnect")
+					return status.Error(codes.Internal, "early exit while waiting for reconnect")
 				}
 
 				continue

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -81,10 +81,9 @@ type Runner struct {
 	// also verify the context didn't cancel. The stateCond will be broadcasted
 	// when the root context cancels.
 	stateCond       *sync.Cond
-	stateConfig     uint64 // config stream is connected
-	stateConfigOnce uint64 // true once we process config once, success or error
-	stateJobReady   uint64 // ready to start accepting jobs
-	stateExit       uint64 // true when exiting
+	stateConfig     uint64 // config stream is connected, increments for each reconnect
+	stateConfigOnce uint64 // >0 once we process config once, success or error
+	stateExit       uint64 // >0 when exiting
 
 	// config is the current runner config.
 	config      *pb.RunnerConfig


### PR DESCRIPTION
This starts by addressing only the initial job stream opening. This still does not add any resilience after the job stream is open (i.e. when a job is running).

I'm opening this PR early since this required some changes to how we track the state of the underlying runner config and it is complex enough on the surface that I didn't want to complicate a future PR. Additionally, this PR on its own still incrementally makes the runner more resilient to failure modes.

This PR builds on #3087 and adds the following scenarios the runner can now withstand:

* The server goes down after runner start but prior to `Accept`.
* The server goes down during `Accept` (its a stream, so while the initial handshake is blocking)
* The runner registration is disconnected at some point prior to or during `Accept`. This is usually due to the server going down, but the behavior that the runner sees is the same. 
  - This last one in particular is nice to resolve since the error was not obvious. The error returned to users was "runner not found". This is no longer possible.

## Runner State from Booleans to Monotonic Ints

A core change made here is the change from a set of booleans to represent state to monotonic unsigned ints. This lets us still retain the boolean-like behavior (anything greater than 0 is "true") while also giving us some "happens after" semantics we can check. This is important because on disconnect, we need to detect when we're reconnected _after_ the disconnect. Before, we only had a true/false of whether we were connected, and it was a race to determine if the "true" was still "true" because we hadn't yet detected its "false." Numbers solve this.

As a bonus, changing to this method let us remove a few cases that required special handling :) 