### PR TITLE
WAYP-204 - Add project deprecation warning

### DIFF
--- a/ui/app/styles/pages/_index.scss
+++ b/ui/app/styles/pages/_index.scss
@@ -2,3 +2,13 @@
 @import 'login';
 @import 'onboarding';
 @import 'projects/create';
+
+.deprecation-banner {
+  margin-bottom: scale.$lg-2;
+}
+
+.deprecation-description {
+  display: flex;
+  flex-direction: column;
+  gap: scale.$sm--3;
+}

--- a/ui/app/templates/workspace/projects/index.hbs
+++ b/ui/app/templates/workspace/projects/index.hbs
@@ -26,6 +26,27 @@
   </Pds::CtaLink>
 </PageHeader>
 
+<Hds::Alert class='deprecation-banner' @type='inline' @color='neutral' @icon='info' as |A|>
+  <A.Title>
+    {{t 'page.project.deprecation-banner.title'}}
+  </A.Title>
+  <A.Description>
+    <div class='deprecation-description'>
+      {{t 'page.project.deprecation-banner.description'}}
+      <div>
+        <Hds::Link::Standalone
+          @icon='external-link'
+          @iconPosition='trailing'
+          @text={{
+            t 'page.project.deprecation-banner.link'
+          }}
+          @href='https://discuss.hashicorp.com/t/deprecating-projects-or-how-i-learned-to-love-apps/40888'
+        />
+      </div>
+    </div>
+  </A.Description>
+</Hds::Alert>
+
 <div data-test-project-list>
   {{#each @model as |project|}}
   <Card>

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -67,6 +67,11 @@ page:
       release-table-caption-prefix: Resources created by <b>Release</b>
     logs:
       heading: Deployment Logs
+  project:
+    deprecation-banner:
+      title: Upcoming changes to projects
+      description: In our upcoming Waypoint 0.10 release, we will be removing "projects" from Waypoint. With this change, all projects settings and variables will be assigned directly to applications. To learn more about this change, visit the link below.
+      link: Upcoming changes to projects
   release:
     title: 'Release'
     resources:


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds an alert banner on the Projects page alerting users about the coming deprecation of Projects.

~~Note: Copy is not finalized. Will confirm final text w/ @evanphx~~

### :camera_flash: Screenshots

![Screen Shot 2022-06-20 at 4 30 54 PM](https://user-images.githubusercontent.com/103146227/174688779-c97eea59-4137-498e-b92b-b7d31731d62f.png)


### :link: External Links

WAYP-204

### :building_construction: How to Build and Test the Change

1. Pull down branch
2. `yarn start`
3. Navigate to Projects page - verify deprecation banner matches [design](https://www.figma.com/file/7QlirFzbLnDuImRqPmYEfS/Project-Removal-Warnings?node-id=4108%3A7127)

