### PR TITLE
Deprecate `-env-vars` flag in `runner profile set`, replace with `-env-var`

### DIFF
--- a/.changelog/3136.txt
+++ b/.changelog/3136.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: `runner profile set` deprecates the `-env-vars` flag in favor of the `-env-var` flag instead.
+```

--- a/pkg/server/gen/server.pb.json.go
+++ b/pkg/server/gen/server.pb.json.go
@@ -655,6 +655,7 @@ func (msg *Ref_Runner) UnmarshalJSON(b []byte) error {
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)
+<<<<<<< HEAD
 }
 
 // MarshalJSON implements json.Marshaler
@@ -673,6 +674,8 @@ func (msg *Ref_RunnerAny) UnmarshalJSON(b []byte) error {
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)
+=======
+>>>>>>> 75edb3685 (gen website and server)
 }
 
 // MarshalJSON implements json.Marshaler
@@ -694,7 +697,11 @@ func (msg *Ref_RunnerId) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+<<<<<<< HEAD
 func (msg *Ref_RunnerLabels) MarshalJSON() ([]byte, error) {
+=======
+func (msg *Ref_RunnerAny) MarshalJSON() ([]byte, error) {
+>>>>>>> 75edb3685 (gen website and server)
 	var buf bytes.Buffer
 	err := (&jsonpb.Marshaler{
 		EnumsAsInts:  false,
@@ -705,7 +712,11 @@ func (msg *Ref_RunnerLabels) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
+<<<<<<< HEAD
 func (msg *Ref_RunnerLabels) UnmarshalJSON(b []byte) error {
+=======
+func (msg *Ref_RunnerAny) UnmarshalJSON(b []byte) error {
+>>>>>>> 75edb3685 (gen website and server)
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)

--- a/pkg/server/gen/server.pb.json.go
+++ b/pkg/server/gen/server.pb.json.go
@@ -655,7 +655,6 @@ func (msg *Ref_Runner) UnmarshalJSON(b []byte) error {
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)
-<<<<<<< HEAD
 }
 
 // MarshalJSON implements json.Marshaler
@@ -674,8 +673,6 @@ func (msg *Ref_RunnerAny) UnmarshalJSON(b []byte) error {
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)
-=======
->>>>>>> 75edb3685 (gen website and server)
 }
 
 // MarshalJSON implements json.Marshaler
@@ -697,11 +694,7 @@ func (msg *Ref_RunnerId) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
-<<<<<<< HEAD
 func (msg *Ref_RunnerLabels) MarshalJSON() ([]byte, error) {
-=======
-func (msg *Ref_RunnerAny) MarshalJSON() ([]byte, error) {
->>>>>>> 75edb3685 (gen website and server)
 	var buf bytes.Buffer
 	err := (&jsonpb.Marshaler{
 		EnumsAsInts:  false,
@@ -712,11 +705,7 @@ func (msg *Ref_RunnerAny) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-<<<<<<< HEAD
 func (msg *Ref_RunnerLabels) UnmarshalJSON(b []byte) error {
-=======
-func (msg *Ref_RunnerAny) UnmarshalJSON(b []byte) error {
->>>>>>> 75edb3685 (gen website and server)
 	return (&jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}).Unmarshal(bytes.NewReader(b), msg)

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -38,7 +38,8 @@ lifecycle operation.
 
 - `-name=<string>` - The name of an existing runner profile to update.
 - `-oci-url=<string>` - The url for the OCI image to launch for the on-demand runner.
-- `-env-vars=<string>` - Environment variable to expose to the on-demand runner. Typically used to introduce configuration for the plugins that the runner will execute. Can be specified multiple times.
+- `-env-var=<key=value>` - Environment variable to expose to the on-demand runner set in 'k=v' format. Typically used to introduce configuration for the plugins that the runner will execute. Can be specified multiple times.
+- `-env-vars=<string>` - DEPRECATED. Please see `-env-var`.
 - `-plugin-type=<string>` - The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.
 - `-plugin-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
 - `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner.


### PR DESCRIPTION
Per an internal discussion, we have decided to standardize using singular flags with `-flag=key=value` format to define repeatable configuration variables.

For example, instead of:

`runner profile set -plugin-type=docker -env-vars="foo=bar,bar=baz"`

the new standard is:

`runner profile set -plugin-type=docker -env-var=foo=bar -env-var=bar=baz`