### PR TITLE
ui: enable `skipLibCheck` in `tsconfig.json`

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -21,6 +21,7 @@
     "baseUrl": ".",
     "module": "es6",
     "experimentalDecorators": true,
+    "skipLibCheck": true,
     "paths": {
       "ember-cli-flash/*": ["node_modules/ember-cli-flash/index.d.ts"],
       "waypoint/tests/*": ["tests/*"],


### PR DESCRIPTION
## Why the change?

This suppresses a bunch of typechecking noise from the generated protobuf libraries.

## What does it look like?

### Before

```
❯ yarn tsc --noEmit

node_modules/waypoint-pb/server_pb.d.ts:967:26 - error TS2694: Namespace '"/Users/jamie/Code/hashicorp/waypoint/ui/node_modules/waypoint-pb/server_pb".Ref.Component' has no exported member 'Type'.
967     getType(): Component.Type;
                             ~~~~

node_modules/waypoint-pb/server_pb.d.ts:968:30 - error TS2694: Namespace '"/Users/jamie/Code/hashicorp/waypoint/ui/node_modules/waypoint-pb/server_pb".Ref.Component' has no exported member 'Type'.
968     setType(value: Component.Type): Component;
                                 ~~~~

node_modules/waypoint-pb/server_pb.d.ts:983:23 - error TS2694: Namespace '"/Users/jamie/Code/hashicorp/waypoint/ui/node_modules/waypoint-pb/server_pb".Ref.Component' has no exported member 'Type'.
983       type: Component.Type,
                          ~~~~

Found 3 errors.
```

A bunch of errors in generated code, that we can’t easily fix.

### After

```
❯ yarn tsc --noEmit
✨  Done in 4.48s.
```

Blissful silence