### PR TITLE
Remove trailing whitespace to pacify the linter

### DIFF
--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -44,7 +44,7 @@ func startInstance(
 		return nil, err
 	}
 
-	// Look for any reattach plugins to allow debugging task launcher plugins 
+	// Look for any reattach plugins to allow debugging task launcher plugins
 	var reattachPluginConfigs map[string]*goplugin.ReattachConfig
 	reattachPluginsStr := os.Getenv("WP_REATTACH_PLUGINS")
 	if reattachPluginsStr != "" {


### PR DESCRIPTION
That's a pretty aggressive stance for the linter to take, I think.