### PR TITLE
internal/server: Ignore WatchTask on job ack and complete

### DIFF
--- a/internal/server/boltdbstate/job.go
+++ b/internal/server/boltdbstate/job.go
@@ -1633,6 +1633,8 @@ func (s *State) taskAck(jobId string) error {
 		// StopJob has been Acked
 		task.JobState = pb.Task_STOPPING
 		s.log.Trace("stop job is running", "job", job.Id, "task", task.Id)
+	case task.WatchJob.Id:
+		s.log.Trace("ignoring watch task job")
 	default:
 		return status.Errorf(codes.Internal, "no task job id matches the requested job id %q", job.Id)
 	}
@@ -1681,6 +1683,8 @@ func (s *State) taskComplete(jobId string) error {
 		// StopJob has completed, the whole task is finished
 		task.JobState = pb.Task_STOPPED
 		s.log.Trace("stop job has completed", "job", job.Id, "task", task.Id)
+	case task.WatchJob.Id:
+		s.log.Trace("ignoring watch task job")
 	default:
 		return status.Errorf(codes.Internal, "no task job id matches the requested job id %q", job.Id)
 	}

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1503,6 +1503,15 @@ func TestJobTask_AckAndComplete(t *testing.T, factory Factory, rf RestartFactory
 			},
 		})))
 
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "watch_job",
+			Task: &pb.Ref_Task{
+				Ref: &pb.Ref_Task_Id{
+					Id: task_id,
+				},
+			},
+		})))
+
 		// Create a pending task. note that `service_job` does this when it wraps
 		// a requested job with an on-demand runner job triple.
 		err := s.TaskPut(&pb.Task{
@@ -1510,6 +1519,7 @@ func TestJobTask_AckAndComplete(t *testing.T, factory Factory, rf RestartFactory
 			TaskJob:  &pb.Ref_Job{Id: "task_job"},
 			StartJob: &pb.Ref_Job{Id: "start_job"},
 			StopJob:  &pb.Ref_Job{Id: "stop_job"},
+			WatchJob: &pb.Ref_Job{Id: "watch_job"},
 		})
 		require.NoError(err)
 


### PR DESCRIPTION
Prior to this commit, when a job when to ack or complete its state, it
would return an error because it didn't account for the WatchJob id.
This commit fixes that by ignoring any WatchJob acks given it does not
affect the task state machine.

This was supposed to be included in https://github.com/hashicorp/waypoint/pull/3420 but was missed. This will fix any job ack job complete failures on `main`.