### PR TITLE
Option 1 of 2: use github pkg for protoc-gen-go for plugin support

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -9,7 +9,7 @@
 package tools
 
 //go:generate go install github.com/kevinburke/go-bindata
-//go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
+//go:generate go get github.com/golang/protobuf/protoc-gen-go
 //go:generate go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 //go:generate go install github.com/mitchellh/protoc-gen-go-json
 


### PR DESCRIPTION
Option 1 of 2 to fix our plugin generation (option 2 is PR #3366):

Installing `protoc-gen-go` via `go install google.golang.org/protobuf/cmd/protoc-gen-go` results in the following errors when running `make gen/plugins`:
```
See https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code for more information.
builtin/k8s/k8s.go:8: running "protoc": exit status 1
--go_out: protoc-gen-go: plugins are not supported; use 'protoc --go-grpc_out=...' to generate gRPC
```

Installing `protoc-gen-go` via `go get github.com/golang/protobuf/protoc-gen-go` fixes this issue. We do receive the warning:
```
go: module github.com/golang/protobuf is deprecated: Use the "google.golang.org/protobuf" module instead.
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```