### PR TITLE
internal/server: Ensure task plugin is properly parsed when invoked

### DIFF
--- a/.changelog/3475.txt
+++ b/.changelog/3475.txt
@@ -1,0 +1,8 @@
+```release-note:bug
+plugin/k8s: Properly parse kubernetes task launcher config on plugin invoke.
+```
+
+```release-note:improvement
+serverinstall/k8s: By default, do not set a mem or cpu limit or request for
+the default runner profile installed.
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -421,11 +421,11 @@ func configureContainer(
 	resourceRequests := make(map[corev1.ResourceName]k8sresource.Quantity)
 
 	if c.CPU != nil {
-		if c.CPU.Requested != "" {
-			q, err := k8sresource.ParseQuantity(c.CPU.Requested)
+		if c.CPU.Request != "" {
+			q, err := k8sresource.ParseQuantity(c.CPU.Request)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %s to k8s quantity: %s", c.CPU.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %s to k8s quantity: %s", c.CPU.Request, err)
 			}
 			resourceRequests[corev1.ResourceCPU] = q
 		}
@@ -441,11 +441,11 @@ func configureContainer(
 	}
 
 	if c.Memory != nil {
-		if c.Memory.Requested != "" {
-			q, err := k8sresource.ParseQuantity(c.Memory.Requested)
+		if c.Memory.Request != "" {
+			q, err := k8sresource.ParseQuantity(c.Memory.Request)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %s to k8s quantity: %s", c.Memory.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %s to k8s quantity: %s", c.Memory.Request, err)
 			}
 			resourceRequests[corev1.ResourceMemory] = q
 		}
@@ -1475,8 +1475,8 @@ type Config struct {
 // ResourceConfig describes the request and limit of a resource. Used for
 // cpu and memory resource configuration.
 type ResourceConfig struct {
-	Requested string `hcl:"request,optional"`
-	Limit     string `hcl:"limit,optional"`
+	Request string `hcl:"request,optional" json:"request"`
+	Limit   string `hcl:"limit,optional" json:"limit"`
 }
 
 // AutoscaleConfig describes the possible configuration for creating a

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -312,11 +312,11 @@ func (p *TaskLauncher) StartTask(
 	resourceRequests := make(map[corev1.ResourceName]k8sresource.Quantity)
 
 	if p.config.CPU != nil {
-		if p.config.CPU.Requested != "" {
-			q, err := k8sresource.ParseQuantity(p.config.CPU.Requested)
+		if p.config.CPU.Request != "" {
+			q, err := k8sresource.ParseQuantity(p.config.CPU.Request)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %q to k8s quantity: %s", p.config.CPU.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse cpu request %q to k8s quantity: %s", p.config.CPU.Request, err)
 			}
 			resourceRequests[corev1.ResourceCPU] = q
 		}
@@ -332,11 +332,11 @@ func (p *TaskLauncher) StartTask(
 	}
 
 	if p.config.Memory != nil {
-		if p.config.Memory.Requested != "" {
-			q, err := k8sresource.ParseQuantity(p.config.Memory.Requested)
+		if p.config.Memory.Request != "" {
+			q, err := k8sresource.ParseQuantity(p.config.Memory.Request)
 			if err != nil {
 				return nil,
-					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %q to k8s quantity: %s", p.config.Memory.Requested, err)
+					status.Errorf(codes.InvalidArgument, "failed to parse memory requested %q to k8s quantity: %s", p.config.Memory.Request, err)
 			}
 			resourceRequests[corev1.ResourceMemory] = q
 		}

--- a/internal/plugin/invoke.go
+++ b/internal/plugin/invoke.go
@@ -152,6 +152,7 @@ func Open(
 		return nil, nil, diags
 	}
 
+	// Only configure plugin config if it exists
 	if file.Body != nil {
 		diag := component.Configure(pi.Component, file.Body, hclCtx.NewChild())
 		if diag.HasErrors() {

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1578,32 +1578,37 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 		Default: "",
 	})
 
+	// NOTE(briancain): We set the default for these values to 0. In the k8s API,
+	// setting the limits and requests values to 0 is the same as not setting it all.
+	// This is the expected behavior we'll want. If someone _does_ set a value using
+	// these flags, they will be parsed and used instead.
+
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-cpu-request",
 		Target:  &i.config.cpuRequest,
 		Usage:   "Configures the requested CPU amount for the Waypoint server in Kubernetes.",
-		Default: "100m",
+		Default: "0",
 	})
 
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-mem-request",
 		Target:  &i.config.memRequest,
 		Usage:   "Configures the requested memory amount for the Waypoint server in Kubernetes.",
-		Default: "256Mi",
+		Default: "0",
 	})
 
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-cpu-limit",
 		Target:  &i.config.cpuLimit,
 		Usage:   "Configures the CPU limit for the Waypoint server in Kubernetes.",
-		Default: "100m",
+		Default: "0",
 	})
 
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-mem-limit",
 		Target:  &i.config.memLimit,
 		Usage:   "Configures the memory limit for the Waypoint server in Kubernetes.",
-		Default: "256Mi",
+		Default: "0",
 	})
 
 	set.StringVar(&flag.StringVar{

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -1140,10 +1140,10 @@ func (i *K8sInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	var cpuConfig k8s.ResourceConfig
 	var memConfig k8s.ResourceConfig
 	if v := i.config.cpuRequest; v != "" {
-		cpuConfig.Requested = v
+		cpuConfig.Request = v
 	}
 	if v := i.config.memRequest; v != "" {
-		memConfig.Requested = v
+		memConfig.Request = v
 	}
 	if v := i.config.cpuLimit; v != "" {
 		cpuConfig.Limit = v


### PR DESCRIPTION
Prior to this commit, when the server install function went to json
marshall its config into a k8s task config, it would translate the k8s
config to be `Requested`, but the k8s platform config expected `request`
and would fail to parse the profile. This commit ensures that the task
runner profile properly sets request for both mem and CPU so that it can
be parsed.

Additionally, instead of small resource limits and requests, the default
ODR profile for k8s will instead set each value to `"0"`, which according
to the k8s API is the same as being unset.