### PR TITLE
feat(aws-lambda): `static_environment`

### DIFF
--- a/.changelog/3282.txt
+++ b/.changelog/3282.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/lambda: Add `static_environment` to deploy plugin
+```

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -932,6 +932,12 @@ deploy {
 	doc.SetField(
 		"static_environment",
 		"environment variables to expose to the lambda function",
+		docs.Summary(
+			"environment variables that are meant to configure the application in a static",
+			"way. This might be to control an image that has multiple modes of operation,",
+			"selected via environment variable. Most configuration should use the waypoint",
+			"config commands.",
+		),
 	)
 
 	return doc, nil

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -298,6 +298,11 @@ func (p *Platform) Deploy(
 		storage = DefaultStorageSize
 	}
 
+	envVars := make(map[string]*string)
+	for k, v := range p.config.StaticEnvVars {
+		envVars[k] = aws.String(v)
+	}
+
 	step.Done()
 
 	step = sg.Add("Reading Lambda function: %s", src.App)
@@ -331,6 +336,25 @@ func (p *Platform) Deploy(
 				Size: aws.Int64(storage),
 			}
 			reset = true
+		}
+
+		// if the lambda has no env vars, Environment will be nil
+		if curFunc.Configuration.Environment != nil {
+			// compare config to AWS
+			if !reflect.DeepEqual(envVars, curFunc.Configuration.Environment.Variables) {
+				update.Environment = &lambda.Environment{
+					Variables: envVars,
+				}
+				reset = true
+			}
+		} else {
+			// only update if we have any envVars to set
+			if len(envVars) > 0 {
+				update.Environment = &lambda.Environment{
+					Variables: envVars,
+				}
+				reset = true
+			}
 		}
 
 		if reset {
@@ -419,6 +443,9 @@ func (p *Platform) Deploy(
 				},
 				ImageConfig:   &lambda.ImageConfig{},
 				Architectures: aws.StringSlice([]string{architecture}),
+				Environment: &lambda.Environment{
+					Variables: envVars,
+				},
 			})
 
 			if err != nil {
@@ -902,6 +929,11 @@ deploy {
 		docs.Default("512"),
 	)
 
+	doc.SetField(
+		"static_environment",
+		"environment variables to expose to the lambda function",
+	)
+
 	return doc, nil
 }
 
@@ -933,6 +965,12 @@ type Config struct {
 	// Must be a value between 512 and 10240.
 	// Defaults to 512 MB.
 	StorageMB int `hcl:"storagemb,optional"`
+
+	// Environment variables that are meant to configure the application in a static
+	// way. This might be control an image that has multiple modes of operation,
+	// selected via environment variable. Most configuration should use the waypoint
+	// config commands.
+	StaticEnvVars map[string]string `hcl:"static_environment,optional"`
 }
 
 var (

--- a/builtin/aws/lambda/plugin.proto
+++ b/builtin/aws/lambda/plugin.proto
@@ -22,4 +22,8 @@ message Deployment {
 
   // The version identifier AWS uses for this version (basically a serial increasing number)
   string version = 7;
+
+  // The storage size (in MB) of the Lambda function's `/tmp` directory. 
+  // Must be a value between 512 and 10240.
+  int64 storage = 8;
 }

--- a/website/content/partials/components/platform-aws-lambda.mdx
+++ b/website/content/partials/components/platform-aws-lambda.mdx
@@ -60,6 +60,8 @@ The amount of memory, in megabytes, to assign the function.
 
 Environment variables to expose to the lambda function.
 
+Environment variables that are meant to configure the application in a static way. This might be to control an image that has multiple modes of operation, selected via environment variable. Most configuration should use the waypoint config commands.
+
 - Type: **map of string to string**
 - **Optional**
 

--- a/website/content/partials/components/platform-aws-lambda.mdx
+++ b/website/content/partials/components/platform-aws-lambda.mdx
@@ -56,6 +56,13 @@ The amount of memory, in megabytes, to assign the function.
 - **Optional**
 - Default: 265
 
+#### static_environment
+
+Environment variables to expose to the lambda function.
+
+- Type: **map of string to string**
+- **Optional**
+
 #### storagemb
 
 The storage size (in MB) of the Lambda function's `/tmp` directory. Must be a value between 512 and 10240.


### PR DESCRIPTION
Note: this PR is temporarily based off https://github.com/hashicorp/waypoint/pull/3213 because of a bug fix that it contains to wait for the lambda config to finish updating before updating the function code.

# Description

This adds `static_environment` to the `aws-lambda` `deploy` component

example usage
```hcl
  deploy {
    use "aws-lambda" {
      region = var.region
      memory = 512
      static_environment = {
        "PORT" = "8001"
        "READINESS_CHECK_PORT" = "8001"
      }
    }
  }
```

Closes #2947 