### PR TITLE
builtin/nomad/jobspec: fix dropped error

### DIFF
--- a/builtin/nomad/jobspec/releaser.go
+++ b/builtin/nomad/jobspec/releaser.go
@@ -187,6 +187,9 @@ func (r *Releaser) resourceJobCreate(
 						return status.Errorf(codes.Aborted, "Context cancelled from timeout checking health of task group %q: %s", group, ctx.Err())
 					}
 					deploy, _, err = jobClient.LatestDeployment(*job.ID, q)
+					if err != nil {
+						return status.Errorf(codes.Aborted, "Unable to fetch latest deployment: %s", err.Error())
+					}
 					currentTaskGroupState = deploy.TaskGroups[group]
 					log.Info(fmt.Sprintf("Task group not healthy: %s", group))
 				} else {


### PR DESCRIPTION
This fixes a dropped `err` variable in `builtin/nomad/jobspec`.  No changelog entry is warranted.