### PR TITLE
Feat/nomad consul vault tokens

### DIFF
--- a/.changelog/3222.txt
+++ b/.changelog/3222.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad: Support Consul & Vault tokens for job submission
+```

--- a/builtin/nomad/auth.go
+++ b/builtin/nomad/auth.go
@@ -1,0 +1,11 @@
+package nomad
+
+import "os"
+
+func ConsulAuth() (string, error) {
+	return os.Getenv("CONSUL_HTTP_TOKEN"), nil
+}
+
+func VaultAuth() (string, error) {
+	return os.Getenv("VAULT_TOKEN"), nil
+}

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"time"
 
@@ -118,10 +117,16 @@ func (p *Platform) resourceJobCreate(
 	client.NomadClient.SetNamespace(*job.Namespace)
 
 	// Get Consul ACL token from environment
-	*job.ConsulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+	*job.ConsulToken, err = nomad.ConsulAuth()
+	if err != nil {
+		return err
+	}
 
 	// Get Vault token from environment
-	*job.VaultToken = os.Getenv("VAULT_TOKEN")
+	*job.VaultToken, err = nomad.VaultAuth()
+	if err != nil {
+		return err
+	}
 
 	// Register job
 	st.Update("Registering job " + *job.Name + "...")

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -624,6 +624,20 @@ job "web" {
 		"Path to a Nomad job specification file.",
 	)
 
+	doc.SetField(
+		"consul_token",
+		"The Consul ACL token used to register services with the Nomad job.",
+		docs.Summary("Uses the environment variable CONSUL_HTTP_TOKEN."),
+		docs.EnvVar("CONSUL_HTTP_TOKEN"),
+	)
+
+	doc.SetField(
+		"vault_token",
+		"The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.",
+		docs.Summary("Uses the environment variable VAULT_TOKEN."),
+		docs.EnvVar("VAULT_TOKEN"),
+	)
+
 	return doc, nil
 }
 

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -115,6 +116,12 @@ func (p *Platform) resourceJobCreate(
 
 	// Update our client to use the Namespace set in the jobspec
 	client.NomadClient.SetNamespace(*job.Namespace)
+
+	// Get Consul ACL token from environment
+	*job.ConsulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+
+	// Get Vault token from environment
+	*job.VaultToken = os.Getenv("VAULT_TOKEN")
 
 	// Register job
 	st.Update("Registering job " + *job.Name + "...")

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -627,14 +627,14 @@ job "web" {
 	doc.SetField(
 		"consul_token",
 		"The Consul ACL token used to register services with the Nomad job.",
-		docs.Summary("Uses the environment variable CONSUL_HTTP_TOKEN."),
+		docs.Summary("Uses the runner config environment variable CONSUL_HTTP_TOKEN."),
 		docs.EnvVar("CONSUL_HTTP_TOKEN"),
 	)
 
 	doc.SetField(
 		"vault_token",
 		"The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.",
-		docs.Summary("Uses the environment variable VAULT_TOKEN."),
+		docs.Summary("Uses the runner config environment variable VAULT_TOKEN."),
 		docs.EnvVar("VAULT_TOKEN"),
 	)
 

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -210,6 +211,12 @@ func (p *Platform) resourceJobCreate(
 
 	job.TaskGroups[0].Tasks[0].Config = config
 	job.TaskGroups[0].Tasks[0].Env = env
+
+	// Get Consul ACL token from environment
+	*job.ConsulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+
+	// Get Vault token from environment
+	*job.VaultToken = os.Getenv("VAULT_TOKEN")
 
 	// Register job
 	st.Update("Registering job...")

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -3,7 +3,6 @@ package nomad
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -213,10 +212,16 @@ func (p *Platform) resourceJobCreate(
 	job.TaskGroups[0].Tasks[0].Env = env
 
 	// Get Consul ACL token from environment
-	*job.ConsulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+	*job.ConsulToken, err = ConsulAuth()
+	if err != nil {
+		return err
+	}
 
 	// Get Vault token from environment
-	*job.VaultToken = os.Getenv("VAULT_TOKEN")
+	*job.VaultToken, err = VaultAuth()
+	if err != nil {
+		return err
+	}
 
 	// Register job
 	st.Update("Registering job...")

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -530,6 +530,20 @@ deploy {
 	)
 
 	doc.SetField(
+		"consul_token",
+		"The Consul ACL token used to register services with the Nomad job.",
+		docs.Summary("Uses the environment variable CONSUL_HTTP_TOKEN."),
+		docs.EnvVar("CONSUL_HTTP_TOKEN"),
+	)
+
+	doc.SetField(
+		"vault_token",
+		"The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.",
+		docs.Summary("Uses the environment variable VAULT_TOKEN."),
+		docs.EnvVar("VAULT_TOKEN"),
+	)
+
+	doc.SetField(
 		"static_environment",
 		"Environment variables to add to the job.",
 	)

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -532,14 +532,14 @@ deploy {
 	doc.SetField(
 		"consul_token",
 		"The Consul ACL token used to register services with the Nomad job.",
-		docs.Summary("Uses the environment variable CONSUL_HTTP_TOKEN."),
+		docs.Summary("Uses the runner config environment variable CONSUL_HTTP_TOKEN."),
 		docs.EnvVar("CONSUL_HTTP_TOKEN"),
 	)
 
 	doc.SetField(
 		"vault_token",
 		"The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.",
-		docs.Summary("Uses the environment variable VAULT_TOKEN."),
+		docs.Summary("Uses the runner config environment variable VAULT_TOKEN."),
 		docs.EnvVar("VAULT_TOKEN"),
 	)
 

--- a/website/content/partials/components/platform-nomad-jobspec.mdx
+++ b/website/content/partials/components/platform-nomad-jobspec.mdx
@@ -88,11 +88,23 @@ job "web" {
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
 
+#### consul_token
+
+The Consul ACL token used to register services with the Nomad job.
+
+Uses the runner config environment variable CONSUL_HTTP_TOKEN.
+
 #### jobspec
 
 Path to a Nomad job specification file.
 
 - Type: **string**
+
+#### vault_token
+
+The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.
+
+Uses the runner config environment variable VAULT_TOKEN.
 
 ### Optional Parameters
 

--- a/website/content/partials/components/platform-nomad.mdx
+++ b/website/content/partials/components/platform-nomad.mdx
@@ -35,6 +35,12 @@ The credentials for docker registry.
 
 - Type: **nomad.AuthConfig**
 
+#### consul_token
+
+The Consul ACL token used to register services with the Nomad job.
+
+Uses the runner config environment variable CONSUL_HTTP_TOKEN.
+
 #### resources (category)
 
 The amount of resources to allocate to the deployed allocation.
@@ -54,6 +60,12 @@ Amount of memory in MB to allocate to this task.
 - Type: **int**
 - **Optional**
 - Default: 300
+
+#### vault_token
+
+The Vault token used to deploy the Nomad job with a token having specific Vault policies attached.
+
+Uses the runner config environment variable VAULT_TOKEN.
 
 ### Optional Parameters
 


### PR DESCRIPTION
Add support for authenticating to Consul & Vault when registering Nomad job for both Nomad deployers. Consul token should be supplied via the `CONSUL_HTTP_TOKEN` env var, and Vault token via the `VAULT_TOKEN` env var of the runner.

Relevant Nomad API code:
https://github.com/hashicorp/nomad/blob/8f7abae89fb6aef25161a90457e42a1a3cc07fa5/api/jobs.go#L843-L844

Addresses #3206 