### PR TITLE
More error wrapping around ops

### DIFF
--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -2,11 +2,11 @@ package core
 
 import (
 	"context"
-	"errors"
 
 	"github.com/hashicorp/go-argmapper"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/opaqueany"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -147,7 +147,7 @@ func (op *buildOperation) Upsert(
 		Build: msg.(*pb.Build),
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting build operation")
 	}
 
 	return resp.Build, nil

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/opaqueany"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -275,7 +276,7 @@ func (op *deployOperation) Upsert(
 		AutoHostname: op.autoHostname,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting deployment operation")
 	}
 
 	if op.id == "" {

--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/opaqueany"
+	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
@@ -222,7 +223,7 @@ func (op *deployDestroyOperation) Upsert(
 		Deployment: d,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting deployment destroy operation")
 	}
 
 	return resp.Deployment, nil

--- a/internal/core/app_push.go
+++ b/internal/core/app_push.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/opaqueany"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -148,7 +149,7 @@ func (op *pushBuildOperation) Upsert(
 		Artifact: msg.(*pb.PushedArtifact),
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting pushed artifact operation")
 	}
 
 	return resp.Artifact, nil

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/opaqueany"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -205,7 +206,7 @@ func (op *releaseOperation) Upsert(
 		Release: msg.(*pb.Release),
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting release operation")
 	}
 
 	return resp.Release, nil

--- a/internal/core/app_release_destroy.go
+++ b/internal/core/app_release_destroy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/opaqueany"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -230,7 +231,7 @@ func (op *releaseDestroyOperation) Upsert(
 		Release: d,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting release destroy operation")
 	}
 
 	return resp.Release, nil

--- a/internal/core/app_status_report.go
+++ b/internal/core/app_status_report.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/opaqueany"
 	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -77,7 +78,7 @@ func (a *App) DeploymentStatusReport(
 	// deployment. If there is a non-nil error, just return immediately.
 	report, rErr := a.statusReport(ctx, "deploy_statusreport", c, deployTarget, lastResp)
 	if rErr != nil {
-		return report, rErr
+		return report, errors.Wrapf(rErr, "failed generating status report")
 	}
 
 	// Currently the statusReport() call above will only return a nil report if
@@ -195,7 +196,7 @@ func (a *App) statusReport(
 		Last:      last,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed performing status report op")
 	}
 
 	reportResp, ok := msg.(*pb.StatusReport)
@@ -347,7 +348,7 @@ func (op *statusReportOperation) Upsert(
 		StatusReport: msg.(*pb.StatusReport),
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed upserting status report operation")
 	}
 
 	return resp.StatusReport, nil


### PR DESCRIPTION
Due to an unrelated bug in the waypoint server, we were exiting early when creating status reports. The only error the client cound see was:

```
unknown error
```

Which is not helpful. This wrapps the errors in that flow to give more context as to what the client was attempting to do when it encountered the error.