### PR TITLE
CLI respects server ordering

### DIFF
--- a/internal/cli/artifact_list.go
+++ b/internal/cli/artifact_list.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-	serversort "github.com/hashicorp/waypoint/pkg/server/sort"
 )
 
 type ArtifactListCommand struct {
@@ -75,7 +74,6 @@ func (c *ArtifactListCommand) Run(args []string) int {
 			)
 			return nil
 		}
-		sort.Sort(serversort.ArtifactStartDesc(resp.Artifacts))
 
 		if c.flagJson {
 			return c.displayJson(resp.Artifacts)

--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/version"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-	serversort "github.com/hashicorp/waypoint/pkg/server/sort"
 )
 
 type DeploymentListCommand struct {
@@ -144,7 +143,6 @@ func (c *DeploymentListCommand) Run(args []string) int {
 			)
 			return nil
 		}
-		sort.Sort(serversort.DeploymentBundleCompleteDesc(resp.Deployments))
 
 		if c.flagJson {
 			return c.displayJson(resp.Deployments)

--- a/internal/cli/release_list.go
+++ b/internal/cli/release_list.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/version"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-	serversort "github.com/hashicorp/waypoint/pkg/server/sort"
 )
 
 type ReleaseListCommand struct {
@@ -91,7 +90,6 @@ func (c *ReleaseListCommand) Run(args []string) int {
 			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 			return ErrSentinel
 		}
-		sort.Sort(serversort.ReleaseBundleCompleteDesc(resp.Releases))
 
 		if c.flagJson {
 			return c.displayJson(resp.Releases)


### PR DESCRIPTION
It's up to the server to choose the order (based on the -order-by and -desc flags).

NOTE: the server, in practice, doesn't respect any of the ordering flags. It only references the COMPLETE_TIME index (in app_operation), and totally ignores `-desc` and `-order-by=start-time` options.

In practice, this doesn't change any behavior - operations always come in ordered by sequence id, descending. But this opens the door for us to fix this in the server later (or for other server implementations to do this right).