### PR TITLE
UI: Fix Add variable icon is misaligned

### DIFF
--- a/ui/app/components/project-input-variables/list.hbs
+++ b/ui/app/components/project-input-variables/list.hbs
@@ -13,7 +13,7 @@
     {{/each}}
   </ul>
   <Pds::ButtonSet>
-    <Pds::Button data-test-input-variables-add-variable disabled={{this.isCreating}} @variant="primary" {{on "click" this.addVariable}}>
+    <Pds::Button data-test-input-variables-add-variable disabled={{this.isCreating}} @variant="primary" class="button--add-variable" {{on "click" this.addVariable}}>
       <FlightIcon @name="plus" />{{t "form.project_variables_settings.button_apply"}}
     </Pds::Button>
   </Pds::ButtonSet>


### PR DESCRIPTION
The `Add variable` button in the `true` block was missing the `"button--add-variable"` CSS class, causing the icon to become misaligned when the component was displaying existing input variables / add new input variable form.

Before:
![Screen Shot 2022-04-15 at 1 50 58 PM](https://user-images.githubusercontent.com/103146227/163631989-9601eaaa-aa8c-4df9-a739-9a3eeee87c29.png)

After:
![Screen Shot 2022-04-15 at 1 50 19 PM](https://user-images.githubusercontent.com/103146227/163632009-ec226ce2-8e67-4240-b713-a6443f25e81f.png)

This matches how it's implemented in [`waypoint/ui/app/components/project-config-variables/list.hbs`](https://github.com/hashicorp/waypoint/blob/main/ui/app/components/project-config-variables/list.hbs)

Closes https://github.com/hashicorp/waypoint/issues/3175