### PR TITLE
internal/server: Set expiry time on runner accept

### DIFF
--- a/internal/server/boltdbstate/job.go
+++ b/internal/server/boltdbstate/job.go
@@ -771,6 +771,13 @@ func (s *State) JobUpdateRef(id string, ref *pb.Job_DataSource_Ref) error {
 	})
 }
 
+func (s *State) JobUpdateExpiry(id string, newExpire *timestamppb.Timestamp) error {
+	return s.JobUpdate(id, func(jobpb *pb.Job) error {
+		jobpb.ExpireTime = newExpire
+		return nil
+	})
+}
+
 // JobUpdate calls the given callback to update fields on the job data.
 // The callback is called in the context of a database write lock so it
 // should NOT compute anything and should be fast. The callback can return

--- a/internal/server/boltdbstate/job.go
+++ b/internal/server/boltdbstate/job.go
@@ -771,6 +771,10 @@ func (s *State) JobUpdateRef(id string, ref *pb.Job_DataSource_Ref) error {
 	})
 }
 
+// JobUpdateExpiry will update the jobs expiration time with the new value. This
+// method is used when a runner has accepted a job and peeks at its runner
+// config. By this point, we know the runner has accepted a job to work on,
+// so the runner should handle the job soon.
 func (s *State) JobUpdateExpiry(id string, newExpire *timestamppb.Timestamp) error {
 	return s.JobUpdate(id, func(jobpb *pb.Job) error {
 		jobpb.ExpireTime = newExpire

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -508,19 +508,6 @@ func (s *Service) onDemandRunnerStartJob(
 	}
 	job.Id = id
 
-	// NOTE(briancain): We set this value to something long for now, because it's
-	// possible during a pipeline run for jobs to be waiting in the QUEUED status
-	// while upstream jobs continue to run. Once a runner accepts a job however,
-	// we will update the jobs expiration time to be 60 seconds because by that
-	// point it should be executing quickly.
-	dur, err := time.ParseDuration("60m")
-	if err != nil {
-		return nil, "", status.Errorf(codes.FailedPrecondition,
-			"Invalid expiry duration: %s", err.Error())
-	}
-
-	job.ExpireTime = timestamppb.New(time.Now().Add(dur))
-
 	// This will be either "Any" or a specific static runner.
 	job.TargetRunner = od.TargetRunner
 

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -508,14 +508,11 @@ func (s *Service) onDemandRunnerStartJob(
 	}
 	job.Id = id
 
-	// We're going to wait up to 60s for the job be picked up. No reason it won't be
-	// picked up immediately.
-	// JK - for pipelines, there IS a reason it won't be picked up immediately,
-	// and it's because we could queue a LOT of jobs. Downstream jobs could be waiting
-	// for a while, like say if a pipeline has a few build steps and a few deploy
-	// steps, a release step might not run within ~60 seconds.
-	// NOTE(briancain): Setting this to 60 minutes for pipelines for now
-	// We should actually set this when the runner peaks at the job
+	// NOTE(briancain): We set this value to something long for now, because it's
+	// possible during a pipeline run for jobs to be waiting in the QUEUED status
+	// while upstream jobs continue to run. Once a runner accepts a job however,
+	// we will update the jobs expiration time to be 60 seconds because by that
+	// point it should be executing quickly.
 	dur, err := time.ParseDuration("60m")
 	if err != nil {
 		return nil, "", status.Errorf(codes.FailedPrecondition,

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -13,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	empty "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/logstream"
@@ -364,10 +366,20 @@ func (s *Service) RunnerConfig(
 		// Set our job
 		job = sjob.Job
 
-		// TODO(briancain): update expiry time here to 60 seconds instead!! We know a job
-		// was accepted, so it shouldn't be hanging around because this runner
-		// is available
-		// Actually this method of updating the expiry time might be a db state func??
+		// We know a job was accepted, so it shouldn't be hanging around because this runner
+		// is available.
+		log.Trace("updating expiry time for job to be 60 seconds now that runner has been assigned job")
+		dur, err := time.ParseDuration("60s")
+		if err != nil {
+			return status.Errorf(codes.FailedPrecondition,
+				"Invalid expiry duration: %s", err.Error())
+		}
+
+		newExpireTime := timestamppb.New(time.Now().Add(dur))
+		if err := s.state(ctx).JobUpdateExpiry(job.Id, newExpireTime); err != nil {
+			log.Error("failed to update job expiry time after runner accepted job!", "err", err)
+			return err
+		}
 
 		log.Debug("runner is scoped for config",
 			"project/application", job.Application,

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-memdb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
@@ -162,6 +163,7 @@ type Interface interface {
 	JobAssignForRunner(context.Context, *pb.Runner) (*Job, error)
 	JobAck(string, bool) (*Job, error)
 	JobUpdateRef(string, *pb.Job_DataSource_Ref) error
+	JobUpdateExpiry(string, *timestamppb.Timestamp) error
 	JobUpdate(string, func(*pb.Job) error) error
 	JobComplete(string, *pb.Job_Result, error) error
 	JobCancel(string, bool) error

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/waypoint/pkg/serverstate"
@@ -29,6 +30,7 @@ func init() {
 		TestJobCancel,
 		TestJobHeartbeat,
 		TestJobUpdateRef,
+		TestJobUpdateExpiry,
 	}
 }
 
@@ -2410,5 +2412,55 @@ func TestJobUpdateRef(t *testing.T, factory Factory, rf RestartFactory) {
 
 		ref := job.DataSourceRef.Ref.(*pb.Job_DataSource_Ref_Git).Git
 		require.Equal(ref.Commit, "hello")
+	})
+}
+
+func TestJobUpdateExpiry(t *testing.T, factory Factory, rf RestartFactory) {
+	t.Run("new expire time", func(t *testing.T) {
+		require := require.New(t)
+
+		s := factory(t)
+		defer s.Close()
+
+		// Create a build
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "A",
+		})))
+
+		// Assign it, we should get this build
+		job, err := s.JobAssignForRunner(context.Background(), &pb.Runner{Id: "R_A"})
+		require.NoError(err)
+		require.NotNil(job)
+		require.Equal("A", job.Id)
+		require.Nil(job.ExpireTime)
+
+		// Ack it
+		_, err = s.JobAck(job.Id, true)
+		require.NoError(err)
+
+		// Create a watchset on the job
+		ws := memdb.NewWatchSet()
+
+		// Verify it was changed
+		job, err = s.JobById(job.Id, ws)
+		require.NoError(err)
+		require.Nil(job.DataSourceRef)
+
+		// Watch should block
+		require.True(ws.Watch(time.After(10 * time.Millisecond)))
+
+		// Update the expire time
+		dur, err := time.ParseDuration("60s")
+		newExpireTime := timestamppb.New(time.Now().Add(dur))
+		require.NoError(s.JobUpdateExpiry(job.Id, newExpireTime))
+
+		// Should be triggered. This is a very important test because
+		// we need to ensure that the watchers can detect ref changes.
+		require.False(ws.Watch(time.After(3 * time.Second)))
+
+		// Verify it was set
+		job, err = s.JobById(job.Id, nil)
+		require.NoError(err)
+		require.NotNil(job.ExpireTime)
 	})
 }


### PR DESCRIPTION
Prior to this commit, Waypoint server only expected queued jobs to wait
for 60 seconds before a runner accepted the job and began executing it
from its creation time. With the introduction of pipelines, this no
longer makes sense because a pipeline will queue all jobs in a pipeline
right away. This means downstream jobs could be waiting around to be
executing for a while, much longer than 1 minute. This is expected.

Given that, this commit updates the server behavior to set a jobs expiry
time to something much longer, 60 minutes, and then when the runner goes
to accept the job, we update the expiry time to the original expected
behavior of 60 seconds, because if the runner has accepted a job to work
on, it should run that job fairly quickly like the original intended
behavior.