### PR TITLE
Makefile: Add make targets for running full state and service tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,5 +191,6 @@ test/boltdbstate:
 
 .PHONY: test/service
 test/service:
+	$(warning "Running the full service suite requires `docker-compose up`! Some Tests rely on a local Horizon instance to be running.")
 	@echo "Running service API server tests..."
 	go test -test.v ./pkg/server/singleprocess/ 

--- a/Makefile
+++ b/Makefile
@@ -182,3 +182,14 @@ tools: # install dependencies and tools required to build
 	$(GO_CMD) generate -tags tools tools/tools.go
 	@echo
 	@echo "Done!"
+
+.PHONY: test/boltdbstate
+test/boltdbstate:
+	@echo "Running state tests..."
+	go test -test.v ./internal/server/boltdbstate 
+
+
+.PHONY: test/service
+test/service:
+	@echo "Running service API server tests..."
+	go test -test.v ./pkg/server/singleprocess/ 

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,6 @@ endif
 	mkdir -p $(GOPATH)/bin
 	cp ./waypoint $(GOPATH)/bin/waypoint
 
-.PHONY: test
-test: # run tests
-	go test ./...
-
 .PHONY: format
 format: # format go code
 	gofmt -s -w ./
@@ -183,11 +179,14 @@ tools: # install dependencies and tools required to build
 	@echo
 	@echo "Done!"
 
+.PHONY: test
+test: # run tests
+	go test ./...
+
 .PHONY: test/boltdbstate
 test/boltdbstate:
 	@echo "Running state tests..."
 	go test -test.v ./internal/server/boltdbstate 
-
 
 .PHONY: test/service
 test/service:


### PR DESCRIPTION
This commit adds two makefile target helpers for running the full test
suite for both boltdbstate and the service API functions.