### PR TITLE
internal/cli: Add a `-json` flag for project list

### DIFF
--- a/website/content/commands/project-list.mdx
+++ b/website/content/commands/project-list.mdx
@@ -24,4 +24,18 @@ Usage: `waypoint project list`
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, Waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
+#### Command Options
+
+- `-json` - Output the Project names as json.
+
 @include "commands/project-list_more.mdx"


### PR DESCRIPTION
This commit adds a simple -json flag to output the project list as json