### PR TITLE
Add /ui PR template

### DIFF
--- a/ui/.github/pull_request_template.md
+++ b/ui/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## ✅ Reviewer's checklist
+
+- [ ] +1 Percy, if applicable


### PR DESCRIPTION
From last week's Frontend Sync, add a PR template re: Percy responsibility in code review. 

With this change, the process for the PR reviewer, not the author, will be pre-populated in the PR template. This should only affect PR's from the /ui directory, not all https://github.com/hashicorp/waypoint PR's. It needs to be merged in to see it in action. 

Follow-on to https://github.com/hashicorp/waypoint/pull/3317
