### PR TITLE
ui: updated breadcrumbs to include current page

### DIFF
--- a/.changelog/3166.txt
+++ b/.changelog/3166.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Updated UI of breadcrumbs and UX to include current page
+```

--- a/ui/app/routes/workspace/projects/project/app.ts
+++ b/ui/app/routes/workspace/projects/project/app.ts
@@ -39,7 +39,10 @@ export default class App extends Route {
     return [
       {
         label: model.application.project,
-        icon: 'folder',
+        route: 'workspace.projects.project.apps',
+      },
+      {
+        label: 'Applications',
         route: 'workspace.projects.project.apps',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/build.ts
+++ b/ui/app/routes/workspace/projects/project/app/build.ts
@@ -28,13 +28,15 @@ export default class BuildDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Builds',
-        icon: 'hammer',
         route: 'workspace.projects.project.app.builds',
+      },
+      {
+        label: `v${model.sequence}`,
+        route: 'workspace.projects.project.app.build',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/builds.ts
+++ b/ui/app/routes/workspace/projects/project/app/builds.ts
@@ -14,12 +14,10 @@ export default class Builds extends Route {
     return [
       {
         label: model.app ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Builds',
-        icon: 'hammer',
         route: 'workspace.projects.project.app.builds',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/deployments/deployment.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployments/deployment.ts
@@ -25,13 +25,15 @@ export default class DeploymentDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Deployments',
-        icon: 'upload',
         route: 'workspace.projects.project.app.deployments',
+      },
+      {
+        label: `v${model.sequence}`,
+        route: 'workspace.projects.project.app.deployments.deployment',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/deployments/deployment/resource.ts
+++ b/ui/app/routes/workspace/projects/project/app/deployments/deployment/resource.ts
@@ -12,15 +12,15 @@ type Model = StatusReport.Resource.AsObject;
 
 export default class extends Route {
   @action
-  breadcrumbs(): Breadcrumb[] {
-    let deployment = this.modelFor(
-      'workspace.projects.project.app.deployments.deployment'
-    ) as DeploymentRouteModel;
+  breadcrumbs(model: Model): Breadcrumb[] {
     return [
       {
-        label: `v${deployment.sequence}`,
+        label: 'Resources',
         route: 'workspace.projects.project.app.deployments.deployment',
-        icon: 'upload',
+      },
+      {
+        label: model.name,
+        route: 'workspace.projects.project.app.deployments.deployment.resource',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/exec.ts
+++ b/ui/app/routes/workspace/projects/project/app/exec.ts
@@ -12,12 +12,10 @@ export default class Exec extends Route {
     return [
       {
         label: model.application.application ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Exec',
-        icon: 'terminal-screen',
         route: 'workspace.projects.project.app.exec',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/logs.ts
+++ b/ui/app/routes/workspace/projects/project/app/logs.ts
@@ -19,12 +19,10 @@ export default class Logs extends Route {
     return [
       {
         label: model.app ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Logs',
-        icon: 'outline',
         route: 'workspace.projects.project.app.logs',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/release.ts
+++ b/ui/app/routes/workspace/projects/project/app/release.ts
@@ -28,13 +28,15 @@ export default class ReleaseDetail extends Route {
     return [
       {
         label: model.application?.application ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Releases',
-        icon: 'globe',
         route: 'workspace.projects.project.app.releases',
+      },
+      {
+        label: `v${model.sequence}`,
+        route: 'workspace.projects.project.app.release',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/release/resource.ts
+++ b/ui/app/routes/workspace/projects/project/app/release/resource.ts
@@ -12,13 +12,15 @@ type Model = StatusReport.Resource.AsObject;
 
 export default class extends Route {
   @action
-  breadcrumbs(): Breadcrumb[] {
-    let release = this.modelFor('workspace.projects.project.app.release') as ReleaseRouteModel;
+  breadcrumbs(model: Model): Breadcrumb[] {
     return [
       {
-        label: `v${release.sequence}`,
-        icon: 'globe',
+        label: 'Resources',
         route: 'workspace.projects.project.app.release',
+      },
+      {
+        label: model.name,
+        route: 'workspace.projects.project.app.release.resource',
       },
     ];
   }

--- a/ui/app/routes/workspace/projects/project/app/releases.ts
+++ b/ui/app/routes/workspace/projects/project/app/releases.ts
@@ -14,12 +14,10 @@ export default class Releases extends Route {
     return [
       {
         label: model.app ?? 'unknown',
-        icon: 'git-repo',
         route: 'workspace.projects.project.app',
       },
       {
         label: 'Releases',
-        icon: 'globe',
         route: 'workspace.projects.project.app.releases',
       },
     ];

--- a/ui/app/routes/workspace/projects/project/app/resources.ts
+++ b/ui/app/routes/workspace/projects/project/app/resources.ts
@@ -1,10 +1,13 @@
 import { DeploymentExtended, ReleaseExtended } from 'waypoint/services/api';
-
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { Model as AppRouteModel } from '../app';
 import Route from '@ember/routing/route';
 import { StatusReport } from 'waypoint-pb';
 
-type Model = ResourceMap[];
+type Model = {
+  resources: ResourceMap[];
+  application: string;
+};
 
 interface ResourceMap {
   resource: StatusReport.Resource.AsObject;
@@ -12,6 +15,20 @@ interface ResourceMap {
   source: DeploymentExtended | ReleaseExtended;
 }
 export default class Resources extends Route {
+  breadcrumbs(model: Model): Breadcrumb[] {
+    if (!model) return [];
+    return [
+      {
+        label: model.application ?? 'unknown',
+        route: 'workspace.projects.project.app',
+      },
+      {
+        label: 'Resources',
+        route: 'workspace.projects.project.app.resources',
+      },
+    ];
+  }
+
   async model(): Promise<Model> {
     let app = this.modelFor('workspace.projects.project.app') as AppRouteModel;
 
@@ -39,6 +56,6 @@ export default class Resources extends Route {
       });
     });
 
-    return resources;
+    return { application: app.application.application, resources };
   }
 }

--- a/ui/app/routes/workspace/projects/project/apps.ts
+++ b/ui/app/routes/workspace/projects/project/apps.ts
@@ -1,9 +1,25 @@
 import Route from '@ember/routing/route';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { Model as ProjectRouteModel } from 'waypoint/routes/workspace/projects/project';
 
 type Model = ProjectRouteModel;
 
 export default class Apps extends Route {
+  breadcrumbs(model: Model): Breadcrumb[] {
+    if (!model) return [];
+
+    return [
+      {
+        label: model.name,
+        route: 'workspace.projects.project.apps',
+      },
+      {
+        label: 'Applications',
+        route: 'workspace.projects.project.apps',
+      },
+    ];
+  }
+
   async model(): Promise<Model> {
     // Technically we get this behavior for free because, in Ember, if a
     // route doesn’t define a model hook then it automatically receives

--- a/ui/app/routes/workspace/projects/project/settings/config-variables.ts
+++ b/ui/app/routes/workspace/projects/project/settings/config-variables.ts
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApiService from 'waypoint/services/api';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 import { ConfigGetRequest, ConfigGetResponse, Ref } from 'waypoint-pb';
 import {
   Model as ProjectRouteModel,
@@ -10,6 +11,15 @@ import ConfigVariablesController from 'waypoint/controllers/workspace/projects/p
 
 export default class WorkspaceProjectsProjectSettingsConfigVariables extends Route {
   @service api!: ApiService;
+
+  breadcrumbs(): Breadcrumb[] {
+    return [
+      {
+        label: 'Config Variables',
+        route: 'workspace.projects.project.settings.config-variables',
+      },
+    ];
+  }
 
   async model(): Promise<ConfigGetResponse.AsObject> {
     let ref = new Ref.Project();

--- a/ui/app/routes/workspace/projects/project/settings/input-variables.ts
+++ b/ui/app/routes/workspace/projects/project/settings/input-variables.ts
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
-export default class WorkspaceProjectsProjectSettingsInputVariables extends Route {}
+export default class WorkspaceProjectsProjectSettingsInputVariables extends Route {
+  breadcrumbs(): Breadcrumb[] {
+    return [
+      {
+        label: 'Input Variables',
+        route: 'workspace.projects.project.settings.config-variables',
+      },
+    ];
+  }
+}

--- a/ui/app/routes/workspace/projects/project/settings/repository.ts
+++ b/ui/app/routes/workspace/projects/project/settings/repository.ts
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { Breadcrumb } from 'waypoint/services/breadcrumbs';
 
-export default class WorkspaceProjectsProjectSettingsRepository extends Route {}
+export default class WorkspaceProjectsProjectSettingsRepository extends Route {
+  breadcrumbs(): Breadcrumb[] {
+    return [
+      {
+        label: 'Git Repository',
+        route: 'workspace.projects.project.settings.config-variables',
+      },
+    ];
+  }
+}

--- a/ui/app/templates/workspace/projects/project/app/resources.hbs
+++ b/ui/app/templates/workspace/projects/project/app/resources.hbs
@@ -1,6 +1,6 @@
-{{#if @model.length}}
+{{#if @model.resources.length}}
   <ResourcesTableExtended
-    @resources={{@model}}
+    @resources={{@model.resources}}
   />
 {{else}}
   <EmptyState>


### PR DESCRIPTION
## Other updates in this PR
- Removed icons to make more streamlined
- Included breadcrumbs for list views (applications, etc) and operation versions

## Additional notes
- Originally, there was no differentiation between `Applications` page and a project's page in breadcrumbs. Apps list is the first and only thing you see when selecting a project right now. But an `Applications` breadcrumb was added in the future case that there will most likely be other screens that are top-level to a project and not about specific applications. (The `Settings` page did have its own breadcrumb already, also adding to the argument to add the `Applications` breadcrumb)
- With removal of icons, the breadcrumb stating the list before a specific page (ie `Projects / marketing-public / Applications / web` we now know what object type `marketing-public` is and `web` is without relying on the icons as clues (removes some mental overhead for users to memorize what each icon correlates with).

## Screenshots
<img width="1436" alt="Screen Shot 2022-03-31 at 4 36 54 PM" src="https://user-images.githubusercontent.com/60155296/161145847-3c47e142-f237-45dc-a8fb-6d55d06139de.png">
<img width="1440" alt="Screen Shot 2022-03-31 at 4 37 04 PM" src="https://user-images.githubusercontent.com/60155296/161145849-0f29b3a0-dc07-4756-8c28-2d9450ec67de.png">
<img width="1436" alt="Screen Shot 2022-03-31 at 4 37 40 PM" src="https://user-images.githubusercontent.com/60155296/161145852-0e75ea04-c42c-47f1-b2ac-6c81409ade81.png">
