### PR TITLE
Extract `internal/jobstream` from `internal/client`

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,8 +13,7 @@ import (
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	configpkg "github.com/hashicorp/waypoint/internal/config"
-	"github.com/hashicorp/waypoint/internal/jobstreamui"
-	"github.com/hashicorp/waypoint/internal/pkg/finalcontext"
+	"github.com/hashicorp/waypoint/internal/jobstream"
 	"github.com/hashicorp/waypoint/internal/pkg/gitdirty"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/grpcmetadata"
@@ -295,182 +293,15 @@ func (c *Project) queueAndStreamJob(
 	}
 	log = log.With("job_id", queueResp.JobId)
 
-	// Get the stream
-	log.Debug("opening job stream")
-	stream, err := c.client.GetJobStream(ctx, &pb.GetJobStreamRequest{
-		JobId: queueResp.JobId,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Wait for open confirmation
-	resp, err := stream.Recv()
-	if err != nil {
-		return nil, err
-	}
-	if _, ok := resp.Event.(*pb.GetJobStreamResponse_Open_); !ok {
-		return nil, status.Errorf(codes.Aborted,
-			"job stream failed to open, got unexpected message %T",
-			resp.Event)
-	}
-
-	type stepData struct {
-		terminal.Step
-
-		out io.Writer
-	}
-
-	// Process events
-	var (
-		completed       bool
-		streamUI        = &jobstreamui.UI{UI: ui}
-		stateEventTimer *time.Timer
+	// Stream
+	return jobstream.Stream(ctx, queueResp.JobId,
+		jobstream.WithClient(c.client),
+		jobstream.WithLogger(log),
+		jobstream.WithUI(ui),
+		jobstream.WithCancelOnError(localJob),
+		jobstream.WithIgnoreTerminal(localJob),
+		jobstream.WithStateCh(monCh),
 	)
-
-	if localJob {
-		defer func() {
-			// If we completed then do nothing, or if the context is still
-			// active since this means that we're not cancelled.
-			if completed || ctx.Err() == nil {
-				return
-			}
-
-			ctx, cancel := finalcontext.Context(log)
-			defer cancel()
-
-			log.Warn("canceling job")
-			_, err := c.client.CancelJob(ctx, &pb.CancelJobRequest{
-				JobId: queueResp.JobId,
-			})
-			if err != nil {
-				log.Warn("error canceling job", "err", err)
-			} else {
-				log.Info("job cancelled successfully")
-			}
-		}()
-	}
-
-	var assignedRunner *pb.Ref_RunnerId
-
-	for {
-		resp, err := stream.Recv()
-		if err != nil {
-			return nil, err
-		}
-		if resp == nil {
-			// This shouldn't happen, but if it does, just ignore it.
-			log.Warn("nil response received, ignoring")
-			continue
-		}
-
-		switch event := resp.Event.(type) {
-
-		case *pb.GetJobStreamResponse_Complete_:
-			completed = true
-
-			if event.Complete.Error == nil {
-				log.Info("job completed successfully")
-				return event.Complete.Result, nil
-			}
-
-			st := status.FromProto(event.Complete.Error)
-			log.Warn("job failed", "code", st.Code(), "message", st.Message())
-			return nil, st.Err()
-
-		case *pb.GetJobStreamResponse_Error_:
-			completed = true
-
-			st := status.FromProto(event.Error.Error)
-			log.Warn("job stream failure", "code", st.Code(), "message", st.Message())
-			return nil, st.Err()
-
-		case *pb.GetJobStreamResponse_Terminal_:
-			// Ignore this for local jobs since we're using our UI directly.
-			if localJob {
-				continue
-			}
-
-			if err := streamUI.Write(event.Terminal.Events); err != nil {
-				log.Warn("job stream UI failure", "err", err)
-			}
-		case *pb.GetJobStreamResponse_State_:
-			// Stop any state event timers if we have any since the state
-			// has changed and we don't want to output that information anymore.
-			if stateEventTimer != nil {
-				stateEventTimer.Stop()
-				stateEventTimer = nil
-			}
-
-			// Check if this job has been assigned a runner for the first time
-			if event.State != nil &&
-				event.State.Job != nil &&
-				event.State.Job.AssignedRunner != nil &&
-				assignedRunner == nil {
-
-				assignedRunner = event.State.Job.AssignedRunner
-
-				runner, err := c.client.GetRunner(ctx, &pb.GetRunnerRequest{RunnerId: assignedRunner.Id})
-				if err != nil {
-					ui.Output("Failed to inspect the runner (id %q) assigned for this operation: %s", assignedRunner.Id, err, terminal.WithErrorStyle())
-					break
-				}
-				switch runnerType := runner.Kind.(type) {
-				case *pb.Runner_Local_:
-					ui.Output("Performing operation locally", terminal.WithInfoStyle())
-				case *pb.Runner_Remote_:
-					ui.Output("Performing this operation on a remote runner with id %q", runner.Id, terminal.WithInfoStyle())
-				case *pb.Runner_Odr:
-					log.Debug("Executing operation on an on-demand runner from profile with ID %q", runnerType.Odr.ProfileId)
-					profile, err := c.client.GetOnDemandRunnerConfig(
-						ctx, &pb.GetOnDemandRunnerConfigRequest{
-							Config: &pb.Ref_OnDemandRunnerConfig{
-								Id: runnerType.Odr.ProfileId,
-							},
-						})
-					if err != nil {
-						ui.Output("Performing operation on an on-demand runner from profile with ID %q", runnerType.Odr.ProfileId, terminal.WithInfoStyle())
-						ui.Output("Failed inspecting runner profile with id %q: %s", runnerType.Odr.GetProfileId(), err, terminal.WithErrorStyle())
-					} else {
-						ui.Output("Performing operation on %q with runner profile %q", profile.Config.PluginType, profile.Config.Name, terminal.WithInfoStyle())
-					}
-				}
-			}
-
-			// For certain states, we do a quality of life UI message if
-			// the wait time ends up being long.
-			switch event.State.Current {
-			case pb.Job_QUEUED:
-				stateEventTimer = time.AfterFunc(stateEventPause, func() {
-					ui.Output("Operation is queued waiting for job %q. Waiting for runner assignment...",
-						queueResp.JobId,
-						terminal.WithHeaderStyle())
-					ui.Output("If you interrupt this command, the job will still run in the background.",
-						terminal.WithInfoStyle())
-				})
-
-			case pb.Job_WAITING:
-				stateEventTimer = time.AfterFunc(stateEventPause, func() {
-					ui.Output("Operation is assigned to a runner. Waiting for start...",
-						terminal.WithHeaderStyle())
-					ui.Output("If you interrupt this command, the job will still run in the background.",
-						terminal.WithInfoStyle())
-				})
-			}
-
-			if monCh != nil {
-				select {
-				case <-ctx.Done():
-					break
-				case monCh <- event.State.Current:
-					// ok
-				}
-			}
-
-		default:
-			log.Warn("unknown stream event", "event", resp.Event)
-		}
-	}
 }
 
 // The time here is meant to encompass the typical case for an operation to begin.

--- a/internal/jobstream/doc.go
+++ b/internal/jobstream/doc.go
@@ -1,0 +1,4 @@
+// Package jobstream has helpers for working more easily with the GetJobStream
+// endpoint, such as handling the full lifecycle of GetJobStream to a UI
+// implementation.
+package jobstream

--- a/internal/jobstream/option.go
+++ b/internal/jobstream/option.go
@@ -1,0 +1,64 @@
+package jobstream
+
+import (
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// Option specifies an option for streaming.
+type Option func(s *stream) error
+
+// Set a logger for the stream watcher.
+func WithLogger(log hclog.Logger) Option {
+	return func(s *stream) error {
+		s.log = log
+		return nil
+	}
+}
+
+// Set the client for the stream watcher. This is required.
+func WithClient(client pb.WaypointClient) Option {
+	return func(s *stream) error {
+		s.client = client
+		return nil
+	}
+}
+
+// Set the UI for all user-facing output to be sent to.
+func WithUI(ui terminal.UI) Option {
+	return func(s *stream) error {
+		s.ui = ui
+		return nil
+	}
+}
+
+// WithCancelOnError causes the job being watched to be canceled (with
+// CancelJob) if the streamer exits unsuccessfully. Defaults to false.
+func WithCancelOnError(v bool) Option {
+	return func(s *stream) error {
+		s.cancelOnErr = v
+		return nil
+	}
+}
+
+// WithIgnoreTerminal ignores the terminal events from the job. Other UI
+// output may happen such as queue delays but the actual terminal events
+// are hidden.
+func WithIgnoreTerminal(v bool) Option {
+	return func(s *stream) error {
+		s.ignoreTerminal = v
+		return nil
+	}
+}
+
+// WithStateCh sets a channel that is sent all the job state changes.
+// This must not block. If the channel blocks, the entire stream watcher may
+// be blocked.
+func WithStateCh(v chan<- pb.Job_State) Option {
+	return func(s *stream) error {
+		s.stateCh = v
+		return nil
+	}
+}

--- a/internal/jobstream/stream.go
+++ b/internal/jobstream/stream.go
@@ -1,0 +1,258 @@
+package jobstream
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/internal/jobstreamui"
+	"github.com/hashicorp/waypoint/internal/pkg/finalcontext"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// Stream a single job and return the result from that job. This function
+// blocks until the job reaches a terminal state (success or fail).
+func Stream(ctx context.Context, jobId string, opts ...Option) (*pb.Job_Result, error) {
+	s := &stream{
+		jobId: jobId,
+	}
+	for _, opt := range opts {
+		if err := opt(s); err != nil {
+			return nil, err
+		}
+	}
+
+	if s.log == nil {
+		s.log = hclog.L()
+	}
+	if s.client == nil {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"client must be set")
+	}
+
+	return s.Run(ctx)
+}
+
+type stream struct {
+	jobId          string
+	log            hclog.Logger
+	client         pb.WaypointClient
+	ui             terminal.UI
+	cancelOnErr    bool
+	ignoreTerminal bool
+	stateCh        chan<- pb.Job_State
+}
+
+// Get the job stream for a single job, handle all the events, and
+// return the final result of the job execution.
+func (s *stream) Run(ctx context.Context) (*pb.Job_Result, error) {
+	log := s.log
+
+	// Get the stream
+	log.Debug("opening job stream")
+	stream, err := s.client.GetJobStream(ctx, &pb.GetJobStreamRequest{
+		JobId: s.jobId,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait for open confirmation
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := resp.Event.(*pb.GetJobStreamResponse_Open_); !ok {
+		return nil, status.Errorf(codes.Aborted,
+			"job stream failed to open, got unexpected message %T",
+			resp.Event)
+	}
+
+	// This timer is used to track whether we're stuck in certain states for
+	// too long and show a UI message. For example, if we're queued for a long
+	// time we notify the user we're queued.
+	var stateEventTimer *time.Timer
+
+	// The UI that will translate terminal events into UI calls.
+	ui := s.ui
+	streamUI := &jobstreamui.UI{UI: ui}
+
+	// If we're canceling the job on non-successful exit, then setup
+	// the defer so that we do that.
+	var completed bool
+	if s.cancelOnErr {
+		defer func() {
+			// If we completed then do nothing, or if the context is still
+			// active since this means that we're not cancelled.
+			if completed || ctx.Err() == nil {
+				return
+			}
+
+			ctx, cancel := finalcontext.Context(log)
+			defer cancel()
+
+			log.Warn("canceling job")
+			_, err := s.client.CancelJob(ctx, &pb.CancelJobRequest{
+				JobId: s.jobId,
+			})
+			if err != nil {
+				log.Warn("error canceling job", "err", err)
+			} else {
+				log.Info("job cancelled successfully")
+			}
+		}()
+	}
+
+	var assignedRunner *pb.Ref_RunnerId
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			// This shouldn't happen, but if it does, just ignore it.
+			log.Warn("nil response received, ignoring")
+			continue
+		}
+
+		switch event := resp.Event.(type) {
+		case *pb.GetJobStreamResponse_Complete_:
+			completed = true
+
+			if event.Complete.Error == nil {
+				log.Info("job completed successfully")
+				return event.Complete.Result, nil
+			}
+
+			st := status.FromProto(event.Complete.Error)
+			log.Warn("job failed", "code", st.Code(), "message", st.Message())
+			return nil, st.Err()
+
+		case *pb.GetJobStreamResponse_Error_:
+			completed = true
+
+			st := status.FromProto(event.Error.Error)
+			log.Warn("job stream failure", "code", st.Code(), "message", st.Message())
+			return nil, st.Err()
+
+		case *pb.GetJobStreamResponse_Terminal_:
+			if s.ignoreTerminal {
+				continue
+			}
+
+			if ui != nil {
+				if err := streamUI.Write(event.Terminal.Events); err != nil {
+					log.Warn("job stream UI failure", "err", err)
+				}
+			}
+
+		case *pb.GetJobStreamResponse_Job:
+			// Job changed, we don't use this information
+
+		case *pb.GetJobStreamResponse_State_:
+			// Stop any state event timers if we have any since the state
+			// has changed and we don't want to output that information anymore.
+			if stateEventTimer != nil {
+				stateEventTimer.Stop()
+				stateEventTimer = nil
+			}
+
+			// Check if this job has been assigned a runner for the first time
+			if event.State != nil &&
+				event.State.Job != nil &&
+				event.State.Job.AssignedRunner != nil &&
+				assignedRunner == nil {
+
+				assignedRunner = event.State.Job.AssignedRunner
+
+				runner, err := s.client.GetRunner(ctx, &pb.GetRunnerRequest{RunnerId: assignedRunner.Id})
+				if err != nil {
+					if ui != nil {
+						ui.Output("Failed to inspect the runner (id %q) assigned for this operation: %s", assignedRunner.Id, err, terminal.WithErrorStyle())
+					}
+
+					break
+				}
+				switch runnerType := runner.Kind.(type) {
+				case *pb.Runner_Local_:
+					if ui != nil {
+						ui.Output("Performing operation locally", terminal.WithInfoStyle())
+					}
+				case *pb.Runner_Remote_:
+					if ui != nil {
+						ui.Output("Performing this operation on a remote runner with id %q", runner.Id, terminal.WithInfoStyle())
+					}
+				case *pb.Runner_Odr:
+					log.Debug("Executing operation on an on-demand runner from profile with ID %q", runnerType.Odr.ProfileId)
+					profile, err := s.client.GetOnDemandRunnerConfig(
+						ctx, &pb.GetOnDemandRunnerConfigRequest{
+							Config: &pb.Ref_OnDemandRunnerConfig{
+								Id: runnerType.Odr.ProfileId,
+							},
+						})
+					if ui != nil {
+						if err != nil {
+							ui.Output("Performing operation on an on-demand runner from profile with ID %q", runnerType.Odr.ProfileId, terminal.WithInfoStyle())
+							ui.Output("Failed inspecting runner profile with id %q: %s", runnerType.Odr.GetProfileId(), err, terminal.WithErrorStyle())
+						} else {
+							ui.Output("Performing operation on %q with runner profile %q", profile.Config.PluginType, profile.Config.Name, terminal.WithInfoStyle())
+						}
+					}
+				}
+			}
+
+			// For certain states, we do a quality of life UI message if
+			// the wait time ends up being long.
+			switch event.State.Current {
+			case pb.Job_QUEUED:
+				if ui != nil {
+					stateEventTimer = time.AfterFunc(stateEventPause, func() {
+						ui.Output(
+							"Operation is queued waiting for job %q. Waiting for runner assignment...",
+							s.jobId,
+							terminal.WithHeaderStyle())
+						ui.Output(
+							"If you interrupt this command, the job will still run in the background.",
+							terminal.WithInfoStyle())
+					})
+				}
+
+			case pb.Job_WAITING:
+				if ui != nil {
+					stateEventTimer = time.AfterFunc(stateEventPause, func() {
+						ui.Output("Operation is assigned to a runner. Waiting for start...",
+							terminal.WithHeaderStyle())
+						ui.Output("If you interrupt this command, the job will still run in the background.",
+							terminal.WithInfoStyle())
+					})
+				}
+			}
+
+			if s.stateCh != nil {
+				select {
+				case <-ctx.Done():
+					break
+				case s.stateCh <- event.State.Current:
+					// ok
+				}
+			}
+
+		default:
+			log.Warn("unknown stream event",
+				"type", fmt.Sprintf("%T", resp.Event),
+				"event", resp.Event,
+			)
+		}
+	}
+}
+
+// The time here is meant to encompass the typical case for an operation to begin.
+// With the introduction of ondemand runners, we bumped it up from 1500 to 3000
+// to accomidate the additional time before the job was picked up when testing in
+// local Docker.
+const stateEventPause = 3000 * time.Millisecond

--- a/internal/jobstream/stream.go
+++ b/internal/jobstream/stream.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"github.com/hashicorp/waypoint/internal/jobstreamui"
 	"github.com/hashicorp/waypoint/internal/pkg/finalcontext"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
@@ -80,7 +79,7 @@ func (s *stream) Run(ctx context.Context) (*pb.Job_Result, error) {
 
 	// The UI that will translate terminal events into UI calls.
 	ui := s.ui
-	streamUI := &jobstreamui.UI{UI: ui}
+	streamUI := &UI{UI: ui}
 
 	// If we're canceling the job on non-successful exit, then setup
 	// the defer so that we do that.

--- a/internal/jobstream/stream_test.go
+++ b/internal/jobstream/stream_test.go
@@ -1,0 +1,46 @@
+package jobstream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/waypoint/internal/runner"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
+	"github.com/hashicorp/waypoint/pkg/server/singleprocess"
+)
+
+func TestStream_single(t *testing.T) {
+	log := hclog.L()
+	ctx := context.Background()
+	require := require.New(t)
+	client := singleprocess.TestServer(t)
+
+	// log.SetLevel(hclog.Trace)
+
+	// Create, should get an ID back
+	singleprocess.TestApp(t, client, serverptypes.TestJobNew(t, nil).Application)
+	resp, err := client.QueueJob(ctx, &pb.QueueJobRequest{
+		Job: serverptypes.TestJobNew(t, nil),
+	})
+	require.NoError(err)
+	require.NotNil(resp)
+	require.NotEmpty(resp.JobId)
+
+	// Create a runner
+	r := runner.TestRunner(t,
+		runner.WithClient(client),
+		runner.WithLogger(log),
+	)
+	defer r.Close()
+	require.NoError(r.Start(ctx))
+	go r.Accept(ctx)
+
+	// Stream should complete
+	result, err := Stream(ctx, resp.JobId, WithClient(client))
+	require.NoError(err)
+	require.NotNil(result)
+}

--- a/internal/jobstream/test/doc.go
+++ b/internal/jobstream/test/doc.go
@@ -1,0 +1,4 @@
+// This package implements some of the tests for the jobstream package.
+// This has to be in a standalone folder to avoid import cycles that only
+// exist for the test code.
+package jobstream

--- a/internal/jobstream/test/stream_test.go
+++ b/internal/jobstream/test/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/waypoint/internal/jobstream"
 	"github.com/hashicorp/waypoint/internal/runner"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
@@ -40,7 +41,7 @@ func TestStream_single(t *testing.T) {
 	go r.Accept(ctx)
 
 	// Stream should complete
-	result, err := Stream(ctx, resp.JobId, WithClient(client))
+	result, err := jobstream.Stream(ctx, resp.JobId, jobstream.WithClient(client))
 	require.NoError(err)
 	require.NotNil(result)
 }

--- a/internal/jobstream/ui.go
+++ b/internal/jobstream/ui.go
@@ -1,6 +1,4 @@
-// Package jobstreamui exposes helpers to convert JobStream response
-// to terminal output.
-package jobstreamui
+package jobstream
 
 import (
 	"io"

--- a/internal/runner/operation_pipeline_step.go
+++ b/internal/runner/operation_pipeline_step.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint/internal/core"
-	"github.com/hashicorp/waypoint/internal/jobstreamui"
+	"github.com/hashicorp/waypoint/internal/jobstream"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
@@ -117,7 +117,7 @@ func (r *Runner) executePipelineStepExec(
 	}
 
 	// Watch job
-	streamUI := &jobstreamui.UI{
+	streamUI := &jobstream.UI{
 		UI:  project.UI,
 		Log: log.Named("ui"),
 	}


### PR DESCRIPTION
This extracts job stream handling from `internal/client` into a dedicated, reusable package. See the tests and `internal/client` for usage. The goal here for pipelines is to be able to build on this to implement `pipeline run`. 

@briancain For an _initial_ step at `pipeline run`, I was thinking we just for loop over the returned IDs and just stream them _sequentially_. It isn't perfect but it gets us started. We can do smarter stuff later.