### PR TITLE
cli: Show error message from Errored job if exists

### DIFF
--- a/internal/cli/job_inspect.go
+++ b/internal/cli/job_inspect.go
@@ -147,6 +147,12 @@ func (c *JobInspectCommand) Run(args []string) int {
 		cancelTime = humanize.Time(resp.CancelTime.AsTime())
 	}
 
+	// job had an error! Let's show the message
+	var errMsg string
+	if resp.Error != nil {
+		errMsg = resp.Error.Message
+	}
+
 	c.ui.Output("Job Configuration", terminal.WithHeaderStyle())
 	c.ui.NamedValues([]terminal.NamedValue{
 		{
@@ -160,6 +166,9 @@ func (c *JobInspectCommand) Run(args []string) int {
 		},
 		{
 			Name: "State", Value: jobState,
+		},
+		{
+			Name: "Error Messsage", Value: errMsg,
 		},
 		{
 			Name: "Complete Time", Value: completeTime,


### PR DESCRIPTION
This commit updates the `waypoint job inspect` CLI to display the error
message off of a Job if that message exists. Note that the NamedValue UI
writer omits keys with empty values.

Fixes #3154