### PR TITLE
Decouple the server from the boltdb instanceExec functionality

### DIFF
--- a/internal/server/boltdbstate/instance_exec_test.go
+++ b/internal/server/boltdbstate/instance_exec_test.go
@@ -27,7 +27,7 @@ func TestInstanceExecCreateByTargetedInstance_disabled(t *testing.T) {
 
 	{
 		// Create an instance exec targetting the specific instance
-		rec := &InstanceExec{
+		rec := &serverstate.InstanceExec{
 			InstanceId: instance.Id,
 		}
 		err := s.InstanceExecCreateByTargetedInstance(instance.Id, rec)
@@ -48,7 +48,7 @@ func TestInstanceExecCreateByDeploymentId_invalidDeployment(t *testing.T) {
 	defer s.Close()
 
 	// Create an instance
-	rec := &InstanceExec{}
+	rec := &serverstate.InstanceExec{}
 	err := s.InstanceExecCreateByDeployment("nope", rec)
 	require.Error(err)
 	require.Equal(codes.ResourceExhausted, status.Code(err))
@@ -67,7 +67,7 @@ func TestInstanceExecCreateByDeploymentId_allDisabled(t *testing.T) {
 
 	{
 		// Create an instance exec targetting the specific instance
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		err := s.InstanceExecCreateByDeployment(instance.DeploymentId, rec)
 		require.Error(err)
 		require.Equal(codes.ResourceExhausted, status.Code(err))
@@ -91,7 +91,7 @@ func TestInstanceExecCreateByDeploymentId_valid(t *testing.T) {
 
 	{
 		// Create an instance exec
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateByDeployment(instance.DeploymentId, rec))
 		require.NotEmpty(rec.Id)
 		require.Equal(instance.Id, rec.InstanceId)
@@ -111,7 +111,7 @@ func TestInstanceExecCreateByDeploymentId_valid(t *testing.T) {
 
 	{
 		// Next one shuld get the same instance since its all we have
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateByDeployment(instance.DeploymentId, rec))
 		require.NotEmpty(rec.Id)
 		require.Equal(instance.Id, rec.InstanceId)
@@ -130,7 +130,7 @@ func TestInstanceExecCreateByDeploymentId_valid(t *testing.T) {
 
 	{
 		// Next one shuld get the B because its less loaded
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateByDeployment(instance.DeploymentId, rec))
 		require.NotEmpty(rec.Id)
 		require.Equal(instance.Id, rec.InstanceId)
@@ -146,7 +146,7 @@ func TestInstanceExecCreateByDeploymentId_valid(t *testing.T) {
 		require.NoError(s.InstanceCreate(instance))
 
 		// Should not get C
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateByDeployment(instance.DeploymentId, rec))
 		require.NotEmpty(rec.Id)
 		require.NotEqual("C", rec.InstanceId)
@@ -157,7 +157,7 @@ func TestInstanceExecCreateByDeploymentId_valid(t *testing.T) {
 
 	{
 		// Create an instance exec targetting the specific instance
-		rec := &InstanceExec{
+		rec := &serverstate.InstanceExec{
 			InstanceId: instance.Id,
 		}
 		require.NoError(s.InstanceExecCreateByTargetedInstance(instance.Id, rec))
@@ -196,7 +196,7 @@ func TestInstanceExecCreateByDeploymentId_longrunningonly(t *testing.T) {
 	// We'll create 3 instance exec and make sure they all go to instance only
 	for i := 0; i < 3; i++ {
 		// Create an instance exec
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateByDeployment(instance.DeploymentId, rec))
 		require.NotEmpty(rec.Id)
 		require.Equal(instance.Id, rec.InstanceId)
@@ -229,7 +229,7 @@ func TestInstanceExecCreateForVirtualInstance(t *testing.T) {
 
 	{
 		// Create an instance exec
-		rec := &InstanceExec{}
+		rec := &serverstate.InstanceExec{}
 		require.NoError(s.InstanceExecCreateForVirtualInstance(ctx, instId, rec))
 		require.NotEmpty(rec.Id)
 		require.Equal(instId, rec.InstanceId)

--- a/pkg/server/singleprocess/service_entrypoint_test.go
+++ b/pkg/server/singleprocess/service_entrypoint_test.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/hashicorp/waypoint/internal/server/boltdbstate"
 	"github.com/hashicorp/waypoint/pkg/server"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
+	"github.com/hashicorp/waypoint/pkg/serverstate"
 )
 
 func TestServiceEntrypointConfig(t *testing.T) {
@@ -459,7 +459,7 @@ func TestServiceEntrypointExecStream_doubleStart(t *testing.T) {
 	require.Nil(resp)
 }
 
-func testRegisterExec(t *testing.T, client pb.WaypointClient, impl pb.WaypointServer) (*boltdbstate.InstanceExec, func()) {
+func testRegisterExec(t *testing.T, client pb.WaypointClient, impl pb.WaypointServer) (*serverstate.InstanceExec, func()) {
 	// Create an instance
 	instanceId, deploymentId, closer := TestEntrypoint(t, client)
 	defer closer()

--- a/pkg/server/singleprocess/service_exec_test.go
+++ b/pkg/server/singleprocess/service_exec_test.go
@@ -11,11 +11,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/hashicorp/waypoint/internal/server/boltdbstate"
 	"github.com/hashicorp/waypoint/pkg/server"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/grpcmetadata"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
+	"github.com/hashicorp/waypoint/pkg/serverstate"
 )
 
 func TestServiceStartExecStream_badOpen(t *testing.T) {
@@ -311,7 +311,7 @@ func TestServiceStartExecStream_entrypointEventChClose(t *testing.T) {
 	require.False(active)
 }
 
-func testGetInstanceExec(t *testing.T, impl pb.WaypointServer, instanceId string) *boltdbstate.InstanceExec {
+func testGetInstanceExec(t *testing.T, impl pb.WaypointServer, instanceId string) *serverstate.InstanceExec {
 	ws := memdb.NewWatchSet()
 	list, err := testStateInmem(impl).InstanceExecListByInstanceId(instanceId, ws)
 	require.NoError(t, err)

--- a/pkg/serverstate/instance.go
+++ b/pkg/serverstate/instance.go
@@ -53,13 +53,37 @@ type InstanceExec struct {
 	Context context.Context
 }
 
+// InstanceExecHandler is an optional interface that the state interface can implement.
+// When it does, the functionality associated with `waypoint exec` will be available.
 type InstanceExecHandler interface {
+	// InstanceExecCreateByTargetedInstance registers an exec request for a specific instance,
+	// identified by it's database id.
 	InstanceExecCreateByTargetedInstance(id string, exec *InstanceExec) error
+
+	// InstanceExecCreateByDeployment looks up the instances running the given deployment,
+	// picks an instance, and assigns the exec to that instance.
 	InstanceExecCreateByDeployment(did string, exec *InstanceExec) error
+
+	// InstanceExecCreateForVirtualInstance is used for plugins that require instances to be
+	// created just to handle exec requests. The given instance id doesn't have to exist yet,
+	// the code will wait for the instance to come online, then assign the exec request to it.
 	InstanceExecCreateForVirtualInstance(ctx context.Context, id string, exec *InstanceExec) error
+
+	// InstanceExecDelete deletes an exec request, identified by it's numeric id (InstanceExec.Id)
 	InstanceExecDelete(id int64) error
+
+	// InstanceExecById retrieves an exec request, identified by it's numeric id (InstanceExec.Id)
 	InstanceExecById(id int64) (*InstanceExec, error)
-	InstanceExecConnect(ctx context.Context, id int64) (*InstanceExec, error)
+
+	// InstanceExecListByInstanceId returns any exec requests for the given instance id.
 	InstanceExecListByInstanceId(id string, ws memdb.WatchSet) ([]*InstanceExec, error)
+
+	// InstanceExecById retrieves an exec request, identified by it's numeric id (InstanceExec.Id).
+	// The implementer also can use this opertunity to do any sychronization of state, such as
+	// connecting to external systems.
+	InstanceExecConnect(ctx context.Context, id int64) (*InstanceExec, error)
+
+	// InstanceExecWaitConnected is run to allow the implementation to sync up with a call to
+	// InstanceExecConnect run elsewhere.
 	InstanceExecWaitConnected(ctx context.Context, exec *InstanceExec) error
 }

--- a/pkg/serverstate/instance.go
+++ b/pkg/serverstate/instance.go
@@ -3,6 +3,7 @@ package serverstate
 import (
 	"context"
 
+	"github.com/hashicorp/go-memdb"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/logbuffer"
 )
@@ -50,4 +51,15 @@ type InstanceExec struct {
 	// It is used by the entrypoint side to detect if the client is still
 	// around or not.
 	Context context.Context
+}
+
+type InstanceExecHandler interface {
+	InstanceExecCreateByTargetedInstance(id string, exec *InstanceExec) error
+	InstanceExecCreateByDeployment(did string, exec *InstanceExec) error
+	InstanceExecCreateForVirtualInstance(ctx context.Context, id string, exec *InstanceExec) error
+	InstanceExecDelete(id int64) error
+	InstanceExecById(id int64) (*InstanceExec, error)
+	InstanceExecConnect(ctx context.Context, id int64) (*InstanceExec, error)
+	InstanceExecListByInstanceId(id string, ws memdb.WatchSet) ([]*InstanceExec, error)
+	InstanceExecWaitConnected(ctx context.Context, exec *InstanceExec) error
 }


### PR DESCRIPTION
The bits within boltdb related to the instanceExec interface have been moved to serverstate, and then boltdb implements that interface.