### PR TITLE
Consumable job service handlers

### DIFF
--- a/internal/server/boltdbstate/job.go
+++ b/internal/server/boltdbstate/job.go
@@ -194,7 +194,7 @@ func jobIsCompleted(state pb.Job_State) bool {
 }
 
 // JobCreate queues the given jobs. If any job fails to queue, no jobs
-// are queued. If partial failures are acceptible, call this multiple times
+// are queued. If partial failures are acceptable, call this multiple times
 // with a single job.
 func (s *State) JobCreate(jobs ...*pb.Job) error {
 	txn := s.inmem.Txn(true)

--- a/pkg/server/logstream/logstream.go
+++ b/pkg/server/logstream/logstream.go
@@ -11,11 +11,30 @@ import (
 
 // Provider provides a log stream tracker
 type Provider interface {
-	StartWriter(ctx context.Context, log hclog.Logger, state serverstate.Interface, job *serverstate.Job) (Tracker, error)
+
+	// StartWriter starts a new log writer. Requires state to persist logs.
+	StartWriter(ctx context.Context, log hclog.Logger, state serverstate.Interface, job *serverstate.Job) (Writer, error)
+
+	// StartReader starts a new log reader.
+	StartReader(ctx context.Context, log hclog.Logger, job *serverstate.Job) (Reader, error)
+
+	// ReadCompleted returns all the log entries for a job that has been completed,
+	// by reading them out of persistent storage.
+	ReadCompleted(ctx context.Context, log hclog.Logger, state serverstate.Interface, job *serverstate.Job) ([]*pb.GetJobStreamResponse_Terminal_Event, error)
 }
 
-// Tracker collects and tracks loggable events
-type Tracker interface {
+// Writer collects and tracks loggable events
+type Writer interface {
 	Flush(ctx context.Context)
 	NewEvent(ctx context.Context, event *pb.RunnerJobStreamRequest_Terminal) error
+}
+
+// Reader reads terminal events for a given
+type Reader interface {
+
+	// ReadStream returns a batch of log entries for a job that's currenly active.
+	// If zero exist and block is true, this will block waiting for
+	// available entries. If block is false and no more log entries exist,
+	// this will return nil.
+	ReadStream(ctx context.Context, block bool) ([]*pb.GetJobStreamResponse_Terminal_Event, error)
 }

--- a/pkg/server/singleprocess/logstream.go
+++ b/pkg/server/singleprocess/logstream.go
@@ -60,7 +60,7 @@ func (l *singleProcessLogStreamProvider) ReadCompleted(ctx context.Context, log 
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read log batch for completed job")
 		}
-		if eventsBatch == nil || len(eventsBatch) == 0 {
+		if len(eventsBatch) == 0 {
 			break
 		}
 		events = append(events, eventsBatch...)

--- a/pkg/server/singleprocess/logstream.go
+++ b/pkg/server/singleprocess/logstream.go
@@ -60,7 +60,7 @@ func (l *singleProcessLogStreamProvider) ReadCompleted(ctx context.Context, log 
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read log batch for completed job")
 		}
-		if eventsBatch == nil {
+		if eventsBatch == nil || len(eventsBatch) == 0 {
 			break
 		}
 		events = append(events, eventsBatch...)

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -623,7 +623,7 @@ func (s *Service) GetJobStream(
 
 				// NOTE: at present (2022-02-25) there is no exposed CLI or UI API that
 				// causes GetJobStream to be called on a completed job. Thusly this code below
-				// is entirely optimistic about future API usage.
+				// is entirely optimistic about future API usage. But it is tested!
 				case pb.Job_SUCCESS, pb.Job_ERROR:
 					// This means that the requested stream finished before GetJobStream was
 					// called. As such, we'll reply the output events from the database instead.
@@ -639,7 +639,8 @@ func (s *Service) GetJobStream(
 					if err := server.Send(&pb.GetJobStreamResponse{
 						Event: &pb.GetJobStreamResponse_Terminal_{
 							Terminal: &pb.GetJobStreamResponse_Terminal{
-								Events: events,
+								Events:   events,
+								Buffered: true,
 							},
 						},
 					}); err != nil {

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -626,7 +626,7 @@ func (s *Service) GetJobStream(
 				// is entirely optimistic about future API usage. But it is tested!
 				case pb.Job_SUCCESS, pb.Job_ERROR:
 					// This means that the requested stream finished before GetJobStream was
-					// called. As such, we'll reply the output events from the database instead.
+					// called. As such, we'll replay the output events.
 					events, err := s.logStreamProvider.ReadCompleted(ctx, log, s.state(ctx), job)
 					if err != nil {
 						msg := "failed to stream logs for completed job"


### PR DESCRIPTION
This is the last in a series of PRs meant to make our service handlers consumable by other projects.

Previous PRs in this series:
https://github.com/hashicorp/waypoint/pull/3169
https://github.com/hashicorp/waypoint/pull/3149

This PR focuses on service_job.go. This adds a new `Reader` method to the `LogStreamProvider`, which allows other projects to inject a log stream reader and not depend on the built-in singleprocess reader.

This should not change any behavior or functionality.