### PR TITLE
rm dup TestJobComplete

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -23,7 +23,6 @@ func init() {
 		TestJobAssign,
 		TestJobAck,
 		TestJobComplete,
-		TestJobComplete,
 		TestJobTask_AckAndComplete,
 		TestJobIsAssignable,
 		TestJobCancel,


### PR DESCRIPTION
Removing the dupped test `TestJobComplete`. This was causing the test to get ran twice.