### PR TITLE
Allow some state tests to be skipped

### DIFF
--- a/internal/server/boltdbstate/state_test.go
+++ b/internal/server/boltdbstate/state_test.go
@@ -23,5 +23,5 @@ func TestImpl(t *testing.T) {
 		v, err := TestStateRestart(t, impl.(*State))
 		require.NoError(t, err)
 		return v
-	})
+	}, nil)
 }

--- a/pkg/server/ptypes/ondemand_runner.go
+++ b/pkg/server/ptypes/ondemand_runner.go
@@ -25,6 +25,14 @@ func TestOnDemandRunnerConfig(t testing.T, src *pb.OnDemandRunnerConfig) *pb.OnD
 		}
 	}
 
+	if src.TargetRunner == nil {
+		src.TargetRunner = &pb.Ref_Runner{
+			Target: &pb.Ref_Runner_Any{
+				Any: &pb.Ref_RunnerAny{},
+			},
+		}
+	}
+
 	require.NoError(t, mergo.Merge(src, &pb.OnDemandRunnerConfig{
 		PluginType: "docker",
 		OciUrl:     "hashicorp/waypoint-odr:latest",

--- a/pkg/serverstate/statetest/statetest.go
+++ b/pkg/serverstate/statetest/statetest.go
@@ -33,13 +33,30 @@ type (
 // Test runs a validation test suite for a state implementation. All
 // state implementations should pass this suite with no errors to ensure
 // the correct behavior of the state when Waypoint uses it.
-func Test(t *testing.T, f Factory, rf RestartFactory) {
+// skipTests are function names of tests in the serverstate package to skip
+// (i.e. TestJobCreate_singleton). It cannot skip sub-tests (called by
+// t.Run() inside a top-level test)
+func Test(t *testing.T, f Factory, rf RestartFactory, skipTests []string) {
 	for name, funcs := range tests {
 		t.Run(name, func(t *testing.T) {
 			for _, tf := range funcs {
 				name := runtime.FuncForPC(reflect.ValueOf(tf).Pointer()).Name()
 				if idx := strings.LastIndexByte(name, '.'); idx >= 0 {
 					name = name[idx+1:]
+				}
+
+				skip := false
+				for _, skipTest := range skipTests {
+					if name == skipTest {
+						skip = true
+						break
+					}
+				}
+				if skip {
+					t.Run(name, func(t *testing.T) {
+						t.Skip("Test is on the skip list - ignoring")
+					})
+					continue
 				}
 
 				t.Run(name, func(t *testing.T) {

--- a/pkg/serverstate/statetest/statetest.go
+++ b/pkg/serverstate/statetest/statetest.go
@@ -54,7 +54,7 @@ func Test(t *testing.T, f Factory, rf RestartFactory, skipTests []string) {
 				}
 				if skip {
 					t.Run(name, func(t *testing.T) {
-						t.Skip("Test is on the skip list - ignoring")
+						t.Skipf("Test %q is on the skip list - ignoring", name)
 					})
 					continue
 				}

--- a/pkg/serverstate/statetest/test_runner_ondemand.go
+++ b/pkg/serverstate/statetest/test_runner_ondemand.go
@@ -106,7 +106,7 @@ func TestOnDemandRunnerConfig(t *testing.T, factory Factory, restartF RestartFac
 		defer s.Close()
 
 		// Set
-		rec := serverptypes.TestOnDemandRunnerConfig(t, &pb.OnDemandRunnerConfig{})
+		rec := serverptypes.TestOnDemandRunnerConfig(t, serverptypes.TestOnDemandRunnerConfig(t, nil))
 
 		err := s.OnDemandRunnerConfigPut(rec)
 		require.NoError(err)


### PR DESCRIPTION
Currently, there's no good way for any other project consuming these tests to selectively skip any of them. Maybe there will be [as of go 1.19](https://github.com/golang/go/issues/41583), but until then, this introduces a new "skipTests" argument that allows users to pass in test names to skip.