### PR TITLE
builtin/k8s/task: Explicitly set container env var for Kaniko

### DIFF
--- a/.changelog/3322.txt
+++ b/.changelog/3322.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+plugin/k8s: Ensure `container=docker` environment variable is set for Kaniko
+to properly detect running inside a container, which prevented on-demand
+runners from working on Kubernetes 1.23.
+```

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -270,6 +270,15 @@ func (p *TaskLauncher) StartTask(
 		})
 	}
 
+	// NOTE(briancain): This is here to help kaniko detect that this is a docker container.
+	// See https://github.com/GoogleContainerTools/kaniko/blob/7e3954ac734534ce5ce68ad6300a2d3143d82f40/vendor/github.com/genuinetools/bpfd/proc/proc.go#L138
+	// for more info.
+	log.Warn("temporarily setting 'container=docker' environment variable to patch Kaniko working on Kubernetes 1.23")
+	env = append(env, corev1.EnvVar{
+		Name:  "container",
+		Value: "docker",
+	})
+
 	// If the user is using the latest tag, then don't specify an overriding pull policy.
 	// This by default means kubernetes will always pull so that latest is used.
 	pullPolicy := corev1.PullIfNotPresent


### PR DESCRIPTION
Prior to this commit, if a certain version of Kaniko was used with the
current latest version of Kubernetes 1.23, Kaniko would fail to detect
that it was being run inside a container. This means Waypoint would then
faill back to try to use Docker inside a container for the build step.
This commit fixes this by setting the proper env var for Kaniko and
keeps ODR remote builds working.

Fixes #2984