### PR TITLE
plugin/k8s: Add CPU/Memory resource limits to ODR

### DIFF
--- a/.changelog/3307.txt
+++ b/.changelog/3307.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/k8s: Add CPU and memory resource limits to on-demand runners through runner profiles and at install time. These resource limits follow the same format that kubernetes expects within `spec.containers[].resources`.
+```

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -64,6 +64,12 @@ type TaskLauncherConfig struct {
 
 	// The namespace to use for launching this task in Kubernetes
 	Namespace string `hcl:"namespace,optional"`
+
+	// Optionally define various cpu resource limits and requests for kubernetes pod containers
+	CPU *ResourceConfig `hcl:"cpu,block"`
+
+	// Optionally define various memory resource limits and requests for kubernetes pod containers
+	Memory *ResourceConfig `hcl:"memory,block"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {
@@ -118,6 +124,16 @@ task {
 			"service account is the name of the Kubernetes service account to add to the pod.",
 			"This is useful to apply Kubernetes RBAC to the application.",
 		),
+	)
+
+	doc.SetField(
+		"memory",
+		"memory resource request to be added to the task container",
+	)
+
+	doc.SetField(
+		"cpu",
+		"cpu resource request to be added to the task container",
 	)
 
 	doc.SetField(
@@ -254,6 +270,47 @@ func (p *TaskLauncher) StartTask(
 	// Get container resource limits and requests
 	resourceLimits := make(map[corev1.ResourceName]k8sresource.Quantity)
 	resourceRequests := make(map[corev1.ResourceName]k8sresource.Quantity)
+
+	if p.config.CPU != nil {
+		if p.config.CPU.Requested != "" {
+			q, err := k8sresource.ParseQuantity(p.config.CPU.Requested)
+			if err != nil {
+				return nil,
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %s to k8s quantity: %s", p.config.CPU.Requested, err)
+			}
+			resourceRequests[corev1.ResourceCPU] = q
+		}
+
+		if p.config.CPU.Limit != "" {
+			q, err := k8sresource.ParseQuantity(p.config.CPU.Limit)
+			if err != nil {
+				return nil,
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu limit %s to k8s quantity: %s", p.config.CPU.Limit, err)
+			}
+			resourceLimits[corev1.ResourceCPU] = q
+		}
+	}
+
+	if p.config.Memory != nil {
+		if p.config.Memory.Requested != "" {
+			q, err := k8sresource.ParseQuantity(p.config.Memory.Requested)
+			if err != nil {
+				return nil,
+					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %s to k8s quantity: %s", p.config.Memory.Requested, err)
+			}
+			resourceRequests[corev1.ResourceMemory] = q
+		}
+
+		if p.config.Memory.Limit != "" {
+			q, err := k8sresource.ParseQuantity(p.config.Memory.Limit)
+			if err != nil {
+				return nil,
+					status.Errorf(codes.InvalidArgument, "failed to parse memory limit %s to k8s quantity: %s", p.config.Memory.Limit, err)
+			}
+			resourceLimits[corev1.ResourceMemory] = q
+		}
+	}
+
 	resourceRequirements := corev1.ResourceRequirements{
 		Limits:   resourceLimits,
 		Requests: resourceRequests,

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -276,7 +276,7 @@ func (p *TaskLauncher) StartTask(
 			q, err := k8sresource.ParseQuantity(p.config.CPU.Requested)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %s to k8s quantity: %s", p.config.CPU.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %q to k8s quantity: %s", p.config.CPU.Requested, err)
 			}
 			resourceRequests[corev1.ResourceCPU] = q
 		}
@@ -285,7 +285,7 @@ func (p *TaskLauncher) StartTask(
 			q, err := k8sresource.ParseQuantity(p.config.CPU.Limit)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse cpu limit %s to k8s quantity: %s", p.config.CPU.Limit, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu limit %q to k8s quantity: %s", p.config.CPU.Limit, err)
 			}
 			resourceLimits[corev1.ResourceCPU] = q
 		}
@@ -296,7 +296,7 @@ func (p *TaskLauncher) StartTask(
 			q, err := k8sresource.ParseQuantity(p.config.Memory.Requested)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %s to k8s quantity: %s", p.config.Memory.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %q to k8s quantity: %s", p.config.Memory.Requested, err)
 			}
 			resourceRequests[corev1.ResourceMemory] = q
 		}
@@ -305,7 +305,7 @@ func (p *TaskLauncher) StartTask(
 			q, err := k8sresource.ParseQuantity(p.config.Memory.Limit)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse memory limit %s to k8s quantity: %s", p.config.Memory.Limit, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse memory limit %q to k8s quantity: %s", p.config.Memory.Limit, err)
 			}
 			resourceLimits[corev1.ResourceMemory] = q
 		}

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -1124,6 +1125,18 @@ func (i *K8sInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	}
 	if v := i.config.imagePullPolicy; v != "" {
 		cfgMap["image_pull_policy"] = v
+	}
+	if v := i.config.cpuRequest; v != "" {
+		cpuRequest := k8s.ResourceConfig{
+			Requested: v,
+		}
+		cfgMap["cpu"] = cpuRequest
+	}
+	if v := i.config.memRequest; v != "" {
+		memRequest := k8s.ResourceConfig{
+			Requested: v,
+		}
+		cfgMap["memory"] = memRequest
 	}
 
 	// Marshal our config

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -54,6 +54,8 @@ type k8sConfig struct {
 	openshift         bool   `hcl:"openshft,optional"`
 	cpuRequest        string `hcl:"cpu_request,optional"`
 	memRequest        string `hcl:"mem_request,optional"`
+	cpuLimit          string `hcl:"cpu_limit,optional"`
+	memLimit          string `hcl:"mem_limit,optional"`
 	storageClassName  string `hcl:"storageclassname,optional"`
 	storageRequest    string `hcl:"storage_request,optional"`
 	secretFile        string `hcl:"secret_file,optional"`
@@ -1032,6 +1034,14 @@ func (i *K8sInstaller) UninstallRunner(
 					i.config.cpuRequest = v.String()
 				}
 			}
+			if m := c.Resources.Limits; len(m) > 0 {
+				if v, ok := m[apiv1.ResourceMemory]; ok {
+					i.config.memLimit = v.String()
+				}
+				if v, ok := m[apiv1.ResourceCPU]; ok {
+					i.config.cpuLimit = v.String()
+				}
+			}
 		}
 
 		// create our wait channel to later poll for statefulset+pod deletion
@@ -1126,18 +1136,23 @@ func (i *K8sInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	if v := i.config.imagePullPolicy; v != "" {
 		cfgMap["image_pull_policy"] = v
 	}
+
+	var cpuConfig k8s.ResourceConfig
+	var memConfig k8s.ResourceConfig
 	if v := i.config.cpuRequest; v != "" {
-		cpuRequest := k8s.ResourceConfig{
-			Requested: v,
-		}
-		cfgMap["cpu"] = cpuRequest
+		cpuConfig.Requested = v
 	}
 	if v := i.config.memRequest; v != "" {
-		memRequest := k8s.ResourceConfig{
-			Requested: v,
-		}
-		cfgMap["memory"] = memRequest
+		memConfig.Requested = v
 	}
+	if v := i.config.cpuLimit; v != "" {
+		cpuConfig.Limit = v
+	}
+	if v := i.config.memLimit; v != "" {
+		memConfig.Limit = v
+	}
+	cfgMap["cpu"] = cpuConfig
+	cfgMap["memory"] = memConfig
 
 	// Marshal our config
 	cfgJson, err := json.MarshalIndent(cfgMap, "", "\t")
@@ -1168,12 +1183,22 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 
 	cpuRequest, err := resource.ParseQuantity(c.cpuRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse cpu request resource %s: %s", c.cpuRequest, err)
+		return nil, fmt.Errorf("could not parse cpu request resource %q: %s", c.cpuRequest, err)
+	}
+
+	cpuLimit, err := resource.ParseQuantity(c.cpuLimit)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse cpu limit resource %q: %s", c.cpuLimit, err)
 	}
 
 	memRequest, err := resource.ParseQuantity(c.memRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse memory request resource %s: %s", c.memRequest, err)
+		return nil, fmt.Errorf("could not parse memory request resource %q: %s", c.memRequest, err)
+	}
+
+	memLimit, err := resource.ParseQuantity(c.memLimit)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse memory limit resource %q: %s", c.memLimit, err)
 	}
 
 	securityContext := &apiv1.PodSecurityContext{}
@@ -1255,6 +1280,10 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 								},
 							},
 							Resources: apiv1.ResourceRequirements{
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceMemory: memLimit,
+									apiv1.ResourceCPU:    cpuLimit,
+								},
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: memRequest,
 									apiv1.ResourceCPU:    cpuRequest,
@@ -1273,17 +1302,27 @@ func newDeployment(c k8sConfig, opts *InstallRunnerOpts) (*appsv1.Deployment, er
 func newStatefulSet(c k8sConfig, rawRunFlags []string) (*appsv1.StatefulSet, error) {
 	cpuRequest, err := resource.ParseQuantity(c.cpuRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse cpu request resource %s: %s", c.cpuRequest, err)
+		return nil, fmt.Errorf("could not parse cpu request resource %q: %s", c.cpuRequest, err)
 	}
 
 	memRequest, err := resource.ParseQuantity(c.memRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse memory request resource %s: %s", c.memRequest, err)
+		return nil, fmt.Errorf("could not parse memory request resource %q: %s", c.memRequest, err)
+	}
+
+	cpuLimit, err := resource.ParseQuantity(c.cpuLimit)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse cpu limit resource %q: %s", c.cpuLimit, err)
+	}
+
+	memLimit, err := resource.ParseQuantity(c.memLimit)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse memory limit resource %q: %s", c.memLimit, err)
 	}
 
 	storageRequest, err := resource.ParseQuantity(c.storageRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse storage request resource %s: %s", c.storageRequest, err)
+		return nil, fmt.Errorf("could not parse storage request resource %q: %s", c.storageRequest, err)
 	}
 
 	securityContext := &apiv1.PodSecurityContext{}
@@ -1385,6 +1424,10 @@ func newStatefulSet(c k8sConfig, rawRunFlags []string) (*appsv1.StatefulSet, err
 								},
 							},
 							Resources: apiv1.ResourceRequirements{
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceMemory: memLimit,
+									apiv1.ResourceCPU:    cpuLimit,
+								},
 								Requests: apiv1.ResourceList{
 									apiv1.ResourceMemory: memRequest,
 									apiv1.ResourceCPU:    cpuRequest,
@@ -1546,6 +1589,20 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 		Name:    "k8s-mem-request",
 		Target:  &i.config.memRequest,
 		Usage:   "Configures the requested memory amount for the Waypoint server in Kubernetes.",
+		Default: "256Mi",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "k8s-cpu-limit",
+		Target:  &i.config.cpuLimit,
+		Usage:   "Configures the CPU limit for the Waypoint server in Kubernetes.",
+		Default: "100m",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "k8s-mem-limit",
+		Target:  &i.config.memLimit,
+		Usage:   "Configures the memory limit for the Waypoint server in Kubernetes.",
 		Default: "256Mi",
 	})
 

--- a/website/README.md
+++ b/website/README.md
@@ -80,7 +80,6 @@ This file can be standard Markdown and also supports [YAML frontmatter](https://
 title: 'My Title'
 description: "A thorough, yet succinct description of the page's contents"
 ---
-
 ```
 
 The significant keys in the YAML frontmatter are:

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -84,6 +84,8 @@ and disable the UI, the command would be:
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
+- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes.
+- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
 - `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -84,6 +84,8 @@ and disable the UI, the command would be:
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
+- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes.
+- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
 - `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.

--- a/website/content/partials/components/task-kubernetes.mdx
+++ b/website/content/partials/components/task-kubernetes.mdx
@@ -20,7 +20,19 @@ task {
 
 ### Required Parameters
 
-This plugin has no required parameters.
+These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
+
+#### cpu
+
+Cpu resource request to be added to the task container.
+
+- Type: **k8s.ResourceConfig**
+
+#### memory
+
+Memory resource request to be added to the task container.
+
+- Type: **k8s.ResourceConfig**
 
 ### Optional Parameters
 


### PR DESCRIPTION
This PR adds plumbing to enable users to add CPU and memory limits to on-demand runner profiles.

Closes #3047 