### PR TITLE
cli: Sort uncomplete jobs as "latest"

### DIFF
--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -106,11 +106,23 @@ func (c *JobListCommand) Run(args []string) int {
 	// sort by complete time
 	if c.flagDesc {
 		sort.Slice(jobs, func(i, j int) bool {
-			return jobs[i].CompleteTime.AsTime().Before(jobs[j].CompleteTime.AsTime())
+			if jobs[i].CompleteTime == nil {
+				return false
+			} else if jobs[j].CompleteTime == nil {
+				return true
+			} else {
+				return jobs[i].CompleteTime.AsTime().Before(jobs[j].CompleteTime.AsTime())
+			}
 		})
 	} else {
 		sort.Slice(jobs, func(i, j int) bool {
-			return jobs[i].CompleteTime.AsTime().After(jobs[j].CompleteTime.AsTime())
+			if jobs[i].CompleteTime == nil {
+				return true
+			} else if jobs[j].CompleteTime == nil {
+				return false
+			} else {
+				return jobs[i].CompleteTime.AsTime().After(jobs[j].CompleteTime.AsTime())
+			}
 		})
 	}
 


### PR DESCRIPTION
Prior to this commit, when the job list CLI would sort on Complete time,
jobs with a nil complete time would be sorted as "oldest". Really as a
user you would expect these to show up as "latest" with no complete time
field set. This commit fixes the original behavior to make these jobs
show up at the beginning when there is no complete time set.