### PR TITLE
Fix "Nomad ODR jobs live beyond the completion of their assigned task…

### DIFF
--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -200,7 +200,7 @@ func (p *TaskLauncher) StartTask(
 
 	log.Trace("creating Nomad job for task")
 	jobclient := client.Jobs()
-	job := api.NewServiceJob(taskName, taskName, p.config.Region, 10)
+	job := api.NewBatchJob(taskName, taskName, p.config.Region, 10)
 	job.Datacenters = []string{p.config.Datacenter}
 	tg := api.NewTaskGroup(taskName, 1)
 	tg.Networks = []*api.NetworkResource{


### PR DESCRIPTION
Convert the job type of a Nomad ODR to "batch" instead of "service". (#2697)
Now the ODR jobs are automatically stopped after completion and removed by the GC.