### PR TITLE
Fix `docker-pull` remote operations build & push

### DIFF
--- a/.changelog/3398.txt
+++ b/.changelog/3398.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/docker: fix issue with remote operations for `docker-pull` builder
+```

--- a/builtin/docker/pull/kaniko.go
+++ b/builtin/docker/pull/kaniko.go
@@ -81,13 +81,10 @@ func (b *Builder) pullWithKaniko(
 		host = "index.docker.io"
 	}
 
-	var insecure bool
 	if ai.Insecure {
 		oci.Upstream = "http://" + host
-		insecure = true
 	} else {
 		oci.Upstream = "https://" + host
-		insecure = false
 	}
 
 	refPath := reference.Path(ref)
@@ -153,7 +150,7 @@ func (b *Builder) pullWithKaniko(
 		"-d", localRef,
 	}
 
-	if insecure {
+	if ai.Insecure {
 		args = append(args, "--insecure-registry")
 	}
 

--- a/builtin/docker/pull/kaniko.go
+++ b/builtin/docker/pull/kaniko.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	empty "google.golang.org/protobuf/types/known/emptypb"
 	"net"
 	"net/http"
 	"os"
@@ -38,7 +37,7 @@ func (b *Builder) pullWithKaniko(
 	target := &wpdocker.Image{
 		Image:    ai.Image,
 		Tag:      ai.Tag,
-		Location: &wpdocker.Image_Docker{Docker: &empty.Empty{}},
+		Location: &wpdocker.Image_Registry{Registry: &wpdocker.Image_RegistryLocation{}},
 	}
 
 	var oci ociregistry.Server


### PR DESCRIPTION
In version 0.8.2 of Waypoint, using remote operations with the `docker-pull` plugin exits without building the app. The error produced is indicated in this log message:
```
[DEBUG] waypoint.runner.agent.runner.app.example-nodejs.mapper.stdio: received EOF, stopping recv loop: job_id=01G4FSXDE0HJMNADYC94CWZ8AN job_op=*gen.Job_Build err="rpc error: code = Unavailable desc = error reading from server: read unix @->/kaniko/tmp/plugin25197406: read: connection reset by peer
```

This PR corrects that problem by updating the OCI registry that's created to align with the `registry` stanza details. The Docker context is now also explicitly provided to Kaniko.

#3394 has more details on the issue with remote operations. [This](https://gist.github.com/paladin-devops/e3cb17ec243a592af38c1a4505ca731d) is a gist of the build log and `waypoint.hcl` where I tested this out.