### PR TITLE
Initial metrics spike for gathering metrics about Waypoint operations

### DIFF
--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -115,7 +115,7 @@ func (c *ServerRunCommand) Run(args []string) int {
 	}
 	path := c.config.DBPath
 	log.Info("opening DB", "path", path)
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		c.ui.Output(
 			"Error opening database: %s", err.Error(),
@@ -271,7 +271,8 @@ func (c *ServerRunCommand) Run(args []string) int {
 	}
 	if httpInsecureLn != nil {
 		values = append(values, terminal.NamedValue{
-			Name: "HTTP Address (Insecure)", Value: httpInsecureLn.Addr().String()})
+			Name: "HTTP Address (Insecure)", Value: httpInsecureLn.Addr().String(),
+		})
 	}
 	if auth {
 		values = append(values, terminal.NamedValue{Name: "Auth Required", Value: "yes"})
@@ -374,6 +375,7 @@ This command will bootstrap the server and setup a CLI context.
 			telemetryOptions = append(telemetryOptions, telemetry.WithDatadogExporter(
 				datadog.Options{
 					TraceAddr: c.flagTelemetryDatadogTraceAddr,
+					StatsAddr: c.flagTelemetryDatadogTraceAddr,
 					Service:   "waypoint",
 				},
 			))

--- a/internal/cli/server_run.go
+++ b/internal/cli/server_run.go
@@ -115,7 +115,7 @@ func (c *ServerRunCommand) Run(args []string) int {
 	}
 	path := c.config.DBPath
 	log.Info("opening DB", "path", path)
-	db, err := bolt.Open(path, 0o600, nil)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		c.ui.Output(
 			"Error opening database: %s", err.Error(),
@@ -377,6 +377,7 @@ This command will bootstrap the server and setup a CLI context.
 					TraceAddr: c.flagTelemetryDatadogTraceAddr,
 					StatsAddr: c.flagTelemetryDatadogTraceAddr,
 					Service:   "waypoint",
+					Namespace: "waypoint",
 				},
 			))
 		}

--- a/internal/telemetry/metrics/stats.go
+++ b/internal/telemetry/metrics/stats.go
@@ -1,0 +1,113 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	// Register OpenCensus views.
+	if err := view.Register(statsViews...); err != nil {
+		log.Printf("========================")
+		log.Printf("=== error registering view ===")
+		log.Printf("=== %v ===", err)
+		log.Printf("========================")
+		fmt.Fprintf(os.Stderr, "error registering OpenCensus views: %v", err)
+	} else {
+		log.Printf("========================")
+		log.Printf("=== no registering view ===")
+		log.Printf("========================")
+	}
+}
+
+var (
+	// TagMethod is a tag for capturing the method.
+	TagOperation = tag.MustNewKey("operation")
+
+	operationDurationMeasure = stats.Float64(
+		"waypoint_operation",
+		"The number of seconds duration for this operation",
+		stats.UnitSeconds,
+	)
+
+	operationCountMeasure = stats.Int64(
+		"waypoint_operation_count",
+		"count of operations",
+		stats.UnitDimensionless,
+	)
+
+	waypointOperationCounts = &view.View{
+		Name:        operationCountMeasure.Name(),
+		Description: operationCountMeasure.Description(),
+		TagKeys:     []tag.Key{TagOperation},
+		Measure:     operationCountMeasure,
+		Aggregation: view.Count(),
+	}
+
+	waypointOperationDurations = &view.View{
+		Name:        operationDurationMeasure.Name(),
+		Description: operationDurationMeasure.Description(),
+		TagKeys:     []tag.Key{TagOperation},
+		Measure:     operationDurationMeasure,
+		// add a custom distribution bucket of 10 second intervals between
+		// 0 and 240 seconds, then 10 minute intervals up to 60 minutes
+		Aggregation: view.Distribution(
+			(10 * time.Second).Seconds(),
+			(20 * time.Second).Seconds(),
+			(30 * time.Second).Seconds(),
+			(40 * time.Second).Seconds(),
+			(50 * time.Second).Seconds(),
+			(60 * time.Second).Seconds(),
+			(70 * time.Second).Seconds(),
+			(80 * time.Second).Seconds(),
+			(90 * time.Second).Seconds(),
+			(100 * time.Second).Seconds(),
+			(110 * time.Second).Seconds(),
+			(120 * time.Second).Seconds(),
+			(130 * time.Second).Seconds(),
+			(140 * time.Second).Seconds(),
+			(150 * time.Second).Seconds(),
+			(160 * time.Second).Seconds(),
+			(170 * time.Second).Seconds(),
+			(180 * time.Second).Seconds(),
+			(190 * time.Second).Seconds(),
+			(200 * time.Second).Seconds(),
+			(210 * time.Second).Seconds(),
+			(220 * time.Second).Seconds(),
+			(230 * time.Second).Seconds(),
+			(240 * time.Second).Seconds(),
+			(10 * time.Minute).Seconds(),
+			(20 * time.Minute).Seconds(),
+			(30 * time.Minute).Seconds(),
+			(40 * time.Minute).Seconds(),
+			(50 * time.Minute).Seconds(),
+			(60 * time.Minute).Seconds(),
+		),
+	}
+
+	// statsViews is a list of all stats views for
+	// measurements emitted by this package.
+	statsViews = []*view.View{
+		waypointOperationDurations,
+		waypointOperationCounts,
+	}
+)
+
+func MeasureOperation(ctx context.Context, lastWriteAt time.Time, operationName string) {
+	_ = stats.RecordWithTags(ctx, []tag.Mutator{
+		tag.Upsert(TagOperation, operationName),
+	}, operationDurationMeasure.M(time.Since(lastWriteAt).Seconds()))
+}
+
+func CountOperation(ctx context.Context, operationName string) {
+	_ = stats.RecordWithTags(ctx, []tag.Mutator{
+		tag.Upsert(TagOperation, operationName),
+	}, operationCountMeasure.M(1))
+}

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -2,7 +2,6 @@ package singleprocess
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -538,16 +537,9 @@ func (s *Service) RunnerJobStream(
 	}
 	log.Trace("loaded config sources for job", "total_sourcers", len(cfgSrcs))
 
-	operation := opString(job.Job)
-	log.Debug("sending job assignment to runner")
-	log.Debug("===>                      ")
-	log.Debug(fmt.Sprintf("===> defer func start  (%s) <===", operation))
-	log.Debug("===>                      ")
+	operation := operationString(job.Job)
 	defer func(start time.Time) {
 		metrics.MeasureOperation(ctx, start, operation)
-		log.Debug("===>                      ")
-		log.Debug(fmt.Sprintf("===> defer func execute (%s) <===", operation))
-		log.Debug("===>                      ")
 	}(time.Now())
 	metrics.CountOperation(ctx, operation)
 	// Send the job assignment.
@@ -889,52 +881,49 @@ func (s *Service) runnerVerifyToken(
 	return nil
 }
 
-func opString(job *pb.Job) string {
+func operationString(job *pb.Job) string {
+	// Types that are assignable to Operation:
 	switch job.Operation.(type) {
 	case *pb.Job_Noop_:
 		return "Noop"
-	case *pb.Job_Up:
-		return "up"
 	case *pb.Job_Build:
 		return "build"
-
 	case *pb.Job_Push:
 		return "push"
-
 	case *pb.Job_Deploy:
 		return "deploy"
 	case *pb.Job_Destroy:
 		return "destroy"
-
 	case *pb.Job_Release:
 		return "release"
-
 	case *pb.Job_Validate:
 		return "validate"
-
 	case *pb.Job_Auth:
 		return "auth"
-
 	case *pb.Job_Docs:
 		return "docs"
-
 	case *pb.Job_ConfigSync:
 		return "config_sync"
-
 	case *pb.Job_Exec:
 		return "exec"
-
+	case *pb.Job_Up:
+		return "up"
 	case *pb.Job_Logs:
 		return "logs"
-
 	case *pb.Job_QueueProject:
 		return "queue_project"
-
+	case *pb.Job_Poll:
+		return "poll"
 	case *pb.Job_StatusReport:
-		return "status"
-
+		return "status_report"
+	case *pb.Job_StartTask:
+		return "start_task"
+	case *pb.Job_StopTask:
+		return "stop_task"
+	case *pb.Job_WatchTask:
+		return "watch_task"
 	case *pb.Job_Init:
 		return "init"
 	}
-	return "none"
+	return "unknown"
 }


### PR DESCRIPTION
This PR is a spiritual continuation of https://github.com/hashicorp/waypoint/pull/2402 where we initially introduce telemetry. Here we build off of the inclusion of the DataDog exporter and enable collecting basic metrics for our operations. 

Example of collected operation metrics:

![metrics](https://user-images.githubusercontent.com/61721/172727545-894a6f42-c053-49b6-bf8b-028c06ab0ef4.png)

There are some caveats here, in that the operation times are reported as gauges and not distributions (see https://github.com/DataDog/opencensus-go-exporter-datadog/issues/17). This pattern is however consistent with some of our internal (private) packages from other projects. 

Additional metrics can be collected by adding new OpenCensus Views and Stats in `metrics/stats.go` and exposed to Waypoint as public methods in the `metrics` package. 