### PR TITLE
Fix git branch warn

### DIFF
--- a/internal/pkg/gitdirty/gitdirty.go
+++ b/internal/pkg/gitdirty/gitdirty.go
@@ -140,7 +140,7 @@ func getDefaultBranch(log hclog.Logger, repoPath string, remoteName string) (str
 	return defaultBranch, nil
 }
 
-// remoteHasBranch checks to see if the configured remote
+// remoteHasBranch checks to see if the configured remote has the specified branch
 func remoteHasBranch(log hclog.Logger, repoPath string, branch string) (bool, error) {
 	remoteBranchOutput, err := runGitCommand(log, repoPath, "branch", "-r")
 	if err != nil {
@@ -148,6 +148,10 @@ func remoteHasBranch(log hclog.Logger, repoPath string, branch string) (bool, er
 	}
 	branches := strings.Split(remoteBranchOutput, "\n")
 	for _, thisBranch := range branches {
+		arrowIdx := strings.Index(thisBranch, "->")
+		if arrowIdx > 0 {
+			thisBranch = thisBranch[0:arrowIdx]
+		}
 		thisBranch = strings.TrimSpace(thisBranch)
 		if thisBranch == branch {
 			return true, nil


### PR DESCRIPTION

Fixing the warning seen when running waypoint build -vv. 

```
$waypoint build -vv
2022-06-07T15:49:35.531-0500 [WARN]  waypoint.setupLocalJobSystem: failed to determine if local vcs is dirty: err="failed to diff repo at "/Users/cassiecoyle/go/src/github.com/waypoint-examples" subpath "/Users/cassiecoyle/go/src/github.com/waypoint-examples/kubernetes/nodejs" against remote with url "https://github.com/hashicorp/waypoint-examples.git" ref "HEAD": remote origin does not have specified branch "HEAD". To fix this, try running `git fetch origin`"
```