### PR TITLE
builtin/k8s: Ensure `pod.container.static_environment` is applied

### DIFF
--- a/.changelog/3197.txt
+++ b/.changelog/3197.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+builtin/k8s: Ensure pod.container.static_environment is applied
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -640,6 +640,11 @@ func (p *Platform) resourceDeploymentCreate(
 	for k, v := range p.config.StaticEnvVars {
 		envVars[k] = v
 	}
+	if p.config.Pod != nil && p.config.Pod.Container != nil {
+		for k, v := range p.config.Pod.Container.StaticEnvVars {
+			envVars[k] = v
+		}
+	}
 	for k, v := range deployConfig.Env() {
 		envVars[k] = v
 	}


### PR DESCRIPTION
## Why the change?

I noticed that the following configuration did not apply the env vars to the app container as expected.

```hcl
deployment {
  use "kubernetes" {
    pod {
      container {
        static_environment = {
          "MY_COOL_ENV_VAR" = "MY_COOL_VALUE"
        }
      }
      # ...
```

## How do I test this?

1. `git checkout k8s/container-static-env`
2. `make bin`
3. Configure a deployment with `pod.container.static_environment` as above
4. Deploy
5. Verify the defined env vars were applied to the app container correctly
6. Try hoisting the `static_environment` config:
   ```hcl
   deployment {
     use "kubernetes" {
       static_environment = {
         # ...
   ```
7. Deploy again
8. Verify the env vars are still applied correctly