### PR TITLE
ui: Rename update to `upsert` for clarity

### DIFF
--- a/ui/mirage/config.ts
+++ b/ui/mirage/config.ts
@@ -40,7 +40,7 @@ export default function (this: Server): void {
   this.post('/ListDeployments', deployment.list);
   this.post('/UI_ListDeployments', deployment.ui_list);
   this.post('/GetDeployment', deployment.get);
-  this.post('/UpsertProject', project.update);
+  this.post('/UpsertProject', project.upsert);
   this.post('/ListProjects', project.list);
   this.post('/GetProject', project.get);
   this.post('/UI_GetProject', project.uiGet);

--- a/ui/mirage/services/project.ts
+++ b/ui/mirage/services/project.ts
@@ -43,7 +43,7 @@ export function uiGet(this: RouteHandler, schema: any, { requestBody }: Request)
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function update(this: RouteHandler, schema: any, { requestBody }: Request): Response {
+export function upsert(this: RouteHandler, schema: any, { requestBody }: Request): Response {
   let requestMsg = decode(UpsertProjectRequest, requestBody);
   let name = requestMsg.getProject()?.getName();
   let variablesList = requestMsg


### PR DESCRIPTION
Following internal discussion, renaming the mocked Mirage endpoint for clarity.

IS (no user facing change, things working as expected):
![waypoint](https://user-images.githubusercontent.com/1372946/171759710-29754fae-e850-4455-9f8d-847d8ad2ed44.gif)

