### PR TITLE
update mockery version for make tools

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -17,7 +17,7 @@ package tools
 //go:generate go install github.com/evanphx/grpc-gateway/protoc-gen-swagger
 
 //go:generate go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-//go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=1.1.2" github.com/vektra/mockery/cmd/mockery
+//go:generate go install "-ldflags=-s -w -X github.com/vektra/mockery/mockery.SemVer=2.12.1" github.com/vektra/mockery/cmd/mockery
 
 import (
 	_ "github.com/evanphx/grpc-gateway/protoc-gen-swagger"


### PR DESCRIPTION
This is just upgrading the tools version for the upgrade that already happened https://github.com/hashicorp/waypoint/pull/3444. After making this change, running `make tools`, verifying the `mockery` version had upgraded, and running `make gen/server`, there were no generated changes to our pbs.