### PR TITLE
ui/mirage: set version to `[Mirage]` in `VersionInfo` handler

### DIFF
--- a/ui/mirage/services/version-info.ts
+++ b/ui/mirage/services/version-info.ts
@@ -8,7 +8,7 @@ function createVersionInfo(): VersionInfo {
   protocolVersion.setCurrent(1);
   versionInfo.setApi(protocolVersion);
   versionInfo.setEntrypoint(protocolVersion);
-  versionInfo.setVersion('0.4.2');
+  versionInfo.setVersion('[Mirage]');
   return versionInfo;
 }
 


### PR DESCRIPTION
## Why the change?

This is mainly to help us tell Mirage screenshots from “real” screenshots but also because I didn’t want to invest time into making the value update dynamically.

## What does it look like?

### Before

![localhost_4200_default](https://user-images.githubusercontent.com/34030/162199664-673b370a-d809-4689-9607-c869479bf2ac.png)

### After

![localhost_4200_default (1)](https://user-images.githubusercontent.com/34030/162199697-5fb83e0f-d48c-4e53-8a20-dfb01d947a73.png)

## How do I test it?

1. `git checkout ui/mirage-version`
2. `cd ui && yarn start`
3. [localhost:4200](http://localhost:4200)
4. Verify you see `[Mirage]` in the footer