### PR TITLE
chore: `make install` conditionally remove existing waypoint file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ bin/entrypoint: # create the entrypoint for the current platform
 
 .PHONY: install
 install: bin # build and copy binaries to $GOPATH/bin/waypoint
+ifneq ("$(wildcard $(GOPATH)/bin/waypoint)","")
 	rm $(GOPATH)/bin/waypoint
+endif
 	mkdir -p $(GOPATH)/bin
 	cp ./waypoint $(GOPATH)/bin/waypoint
 


### PR DESCRIPTION
If you don't have a `waypoint` file at `$(GOPATH)/bin` then `make install` fails here.

But you could just as easily `touch $GOPATH/bin/waypoint`.