### PR TITLE
Nomad interpolation doc note

### DIFF
--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -552,6 +552,10 @@ An example below shows this by using ` + "`templatefile`" + ` mixed with
 variables such as ` + "`artifact.image`" + ` to dynamically configure the
 Docker image within the Nomad job specification.
 
+-> **Note:** If using [Nomad interpolation](https://www.nomadproject.io/docs/runtime/interpolation) in your jobspec file,
+and the ` + "`templatefile`" + ` function in your waypoint.hcl file, any interpolated values must be escaped with a second 
+` + "`$`" + `. For example: ` + "`$${meta.metadata}`" + ` instead of ` + "`${meta.metadata}`" + `.
+
 ### Entrypoint Functionality
 
 Waypoint [entrypoint functionality](/docs/entrypoint#functionality) such

--- a/website/content/partials/components/platform-nomad-jobspec-canary.mdx
+++ b/website/content/partials/components/platform-nomad-jobspec-canary.mdx
@@ -16,6 +16,10 @@ An example below shows this by using `templatefile` mixed with
 variables such as `artifact.image` to dynamically configure the
 Docker image within the Nomad job specification.
 
+-> **Note:** If using [Nomad interpolation](https://www.nomadproject.io/docs/runtime/interpolation) in your jobspec file,
+and the `templatefile` function in your waypoint.hcl file, any interpolated values must be escaped with a second
+`$`. For example: `$${meta.metadata}` instead of `${meta.metadata}`.
+
 ### Entrypoint Functionality
 
 Waypoint [entrypoint functionality](/docs/entrypoint#functionality) such

--- a/website/content/partials/components/platform-nomad-jobspec.mdx
+++ b/website/content/partials/components/platform-nomad-jobspec.mdx
@@ -16,6 +16,10 @@ An example below shows this by using `templatefile` mixed with
 variables such as `artifact.image` to dynamically configure the
 Docker image within the Nomad job specification.
 
+-> **Note:** If using [Nomad interpolation](https://www.nomadproject.io/docs/runtime/interpolation) in your jobspec file,
+and the `templatefile` function in your waypoint.hcl file, any interpolated values must be escaped with a second
+`$`. For example: `$${meta.metadata}` instead of `${meta.metadata}`.
+
 ### Entrypoint Functionality
 
 Waypoint [entrypoint functionality](/docs/entrypoint#functionality) such


### PR DESCRIPTION
Add note to the docs regarding Nomad interpolation for the jobspec plugin being used with Waypoint's `templatefile` function. Closes #1615 .