### PR TITLE
Fix panic in `waypoint status`

### DIFF
--- a/.changelog/3425.txt
+++ b/.changelog/3425.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: fix panic when running status report on app with zero prior deployments
+```

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -591,6 +591,11 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 		deployBundle := respDeployList.Deployments[0]
 		deploy := deployBundle.Deployment
 		appDeployStatus := deployBundle.LatestStatusReport
+
+		var instancesCount uint32
+		if appDeployStatus != nil {
+			instancesCount = appDeployStatus.InstancesCount
+		}
 		statusColor := ""
 
 		var details string
@@ -613,7 +618,7 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 			deploy.Component.Name,
 			details,
 			deploy.Status.State.String(),
-			fmt.Sprintf("%d", appDeployStatus.InstancesCount),
+			fmt.Sprintf("%d", instancesCount),
 		}
 
 		// Add column data to table


### PR DESCRIPTION
If an application has not been deployed, there will be no initial status report for it, and running `waypoint status -app=<name>` will panic. We fix that here by guarding on `nil`