### PR TITLE
K8s: Don't error/hang if deleting a service that isn't found

### DIFF
--- a/.changelog/3111.txt
+++ b/.changelog/3111.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/k8s: fix issue when destroying multiple deployments
+```

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -338,6 +338,7 @@ func (r *Releaser) resourceServiceCreate(
 
 func (r *Releaser) resourceServiceDestroy(
 	ctx context.Context,
+	log hclog.Logger,
 	state *Resource_Service,
 	sg terminal.StepGroup,
 	csinfo *clientsetInfo,
@@ -361,6 +362,7 @@ func (r *Releaser) resourceServiceDestroy(
 		if !errors.IsNotFound(err) {
 			return err
 		}
+		log.Debug("no service found, continuing")
 	}
 
 	step.Update("Service deleted")

--- a/builtin/k8s/releaser.go
+++ b/builtin/k8s/releaser.go
@@ -358,7 +358,9 @@ func (r *Releaser) resourceServiceDestroy(
 
 	step = sg.Add("Deleting service...")
 	if err := serviceclient.Delete(ctx, state.Name, metav1.DeleteOptions{}); err != nil {
-		return err
+		if !errors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	step.Update("Service deleted")


### PR DESCRIPTION
If a K8s deployment has multiple active deployments and a user runs `waypoint destroy -auto-approve`, Waypoint will hang trying to destroy the service multiple times. 

Here we check to see if the service is not found, and if so simply continue.