### PR TITLE
ui: guard against prototype pollution

### DIFF
--- a/ui/app/components/app-form/project-repository-settings.ts
+++ b/ui/app/components/app-form/project-repository-settings.ts
@@ -131,6 +131,11 @@ export default class AppFormProjectRepositorySettings extends Component<ProjectS
 
   populateExistingFields(projectFromArgs: Project.AsObject, currentModel: Project.AsObject): void {
     for (let [key, value] of Object.entries(projectFromArgs)) {
+      // Guard against prototype pollution
+      if (!Object.prototype.hasOwnProperty.call(currentModel, key)) {
+        continue;
+      }
+
       if (isEmpty(value)) {
         currentModel[key] = this.defaultProject[key];
         continue;


### PR DESCRIPTION
## Why the change?

Addresses https://github.com/hashicorp/waypoint/security/code-scanning/34

## What’s the plan?

- [x] Add a `hasOwnProperty` guard
- [x] Test it for reals

## What does it look like?

Hopefully identical to `main`.

## How do I test it?

1. `git checkout ui/code-scanning-34-fix`
2. `cd ui && yarn && yarn start`
3. [localhost:4200](http://localhost:4200)
4. Visit the project settings screen
5. Try changing project settings
6. Verify that the new values are applied correctly