### PR TITLE
builtin/k8s: Implement `WatchTask` for k8s task plugin

### DIFF
--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -564,7 +564,7 @@ func (p *TaskLauncher) WatchTask(
 
 		// stream message to the ui
 		message := string(buf[:numBytes])
-		log.Info("msg", message)
+		log.Info(message)
 		ui.Output(message)
 	}
 

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -167,7 +167,7 @@ task {
 		"This option configures how long the WatchTask should wait for a task pod to start-up "+
 			"before attempting to stream its logs. If the pod does not start up within "+
 			"the given timeout, WatchTask will exit.",
-		docs.Default(30),
+		docs.Default("30"),
 	)
 
 	return doc, nil

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -537,6 +537,9 @@ func (p *TaskLauncher) WatchTask(
 				// Unknown state, still wait
 				logsDoneCh <- false
 			}
+
+			// Sleep a bit so we don't hammer the k8s cluster
+			time.Sleep(500 * time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
This commit introduces an implementation of WatchTask for the kubernetes
Task plugin. It will poll initially to ensure that the pod being watched
properly starts up before attempting to stream its logs. Once the pod
has started, WatchTask will stream the pod logs and send it to the
runner logs as well as the UI output for the job.