### PR TITLE
Adds default status for flag '-release' on 'deploy' command

### DIFF
--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -42,6 +42,6 @@ using the "artifact list" command.
 
 #### Command Options
 
-- `-release` - Release this deployment immediately.
+- `-release` - Release this deployment immediately. The default is true.
 
 @include "commands/deploy_more.mdx"


### PR DESCRIPTION
Adds the default setting to the `-release` flag in the `deploy` CLI docs.