### PR TITLE
Server install: Nomad service discovery

### DIFF
--- a/.changelog/3500.txt
+++ b/.changelog/3500.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli/serverinstall/nomad: Add service discovery provider configuration
+to server install for Nomad.
+```

--- a/internal/runnerinstall/runnerinstall_test.go
+++ b/internal/runnerinstall/runnerinstall_test.go
@@ -1,1 +1,0 @@
-package runnerinstall

--- a/internal/runnerinstall/runnerinstall_test.go
+++ b/internal/runnerinstall/runnerinstall_test.go
@@ -1,0 +1,1 @@
+package runnerinstall

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -3,6 +3,7 @@ package serverinstall
 import (
 	"context"
 	json "encoding/json"
+	"errors"
 	"fmt"
 	"github.com/hashicorp/waypoint/internal/installutil"
 	"os"
@@ -350,8 +351,9 @@ func (i *NomadInstaller) Upgrade(
 				clierrors.Humanize(err),
 				terminal.WithErrorStyle(),
 			)
-		} else if strings.ToLower(proceed) != "yes" {
 			return nil, err
+		} else if strings.ToLower(proceed) != "yes" {
+			return nil, errors.New("upgrade aborted")
 		}
 	}
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -244,6 +244,9 @@ func (i *NomadInstaller) Install(
 	// if Nomad restarts the server allocation, a new IP will be assigned and any
 	// configured clients will be invalid
 	httpAddr, addr.Addr, err = i.getWaypointAddress(client, allocID)
+	if err != nil {
+		return nil, err
+	}
 
 	clicfg = clicontext.Config{
 		Server: serverconfig.Client{
@@ -507,6 +510,9 @@ func (i *NomadInstaller) Upgrade(
 	// if Nomad restarts the server allocation, a new IP will be assigned and any
 	// configured clients will be invalid
 	httpAddr, addr.Addr, err = i.getWaypointAddress(client, allocID)
+	if err != nil {
+		return nil, err
+	}
 
 	clicfg = clicontext.Config{
 		Server: serverconfig.Client{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -844,8 +844,8 @@ func waypointNomadJob(c nomadConfig, rawRunFlags []string, upgrade bool) *api.Jo
 
 	// Include services to be registered. Currently configured to happen with Consul by default
 	// One service added for Waypoint UI, and one for Waypoint backend port
-	services := []*api.Service{}
-	if c.serviceProvider == "consul" || (c.consulService && c.serviceProvider == "consul") || (c.consulService && upgrade) {
+	var services []*api.Service
+	if (c.serviceProvider == "consul" && (c.consulService || upgrade)) || (c.consulService && (c.serviceProvider == "consul" || upgrade)) {
 		token := ""
 		if c.consulToken == "" {
 			token = os.Getenv("CONSUL_HTTP_TOKEN")

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -304,21 +304,17 @@ func (i *NomadInstaller) Install(
 
 	switch i.config.serviceProvider {
 	case "consul":
-		s = sg.Add("The CLI has been configured to automatically install a Consul service for\n" +
+		opts.UI.Output("The CLI has been configured to automatically install a Consul service for\n" +
 			"the Waypoint service backend and ui service in Nomad.")
-		s.Done()
 	case "nomad":
-		s = sg.Add("The CLI has been configured to automatically install a Nomad service for\n" +
+		opts.UI.Output("The CLI has been configured to automatically install a Nomad service for\n" +
 			"the Waypoint service backend and ui service in Nomad.")
-		s.Done()
 	default:
-		s = sg.Add("Waypoint server running on Nomad is being accessed via its allocation IP and port.\n" +
+		opts.UI.Output("Waypoint server running on Nomad is being accessed via its allocation IP and port.\n" +
 			"This could change in the future if Nomad creates a new allocation for the Waypoint server,\n" +
 			"which would break all existing Waypoint contexts.\n\n" +
 			"It is recommended to use Consul for determining Waypoint servers IP running on Nomad rather than\n" +
 			"relying on the static IP that is initially set up for this allocation.")
-		s.Status(terminal.StatusWarn)
-		s.Done()
 	}
 
 	return &InstallResults{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -339,10 +339,22 @@ func (i *NomadInstaller) Upgrade(
 	if i.config.serviceProvider == "none" && !i.config.consulService {
 		// By default, we don't auto-enable the consul service because prior to Waypoint
 		// version 0.6.2, we did not enable it by default.
-		sw := sg.Add("Service discovery is disabled for the Waypoint Nomad job. If you had previously enabled " +
-			"it in the last installation, please stop this upgrade and re-run with -nomad-service-provider flag.")
-		sw.Status(terminal.StatusWarn)
-		sw.Done()
+		proceed, err := opts.UI.Input(&terminal.Input{
+			Prompt: "Service discovery is disabled for the Waypoint Nomad job. If you had previously enabled " +
+				"it in the last installation, please stop this upgrade and re-run with the -nomad-service-provider flag. " +
+				"Otherwise, enter 'yes' to continue the upgrade: ",
+			Style:  "",
+			Secret: false,
+		})
+		if err != nil {
+			opts.UI.Output(
+				"Error upgrading server: %s",
+				clierrors.Humanize(err),
+				terminal.WithErrorStyle(),
+			)
+		} else if strings.ToLower(proceed) != "yes" {
+			return nil, err
+		}
 	}
 
 	s := sg.Add("Initializing Nomad client...")

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -120,10 +120,12 @@ and disable the UI, the command would be:
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server in Consul. One possible value from: consul, nomad, none. The default is consul.
+- `-nomad-service-ui-tags=<string>` - Tags for the Waypoint UI service. The default is waypoint.
+- `-nomad-service-backend-tags=<string>` - Tags for the Waypoint backend service. The default is waypoint.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
 - `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
 - `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 - `-nomad-consul-token=<string>` - If set, the passed Consul token is stored in the job before sending to the Nomad servers. Overrides the CONSUL_HTTP_TOKEN environment variable if set.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -119,6 +119,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server in Consul. One possible value from: consul, nomad, none. The default is consul.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
 - `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -120,10 +120,12 @@ and disable the UI, the command would be:
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server in Consul. One possible value from: consul, nomad, none. The default is consul.
+- `-nomad-service-ui-tags=<string>` - Tags for the Waypoint UI service. The default is waypoint.
+- `-nomad-service-backend-tags=<string>` - Tags for the Waypoint backend service. The default is waypoint.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
 - `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
 - `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 - `-nomad-consul-token=<string>` - If set, the passed Consul token is stored in the job before sending to the Nomad servers. Overrides the CONSUL_HTTP_TOKEN environment variable if set.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -119,6 +119,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server in Consul. One possible value from: consul, nomad, none. The default is consul.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
 - `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -90,6 +90,7 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-host-volume=<string>` - Nomad host volume name.
+- `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server. One possible value from: consul, nomad, none. The default is none.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is false.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
 - `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -91,10 +91,12 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-host-volume=<string>` - Nomad host volume name.
 - `-nomad-service-provider=<string>` - Create service for Waypoint UI and Server. One possible value from: consul, nomad, none. The default is none.
+- `-nomad-service-ui-tags=<string>` - Tags for the Waypoint UI service. The default is waypoint.
+- `-nomad-service-backend-tags=<string>` - Tags for the Waypoint backend service. The default is waypoint.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is false.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
 - `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
 - `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 


### PR DESCRIPTION
This PR updates the server installation for Nomad to support service discovery for Nomad or Consul by specifying the service discovery provider as a flag for the `waypoint install` command. 

Closes #3376.

NOTE: The old config, `-nomad-consul-service`, is still supported with this PR update, but it should be phased out eventually. The new `-nomad-service-provider` config supports pre- and post-1.3.0 Waypoint installs to Nomad.