### PR TITLE
add cli output if no runners found for 'list'

### DIFF
--- a/.changelog/3266.txt
+++ b/.changelog/3266.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Output message if no runners are found for 'runner list'
+```

--- a/internal/cli/runner_list.go
+++ b/internal/cli/runner_list.go
@@ -40,6 +40,7 @@ func (c *RunnerListCommand) Run(args []string) int {
 	}
 
 	if len(resp.Runners) == 0 {
+		c.ui.Output("No runners found")
 		return 0
 	}
 


### PR DESCRIPTION
Papercut fix

Before:
```
$ waypoint runner list


$
```

After:
```
$ waypoint runner list
No runners found

$
```