### PR TITLE
Update Nomad ODR job to Batch Job

### DIFF
--- a/.changelog/3468.txt
+++ b/.changelog/3468.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad: convert Nomad job for ODR to batch job
+```

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -211,10 +211,12 @@ func (p *TaskLauncher) StartTask(
 
 	interval, err := time.ParseDuration("5m")
 	if err != nil {
+		log.Error("error parsing Nomad restart interval duration")
 		return nil, err
 	}
 	delay, err := time.ParseDuration("15s")
 	if err != nil {
+		log.Error("error parsing Nomad delay interval duration")
 		return nil, err
 	}
 	attempts := 10


### PR DESCRIPTION
The Nomad job for the on-demand runner is converted to a batch job in this update.

Closes #3408. 