### PR TITLE
Hide dynamic year from Percy

### DIFF
--- a/ui/app/components/app-footer/index.hbs
+++ b/ui/app/components/app-footer/index.hbs
@@ -1,5 +1,5 @@
 <footer id="footer">
   <Pds::Logomark::Hashicorp role="img"/>
-  <span class="copyright">&copy; {{current-year null}} HashiCorp</span>
+  <span class="copyright hide-in-percy">&copy; {{current-year null}} HashiCorp</span>
   <VersionInfo/>
 </footer>

--- a/ui/app/styles/app.scss
+++ b/ui/app/styles/app.scss
@@ -21,3 +21,10 @@
 @import 'pages';
 
 @import 'lab';
+
+// https://docs.percy.io/docs/percy-specific-css#percy-css-media-query
+@media only percy {
+  .hide-in-percy {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
Prevent screenshot diffs when the year changes

Link in comment: https://docs.percy.io/docs/percy-specific-css#percy-css-media-query

See the current Percy diffs to see that the year is now hidden from Percy, which seems a-ok, as not super impt to be Percy'd? 