### PR TITLE
server/ptype: Validate Workspace ref is set for job

### DIFF
--- a/pkg/server/ptypes/job.go
+++ b/pkg/server/ptypes/job.go
@@ -56,12 +56,22 @@ func ValidateJob(job *pb.Job) error {
 		validation.Field(&job.Id, validation.By(isEmpty)),
 		validation.Field(&job.Application, validation.Required),
 		validation.Field(&job.Workspace, validation.Required),
+		validationext.StructField(&job.Workspace, func() []*validation.FieldRules {
+			return ValidateJobWorkspaceRules(job.Workspace)
+		}),
 		validation.Field(&job.TargetRunner, validation.Required),
 		validation.Field(&job.Operation, validation.Required),
 		validationext.StructField(&job.DataSource, func() []*validation.FieldRules {
 			return ValidateJobDataSourceRules(job.DataSource)
 		}),
 	))
+}
+
+// ValidateJobWorkspaceRules
+func ValidateJobWorkspaceRules(v *pb.Ref_Workspace) []*validation.FieldRules {
+	return []*validation.FieldRules{
+		validation.Field(&v.Workspace, validation.Required),
+	}
 }
 
 // ValidateJobDataSourceRules

--- a/pkg/server/ptypes/job_test.go
+++ b/pkg/server/ptypes/job_test.go
@@ -27,6 +27,12 @@ func TestValidateJob(t *testing.T) {
 		},
 
 		{
+			"workspace is set",
+			func(j *pb.Job) { j.Workspace = nil },
+			"workspace: cannot be blank",
+		},
+
+		{
 			"git: path good",
 			func(j *pb.Job) {
 				j.DataSource = &pb.Job_DataSource{


### PR DESCRIPTION
This came up while working on pipelines. We should be sure to validate workspace refs for job protos, else Waypoint will fail in bad ways when it attempts to write jobs to boltdb.