### PR TITLE
builtin/docker: Do not require `resources` for task launch config

### DIFF
--- a/.changelog/3486.txt
+++ b/.changelog/3486.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+plugin/docker: Ensure that the docker task launcher does not require a resources
+block to be set when attempting to load a task config to launch a task.
+```

--- a/builtin/docker/task.go
+++ b/builtin/docker/task.go
@@ -371,14 +371,14 @@ func (b *TaskLauncher) StartTask(
 	var memory int64
 	var cpuShares int64
 
-	if b.config.Resources != nil && b.config.Resources.MemoryLimit != "" {
-		memory, err = goUnits.FromHumanSize(b.config.Resources.MemoryLimit)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if b.config.Resources != nil {
+		if b.config.Resources.MemoryLimit != "" {
+			memory, err = goUnits.FromHumanSize(b.config.Resources.MemoryLimit)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		cpuShares = b.config.Resources.CpuShares
 	}
 


### PR DESCRIPTION
Prior to this commit, the task launcher was expecting `Resources` to be
a required plugin config option despite it not actually being required.
This was due to the `TaskResources` field being expected to exist in a
task plugin despite being optional. The fix, similar to how we handle
resource plugin configs in kubernetes, is to make the Resources block a
pointer so that when it's unset, the plugin config parser doesn't expect
it to be required.

Fixes #3485