### PR TITLE
kaniko: Include registry host when returning error in entrypoint

### DIFF
--- a/builtin/docker/kaniko.go
+++ b/builtin/docker/kaniko.go
@@ -111,7 +111,7 @@ func (b *Builder) buildWithKaniko(
 
 		err = os.SetupEntrypointLayer(refPath, data)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer: %s", err)
+			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer to host %q, err: %s", os.Upstream, err)
 		}
 	}
 

--- a/builtin/docker/pull/kaniko.go
+++ b/builtin/docker/pull/kaniko.go
@@ -3,6 +3,12 @@ package dockerpull
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/distribution/reference"
 	"github.com/hashicorp/go-hclog"
@@ -13,11 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"net"
-	"net/http"
-	"os"
-	"os/exec"
-	"runtime"
 )
 
 func (b *Builder) pullWithKaniko(
@@ -112,7 +113,7 @@ func (b *Builder) pullWithKaniko(
 		step = sg.Add("Testing registry and uploading entrypoint layer")
 		err = oci.SetupEntrypointLayer(refPath, data)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer: %s", err)
+			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer to host: %q, err: %s", oci.Upstream, err)
 		}
 		step.Done()
 	}

--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -187,7 +187,7 @@ func (b *Builder) BuildODR(
 
 		err = ocis.SetupEntrypointLayer(refPath, data)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer: %s", err)
+			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer to host: %q, err: %s", ocis.Upstream, err)
 		}
 	}
 


### PR DESCRIPTION
Prior to this commit, when a user was confronted with an error about
setting up an entrypoint, it didn't give much context as to what went
wrong. This was often because the user was pushing to a remote registry
which was unexpected. This commit updates that behavior to include the
registry host in the returned error message

Related to https://github.com/hashicorp/waypoint/issues/3435 but doesn't fix the problem fully.