### PR TITLE
Restructure tools/tools.go to prevent gofmt issue

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,26 +8,23 @@
 
 package tools
 
-import (
 //go:generate go install github.com/kevinburke/go-bindata
-	_ "github.com/kevinburke/go-bindata"
-
 //go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
-	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
-
 //go:generate go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
-	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
-
 //go:generate go install github.com/mitchellh/protoc-gen-go-json
-	_ "github.com/mitchellh/protoc-gen-go-json"
 
 // Using a fork of grpc-gateway to fix a bug they have in "nested query param generation"
 //go:generate go install github.com/evanphx/grpc-gateway/protoc-gen-swagger
-	_ "github.com/evanphx/grpc-gateway/protoc-gen-swagger"
 
 //go:generate go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
-
 //go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=1.1.2" github.com/vektra/mockery/cmd/mockery
+
+import (
+	_ "github.com/evanphx/grpc-gateway/protoc-gen-swagger"
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
+	_ "github.com/kevinburke/go-bindata"
+	_ "github.com/mitchellh/protoc-gen-go-json"
 	_ "github.com/vektra/mockery"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
Currently, running `make format` will modify [tools/tools.go](https://github.com/hashicorp/waypoint/blob/993c2759d929b8dd5b35c30831a51fa95daa8ef5/tools/tools.go) in such a way that will break code generation, as `//go:generate` statements [must start at the beginning of the line](https://go.dev/blog/generate). Having these statements in the `import` block was causing `gofmt` to indent them. 

In this PR we simply move `//go:generate` commands above the `import` block.