### PR TITLE
internal: More Descriptive SingletonIds for Poll Jobs

### DIFF
--- a/.changelog/3158.txt
+++ b/.changelog/3158.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+server: Fix project poll job singleton id to only include application on project
+poll jobs if exist. Otherwise, only include the workspace and project.
+```

--- a/internal/runner/operation_poll.go
+++ b/internal/runner/operation_poll.go
@@ -103,6 +103,13 @@ func (r *Runner) executePollOp(
 		}
 	}
 
+	// NOTE(briancain): We set a singleton ID for a poll project operation to ensure that the
+	// poll handler does not fire off many operations of the same kind more than once,
+	// clogging up the job system. By setting a singleton ID that is unique to this
+	// application or project, we can ensure only 1 operation will be active at once rather than
+	// many operations (such as in the case where a poll interval is shorter than it
+	// takes to run the operation)
+
 	// We assume a project and workspace is set given this is Project polling
 	singletonId := strings.ToLower(fmt.Sprintf(
 		"poll-trigger/%s/%s",

--- a/internal/runner/operation_poll.go
+++ b/internal/runner/operation_poll.go
@@ -111,7 +111,7 @@ func (r *Runner) executePollOp(
 	))
 	// Not all jobs set an application
 	if job.Application.Application != "" {
-		singletonId = "/" + job.Application.Application
+		singletonId = "/" + strings.ToLower(job.Application.Application)
 	}
 
 	log.Debug("queueing job")

--- a/internal/runner/operation_poll.go
+++ b/internal/runner/operation_poll.go
@@ -118,7 +118,7 @@ func (r *Runner) executePollOp(
 	))
 	// Not all jobs set an application
 	if job.Application.Application != "" {
-		singletonId = "/" + strings.ToLower(job.Application.Application)
+		singletonId += "/" + strings.ToLower(job.Application.Application)
 	}
 
 	log.Debug("queueing job")

--- a/pkg/server/singleprocess/poll_application.go
+++ b/pkg/server/singleprocess/poll_application.go
@@ -241,6 +241,12 @@ const (
 
 // appStatusPollSingletonId generates an application status polling job singleton ID
 // for the given workspace, project, app and operation type.
+// NOTE(briancain): We set a singleton ID for a poll application operation to ensure that the
+// poll handler does not fire off many operations of the same kind more than once,
+// clogging up the job system. By setting a singleton ID that is unique to this
+// application, we can ensure only 1 operation will be active at once rather than
+// many operations (such as in the case where a poll interval is shorter than it
+// takes to run the operation)
 func appStatusPollSingletonId(
 	workspaceName string,
 	projectName string,

--- a/pkg/server/singleprocess/poll_application.go
+++ b/pkg/server/singleprocess/poll_application.go
@@ -178,7 +178,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		deploymentJob.Job.SingletonId = appStatusPollSingletonId(app.Name, appStatusPollOperationTypeDeployment)
+		deploymentJob.Job.SingletonId = appStatusPollSingletonId(a.workspace, app.Project.Project, app.Name, appStatusPollOperationTypeDeployment)
 
 		jobs = append(jobs, deploymentJob)
 	}
@@ -197,7 +197,7 @@ func (a *applicationPoll) buildPollJobs(
 		}
 		// SingletonId so that we only have one poll operation at
 		// any time queued per app/operation.
-		releaseJob.Job.SingletonId = appStatusPollSingletonId(app.Name, appStatusPollOperationTypeRelease)
+		releaseJob.Job.SingletonId = appStatusPollSingletonId(a.workspace, app.Project.Project, app.Name, appStatusPollOperationTypeRelease)
 
 		jobs = append(jobs, releaseJob)
 	}
@@ -240,7 +240,12 @@ const (
 )
 
 // appStatusPollSingletonId generates an application status polling job singleton ID
-// for the given app and operation type.
-func appStatusPollSingletonId(appName string, operationType appStatusPollOperationType) string {
-	return fmt.Sprintf("app-status-poll/%s/%s", appName, operationType)
+// for the given workspace, project, app and operation type.
+func appStatusPollSingletonId(
+	workspaceName string,
+	projectName string,
+	appName string,
+	operationType appStatusPollOperationType,
+) string {
+	return fmt.Sprintf("app-status-poll/%s/%s/%s/%s", workspaceName, projectName, appName, operationType)
 }

--- a/pkg/server/singleprocess/poll_test.go
+++ b/pkg/server/singleprocess/poll_test.go
@@ -549,7 +549,7 @@ func TestApplicationPollHandler(t *testing.T) {
 
 		raw, err := testServiceImpl(impl).state(ctx).JobList()
 		for _, j := range raw {
-			if j.State != pb.Job_ERROR && j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
+			if j.State != pb.Job_ERROR && j.SingletonId == appStatusPollSingletonId("default", "Example", appName, appStatusPollOperationTypeDeployment) {
 				jobs = append(jobs, j)
 			}
 		}
@@ -669,7 +669,7 @@ func TestApplicationPollHandler_fullLifecycle(t *testing.T) {
 		raw, err := testServiceImpl(impl).state(ctx).JobList()
 		for _, j := range raw {
 			if j.State != pb.Job_ERROR &&
-				j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
+				j.SingletonId == appStatusPollSingletonId("default", "Example", appName, appStatusPollOperationTypeDeployment) {
 				// App status polling should only have this singleton id
 				jobs = append(jobs, j)
 			}
@@ -716,10 +716,10 @@ func TestApplicationPollHandler_fullLifecycle(t *testing.T) {
 		for _, j := range raw {
 			t.Logf("Found job in state %s with id %s", j.State, j.SingletonId)
 			if j.State != pb.Job_ERROR {
-				if j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeRelease) {
+				if j.SingletonId == appStatusPollSingletonId("default", "Example", appName, appStatusPollOperationTypeRelease) {
 					releaseJobs++
 				}
-				if j.SingletonId == appStatusPollSingletonId(appName, appStatusPollOperationTypeDeployment) {
+				if j.SingletonId == appStatusPollSingletonId("default", "Example", appName, appStatusPollOperationTypeDeployment) {
 					deployJobs++
 				}
 			}


### PR DESCRIPTION
Prior to this commit, our poll operation would set the poll jobs
singleton Id to Project/App/Workspace. However not all project
poll operations have an application, such as the initial QueueProject
operation. In this case, we only set Workspace and Project. This means
the singletonId for the Job included a double slash, such as:

```
poll-trigger/go-gitops-0//default
```

Where the application was not set for the job.

This commit fixes this by rearranging the singleton to start at
Workspace, Project, and then optionally Application if exists on the
job.

Discovered via https://github.com/hashicorp/waypoint/issues/3157

edit: This pull request also enhances the application status report poll singletonId to include the workspace and project it belongs to. Otherwise this would of been a job collision issue with multiple separate app names across projects in a single Waypoint server.