### PR TITLE
Prevent the release of a running deployment

### DIFF
--- a/.changelog/3207.txt
+++ b/.changelog/3207.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Prevent panic when releasing unsuccessful deployments
+```
+


### PR DESCRIPTION
If the most recently created deployment is running, and you attempt `waypoint release`, prior to this we would attempt to release that unfinished depoyment, and panic downstream in argmapper.

With this change, it's still possible for `waypoint release` (with no deployment targeting flag) to pick a running deployment, but at least the user will have a hint as to what has happened and can choose a different deploy to release, or wait, or delete the stuck running deployment.

This prevents the argmapper panic: https://github.com/hashicorp/go-argmapper/pull/11