### PR TITLE
pkg/server: fix flaky test around buffered data

### DIFF
--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -621,9 +621,8 @@ func (s *Service) GetJobStream(
 						return status.Error(codes.Internal, msg)
 					}
 
-				// NOTE: at present (2022-02-25) there is no exposed CLI or UI API that
-				// causes GetJobStream to be called on a completed job. Thusly this code below
-				// is entirely optimistic about future API usage. But it is tested!
+				// NOTE: at present (2022-04-20) the CLI does not utilize this
+				// code path but the UI does for historical job viewing.
 				case pb.Job_SUCCESS, pb.Job_ERROR:
 					// This means that the requested stream finished before GetJobStream was
 					// called. As such, we'll replay the output events.
@@ -687,7 +686,6 @@ func (s *Service) getJobStreamOutputInit(
 	job *serverstate.Job,
 	server pb.Waypoint_GetJobStreamServer,
 ) (<-chan []*pb.GetJobStreamResponse_Terminal_Event, error) {
-
 	// Start a log stream reader for this job
 	lsReader, err := s.logStreamProvider.StartReader(ctx, log, job)
 	if err != nil {

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -806,7 +806,6 @@ func (s *Service) handleJobStreamRequest(
 		})
 
 	case *pb.RunnerJobStreamRequest_Terminal:
-
 		// Write the events
 		logStreamWriter.NewEvent(ctx, event)
 


### PR DESCRIPTION
To fix this, we need to retry a connection until we get buffered data.
We have to do this because the buffered data is read on connection and
immediately queued to send. It is not dependent on the client receiving
(though, it'll block due to TCP backpressure if they aren't receiving).