### PR TITLE
internal/server: RunnerJobStream verifies runner tokens

### DIFF
--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -21031,6 +21031,8 @@ type RunnerJobStreamRequest_Request struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The ID of the runner opening the job stream. This ID must match
+	// the ID of the runner token in use.
 	RunnerId string `protobuf:"bytes,1,opt,name=runner_id,json=runnerId,proto3" json:"runner_id,omitempty"`
 }
 

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -7606,7 +7606,8 @@
       "type": "object",
       "properties": {
         "runner_id": {
-          "type": "string"
+          "type": "string",
+          "description": "The ID of the runner opening the job stream. This ID must match\nthe ID of the runner token in use."
         }
       }
     },

--- a/pkg/server/proto/server.proto
+++ b/pkg/server/proto/server.proto
@@ -2385,6 +2385,8 @@ message RunnerJobStreamRequest {
   }
 
   message Request {
+    // The ID of the runner opening the job stream. This ID must match
+    // the ID of the runner token in use.
     string runner_id = 1;
   }
 


### PR DESCRIPTION
This fixes a possible vulnerability with runner adoption. Note this
vulnerability is not in any released Waypoint version, so there is no
broad communication necessary.

We were not validating the runner token against the runner identity for
RunnerJobStream. So long as the token was valid, any runner could
request a job impersonating any other runner. This did require that the
runner was authenticated already.

This adds token verification and a unit test to validate it.