### PR TITLE
chore(docs): k8s troubleshooting improvements

### DIFF
--- a/website/content/docs/troubleshooting.mdx
+++ b/website/content/docs/troubleshooting.mdx
@@ -40,7 +40,7 @@ Ensure that you have the latest `hashicorp/waypoint` Docker image.
 $ docker pull hashicorp/waypoint:latest
 ```
 
-`waypoint install` for Docker creates a container and a volume. These resources should be removed when Waypoint Server is no longer needed. These are some example `docker` commands that should clean up after a Waypoint Server installation.
+[`waypoint install`] for Docker creates a container and a volume. These resources should be removed when Waypoint Server is no longer needed. These are some example `docker` commands that should clean up after a Waypoint Server installation.
 
 ```shell-session
 $ docker stop waypoint-server
@@ -50,12 +50,21 @@ $ docker volume prune -f
 
 #### Waypoint Server in Kubernetes
 
-`waypoint install` for Kubernetes creates a StatefulSet, Service and PersistentVolumeClaim. These resources should be removed when Waypoint Server is no longer needed. These are some example `kubectl` commands that should clean up after a Waypoint Server installation.
+[`waypoint install`] for Kubernetes creates a [StatefulSet][k8s.sts], [Service][k8s.svc], [PersistentVolumeClaim][k8s.pvc], and a [Deployment][k8s.deploy].
+These resources should be removed when Waypoint Server is no longer needed. These are some example `kubectl` commands that should
+clean up after a Waypoint Server installation.
+
+[`waypoint install`]: /commands/install
+[k8s.sts]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+[k8s.svc]: https://kubernetes.io/docs/concepts/services-networking/service/
+[k8s.pvc]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+[k8s.deploy]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 
 ```shell-session
-$ kubectl delete statefulset waypoint-server
+$ kubectl delete sts waypoint-server
 $ kubectl delete pvc data-waypoint-server-0
 $ kubectl delete svc waypoint
+$ kubectl delete deploy waypoint-runner
 ```
 
 ## Pack Builder No Such Image


### PR DESCRIPTION
# Description

This adds 1 additional `kubectl` cleanup command to 
https://www.waypointproject.io/docs/troubleshooting#waypoint-server-in-kubernetes

<img width="948" alt="CleanShot 2022-05-25 at 19 45 37@2x" src="https://user-images.githubusercontent.com/26389321/170387197-ef9386cc-f918-4da9-aa5d-6863ff6f1754.png">
