### PR TITLE
contrib: Specify explicit Kind/K8s version in setup script 

### DIFF
--- a/contrib/serverinstall/kind-k8s/README.md
+++ b/contrib/serverinstall/kind-k8s/README.md
@@ -45,6 +45,9 @@ and the rest should be taken care of.
 
 - `WP_K8S_INGRESS` - setting this var to any non-empty value will include ingress configuration for the
 setup k8s cluster.
+- `KIND_NODE_VERSION` - if you wish, you can override the node version Kind sets
+up by default. If not set, this script will automatically use `kindest/node:v1.22.7`
+which includes Kubernetes version 1.22.
 
 After this script runs, you should be ready to run a `waypoint install` for
 the kubernetes platform!

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -8,6 +8,11 @@ set -o errexit
 
 setupIngress=$WP_K8S_INGRESS
 
+# NOTE(briancain): This version is both the kind node version as well as the
+# version of Kubernetes that kind sets up. In this case, we'd be installing
+# kubernetes version 1.22.
+kindVersion="${KIND_NODE_VERSION:-'kindest/node:v1.22.7'}"
+
 echo "Setting up local docker registry..."
 echo
 
@@ -26,7 +31,7 @@ echo
 if [ -n "${setupIngress}" ]; then
   echo "Creating kind cluster with ingress controller..."
   echo
-cat <<EOF | kind create cluster --config=-
+cat <<EOF | kind create cluster --image="$kindVersion" --config=-
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4
   containerdConfigPatches:
@@ -55,7 +60,7 @@ EOF
 else
   echo "Creating kind cluster with cluster-config.yaml..."
   echo
-cat <<EOF | kind create cluster --config=-
+cat <<EOF | kind create cluster --image="$kindVersion" --config=-
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4
   containerdConfigPatches:

--- a/contrib/serverinstall/kind-k8s/setup-k8s.sh
+++ b/contrib/serverinstall/kind-k8s/setup-k8s.sh
@@ -93,7 +93,7 @@ EOF
 echo
 echo "Applying metallb namespace..."
 echo
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.1/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/namespace.yaml
 
 echo "Create secret for metallb-system node..."
 echo
@@ -101,7 +101,7 @@ kubectl create secret generic -n metallb-system memberlist --from-literal=secret
 
 echo "Applying metallb manifest..."
 echo
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.1/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/metallb.yaml
 
 echo
 echo


### PR DESCRIPTION
Due to a bug in Kaniko, there are issues with on-demand runners on the
latest version of Kubernetes, version 1.23. This commit updates the
contrib helper script to install 1.22 by default.

No changelog since this is a local dev helper script.