### PR TITLE
Sanitize user input before sending HTTP response

### DIFF
--- a/internal/server/httpapi/trigger.go
+++ b/internal/server/httpapi/trigger.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"strconv"
 	"sync"
@@ -150,7 +151,7 @@ func HandleTrigger(addr string, tls bool) http.HandlerFunc {
 		}
 		if resp == nil {
 			http.Error(w,
-				fmt.Sprintf("server returned no job ids from run trigger %q", runTriggerId),
+				fmt.Sprintf("server returned no job ids from run trigger %q", html.EscapeString(runTriggerId)),
 				http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
[Caught by code scanner.](https://github.com/hashicorp/waypoint/security/code-scanning/35)

All HTTP responses that print out user-inputted values should be sanitized to avoid XSS.