### PR TITLE
ui/tests: add missing closing brackets from resource-list tests

### DIFF
--- a/ui/tests/acceptance/deployment-resource-list-test.ts
+++ b/ui/tests/acceptance/deployment-resource-list-test.ts
@@ -21,7 +21,7 @@ module('Acceptance | deployment resource list', function (hooks) {
     assert.dom('[data-test-resources-table]').containsText('example-pod');
     assert
       .dom(
-        `[href="/default/${project.name}/app/${application.name}/deployments/${deployment.sequence}/resources/${resource.id}"`
+        `[href="/default/${project.name}/app/${application.name}/deployments/${deployment.sequence}/resources/${resource.id}"]`
       )
       .exists();
   });

--- a/ui/tests/acceptance/release-resource-list-test.ts
+++ b/ui/tests/acceptance/release-resource-list-test.ts
@@ -22,7 +22,7 @@ module('Acceptance | release resource list', function (hooks) {
     assert.dom('[data-test-resources-table]').containsText('example-pod');
     assert
       .dom(
-        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"`
+        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"]`
       )
       .exists();
   });
@@ -40,7 +40,7 @@ module('Acceptance | release resource list', function (hooks) {
     assert.dom('[data-test-resources-table]').containsText('example-service');
     assert
       .dom(
-        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"`
+        `[href="/default/${project.name}/app/${application.name}/release/seq/${release.sequence}/resources/${resource.id}"]`
       )
       .exists();
   });


### PR DESCRIPTION
## Why the change?

Fixes an old typo of mine that luckily hasn’t been causing any problems because browsers are so forgiving of typos.