### PR TITLE
Fix bug in concurrent step groups with remote runner

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -447,10 +447,6 @@ func (c *Project) queueAndStreamJob(
 
 					ui.Table(tbl)
 				case *pb.GetJobStreamResponse_Terminal_Event_StepGroup_:
-					if sg != nil {
-						sg.Wait()
-					}
-
 					if !ev.StepGroup.Close {
 						sg = ui.StepGroup()
 					}


### PR DESCRIPTION
## What problem does this fix?

Currently, if you try to send two open step groups from a remote runner, the client blocks forever. 

To reproduce:

- Run a waypoint server and runner locally
- Configure a project for remote builds (e.x. `waypoint project apply -data-source="git" -git-url="https://github.com/hashicorp/waypoint-examples" -git-path="docker/static" -git-ref=main nginx-project`)
- Run `waypoint build -project=nginx-project -local=false`
- Observe the following output:

```
$ waypoint build -local=false

» Building web...
There are local changes that do not match the remote repository. By default,
Waypoint will perform this operation using a remote runner that will use the
remote repository’s git ref and not these local changes. For these changes
to be used for future operations, either commit and push, or run the operation
locally with the -local flag.
  Performing this operation on a remote runner with id "01FYFF8QE03Y02PM8R2GHY9TQV"

» Cloning data from Git
  URL: https://github.com/hashicorp/waypoint-examples
  Ref: main
⠹ Running build v1
```
It hangs on `Running build v1` forever. It doesn't even respect ctrl-c! (a separate bug)

The problem surfaced since https://github.com/hashicorp/waypoint/pull/3081, when we started emitting concurrent step groups for most ops.

## Root cause

The problem comes in when the second step group comes in as an event from the server to the client. The client sees it has an existing step group, and calls sg.Wait(), which never returns.

## This solution

In practice, if we remove that call to `sg.Wait()`, everything seems to just work. It tracks the concurrent step groups correctly. With this change in place:

Note two concurrent open step groups:
<img width="824" alt="Screen Shot 2022-03-18 at 5 30 44 PM" src="https://user-images.githubusercontent.com/8404559/159086918-3094df8b-1a6f-43d2-9bd9-b41378b32ba1.png">

Note the UI has closed the two step groups from above, and opened then next one:
<img width="818" alt="Screen Shot 2022-03-18 at 5 31 53 PM" src="https://user-images.githubusercontent.com/8404559/159086935-1ce7612a-abd1-4c92-bb75-36197ef982fd.png">

## Unknowns

I admit I have not fully wrapped my head around this step group logic. It sure looks to me like, by setting one global `sg` var inside this event loop, we should only be able to track one step group concurrently. But it works empirically!

If anyone knows why were were calling `sg.Wait()` there in the first place, or why the step groups are all closing when they're supposed to, i'm all ears. But this is a pretty pressing bug and the fix seems to work in practice.


