### PR TITLE
Support HCL1 Jobspec for Nomad

### DIFF
--- a/.changelog/3287.txt
+++ b/.changelog/3287.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad-jobspec: Add configuration option to parse jobspec as HCL1 instead of HCL2
+```

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -102,7 +102,7 @@ func (p *Platform) resourceJobCreate(
 
 	// Parse the HCL
 	st.Update("Parsing the job specification...")
-	job, err := p.jobspec(client.NomadClient, p.config.Jobspec)
+	job, err := p.jobspec(client.NomadClient, p.config.Jobspec, p.config.Hcl1)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (p *Platform) resourceJobStatus(
 	jobClient := client.NomadClient.Jobs()
 
 	s.Update("Parsing the job specification...")
-	jobspec, err := p.jobspec(client.NomadClient, p.config.Jobspec)
+	jobspec, err := p.jobspec(client.NomadClient, p.config.Jobspec, p.config.Hcl1)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (p *Platform) Deploy(
 		return nil, err
 	}
 	// Parse the HCL
-	job, err := p.jobspec(client, p.config.Jobspec)
+	job, err := p.jobspec(client, p.config.Jobspec, p.config.Hcl1)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (p *Platform) Generation(
 	}
 
 	// Parse the HCL
-	job, err := p.jobspec(client, p.config.Jobspec)
+	job, err := p.jobspec(client, p.config.Jobspec, p.config.Hcl1)
 	if err != nil {
 		return nil, err
 	}
@@ -419,12 +419,16 @@ func (p *Platform) Generation(
 
 }
 
-func (p *Platform) jobspec(client *api.Client, path string) (*api.Job, error) {
+func (p *Platform) jobspec(client *api.Client, path string, hcl1 bool) (*api.Job, error) {
 	jobspec, err := ioutil.ReadFile(p.config.Jobspec)
 	if err != nil {
 		return nil, err
 	}
-	job, err := client.Jobs().ParseHCL(string(jobspec), true)
+	job, err := client.Jobs().ParseHCLOpts(&api.JobsParseRequest{
+		JobHCL:       string(jobspec),
+		HCLv1:        hcl1,
+		Canonicalize: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -520,6 +524,9 @@ func (p *Platform) Status(
 type Config struct {
 	// The path to the job specification to load.
 	Jobspec string `hcl:"jobspec,attr"`
+
+	// Signifies whether the jobspec should be parsed as HCL1 or not
+	Hcl1 bool `hcl:"hcl1,optional"`
 }
 
 func (p *Platform) Documentation() (*docs.Documentation, error) {
@@ -625,6 +632,12 @@ job "web" {
 	doc.SetField(
 		"jobspec",
 		"Path to a Nomad job specification file.",
+	)
+
+	doc.SetField(
+		"hcl1",
+		"Parses jobspec as HCL1 instead of HCL2.",
+		docs.Default("false"),
 	)
 
 	doc.SetField(

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl/v2 v2.10.1-0.20210621220818-327f3ce2570e
 	github.com/hashicorp/horizon v0.0.0-20210317214650-d2053943be04
-	github.com/hashicorp/nomad/api v0.0.0-20210907162733-cf7675a376b9
+	github.com/hashicorp/nomad/api v0.0.0-20220426182820-059c89dff073
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef
 	github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9
@@ -75,7 +75,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/hashstructure/v2 v2.0.1
-	github.com/mitchellh/mapstructure v1.4.1
+	github.com/mitchellh/mapstructure v1.4.3
 	github.com/mitchellh/pointerstructure v1.2.0
 	github.com/mitchellh/protoc-gen-go-json v1.1.1-0.20211009224639-45822525aa9c
 	github.com/mitchellh/reflectwalk v1.0.1
@@ -93,7 +93,7 @@ require (
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/slack-go/slack v0.6.5
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/vektra/mockery v1.1.2
 	github.com/zclconf/go-cty v1.8.4
 	github.com/zclconf/go-cty-yaml v1.0.2
@@ -204,7 +204,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/consul/api v1.7.0 // indirect
-	github.com/hashicorp/cronexpr v1.1.0 // indirect
+	github.com/hashicorp/cronexpr v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,6 @@ github.com/hashicorp/consul/api v1.7.0/go.mod h1:1NSuaUUkFaJzMasbfq/11wKYWSR67Xn
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.6.0 h1:FfhMEkwvQl57CildXJyGHnwGGM4HMODGyfjGwNM1Vdw=
 github.com/hashicorp/consul/sdk v0.6.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
-github.com/hashicorp/cronexpr v1.1.0 h1:dnNsWtH0V2ReN7JccYe8m//Bj14+PjJDntR1dz0Cixk=
-github.com/hashicorp/cronexpr v1.1.0/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=
 github.com/hashicorp/cronexpr v1.1.1/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -1119,8 +1117,6 @@ github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC7AO2g=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/nomad/api v0.0.0-20210907162733-cf7675a376b9 h1:MJohpDqE60LZmJXdhTdnUz3n4dW/0C5OQWkpqbQSETM=
-github.com/hashicorp/nomad/api v0.0.0-20210907162733-cf7675a376b9/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/hashicorp/nomad/api v0.0.0-20220426182820-059c89dff073 h1:Rvw2TS44h5hrKXWxIf6wd5EeFoo3+tCsDY9plo5X7DY=
 github.com/hashicorp/nomad/api v0.0.0-20220426182820-059c89dff073/go.mod h1:b/AoT79m3PEpb6tKCFKva/M+q1rKJNUk5mdu1S8DymM=
 github.com/hashicorp/opaqueany v0.0.0-20220321170339-a5c6ff5bb0ec h1:WfdoyL0vJ+mQWaUdzNMkk+o1ACVa6aO2i9AzGPboF5k=
@@ -1419,7 +1415,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -1798,7 +1793,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -1028,6 +1028,8 @@ github.com/hashicorp/consul/sdk v0.6.0 h1:FfhMEkwvQl57CildXJyGHnwGGM4HMODGyfjGwN
 github.com/hashicorp/consul/sdk v0.6.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/cronexpr v1.1.0 h1:dnNsWtH0V2ReN7JccYe8m//Bj14+PjJDntR1dz0Cixk=
 github.com/hashicorp/cronexpr v1.1.0/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
+github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=
+github.com/hashicorp/cronexpr v1.1.1/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
@@ -1119,6 +1121,8 @@ github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/nomad/api v0.0.0-20210907162733-cf7675a376b9 h1:MJohpDqE60LZmJXdhTdnUz3n4dW/0C5OQWkpqbQSETM=
 github.com/hashicorp/nomad/api v0.0.0-20210907162733-cf7675a376b9/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
+github.com/hashicorp/nomad/api v0.0.0-20220426182820-059c89dff073 h1:Rvw2TS44h5hrKXWxIf6wd5EeFoo3+tCsDY9plo5X7DY=
+github.com/hashicorp/nomad/api v0.0.0-20220426182820-059c89dff073/go.mod h1:b/AoT79m3PEpb6tKCFKva/M+q1rKJNUk5mdu1S8DymM=
 github.com/hashicorp/opaqueany v0.0.0-20220321170339-a5c6ff5bb0ec h1:WfdoyL0vJ+mQWaUdzNMkk+o1ACVa6aO2i9AzGPboF5k=
 github.com/hashicorp/opaqueany v0.0.0-20220321170339-a5c6ff5bb0ec/go.mod h1:adXen43rUDlxaaEpSsu3lcG4bfteZNptunpxPvx0sW8=
 github.com/hashicorp/protostructure v0.0.0-20220321173139-813f7b927cb7 h1:jTrmnIPP65IvMLaFr05QzwGGHpK2rMpwFxqh9n3nv3o=
@@ -1417,6 +1421,8 @@ github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
+github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
@@ -1794,6 +1800,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/website/content/partials/components/platform-nomad-jobspec-canary.mdx
+++ b/website/content/partials/components/platform-nomad-jobspec-canary.mdx
@@ -111,7 +111,15 @@ Uses the runner config environment variable VAULT_TOKEN.
 
 ### Optional Parameters
 
-This plugin has no optional parameters.
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
+
+#### hcl1
+
+Parses jobspec as HCL1 instead of HCL2.
+
+- Type: **bool**
+- **Optional**
+- Default: false
 
 ### Output Attributes
 

--- a/website/content/partials/components/platform-nomad-jobspec.mdx
+++ b/website/content/partials/components/platform-nomad-jobspec.mdx
@@ -111,7 +111,15 @@ Uses the runner config environment variable VAULT_TOKEN.
 
 ### Optional Parameters
 
-This plugin has no optional parameters.
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
+
+#### hcl1
+
+Parses jobspec as HCL1 instead of HCL2.
+
+- Type: **bool**
+- **Optional**
+- Default: false
 
 ### Output Attributes
 


### PR DESCRIPTION
Use [new API in Nomad](https://github.com/hashicorp/nomad/pull/12777) to parse a jobspec as HCL1 instead of HCL2.

Closes #3294.