### PR TITLE
Delete job and pods in k8s StopTask if stuck in pending

### DIFF
--- a/.changelog/3143.txt
+++ b/.changelog/3143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/k8s: clean up pending pods from cancelled jobs
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -480,7 +480,7 @@ func configureContainer(
 			}
 			resourceRequests[resourceName] = q
 		} else {
-			log.Warn("ignoring unrecognized k8s resources key: %q", k)
+			log.Warn("ignoring unrecognized k8s resources key", "key", k)
 		}
 	}
 
@@ -622,7 +622,7 @@ func (p *Platform) resourceDeploymentCreate(
 
 	// App container must have some kind of port
 	if len(appContainerSpec.Ports) == 0 {
-		log.Warn("No ports defined in waypoint.hcl - defaulting to http on port %d", DefaultServicePort)
+		log.Warn("No ports defined in waypoint.hcl - defaulting to http on port", "port", DefaultServicePort)
 		appContainerSpec.Ports = append(appContainerSpec.Ports, &Port{Port: DefaultServicePort, Name: "http"})
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/2641 by deleting the Kubernetes job and examining any pods stuck in `Pending` for the given job. Optionally we can expand to delete [other pods phases](https://pkg.go.dev/k8s.io/api@v0.23.5/core/v1#PodPhase) like `Running` or `Failed`, but for now it's just `Pending`