### PR TITLE
internal/server: Set correct bucket var for runnerIndexInit

### DIFF
--- a/.changelog/3200.txt
+++ b/.changelog/3200.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+server: Fix runner database by setting proper runner bucket for initialization.
+Sever upgrades to 0.8.0 would previously fail before this fix.
+```

--- a/internal/server/boltdbstate/runner.go
+++ b/internal/server/boltdbstate/runner.go
@@ -359,7 +359,7 @@ func (s *State) runnerEmpty(memTxn *memdb.Txn) (bool, error) {
 
 // runnerIndexInit initializes the config index from persisted data.
 func (s *State) runnerIndexInit(dbTxn *bolt.Tx, memTxn *memdb.Txn) error {
-	bucket := dbTxn.Bucket(jobBucket)
+	bucket := dbTxn.Bucket(runnerBucket)
 	c := bucket.Cursor()
 
 	for k, v := c.Last(); k != nil; k, v = c.Prev() {


### PR DESCRIPTION
Prior to this commit, if the server ever restarted, the runner db would
fail to parse the correct bucket in the server. This also means server
upgrades would fail with an invalid wire format. This commit fixes that
by ensuring the runner init uses the proper runner bucket.

Fixes #3192