### PR TITLE
bugfix: Pass region to lambda-function releaser

### DIFF
--- a/builtin/aws/lambda/function_url/releaser.go
+++ b/builtin/aws/lambda/function_url/releaser.go
@@ -116,8 +116,10 @@ func (r *Releaser) resourceManager(log hclog.Logger) *resource.Manager {
 func (r *Releaser) getSession(
 	_ context.Context,
 	log hclog.Logger,
+	dep *lambdaplugin.Deployment,
 ) (*session.Session, error) {
 	return utils.GetSession(&utils.SessionConfig{
+		Region: dep.Region,
 		Logger: log,
 	})
 }


### PR DESCRIPTION
Before this commit the aws configuration which was initialized as part
of the lambda-function releaser didn't inherit the region from the
lambda deploy step. This caused the lambda-function releaser to fail
with a "Region not specified" error from AWS during the deployment.

This commit grabs the region from the deployment phase so that we don't
have to rely on a users environment when initializing the AWS config for
determining the correct region the lambda is in for configuring the
lambda function url.