### PR TITLE
ci: Only notify PR check failures if `website/content` has changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run:
           command: cd ./website; npx --no-install next-hashicorp format
       - run: |
-          if ! git diff --exit-code > /dev/null; then
+          if ! git diff --exit-code website/content > /dev/null; then
             echo "Website directory has unstaged mdx changes. This is because you have modified doc strings"
             echo "that must be reflected in the website. Run the following make command:"
             echo


### PR DESCRIPTION
Prior to this commit, any changes at all from running `make
gen/website-mdx` would notify a failure. This is extra tricky because
npm and lock files might change which causes `git diff` to notify the PR
that a failure occured. In reality, this check was only to tell the PR
author that they needed to run `make gen/website-mdx` to generate CLI
docs automatically. This commit updates that behavior to only check a
`git diff` in the `website/content` folder, where the auto generated
docs live.