### PR TITLE
Update links in ResourcesTableExtended component

### DIFF
--- a/.changelog/3172.txt
+++ b/.changelog/3172.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix missing links to resources
+```

--- a/ui/app/components/resources-table-extended.hbs
+++ b/ui/app/components/resources-table-extended.hbs
@@ -28,7 +28,7 @@
           (hash
             route=(or
               (and (eq resourceObject.type "deployment") "workspace.projects.project.app.deployments.deployment")
-              (and (eq resourceObject.type  "release") "workspace.projects.project.app.releases.release")
+              (and (eq resourceObject.type  "release") "workspace.projects.project.app.release")
             )
           )
           as |vars|}}

--- a/ui/app/components/resources-table-extended.hbs
+++ b/ui/app/components/resources-table-extended.hbs
@@ -30,6 +30,10 @@
               (and (eq resourceObject.type "deployment") "workspace.projects.project.app.deployments.deployment")
               (and (eq resourceObject.type  "release") "workspace.projects.project.app.release")
             )
+            title=(or
+              (and (eq resourceObject.type "deployment") (concat (t "page.deployment.title") " v" resourceObject.source.sequence))
+              (and (eq resourceObject.type  "release") (concat (t "page.release.title") " v" resourceObject.source.sequence))
+            )
           )
           as |vars|}}
         <tr>
@@ -48,7 +52,7 @@
           <td>
             {{#if (eq resourceObject.type 'deployment')}}
               <LinkTo
-                title={{concat (t "page.deployment.title") " v" resourceObject.source.sequence}}
+                title={{vars.title}}
                 @route="workspace.projects.project.app.deployments.deployment"
                 @models={{array resourceObject.source.sequence}}
                 >
@@ -57,7 +61,7 @@
             {{/if}}
             {{#if (eq resourceObject.type 'release')}}
               <LinkTo
-                title={{concat (t "page.release.title") " v" resourceObject.source.sequence}}
+                title={{vars.title}}
                 @route="workspace.projects.project.app.release-id"
                 @models={{array resourceObject.source.sequence}}
                 >

--- a/ui/app/components/resources-table-extended.hbs
+++ b/ui/app/components/resources-table-extended.hbs
@@ -24,40 +24,49 @@
   <tbody>
     {{#each @resources key="resource.id" as |resourceObject|}}
       {{#let resourceObject.resource as |resource|}}
-      <tr>
-        <th scope="row">
-          <LinkTo
-            title={{resource.name}}
-            @route={{@route}}
-            @models={{append (or @models (array)) resource.id}}
-          >
-            {{resource.name}}
-          </LinkTo>
-        </th>
-        <td class="resource-icon"><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
-        <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
-        <td><ResourceHealthIndicator @resource={{resource}} /></td>
-        <td>
-          {{#if (eq resourceObject.type 'deployment')}}
+        {{#let
+          (hash
+            route=(or
+              (and (eq resourceObject.type "deployment") "workspace.projects.project.app.deployments.deployment")
+              (and (eq resourceObject.type  "release") "workspace.projects.project.app.releases.release")
+            )
+          )
+          as |vars|}}
+        <tr>
+          <th scope="row">
             <LinkTo
-              title={{concat (t "page.deployment.title") " v" resourceObject.source.sequence}}
-              @route="workspace.projects.project.app.deployments.deployment"
-              @models={{array resourceObject.source.sequence}}
-              >
-              {{t "page.resources.table.deployment"}} <b class="badge badge--version">v{{resourceObject.source.sequence}}</b>
+              title={{resource.name}}
+              @route={{concat vars.route ".resource"}}
+              @models={{append (array resourceObject.source.sequence) resource.id}}
+            >
+              {{resource.name}}
             </LinkTo>
-          {{/if}}
-          {{#if (eq resourceObject.type 'release')}}
-            <LinkTo
-              title={{concat (t "page.release.title") " v" resourceObject.source.sequence}}
-              @route="workspace.projects.project.app.release-id"
-              @models={{array resourceObject.source.sequence}}
-              >
-              {{t "page.resources.table.release"}} <b class="badge badge--version">v{{resourceObject.source.sequence}}</b>
-            </LinkTo>
-          {{/if}}
-        </td>
-      </tr>
+          </th>
+          <td class="resource-icon"><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
+          <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>
+          <td><ResourceHealthIndicator @resource={{resource}} /></td>
+          <td>
+            {{#if (eq resourceObject.type 'deployment')}}
+              <LinkTo
+                title={{concat (t "page.deployment.title") " v" resourceObject.source.sequence}}
+                @route="workspace.projects.project.app.deployments.deployment"
+                @models={{array resourceObject.source.sequence}}
+                >
+                {{t "page.resources.table.deployment"}} <b class="badge badge--version">v{{resourceObject.source.sequence}}</b>
+              </LinkTo>
+            {{/if}}
+            {{#if (eq resourceObject.type 'release')}}
+              <LinkTo
+                title={{concat (t "page.release.title") " v" resourceObject.source.sequence}}
+                @route="workspace.projects.project.app.release-id"
+                @models={{array resourceObject.source.sequence}}
+                >
+                {{t "page.resources.table.release"}} <b class="badge badge--version">v{{resourceObject.source.sequence}}</b>
+              </LinkTo>
+            {{/if}}
+          </td>
+        </tr>
+        {{/let}}
       {{/let}}
     {{/each}}
   </tbody>


### PR DESCRIPTION
Fixes #3156 

Looks some data was not passed in https://github.com/hashicorp/waypoint/pull/2777 and that carried over with the new routes. This PR removes the need for a `@route` argument in the `ResourcesTableExtended` component and instead infers it from the resource type for each link

https://user-images.githubusercontent.com/1416421/161602644-cbc0394d-0bcb-4c7e-af26-1d07e1c9e687.mov

