### PR TITLE
Fix paths to proto files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,12 @@ gen/ts:
 	@rm -rf ./ui/lib/api-common-protos/google 2> /dev/null
 	protoc -I=. \
 		-I=./thirdparty/proto/api-common-protos/ \
-		./internal/server/proto/server.proto \
+		./pkg/server/proto/server.proto \
 		--js_out=import_style=commonjs:ui/lib/waypoint-pb/ \
 		--grpc-web_out=import_style=typescript,mode=grpcwebtext:ui/lib/waypoint-client/
-	@mv ./ui/lib/waypoint-client/internal/server/proto/* ./ui/lib/waypoint-client/
+	@mv ./ui/lib/waypoint-client/pkg/server/proto/* ./ui/lib/waypoint-client/
 	@mv ./ui/lib/waypoint-client/server_pb.d.ts ./ui/lib/waypoint-pb/
-	@mv ./ui/lib/waypoint-pb/internal/server/proto/* ./ui/lib/waypoint-pb/
+	@mv ./ui/lib/waypoint-pb/pkg/server/proto/* ./ui/lib/waypoint-pb/
 	# Hack: fix import of api-common-protos and various JS/TS imports
 	# These issues below will help:
 	#   https://github.com/protocolbuffers/protobuf/issues/5119
@@ -150,7 +150,7 @@ gen/doc:
 	protoc -I=. \
 		-I=./thirdparty/proto/api-common-protos/ \
 		--doc_out=./doc --doc_opt=html,index.html \
-		./internal/server/proto/server.proto
+		./pkg/server/proto/server.proto
 
 .PHONY: gen/website-mdx
 gen/website-mdx:


### PR DESCRIPTION
Some of our make commands referenced the old path to our protobufs. This fixes the `make gen/doc` and `make gen/ts` commands.

Closes https://github.com/hashicorp/waypoint/issues/3080