### PR TITLE
Feature/CLI: `waypoint pipeline run` CLI implementation

### DIFF
--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -32,8 +32,10 @@ func (c *PipelineRunCommand) Run(args []string) int {
 	if len(c.args) == 0 && c.flagPipelineId == "" {
 		c.ui.Output("Pipeline Name required.\n\n%s", c.Help(), terminal.WithErrorStyle())
 		return 1
-	} else {
+	} else if c.flagPipelineId == "" {
 		pipelineName = c.args[0]
+	} else {
+		c.ui.Output("Both pipeline name and id was specified, using pipeline id", terminal.WithWarningStyle())
 	}
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -1,9 +1,16 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/posener/complete"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	clientpkg "github.com/hashicorp/waypoint/internal/client"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	jobstream "github.com/hashicorp/waypoint/internal/jobstream"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
 type PipelineRunCommand struct {
@@ -16,6 +23,94 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		WithArgs(args),
 		WithFlags(c.Flags()),
 	); err != nil {
+		return 1
+	}
+
+	var pipelineName string
+	if len(c.args) == 0 {
+		c.ui.Output("Pipeline Name required.\n\n%s", c.Help(), terminal.WithErrorStyle())
+		return 1
+	} else {
+		pipelineName = c.args[0]
+	}
+
+	// Pre-calculate our project ref
+	projectRef := &pb.Ref_Project{Project: c.flagProject}
+	if c.flagProject == "" {
+		if c.project != nil {
+			projectRef = c.project.Ref()
+		}
+
+		if projectRef == nil {
+			c.ui.Output("You must specify a project with -project or be inside an existing project directory.\n"+c.Help(),
+				terminal.WithErrorStyle())
+			return 1
+		}
+	}
+
+	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+		app.UI.Output("Running pipeline %q for application %q",
+			pipelineName, app.Ref().Application, terminal.WithHeaderStyle())
+
+		sg := app.UI.StepGroup()
+		defer sg.Wait()
+
+		step := sg.Add("Building pipeline execution request...")
+		defer step.Abort()
+
+		runJobTemplate := &pb.Job{
+			Application: app.Ref(),
+			Workspace:   &pb.Ref_Workspace{Workspace: c.flagWorkspace},
+
+			TargetRunner: &pb.Ref_Runner{Target: &pb.Ref_Runner_Any{}},
+		}
+
+		runPipelineReq := &pb.RunPipelineRequest{
+			JobTemplate: runJobTemplate,
+
+			Pipeline: &pb.Ref_Pipeline{
+				Ref: &pb.Ref_Pipeline_Owner{
+					Owner: &pb.Ref_PipelineOwner{
+						Project:      projectRef,
+						PipelineName: pipelineName,
+					},
+				},
+			},
+		}
+
+		step.Update("Requesting to queue run of pipeline %q...", pipelineName)
+
+		// take pipeline id and queue a RunPipeline with a Job Template.
+		resp, err := c.project.Client().RunPipeline(c.Ctx, runPipelineReq)
+		if err != nil {
+			return err
+		}
+
+		step.Update("Pipeline %q has started running. Attempting to read job stream sequentially in order", pipelineName)
+		step.Done()
+
+		// TODO: do we need a stream timeout?
+		// Receieve job ids from running pipeline, use job client to attach to job stream
+		// and stream here. First pass can be linear job streaming
+		for _, jobId := range resp.AllJobIds {
+			app.UI.Output("Reading job stream (jobId: %s)...", jobId, terminal.WithHeaderStyle())
+			app.UI.Output("")
+
+			// Throw away the job result for now. We could do something fancy with this
+			// later.
+			// TODO: unknown stream event: type=*gen.GetJobStreamResponse_Download_ ??
+			_, err := jobstream.Stream(c.Ctx, jobId, jobstream.WithClient(c.project.Client()))
+			if err != nil {
+				return err
+			}
+		}
+
+		app.UI.Output("✔ Pipeline %q (%s) finished!", pipelineName, projectRef, terminal.WithSuccessStyle())
+
+		return nil
+	})
+	if err != nil {
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -35,14 +130,15 @@ func (c *PipelineRunCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *PipelineRunCommand) Synopsis() string {
-	return "Manually execute a pipeline"
+	return "Manually execute a pipeline by name."
 }
 
 func (c *PipelineRunCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint pipeline run [options] <pipeline-id>
+Usage: waypoint pipeline run [options] <pipeline-name>
 
-  Run a pipeline by id.
+  Run a pipeline by name. If run outside of a project dir, a '-project' flag is
+	required.
 
 ` + c.Flags().Help())
 }

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -99,7 +99,9 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			// Throw away the job result for now. We could do something fancy with this
 			// later.
 			// TODO: unknown stream event: type=*gen.GetJobStreamResponse_Download_ ??
-			_, err := jobstream.Stream(c.Ctx, jobId, jobstream.WithClient(c.project.Client()))
+			_, err := jobstream.Stream(c.Ctx, jobId,
+				jobstream.WithClient(c.project.Client()),
+				jobstream.WithUI(app.UI))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -15,6 +15,8 @@ import (
 
 type PipelineRunCommand struct {
 	*baseCommand
+
+	flagPipelineId string
 }
 
 func (c *PipelineRunCommand) Run(args []string) int {
@@ -27,30 +29,22 @@ func (c *PipelineRunCommand) Run(args []string) int {
 	}
 
 	var pipelineName string
-	if len(c.args) == 0 {
+	if len(c.args) == 0 && c.flagPipelineId == "" {
 		c.ui.Output("Pipeline Name required.\n\n%s", c.Help(), terminal.WithErrorStyle())
 		return 1
 	} else {
 		pipelineName = c.args[0]
 	}
 
-	// Pre-calculate our project ref
-	projectRef := &pb.Ref_Project{Project: c.flagProject}
-	if c.flagProject == "" {
-		if c.project != nil {
-			projectRef = c.project.Ref()
-		}
-
-		if projectRef == nil {
-			c.ui.Output("You must specify a project with -project or be inside an existing project directory.\n"+c.Help(),
-				terminal.WithErrorStyle())
-			return 1
-		}
-	}
-
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
+		// setup pipeline name to be used for UI printing
+		pipelineIdent := pipelineName
+		if c.flagPipelineId != "" {
+			pipelineIdent = c.flagPipelineId
+		}
+
 		app.UI.Output("Running pipeline %q for application %q",
-			pipelineName, app.Ref().Application, terminal.WithHeaderStyle())
+			pipelineIdent, app.Ref().Application, terminal.WithHeaderStyle())
 
 		sg := app.UI.StepGroup()
 		defer sg.Wait()
@@ -58,6 +52,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		step := sg.Add("Building pipeline execution request...")
 		defer step.Abort()
 
+		// build the initial job template for running the pipeline
 		runJobTemplate := &pb.Job{
 			Application: app.Ref(),
 			Workspace:   &pb.Ref_Workspace{Workspace: c.flagWorkspace},
@@ -65,20 +60,32 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			TargetRunner: &pb.Ref_Runner{Target: &pb.Ref_Runner_Any{}},
 		}
 
+		// build the base api request
 		runPipelineReq := &pb.RunPipelineRequest{
 			JobTemplate: runJobTemplate,
+		}
 
-			Pipeline: &pb.Ref_Pipeline{
+		// Reference by ID if set, otherwise by name
+		if c.flagPipelineId != "" {
+			runPipelineReq.Pipeline = &pb.Ref_Pipeline{
+				Ref: &pb.Ref_Pipeline_Id{
+					Id: &pb.Ref_PipelineId{
+						Id: c.flagPipelineId,
+					},
+				},
+			}
+		} else {
+			runPipelineReq.Pipeline = &pb.Ref_Pipeline{
 				Ref: &pb.Ref_Pipeline_Owner{
 					Owner: &pb.Ref_PipelineOwner{
-						Project:      projectRef,
+						Project:      &pb.Ref_Project{Project: app.Ref().Project},
 						PipelineName: pipelineName,
 					},
 				},
-			},
+			}
 		}
 
-		step.Update("Requesting to queue run of pipeline %q...", pipelineName)
+		step.Update("Requesting to queue run of pipeline %q...", pipelineIdent)
 
 		// take pipeline id and queue a RunPipeline with a Job Template.
 		resp, err := c.project.Client().RunPipeline(c.Ctx, runPipelineReq)
@@ -86,10 +93,9 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			return err
 		}
 
-		step.Update("Pipeline %q has started running. Attempting to read job stream sequentially in order", pipelineName)
+		step.Update("Pipeline %q has started running. Attempting to read job stream sequentially in order", pipelineIdent)
 		step.Done()
 
-		// TODO: do we need a stream timeout?
 		// Receieve job ids from running pipeline, use job client to attach to job stream
 		// and stream here. First pass can be linear job streaming
 		for _, jobId := range resp.AllJobIds {
@@ -98,7 +104,6 @@ func (c *PipelineRunCommand) Run(args []string) int {
 
 			// Throw away the job result for now. We could do something fancy with this
 			// later.
-			// TODO: unknown stream event: type=*gen.GetJobStreamResponse_Download_ ??
 			_, err := jobstream.Stream(c.Ctx, jobId,
 				jobstream.WithClient(c.project.Client()),
 				jobstream.WithUI(app.UI))
@@ -107,7 +112,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			}
 		}
 
-		app.UI.Output("✔ Pipeline %q (%s) finished!", pipelineName, projectRef, terminal.WithSuccessStyle())
+		app.UI.Output("✔ Pipeline %q (%s) finished!", pipelineIdent, app.Ref().Project, terminal.WithSuccessStyle())
 
 		return nil
 	})
@@ -120,7 +125,15 @@ func (c *PipelineRunCommand) Run(args []string) int {
 }
 
 func (c *PipelineRunCommand) Flags() *flag.Sets {
-	return c.flagSet(0, nil)
+	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
+		f := set.NewSet("Command Options")
+		f.StringVar(&flag.StringVar{
+			Name:    "pipeline-id",
+			Target:  &c.flagPipelineId,
+			Default: "",
+			Usage:   "Run a pipeline by ID.",
+		})
+	})
 }
 
 func (c *PipelineRunCommand) AutocompleteArgs() complete.Predictor {

--- a/internal/cli/task_list.go
+++ b/internal/cli/task_list.go
@@ -137,10 +137,15 @@ func (c *TaskListCommand) Run(args []string) int {
 			op = "StartTask"
 		case *pb.Job_StopTask:
 			op = "StopTask"
+		case *pb.Job_WatchTask:
+			op = "WatchTask"
 		case *pb.Job_Init:
 			op = "Init"
+		case *pb.Job_PipelineStep:
+			op = "PipelineStep"
 		default:
 			op = "Unknown"
+			c.Log.Debug("encountered unsupported task operation", "op", t.TaskJob.Operation)
 		}
 
 		var project string

--- a/internal/jobstream/stream.go
+++ b/internal/jobstream/stream.go
@@ -139,6 +139,17 @@ func (s *stream) Run(ctx context.Context) (*pb.Job_Result, error) {
 			log.Warn("job stream failure", "code", st.Code(), "message", st.Message())
 			return nil, st.Err()
 
+		case *pb.GetJobStreamResponse_Download_:
+			if ui != nil {
+				ui.Output("Downloading from Git", terminal.WithHeaderStyle())
+
+				// Assume git type for now
+				git := event.Download.DataSourceRef.Ref.(*pb.Job_DataSource_Ref_Git)
+
+				ui.Output("Git Commit: %s", git.Git.Commit, terminal.WithInfoStyle())
+				ui.Output(" Timestamp: %s", git.Git.Timestamp.AsTime(), terminal.WithInfoStyle())
+			}
+
 		case *pb.GetJobStreamResponse_Terminal_:
 			if s.ignoreTerminal {
 				continue

--- a/website/content/commands/pipeline-run.mdx
+++ b/website/content/commands/pipeline-run.mdx
@@ -2,22 +2,23 @@
 layout: commands
 page_title: 'Commands: Pipeline run'
 sidebar_title: 'pipeline run'
-description: 'Manually execute a pipeline'
+description: 'Manually execute a pipeline by name.'
 ---
 
 # Waypoint Pipeline run
 
 Command: `waypoint pipeline run`
 
-Manually execute a pipeline
+Manually execute a pipeline by name.
 
 @include "commands/pipeline-run_desc.mdx"
 
 ## Usage
 
-Usage: `waypoint pipeline run [options] <pipeline-id>`
+Usage: `waypoint pipeline run [options] <pipeline-name>`
 
-Run a pipeline by id.
+Run a pipeline by name. If run outside of a project dir, a '-project' flag is
+required.
 
 #### Global Options
 

--- a/website/content/commands/pipeline-run.mdx
+++ b/website/content/commands/pipeline-run.mdx
@@ -27,4 +27,18 @@ required.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, Waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
+#### Command Options
+
+- `-pipeline-id=<string>` - Run a pipeline by ID.
+
 @include "commands/pipeline-run_more.mdx"


### PR DESCRIPTION
This pull request introduces a CLI for manually executing pipeline runs via `waypoint pipeline run`. It currently streams the job stream sequentially in the order that the pipeline queued the job on Waypoint server.

Note, I haven't had a successful run of a `PipelineStep` operation yet, but I think the CLI is mostly there despite that.

This PR relies on https://github.com/hashicorp/waypoint/pull/3397 so that you can sync a pipeline config and run it.