### PR TITLE
Nomad plugin: Nomad service discovery

### DIFF
--- a/.changelog/3461.txt
+++ b/.changelog/3461.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad: Support Nomad service discovery in Nomad platform plugin
+```

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -139,12 +139,12 @@ func (p *Platform) resourceJobCreate(
 			},
 		}
 
-		// Register app to Consul. If Nomad is not using Consul, this service
-		// is not used when job is registered
+		// Register service with app deployment
 		tg.Services = []*api.Service{
 			{
 				Name:      result.Name,
 				PortLabel: "waypoint", // matches dynamic port label in NetworkResource
+				Provider:  p.config.ServiceProvider,
 			},
 		}
 
@@ -438,6 +438,9 @@ type Config struct {
 	// or default to another port.
 	ServicePort uint `hcl:"service_port,optional"`
 
+	// Specifies the service registration provider to use for service registrations
+	ServiceProvider string `hcl:"service_provider,optional"`
+
 	// Environment variables that are meant to configure the application in a static
 	// way. This might be control an image that has multiple modes of operation,
 	// selected via environment variable. Most configuration should use the waypoint
@@ -548,6 +551,12 @@ deploy {
 	doc.SetField(
 		"static_environment",
 		"Environment variables to add to the job.",
+	)
+
+	doc.SetField(
+		"service_provider",
+		"Specifies the service registration provider to use for registering a service for the job",
+		docs.Default("consul"),
 	)
 
 	doc.SetField(

--- a/website/content/partials/components/platform-nomad.mdx
+++ b/website/content/partials/components/platform-nomad.mdx
@@ -109,6 +109,14 @@ TCP port the job is listening on.
 - Type: **uint**
 - **Optional**
 
+#### service_provider
+
+Specifies the service registration provider to use for registering a service for the job.
+
+- Type: **string**
+- **Optional**
+- Default: consul
+
 #### static_environment
 
 Environment variables to add to the job.


### PR DESCRIPTION
Update Nomad plugin to support specifying the service provider, which enables the use of Nomad service discovery. Consul remains the default service provider, which is consistent with Nomad.