### PR TITLE
cli: Show error message if no Waypoint contexts found

### DIFF
--- a/.changelog/3262.txt
+++ b/.changelog/3262.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Show better error message when there are no Waypoint contexts when attempting
+to open the UI
+```

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
@@ -44,14 +43,8 @@ func (c *UICommand) Run(args []string) int {
 		return 1
 	}
 
-	var ctxConfig *clicontext.Config
-	if name != "" {
-		ctxConfig, err = c.contextStorage.Load(name)
-		if err != nil {
-			c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
-			return 1
-		}
-	} else {
+	if name == "" {
+		// No default context found, do they have any at all?
 		if allContexts, err := c.contextStorage.List(); len(allContexts) == 0 || err != nil {
 			if err != nil {
 				c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
@@ -62,7 +55,14 @@ func (c *UICommand) Run(args []string) int {
 			return 1
 		}
 
+		// They have some context, but no default set
 		c.ui.Output("\n"+wpNoServerContext, terminal.WithWarningStyle())
+		return 1
+	}
+
+	ctxConfig, err := c.contextStorage.Load(name)
+	if err != nil {
+		c.project.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 


### PR DESCRIPTION
Prior to this commit, if Waypoint had no contexts locally on disk, it
would still attempt to load one with an empty name, resulting in an
error about a nil context. This commit fixes that by first seeing if any
contexts exist at all, or if there's no default, showing a better error
message to tell the user what to do about it.

Fixes #3243

I paired with @demophoon on fixing this one!