### PR TITLE
Adds $TESTARGS option to test/boltdbstate step, with doc/example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,18 @@ tools: # install dependencies and tools required to build
 test: # run tests
 	go test ./...
 
+# Run state tests found in pkg/serverstate/statetest/
+# To run a specific test, use TESTARGS
+# Ex:
+#
+# >$ TESTARGS="-run TestImpl/runner_ondemand/TestOnDemandRunnerConfig" make test/boltdbstate
 .PHONY: test/boltdbstate
 test/boltdbstate:
 	@echo "Running state tests..."
-	go test -test.v ./internal/server/boltdbstate 
+	go test -test.v ./internal/server/boltdbstate $(TESTARGS)
 
 .PHONY: test/service
 test/service:
 	$(warning "Running the full service suite requires `docker-compose up`! Some Tests rely on a local Horizon instance to be running.")
 	@echo "Running service API server tests..."
-	go test -test.v ./pkg/server/singleprocess/ 
+	go test -test.v ./pkg/server/singleprocess/

--- a/pkg/serverstate/statetest/doc.go
+++ b/pkg/serverstate/statetest/doc.go
@@ -7,4 +7,19 @@
 // into any non-test-compiled files will introduce the global test flags
 // into the embedding process. This is due to an issue with Go where it
 // registers test flags globally in an Init function on import.
+//
+// These tests are not invoked directly, but are used via pkg/serverstate
+// implementations, e.g. internal/server/boltdbstate/state.go
+//
+// To run these tests, run the tests for that package.
+//
+// Ex:
+// $ go test -test.v ./internal/server/boltdbstate -count=1
+//
+// To run a specific test, use the -run flag with TestImpl. For example, to run
+// the TestOnDemandRunnerConfig test defined in
+// pkg/serverstate/statetest/test_runner_ondemand.go, use:
+//
+// $ go test -test.v ./internal/server/boltdbstate -count=1 -run=TestImpl/runner_ondemand/TestOnDemandRunnerConfig
+
 package statetest


### PR DESCRIPTION
Adds ability to run a specific state test to the `test/boltdbstate` make target and some minimal docs explaining