### PR TITLE
docs: Include an additional note about reading a Secret vs ConfigMap

### DIFF
--- a/builtin/k8s/config_sourcer.go
+++ b/builtin/k8s/config_sourcer.go
@@ -250,7 +250,9 @@ func (cs *ConfigSourcer) Documentation() (*docs.Documentation, error) {
 		return nil, err
 	}
 
-	doc.Description("Read configuration values from Kubernetes ConfigMap or Secret resources.")
+	doc.Description("Read configuration values from Kubernetes ConfigMap or Secret resources. " +
+		"Note that to read a config value from a Secret, you must set `secret = true`. Otherwise " +
+		"Waypoint will load a dynamic value from a ConfigMap.")
 
 	doc.Example(`
 config {

--- a/website/content/partials/components/configsourcer-kubernetes.mdx
+++ b/website/content/partials/components/configsourcer-kubernetes.mdx
@@ -1,6 +1,6 @@
 ## kubernetes (configsourcer)
 
-Read configuration values from Kubernetes ConfigMap or Secret resources.
+Read configuration values from Kubernetes ConfigMap or Secret resources. Note that to read a config value from a Secret, you must set `secret = true`. Otherwise Waypoint will load a dynamic value from a ConfigMap.
 
 ### Examples
 


### PR DESCRIPTION
It's not immediately obvious in the docs that to read a Kubernetes
secret, you must set secret to be true. This commit adds some additional
notes at the top level description of the kubernetes dynamic config
plugin to explain this.