### PR TITLE
`internal/cli`: Fix `waypoint exec` workspace selection 

### DIFF
--- a/.changelog/3226.txt
+++ b/.changelog/3226.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+internal/cli: Fix `waypoint exec` workspace selection
+```

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -68,6 +68,7 @@ func (c *ExecCommand) searchDeployments(
 	// Get the latest deployment
 	resp, err := client.ListDeployments(ctx, &pb.ListDeploymentsRequest{
 		Application: app.Ref(),
+		Workspace:   c.project.WorkspaceRef(),
 		Order: &pb.OperationOrder{
 			Limit: 1,
 			Order: pb.OperationOrder_COMPLETE_TIME,


### PR DESCRIPTION
The `-workspace` flag was not passed to `ListDeployments()` when running
`waypoint exec`. This resulted in erratic `waypoint exec` behavior, as
any deployment from any workspace became a candidate to execute the given
command.

Fixes #3224 