### PR TITLE
cli: Pass context to `Bootstrapped` in `server_run`

### DIFF
--- a/.changelog/3196.txt
+++ b/.changelog/3196.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix missing bootstrap hint with server run command
+```

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -294,8 +295,8 @@ func (c *ServerRunCommand) Run(args []string) int {
 
 	// If we aren't bootstrapped, let the user know
 	if bs, ok := impl.(interface {
-		Bootstrapped() bool
-	}); ok && auth && !bs.Bootstrapped() {
+		Bootstrapped(ctx context.Context) bool
+	}); ok && auth && !bs.Bootstrapped(c.Ctx) {
 		c.ui.Output("Server requires bootstrapping!", terminal.WithHeaderStyle())
 		c.ui.Output("")
 		c.ui.Output(strings.TrimSpace(`


### PR DESCRIPTION
## Why the change?

Without the context argument, the casting always failed and we’d never show the prompt with the bootstrap command.

## What does it look like?

### Before

<img width="1342" alt="CleanShot 2022-04-08 at 11 42 06@2x" src="https://user-images.githubusercontent.com/34030/162410464-47d7fb4d-78e7-4059-9aae-965ef660ad9a.png">

### After

<img width="1342" alt="CleanShot 2022-04-08 at 11 41 14@2x" src="https://user-images.githubusercontent.com/34030/162410480-22cabb4d-23e2-4502-9042-2ce6c8b42b43.png">

## How do I test it?

1. `git checkout cli/run-bootstrap-fix`
2. `make bin`
3. `rm data.db`
4. `./waypoint server run -accept-tos`
5. Verify you see the bootstrap message