### PR TITLE
Set up dependabot for HashiCorp addons in /ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    allow:
+      # Allow updates for all HashiCorp addons
+      - dependency-name: "@hashicorp/*"


### PR DESCRIPTION
Will allow us to be notified of updates to @hashicorp/design-system-components and @hashicorp/ember-flight-icons on a weekly basis
- Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

(Piecewise part of https://github.com/hashicorp/waypoint/pull/3288)