### PR TITLE
Bug fix: Patch k8s stop task to only delete the job if it had pending pods

### DIFF
--- a/.changelog/3299.txt
+++ b/.changelog/3299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: fix issue cleaning up tasks in Kubernetes that completed successfully
+```


### PR DESCRIPTION
https://github.com/hashicorp/waypoint/pull/3143 introduced changes to remove pods/jobs if any of the pods were stuck in pending. As written it unintentionally introduced a bug where no pods were getting automatically cleaned up, because we always destroyed the job when `StopTask` was called. This prevented the auto cleanup of pods via the `TTLSecondsAfterFinished` setting in the job spec.

In this PR we only destroy the job if it has any pods stuck in pending, otherwise we let Kubernetes clean things up when the TTL expires. 