### PR TITLE
`runner list` shows runner labels

### DIFF
--- a/.changelog/3133.txt
+++ b/.changelog/3133.txt
@@ -1,0 +1,4 @@
+```
+release-note:improvement
+cli: `runner list` shows runner labels
+```

--- a/internal/cli/runner_list.go
+++ b/internal/cli/runner_list.go
@@ -59,7 +59,7 @@ func (c *RunnerListCommand) Run(args []string) int {
 		return 0
 	}
 
-	tblHeaders := []string{"ID", "State", "Kind", "Last Registered"}
+	tblHeaders := []string{"ID", "State", "Kind", "Labels", "Last Registered"}
 	tbl := terminal.NewTable(tblHeaders...)
 
 	var kindStr string
@@ -87,10 +87,16 @@ func (c *RunnerListCommand) Run(args []string) int {
 			stateStr = "unknown"
 		}
 
+		var labelStr string
+		for k, v := range r.Labels {
+			labelStr += k + ":" + v + " "
+		}
+
 		tblColumn := []string{
 			r.Id,
 			stateStr,
 			kindStr,
+			labelStr,
 			lastSeenStr,
 		}
 


### PR DESCRIPTION
Adds a "labels" column in `runner list`.

```
❯ waypointdev runner list
              ID             |   STATE    |  KIND  |          LABELS           | LAST REGISTERED  
-----------------------------+------------+--------+---------------------------+------------------
  prod-static                | adopted    | remote |                           | 1 month ago      
  dev-static                 | preadopted | remote |                           | 1 week ago       
  01FYT7AKV1QNPDYKE1WNH87TH4 | preadopted | remote | region:testland env:test  | 5 seconds ago   
```
