### PR TITLE
Fixing `make tools`

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -9,25 +9,25 @@
 package tools
 
 import (
-	//go:generate go install github.com/kevinburke/go-bindata
+//go:generate go install github.com/kevinburke/go-bindata
 	_ "github.com/kevinburke/go-bindata"
 
-	//go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
+//go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 
-	//go:generate go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+//go:generate go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 
-	//go:generate go install github.com/mitchellh/protoc-gen-go-json
+//go:generate go install github.com/mitchellh/protoc-gen-go-json
 	_ "github.com/mitchellh/protoc-gen-go-json"
 
-	// Using a fork of grpc-gateway to fix a bug they have in "nested query param generation"
-	//go:generate go install github.com/evanphx/grpc-gateway/protoc-gen-swagger
+// Using a fork of grpc-gateway to fix a bug they have in "nested query param generation"
+//go:generate go install github.com/evanphx/grpc-gateway/protoc-gen-swagger
 	_ "github.com/evanphx/grpc-gateway/protoc-gen-swagger"
 
-	//go:generate go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+//go:generate go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
 
-	//go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=1.1.2" github.com/vektra/mockery/cmd/mockery
+//go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=1.1.2" github.com/vektra/mockery/cmd/mockery
 	_ "github.com/vektra/mockery"
 )


### PR DESCRIPTION
Turns out, leading whitespace is not allowed for go generate commands.