### PR TITLE
internal/core: Add ConfigSync for pipeline configs

### DIFF
--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -118,6 +118,11 @@ func (c *Config) PipelineProtos() ([]*pb.Pipeline, error) {
 	for _, pl := range c.hclConfig.Pipelines {
 		pipe := &pb.Pipeline{
 			Name: pl.Name,
+			Owner: &pb.Pipeline_Project{
+				Project: &pb.Ref_Project{
+					Project: c.hclConfig.Project,
+				},
+			},
 		}
 
 		steps := make(map[string]*pb.Pipeline_Step)

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -111,7 +111,8 @@ func (c *Config) Pipeline(id string, ctx *hcl.EvalContext) (*Pipeline, error) {
 // operations such as ConfigSync.
 func (c *Config) PipelineProtos() ([]*pb.Pipeline, error) {
 	if c == nil {
-		return nil, nil
+		// This is likely an internal error if this happens.
+		panic("attempted to construct pipeline proto on a nil genericConfig")
 	}
 
 	// Build our evaluation context for the config vars

--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -4,9 +4,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
-	"github.com/zclconf/go-cty/cty/function"
 
-	"github.com/hashicorp/waypoint/internal/config/dynamic"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
@@ -114,13 +112,6 @@ func (c *Config) PipelineProtos() ([]*pb.Pipeline, error) {
 		// This is likely an internal error if this happens.
 		panic("attempted to construct pipeline proto on a nil genericConfig")
 	}
-
-	// Build our evaluation context for the config vars
-	ctx := c.ctx
-	ctx = appendContext(ctx, &hcl.EvalContext{
-		Functions: dynamic.Register(map[string]function.Function{}),
-	})
-	ctx = finalizeContext(ctx)
 
 	// Load HCL config and convert to a Pipeline proto
 	var result []*pb.Pipeline

--- a/internal/config/testdata/pipelines/pipelines_many.hcl
+++ b/internal/config/testdata/pipelines/pipelines_many.hcl
@@ -1,0 +1,34 @@
+project = "foo"
+
+pipeline "foo" {
+  step "test" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+
+pipeline "bar" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+app "web" {
+    config {
+        env = {
+            static = "hello"
+        }
+    }
+
+    build {}
+
+    deploy {}
+}

--- a/internal/core/pipeline.go
+++ b/internal/core/pipeline.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/config"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// Pipeline represents a single pipeline and exposes all of the operations
+// that can be performed on a pipeline.
+type Pipeline struct {
+	// UI is the UI that should be used for any output that is specific
+	// to this pipeline vs the project or app UI.
+	UI terminal.UI
+
+	client pb.WaypointClient
+	logger hclog.Logger
+
+	config *config.Pipeline
+
+	// References that ties this pipeline to a specific Waypoint app
+	wsRef   *pb.Ref_Workspace
+	ref     *pb.Ref_Pipeline
+	project *Project
+}
+
+// newPipeline creates a Pipeline for the given application and configuration. This
+// will initialize and configure all of the components of this pipeline. An error
+// will be returned if this pipeline fails to initialize: configuration is invalid,
+// a component could not be found, etc.
+func newPipeline(
+	ctx context.Context,
+	project *Project,
+	config *config.Pipeline,
+) (*Pipeline, error) {
+
+	pipeline := &Pipeline{
+		wsRef:   project.WorkspaceRef(),
+		project: project,
+
+		client: project.client,
+		logger: project.logger.Named("pipeline").Named(config.Name),
+		config: config,
+		UI:     project.UI,
+
+		ref: &pb.Ref_Pipeline{
+			Ref: &pb.Ref_Pipeline_Id{
+				Id: &pb.Ref_PipelineId{
+					Id: config.Name,
+				},
+			},
+		},
+	}
+
+	return pipeline, nil
+}
+
+// Ref returns the reference to this pipeline for us in API calls.
+func (p *Pipeline) Ref() *pb.Ref_Pipeline {
+	return p.ref
+}

--- a/internal/core/pipeline_config.go
+++ b/internal/core/pipeline_config.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// ConfigSync will evaluate the current hcl config for a given Pipeline and
+// upsert the proto version based on the current evaluation
+func (p *Pipeline) ConfigSync(ctx context.Context) error {
+	// TODO(briancain): In the future, we can sync config vars for pipelines here
+
+	// Sync the pipeline metadata
+	p.logger.Debug("evaluating pipeline configs for syncing")
+	pipelines, err := p.config.Config.PipelineProtos()
+	if err != nil {
+		return err
+	}
+
+	// TODO(briancain): do we need a Multi upsert?
+	p.logger.Debug("syncing pipeline config")
+	for _, pipeline := range pipelines {
+		_, err := p.client.UpsertPipeline(ctx, &pb.UpsertPipelineRequest{
+			Pipeline: pipeline,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit introduces a way for runners to initiate a pipeline config
sync. It loads the HCL eval context, evals the config, and translates the
parsed pipeline struct into a Proto Pipeline that is upserted to the server.

I've got a couple of questions that I'll ask as a PR comment, otherwise
this PR is ready for review!