### PR TITLE
chore: add lambda platform config validation - add tests

### DIFF
--- a/.changelog/3193.txt
+++ b/.changelog/3193.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws-lambda: Add platform config validation.
+```

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint/builtin/aws/ecr"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
@@ -38,10 +39,44 @@ type Platform struct {
 // ConfigSet is called after a configuration has been decoded
 // we can use this to validate the config
 func (p *Platform) ConfigSet(config interface{}) error {
-	_, ok := config.(*Config)
+	c, ok := config.(*Config)
 	if !ok {
 		// this should never happen
 		return fmt.Errorf("Invalid configuration, expected *lambda.Config, got %s", reflect.TypeOf(config))
+	}
+
+	// validate architecture
+	if c.Architecture != "" {
+		architectures := make([]interface{}, len(lambda.Architecture_Values()))
+
+		for i, ca := range lambda.Architecture_Values() {
+			architectures[i] = ca
+		}
+
+		var validArchitectures []string
+		for _, arch := range lambda.Architecture_Values() {
+			validArchitectures = append(validArchitectures, fmt.Sprintf("\"%s\"", arch))
+		}
+
+		if err := utils.Error(validation.ValidateStruct(c,
+			validation.Field(&c.Architecture,
+				validation.In(architectures...).Error(fmt.Sprintf("Unsupported function architecture \"%s\". Must be one of [%s], or left blank", c.Architecture, strings.Join(validArchitectures, ", "))),
+			),
+		)); err != nil {
+			return err
+		}
+	}
+
+	// validate timeout - max is 900 (15 minutes)
+	if c.Timeout != 0 {
+		if err := utils.Error(validation.ValidateStruct(c,
+			validation.Field(&c.Timeout,
+				validation.Min(0).Error("Timeout must not be negative"),
+				validation.Max(900).Error("Timeout must be less than or equal to 15 minutes"),
+			),
+		)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -822,7 +857,7 @@ type Config struct {
 	Memory int `hcl:"memory,optional"`
 
 	// The number of seconds to wait for a function to complete it's work.
-	// Defaults to 256
+	// Defaults to 60
 	Timeout int `hcl:"timeout,optional"`
 
 	// The instruction set architecture that the function supports.

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -42,7 +42,7 @@ func (p *Platform) ConfigSet(config interface{}) error {
 	c, ok := config.(*Config)
 	if !ok {
 		// this should never happen
-		return fmt.Errorf("Invalid configuration, expected *lambda.Config, got %s", reflect.TypeOf(config))
+		return fmt.Errorf("Invalid configuration, expected *lambda.Config, got %q", reflect.TypeOf(config))
 	}
 
 	// validate architecture
@@ -55,12 +55,12 @@ func (p *Platform) ConfigSet(config interface{}) error {
 
 		var validArchitectures []string
 		for _, arch := range lambda.Architecture_Values() {
-			validArchitectures = append(validArchitectures, fmt.Sprintf("\"%s\"", arch))
+			validArchitectures = append(validArchitectures, fmt.Sprintf("%q", arch))
 		}
 
 		if err := utils.Error(validation.ValidateStruct(c,
 			validation.Field(&c.Architecture,
-				validation.In(architectures...).Error(fmt.Sprintf("Unsupported function architecture \"%s\". Must be one of [%s], or left blank", c.Architecture, strings.Join(validArchitectures, ", "))),
+				validation.In(architectures...).Error(fmt.Sprintf("Unsupported function architecture %q. Must be one of [%s], or left blank", c.Architecture, strings.Join(validArchitectures, ", "))),
 			),
 		)); err != nil {
 			return err

--- a/builtin/aws/lambda/platform_test.go
+++ b/builtin/aws/lambda/platform_test.go
@@ -18,7 +18,8 @@ func TestPlatformConfig(t *testing.T) {
 		cfg := &Config{
 			Architecture: "foobar",
 		}
-		require.Error(t, p.ConfigSet(cfg))
+
+		require.EqualError(t, p.ConfigSet(cfg), "rpc error: code = InvalidArgument desc = Architecture: Unsupported function architecture \"foobar\". Must be one of [\"x86_64\", \"arm64\"], or left blank.")
 	})
 
 	t.Run("disallows invalid timeout", func(t *testing.T) {
@@ -27,14 +28,14 @@ func TestPlatformConfig(t *testing.T) {
 			cfg := &Config{
 				Timeout: 901,
 			}
-			require.Error(t, p.ConfigSet(cfg))
+			require.EqualError(t, p.ConfigSet(cfg), "rpc error: code = InvalidArgument desc = Timeout: Timeout must be less than or equal to 15 minutes.")
 		}
 
 		{
 			cfg := &Config{
 				Timeout: -1,
 			}
-			require.Error(t, p.ConfigSet(cfg))
+			require.EqualError(t, p.ConfigSet(cfg), "rpc error: code = InvalidArgument desc = Timeout: Timeout must not be negative.")
 		}
 	})
 }


### PR DESCRIPTION
# Description

- This adds `aws-lambda` platform config validation for `timeout` and `architecture`
- This updates the platform test