### PR TITLE
ui: a handful of fixes for `<ArtifactOverview>`

### DIFF
--- a/ui/app/components/container-image-tag/index.hbs
+++ b/ui/app/components/container-image-tag/index.hbs
@@ -1,4 +1,4 @@
-{{#each this.imageRefs as |imageRef|}}
+{{#each this.imageRefs key="uri" as |imageRef|}}
   <ImageRef @imageRef={{imageRef}} />
 {{else}}
   n/a

--- a/ui/app/components/container-image-tag/index.hbs
+++ b/ui/app/components/container-image-tag/index.hbs
@@ -1,5 +1,7 @@
-{{#each this.imageRefs key="uri" as |imageRef|}}
-  <ImageRef @imageRef={{imageRef}} />
-{{else}}
-  n/a
-{{/each}}
+<div class="container-image-tag" data-test-container-image-tag>
+  {{#each this.imageRefs key="uri" as |imageRef|}}
+    <ImageRef @imageRef={{imageRef}} />
+  {{else}}
+    n/a
+  {{/each}}
+</div>

--- a/ui/app/components/image-ref.hbs
+++ b/ui/app/components/image-ref.hbs
@@ -16,7 +16,7 @@
       class="image-ref__copy-button focus-ring"
       title={{t "image-ref.copy-button-title"}}
     >
-      <FlightIcon @name={{if this.displayCopySuccess.isRunning "copy-success" "copy-action"}} />
+      <FlightIcon @name={{if this.displayCopySuccess.isRunning "clipboard-checked" "clipboard-copy"}} />
     </CopyButton>
   {{/if}}
 </span> 

--- a/ui/app/styles/components/_index.scss
+++ b/ui/app/styles/components/_index.scss
@@ -4,6 +4,7 @@
 @import 'card';
 @import 'cli-hint';
 @import 'code-editor-field.scss';
+@import 'container-image-tag';
 @import 'copyable-code';
 @import 'empty-state';
 @import 'flash';

--- a/ui/app/styles/components/container-image-tag.scss
+++ b/ui/app/styles/components/container-image-tag.scss
@@ -1,0 +1,4 @@
+.container-image-tag {
+  display: flex;
+  flex-direction: column;
+}

--- a/ui/app/styles/components/image-ref.scss
+++ b/ui/app/styles/components/image-ref.scss
@@ -2,9 +2,17 @@
   display: flex;
   align-items: center;
 
+  &__uri {
+    display: block;
+    flex-shrink: 0;
+  }
+
   &__tag {
+    display: block;
     margin-left: 7px;
-    overflow-wrap: anywhere;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 
   &__copy-button {

--- a/ui/app/styles/components/image-ref.scss
+++ b/ui/app/styles/components/image-ref.scss
@@ -12,11 +12,11 @@
     align-items: center;
     justify-content: center;
     background: transparent;
-    color: inherit;
+    color: rgb(var(--text-muted));
     font-size: inherit;
     line-height: inherit;
 
-    padding: scale.$sm--4;
+    padding: 0;
     border: 0;
     margin: 0;
     margin-left: 0.25rem;

--- a/ui/app/styles/components/navigation/artifact-overview.scss
+++ b/ui/app/styles/components/navigation/artifact-overview.scss
@@ -59,7 +59,7 @@
     .image-ref {
       display: inline-flex;
 
-      :first-child {
+      &:first-child {
         margin-top: -1px;
       }
     }

--- a/ui/app/styles/components/navigation/artifact-overview.scss
+++ b/ui/app/styles/components/navigation/artifact-overview.scss
@@ -7,7 +7,9 @@
     padding-bottom: 0.5rem;
   }
 
-  table, table > tbody, tr {
+  table,
+  table > tbody,
+  tr {
     width: 100%;
     overflow: hidden;
   }
@@ -19,7 +21,7 @@
     font-size: 0.875rem;
     line-height: 17px;
 
-    :first-child > * {
+    > :first-child > * {
       padding-top: 0;
     }
 
@@ -29,10 +31,6 @@
       padding-top: scale.$sm--2;
       padding-bottom: scale.$sm--2;
       vertical-align: top;
-
-      > * {
-        white-space: nowrap;
-      }
     }
 
     th {
@@ -55,12 +53,8 @@
       align-items: baseline;
     }
 
-    .image-ref {
-      display: inline-flex;
-
-      &:first-child {
-        margin-top: -1px;
-      }
+    .container-image-tag {
+      margin-top: -1px;
     }
   }
 }

--- a/ui/app/styles/components/navigation/artifact-overview.scss
+++ b/ui/app/styles/components/navigation/artifact-overview.scss
@@ -31,7 +31,6 @@
       vertical-align: top;
 
       > * {
-        overflow: hidden;
         white-space: nowrap;
       }
     }

--- a/ui/app/styles/components/operation-status-indicator.scss
+++ b/ui/app/styles/components/operation-status-indicator.scss
@@ -1,6 +1,7 @@
 .operation-status-indicator {
   margin-top: 1px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 
   > span {


### PR DESCRIPTION
## Why the change?

Closes #2910 with a few additional fixes for good measure.

The aim here isn’t to solve for really teeny viewport sizes, but rather to implement a small improvement to the current layout.

**Note:** This contains a commit from #3152 in order to make the CI results clean.

## What’s the plan?

- [x] Fix the issue described by #2910
- [x] And any other minor bits in the same area

## What does it look like?

### Before

![CleanShot 2022-01-14 at 12 39 42@2x](https://user-images.githubusercontent.com/34030/149510350-167c0bc8-b824-4a44-9d46-0e687a3ee7fe.png)

### After

<img width="1136" alt="CleanShot 2022-03-28 at 13 35 13@2x" src="https://user-images.githubusercontent.com/34030/160389692-7160a525-6a8c-4ae5-9911-9f91413105a2.png">

## How do I test it?

1. Check out the branch
   ```
   git checkout ui/artifact-overview-fixes
   ```
2. Boot the UI dev server
   ```
   cd ui && yarn start
   ```
3. [Visit localhost:4200](http://localhost:4200)
4. Browse to a deployment page
5. Verify the container image tags look good
6. Shrink your browser
7. Verify the container image tags are still workable