### PR TITLE
server: Ensure primary ODR job gets added as dependency

### DIFF
--- a/internal/server/boltdbstate/task.go
+++ b/internal/server/boltdbstate/task.go
@@ -230,17 +230,17 @@ func (s *State) taskGet(
 	var taskId string
 	switch r := ref.Ref.(type) {
 	case *pb.Ref_Task_Id:
-		s.log.Debug("looking up task", "id", r.Id)
+		s.log.Trace("looking up task", "id", r.Id)
 		taskId = r.Id
 	case *pb.Ref_Task_JobId:
-		s.log.Debug("looking up task by job id", "job_id", r.JobId)
+		s.log.Trace("looking up task by job id", "job_id", r.JobId)
 		// Look up Task by jobid
 		task, err := s.taskByJobId(r.JobId)
 		if err != nil {
 			return nil, err
 		}
 
-		s.log.Debug("found task id", "id", task.Id)
+		s.log.Trace("found task id", "id", task.Id)
 		taskId = task.Id
 	default:
 		return nil, status.Error(codes.FailedPrecondition, "No valid ref id provided in Task ref to taskGet")

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -562,7 +562,7 @@ func (s *Service) onDemandRunnerStopJob(
 	depends := []string{startJob.Id, watchJob.Id}
 
 	// Only add the source job if we're not skipping it.
-	if over := source.OndemandRunnerTask; over != nil && !over.SkipOperation {
+	if over := source.OndemandRunnerTask; over == nil || !over.SkipOperation {
 		depends = append(depends, source.Id)
 	}
 


### PR DESCRIPTION
Prior to this commit, there was a bug with ODR and generating the Stop
Task job. If a plugin did not implement WatchTask, the WatchTask job would fail,
which would invoke the StopTask job and break the task state machine while the
main job was still running. This commit fixes that behavior by ensuring
that if a source job has no overrides defined and is not expected to
skip the operation, the source id gets added as a dependent for the stop
task.