### PR TITLE
Support CSI parameters & secrets with Nomad install

### DIFF
--- a/.changelog/3279.txt
+++ b/.changelog/3279.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+install/nomad: Add support for CSI params & secrets to Nomad install
+```

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -57,6 +57,7 @@ type nomadConfig struct {
 	csiVolumeCapacityMax int64             `hcl:"csi_volume_capacity_max,optional"`
 	csiFS                string            `hcl:"csi_fs,optional"`
 	csiSecrets           map[string]string `hcl:"csi_secrets,optional"`
+	csiParams            map[string]string `hcl:"csi_parameters,optional"`
 	// TODO: Add CSI options here
 
 	nomadHost string `hcl:"nomad_host,optional"`
@@ -208,6 +209,7 @@ func (i *NomadInstaller) Install(
 			},
 			RequestedCapacityMin: defaultCSIVolumeCapacityMin,
 			RequestedCapacityMax: defaultCSIVolumeCapacityMax,
+			Parameters:           i.config.csiParams,
 			PluginID:             i.config.csiVolumeProvider,
 			Secrets:              api.CSISecrets(i.config.csiSecrets),
 		}
@@ -1292,6 +1294,12 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 		Name:   "nomad-csi-secrets",
 		Target: &i.config.csiSecrets,
 		Usage:  "Secrets to provide for the CSI volume.",
+	})
+
+	set.StringMapVar(&flag.StringMapVar{
+		Name:   "nomad-csi-parameters",
+		Target: &i.config.csiParams,
+		Usage:  "Parameters passed directly to the CSI plugin to configure the volume.",
 	})
 }
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -58,7 +58,6 @@ type nomadConfig struct {
 	csiFS                string            `hcl:"csi_fs,optional"`
 	csiSecrets           map[string]string `hcl:"csi_secrets,optional"`
 	csiParams            map[string]string `hcl:"csi_parameters,optional"`
-	// TODO: Add CSI options here
 
 	nomadHost string `hcl:"nomad_host,optional"`
 }
@@ -74,8 +73,6 @@ var (
 	defaultCSIVolumeCapacityMax = int64(2147483648)
 
 	defaultCSIVolumeMountFS = "xfs"
-
-	// TODO: Add any new CSI defaults here
 
 	// Defaults to use for setting up Consul
 	defaultConsulServiceTag       = "waypoint"
@@ -1289,7 +1286,6 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 		Default: defaultCSIVolumeMountFS,
 	})
 
-	// TODO: Add other CSI options here
 	set.StringMapVar(&flag.StringMapVar{
 		Name:   "nomad-csi-secrets",
 		Target: &i.config.csiSecrets,

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -51,11 +51,13 @@ type nomadConfig struct {
 	runnerResourcesCPU    string `hcl:"runner_resources_cpu,optional"`
 	runnerResourcesMemory string `hcl:"runner_resources_memory,optional"`
 
-	hostVolume           string `hcl:"host_volume,optional"`
-	csiVolumeProvider    string `hcl:"csi_volume_provider,optional"`
-	csiVolumeCapacityMin int64  `hcl:"csi_volume_capacity_min,optional"`
-	csiVolumeCapacityMax int64  `hcl:"csi_volume_capacity_max,optional"`
-	csiFS                string `hcl:"csi_fs,optional"`
+	hostVolume           string            `hcl:"host_volume,optional"`
+	csiVolumeProvider    string            `hcl:"csi_volume_provider,optional"`
+	csiVolumeCapacityMin int64             `hcl:"csi_volume_capacity_min,optional"`
+	csiVolumeCapacityMax int64             `hcl:"csi_volume_capacity_max,optional"`
+	csiFS                string            `hcl:"csi_fs,optional"`
+	csiSecrets           map[string]string `hcl:"csi_secrets,optional"`
+	// TODO: Add CSI options here
 
 	nomadHost string `hcl:"nomad_host,optional"`
 }
@@ -71,6 +73,8 @@ var (
 	defaultCSIVolumeCapacityMax = int64(2147483648)
 
 	defaultCSIVolumeMountFS = "xfs"
+
+	// TODO: Add any new CSI defaults here
 
 	// Defaults to use for setting up Consul
 	defaultConsulServiceTag       = "waypoint"
@@ -205,6 +209,7 @@ func (i *NomadInstaller) Install(
 			RequestedCapacityMin: defaultCSIVolumeCapacityMin,
 			RequestedCapacityMax: defaultCSIVolumeCapacityMax,
 			PluginID:             i.config.csiVolumeProvider,
+			Secrets:              api.CSISecrets(i.config.csiSecrets),
 		}
 		if i.config.csiVolumeCapacityMin != 0 {
 			vol.RequestedCapacityMin = i.config.csiVolumeCapacityMin
@@ -1280,6 +1285,13 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.config.csiFS,
 		Usage:   "Nomad CSI volume mount option file system.",
 		Default: defaultCSIVolumeMountFS,
+	})
+
+	// TODO: Add other CSI options here
+	set.StringMapVar(&flag.StringMapVar{
+		Name:   "nomad-csi-secrets",
+		Target: &i.config.csiSecrets,
+		Usage:  "Secrets to provide for the CSI volume.",
 	})
 }
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -122,5 +122,7 @@ and disable the UI, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system.
+- `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
+- `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -122,5 +122,7 @@ and disable the UI, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system.
+- `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
+- `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 
 @include "commands/server-install_more.mdx"


### PR DESCRIPTION
Closes #2801.

In keeping with the current pattern of supplying flags to the install command, this PR adds two new flags to the Nomad install. These flags are for persistence for Waypoint in Nomad provided by CSI (both of which are maps of strings):

- `-nomad-csi-secrets`
- `-nomad-csi-parameters`