### PR TITLE
Avoid race condition reading job stream data before it's buffered.

### DIFF
--- a/pkg/server/singleprocess/service_job_test.go
+++ b/pkg/server/singleprocess/service_job_test.go
@@ -698,6 +698,7 @@ func TestServiceGetJobStream_bufferedData(t *testing.T) {
 			event := resp.Event.(*pb.GetJobStreamResponse_Terminal_)
 			for _, e := range event.Terminal.Events {
 				if lineMsg, ok := e.Event.(*pb.GetJobStreamResponse_Terminal_Event_Line_); ok {
+					t.Logf("Lobby stream: got message %s (buffered %v)", lineMsg.Line.Msg, event.Terminal.Buffered)
 					if lineMsg.Line.Msg == "world" {
 						return true
 					}


### PR DESCRIPTION
Fixes the flaky TestServiceGetJobStream_bufferedData test 🤞 

Brief summary of the problem:

We were emitting job stream events, then connecting to a stream immediately, and assuming they would be buffered. In some cases, we read before the event finishes percolating through the tubes, so it comes through as an unbuffered event.

We could probably just sleep for a few millis after emitting the events, but this method should be more deterministic! We open a separate job stream, and wait for _it_ to see all the events. Good idea @demophoon !

Thanks Brian, Shirley, and Britt for the debug swarming

