### PR TITLE
plugin/aws-ecs: Check target group ARN before destroying listener

### DIFF
--- a/.changelog/3385.txt
+++ b/.changelog/3385.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/aws-ecs: Prevent deployment pruning from removing a load balancer's listener if there is only 1 target group and it is not the deployment's target group,
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1202,8 +1202,9 @@ func (p *Platform) resourceAlbListenerDestroy(
 
 	var tgs []*elbv2.TargetGroupTuple
 
-	// If there is only 1 target group, delete the listener
-	if len(def) == 1 && len(def[0].ForwardConfig.TargetGroups) == 1 {
+	// If there is only 1 target group and if it is this deployment's target group,
+	// delete the listener
+	if len(def) == 1 && len(def[0].ForwardConfig.TargetGroups) == 1 && *def[0].ForwardConfig.TargetGroups[0].TargetGroupArn == state.TargetGroup.Arn {
 		log.Debug("only 1 target group, deleting listener")
 
 		s.Update("Deleting ALB listener (ARN: %q)", state.Arn)


### PR DESCRIPTION
Fixes #3384 