### PR TITLE
ui: fix release URL button

### DIFF
--- a/.changelog/3142.txt
+++ b/.changelog/3142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix missing link on release detail page
+```

--- a/ui/app/controllers/workspace/projects/project/app/release.ts
+++ b/ui/app/controllers/workspace/projects/project/app/release.ts
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+import { Model } from 'waypoint/routes/workspace/projects/project/app/release';
+import { tracked } from '@glimmer/tracking';
+
+export default class extends Controller {
+  @tracked model!: Model;
+
+  get shouldShowURL(): boolean {
+    return !!this.model.url && this.isLatest;
+  }
+
+  get isLatest(): boolean {
+    return this.model.id === this.model.latestRelease?.id;
+  }
+}

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -5,6 +5,7 @@ import { Model as AppRouteModel } from '../app';
 import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { ReleaseExtended } from 'waypoint/services/api';
 import { TimelineModel } from '../../../../../components/timeline';
+import { Operation } from 'waypoint-pb';
 
 type Params = { sequence: string };
 
@@ -12,7 +13,11 @@ interface WithTimeline {
   timeline: TimelineModel;
 }
 
-export type Model = ReleaseExtended & WithTimeline;
+interface WithLatest {
+  latestRelease?: ReleaseExtended;
+}
+
+export type Model = ReleaseExtended & WithTimeline & WithLatest;
 
 export default class ReleaseDetail extends Route {
   @service api!: ApiService;
@@ -45,6 +50,7 @@ export default class ReleaseDetail extends Route {
     let deployment = deployments.find((obj) => obj.id === release?.deploymentId);
     let deploymentArtifactId = deployment?.pushedArtifact?.id ?? deployment?.artifactId;
     let build = builds.find((obj) => obj.pushedArtifact?.id === deploymentArtifactId);
+    let latestRelease = releases.find((r) => r.state === Operation.PhysicalState.CREATED);
 
     let timeline: TimelineModel = {};
     if (build) {
@@ -68,6 +74,6 @@ export default class ReleaseDetail extends Route {
     };
     timeline.release = releaseObj;
 
-    return { ...release, timeline };
+    return { ...release, timeline, latestRelease };
   }
 }

--- a/ui/app/templates/workspace/projects/project/app/release.hbs
+++ b/ui/app/templates/workspace/projects/project/app/release.hbs
@@ -3,11 +3,15 @@
 {{#if (not-eq this.target.currentRouteName "workspace.projects.project.app.release.resource")}}
   <PanelHeader @artifact="release" @sequence={{@model.sequence}}>
     <:actions>
-      {{#if @isLatest}}
-        <button class="button button--primary" type="button">
-          <span>{{@model.release.url}}</span>
+      {{#if this.shouldShowURL}}
+        <ExternalLink
+          href={{enforce-protocol @model.url}}
+          class="button button--primary button--external-link"
+          data-test-release-url
+        >
+          <span>{{lowercase @model.url}}</span>
           <FlightIcon @name="external-link" class="icon" />
-        </button>
+        </ExternalLink>
       {{/if}}
     </:actions>
   </PanelHeader>

--- a/ui/mirage/factories/release.ts
+++ b/ui/mirage/factories/release.ts
@@ -21,7 +21,7 @@ export default Factory.extend({
       'common/vcs-ref': '0d56a9f8456b088dd0e4a7b689b842876fd47352',
       'common/vcs-ref-path': 'https://github.com/hashicorp/waypoint/commit/',
     }),
-    url: 'https://wildly-intent-honeybee.waypoint.run',
+    url: 'https://wp-matrix.example',
   }),
 
   nomad: trait({

--- a/ui/tests/acceptance/release-detail-test.ts
+++ b/ui/tests/acceptance/release-detail-test.ts
@@ -40,4 +40,33 @@ module('Acceptance | release detail', function (hooks) {
 
     assert.equal(currentURL(), `/default/acme-project/app/acme-app/release/seq/${release.sequence}`);
   });
+
+  test('displays the URL where appropriate', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    // Old superceded release
+    this.server.create('release', 'random', {
+      application,
+      sequence: 1,
+      state: 'CREATED',
+      url: 'https://acme-app.test',
+    });
+    // New active release
+    this.server.create('release', 'random', {
+      application,
+      sequence: 2,
+      state: 'CREATED',
+      url: 'https://acme-app.test',
+    });
+
+    await visit('/default/acme-project/app/acme-app/release/seq/1');
+
+    assert.dom('[data-test-release-url]').doesNotExist('Doesn’t show the URL for an old release');
+
+    await visit('/default/acme-project/app/acme-app/release/seq/2');
+
+    assert
+      .dom('[data-test-release-url]')
+      .hasText('https://acme-app.test', 'Shows the URL for the active release');
+  });
 });


### PR DESCRIPTION
## Why the change?

This button/link wasn’t working. Looks like it night never have worked. The tell-tale sign is the presence of `@isLatest` in the template. The only `@argument` route templates receive is `@model`. `@isLatest` will always be falsey. This adds the release URL back in.

## What’s the plan?

- [x] Fix the button
- [x] Fix the mirage data (it was showing a `waypoint.run` URL as a release URL)
- [x] Figure out if `isLatest` is still important, and what to do about it
- [x] Add a regression test
- [x] Add a changelog entry

## What does it look like?

### Before

<img width="1360" alt="CleanShot 2022-03-25 at 13 19 28@2x" src="https://user-images.githubusercontent.com/34030/160119868-be92ef73-f2ad-4dd9-9a24-275ed3f02724.png">

### After

<img width="1360" alt="CleanShot 2022-03-25 at 13 19 12@2x" src="https://user-images.githubusercontent.com/34030/160119884-a33359a9-0c0c-4068-b180-d6de413460b3.png">

## How do I test it?

1. `git checkout ui/fix-release-url-button`
2. `cd ui`
3. `yarn start`
4. `open http://localhost:4200/default/marketing-public/app/wp-matrix/release/seq/3`
5. Verify you see the release URL