### PR TITLE
Show errors interpreting plugin config

### DIFF
--- a/.changelog/3465.txt
+++ b/.changelog/3465.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: show helpful errors when using invalid runner profile plugin config
+```

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -132,7 +132,10 @@ func Open(
 	}
 
 	if file.Body != nil {
-		component.Configure(pi.Component, file.Body, hclCtx.NewChild())
+		diag := component.Configure(pi.Component, file.Body, hclCtx.NewChild())
+		if diag.HasErrors() {
+			return nil, nil, diag
+		}
 	}
 
 	return &Plugin{req: req, Instance: pi}, pi.Component, nil


### PR DESCRIPTION
I had a typo in my task launcher config, and the result was that my plugin wasn't getting configured at all - it was running with the default config.

Now I get this useful error!

```
$ waypoint deploy

» Deploying example-nodejs-eks...

» Operation is queued waiting for job "01G5Q3MYHX95A4JS2BKMH24C4D". Waiting for runner assignment...
  If you interrupt this command, the job will still run in the background.
! plugin.json:4,3-19: Extraneous JSON object property; No argument or block type
  is named "service_accunt". Did you mean "service_account"?
```