### PR TITLE
internal/cli: Include default value for a flag for docs

### DIFF
--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -199,9 +199,21 @@ description: "%s"
 				if len(f.Aliases) > 0 {
 					aliases := strings.Join(f.Aliases, "`, `-")
 
-					fmt.Fprintf(w, "- `-%s` (`-%s`) - %s\n", name, aliases, f.Usage)
+					str := fmt.Sprintf("- `-%s` (`-%s`) - %s", name, aliases, f.Usage)
+					if f.Default != "" {
+						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
+					}
+					str += "\n"
+
+					fmt.Fprint(w, str)
 				} else {
-					fmt.Fprintf(w, "- `-%s` - %s\n", name, f.Usage)
+					str := fmt.Sprintf("- `-%s` - %s", name, f.Usage)
+					if f.Default != "" {
+						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
+					}
+					str += "\n"
+
+					fmt.Fprint(w, str)
 				}
 			})
 		})

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -205,7 +205,7 @@ description: "%s"
 
 				// Add a period at the end of the doc sentence if the field didn't add
 				// one already.
-				if str[len(str)-1:] != "." {
+				if !strings.HasSuffix(str, ".") {
 					str += "."
 				}
 

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -196,25 +196,19 @@ description: "%s"
 					}
 				}
 
+				str := fmt.Sprintf("- `-%s` - %s", name, f.Usage)
 				if len(f.Aliases) > 0 {
 					aliases := strings.Join(f.Aliases, "`, `-")
 
-					str := fmt.Sprintf("- `-%s` (`-%s`) - %s", name, aliases, f.Usage)
-					if f.Default != "" {
-						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
-					}
-					str += "\n"
-
-					fmt.Fprint(w, str)
-				} else {
-					str := fmt.Sprintf("- `-%s` - %s", name, f.Usage)
-					if f.Default != "" {
-						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
-					}
-					str += "\n"
-
-					fmt.Fprint(w, str)
+					str = fmt.Sprintf("- `-%s` (`-%s`) - %s", name, aliases, f.Usage)
 				}
+
+				if f.Default != "" {
+					str = fmt.Sprintf("%s The default is %s.", str, f.Default)
+				}
+				str += "\n"
+
+				fmt.Fprint(w, str)
 			})
 		})
 	} else {

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -204,7 +204,15 @@ description: "%s"
 				}
 
 				if f.Default != "" {
-					str = fmt.Sprintf("%s The default is %s.", str, f.Default)
+					// NOTE(briancain): This is a hacky way around trying to document
+					// default flag values that are dynamic. Currently as of this writing
+					// `context-create` is the only CLI flag with a dynamic default value.
+					if name == "context-create=<string>" {
+						cc := strings.Split(f.Default, "-")
+						str = fmt.Sprintf("%s The default is %s-%s.", str, cc[0], "<timestamp>")
+					} else {
+						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
+					}
 				}
 				str += "\n"
 

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -210,15 +210,7 @@ description: "%s"
 				}
 
 				if f.Default != "" {
-					// NOTE(briancain): This is a hacky way around trying to document
-					// default flag values that are dynamic. Currently as of this writing
-					// `context-create` is the only CLI flag with a dynamic default value.
-					if name == "context-create=<string>" {
-						cc := strings.Split(f.Default, "-")
-						str = fmt.Sprintf("%s The default is %s-%s.", str, cc[0], "<timestamp>")
-					} else {
-						str = fmt.Sprintf("%s The default is %s.", str, f.Default)
-					}
+					str = fmt.Sprintf("%s The default is %s.", str, f.Default)
 				}
 				str += "\n"
 

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -203,6 +203,12 @@ description: "%s"
 					str = fmt.Sprintf("- `-%s` (`-%s`) - %s", name, aliases, f.Usage)
 				}
 
+				// Add a period at the end of the doc sentence if the field didn't add
+				// one already.
+				if str[len(str)-1:] != "." {
+					str += "."
+				}
+
 				if f.Default != "" {
 					// NOTE(briancain): This is a hacky way around trying to document
 					// default flag values that are dynamic. Currently as of this writing

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -263,7 +263,7 @@ func (c *InstallCommand) Run(args []string) int {
 		serverclient.StaticToken(contextConfig.Server.AuthToken)))
 
 	// This is our default, so let's actually set the timestamp.
-	if c.contextName == "install-<timestamp>" || c.contextName == "" {
+	if c.contextName == "install-timestamp" || c.contextName == "" {
 		c.contextName = fmt.Sprintf("install-%d", time.Now().Unix())
 	}
 
@@ -364,7 +364,7 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "context-create",
 			Target:  &c.contextName,
-			Default: "install-<timestamp>",
+			Default: "install-timestamp",
 			Usage: "Create a context with connection information for this installation. " +
 				"The default value will be suffixed with a timestamp at the time the command is executed.",
 		})

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -262,8 +262,8 @@ func (c *InstallCommand) Run(args []string) int {
 	callOpts = append(callOpts, grpc.PerRPCCredentials(
 		serverclient.StaticToken(contextConfig.Server.AuthToken)))
 
-	// This is our default, so let's actually set the timestamp.
-	if c.contextName == "install-timestamp" || c.contextName == "" {
+	// This is our default, so let's actually set the timestamp if not set on the CLI
+	if c.contextName == "" {
 		c.contextName = fmt.Sprintf("install-%d", time.Now().Unix())
 	}
 
@@ -362,11 +362,11 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		})
 
 		f.StringVar(&flag.StringVar{
-			Name:    "context-create",
-			Target:  &c.contextName,
-			Default: "install-timestamp",
+			Name:   "context-create",
+			Target: &c.contextName,
 			Usage: "Create a context with connection information for this installation. " +
-				"The default value will be suffixed with a timestamp at the time the command is executed.",
+				"The default value if not set will be 'install-' and then be suffixed with a " +
+				"timestamp at the time the command is executed.",
 		})
 
 		f.BoolVar(&flag.BoolVar{

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -262,6 +262,11 @@ func (c *InstallCommand) Run(args []string) int {
 	callOpts = append(callOpts, grpc.PerRPCCredentials(
 		serverclient.StaticToken(contextConfig.Server.AuthToken)))
 
+	// This is our default, so let's actually set the timestamp.
+	if c.contextName == "install-<timestamp>" || c.contextName == "" {
+		c.contextName = fmt.Sprintf("install-%d", time.Now().Unix())
+	}
+
 	// If we connected successfully, lets immediately setup our context.
 	if c.contextName != "" {
 		if err := c.contextStorage.Set(c.contextName, contextConfig); err != nil {
@@ -359,7 +364,7 @@ func (c *InstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "context-create",
 			Target:  &c.contextName,
-			Default: fmt.Sprintf("install-%d", time.Now().Unix()),
+			Default: "install-<timestamp>",
 			Usage: "Create a context with connection information for this installation. " +
 				"The default value will be suffixed with a timestamp at the time the command is executed.",
 		})

--- a/internal/cli/runner_agent.go
+++ b/internal/cli/runner_agent.go
@@ -81,6 +81,11 @@ func (c *RunnerAgentCommand) Run(args []string) int {
 	plugin.InsideODR = c.flagODR
 
 	// Flag defaults
+	if c.flagConcurrency == 0 {
+		c.flagConcurrency = runtime.NumCPU() * 3
+	}
+
+	// Check again in case it was set to 0.
 	if c.flagConcurrency < 1 {
 		log.Warn("concurrency flag less than 1 has no effect, using 1")
 		c.flagConcurrency = 1
@@ -366,12 +371,16 @@ func (c *RunnerAgentCommand) Flags() *flag.Sets {
 			Name:   "concurrency",
 			Target: &c.flagConcurrency,
 			Usage: "The number of concurrent jobs that can be running at one time. " +
-				"This has no effect if `-odr` is set. A value of less than 1 will " +
+				"This has no effect if `-odr` is set. The default value applied will be " +
+				"(total number of logical cpus available * 3). A value of less than 1 will " +
 				"default to 1.",
 
 			// Most jobs that a non-ODR runner runs are IO bound, so we use
 			// just a heuristic here of allowing some multiple above the CPUs.
-			Default: runtime.NumCPU() * 3,
+			//Default: runtime.NumCPU() * 3,
+			// NOTE(briancain): We set a default of 0 here, but when the CLI goes
+			// to use this value, if set to 0, we'll attempt to set it to the default
+			// runtime.NumCPU()*3.
 		})
 	})
 }

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -62,7 +62,7 @@ func (c *ServerBootstrapCommand) Run(args []string) int {
 		// specifically sets the flag to empty string. Our flag package will set
 		// the default here, which will never be emptry string
 		return 0
-	} else if c.flagContext == "bootstrap-<timestamp>" {
+	} else if c.flagContext == "bootstrap-timestamp" {
 		c.flagContext = fmt.Sprintf("bootstrap-%d", time.Now().Unix())
 	}
 
@@ -105,7 +105,7 @@ func (c *ServerBootstrapCommand) Flags() *flag.Sets {
 			Usage: "Create a CLI context for this bootstrapped server. The context name " +
 				"will be the value of this flag. If this is an empty string, a context will " +
 				"not be created",
-			Default: "bootstrap-<timestamp>",
+			Default: "bootstrap-timestamp",
 		})
 
 		f.BoolVar(&flag.BoolVar{

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -58,7 +58,12 @@ func (c *ServerBootstrapCommand) Run(args []string) int {
 
 	// If we aren't storing a context, we're done
 	if c.flagContext == "" {
+		// NOTE(briancain): I don't think this will ever happen unless the user
+		// specifically sets the flag to empty string. Our flag package will set
+		// the default here, which will never be emptry string
 		return 0
+	} else if c.flagContext == "bootstrap-<timestamp>" {
+		c.flagContext = fmt.Sprintf("bootstrap-%d", time.Now().Unix())
 	}
 
 	// Get our current context config and set our new token
@@ -100,7 +105,7 @@ func (c *ServerBootstrapCommand) Flags() *flag.Sets {
 			Usage: "Create a CLI context for this bootstrapped server. The context name " +
 				"will be the value of this flag. If this is an empty string, a context will " +
 				"not be created",
-			Default: fmt.Sprintf("bootstrap-%d", time.Now().Unix()),
+			Default: "bootstrap-<timestamp>",
 		})
 
 		f.BoolVar(&flag.BoolVar{

--- a/website/content/commands/artifact-build.mdx
+++ b/website/content/commands/artifact-build.mdx
@@ -23,7 +23,7 @@ Build a new versioned artifact from source.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -40,6 +40,6 @@ Build a new versioned artifact from source.
 
 #### Command Options
 
-- `-push` - Push the artifact to the configured registry.
+- `-push` - Push the artifact to the configured registry. The default is true.
 
 @include "commands/artifact-build_more.mdx"

--- a/website/content/commands/artifact-list-builds.mdx
+++ b/website/content/commands/artifact-list-builds.mdx
@@ -23,14 +23,14 @@ expected to be stored in a registry.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-workspace-all` - List builds in all workspaces for this project and application.
-- `-long-ids` - Show long identifiers rather than sequence numbers.
+- `-workspace-all` - List builds in all workspaces for this project and application. The default is false.
+- `-long-ids` - Show long identifiers rather than sequence numbers. The default is false.
 
 @include "commands/artifact-list-builds_more.mdx"

--- a/website/content/commands/artifact-list.mdx
+++ b/website/content/commands/artifact-list.mdx
@@ -22,22 +22,22 @@ list the artifacts that are just part of local builds.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-workspace-all` - List builds in all workspaces for this project and application.
-- `-verbose` (`-V`) - Display more details about each deployment.
-- `-json` - Output the deployment information as JSON.
-- `-long-ids` - Show long identifiers rather than sequence numbers.
+- `-workspace-all` - List builds in all workspaces for this project and application. The default is false.
+- `-verbose` (`-V`) - Display more details about each deployment. The default is false.
+- `-json` - Output the deployment information as JSON. The default is false.
+- `-long-ids` - Show long identifiers rather than sequence numbers. The default is false.
 
 #### Filter Options
 
 - `-order-by=<string>` - Order the values by which field. One possible value from: start-time, complete-time.
-- `-desc` - Sort the values in descending order.
+- `-desc` - Sort the values in descending order. The default is false.
 - `-limit=<uint>` - How many values to show.
 
 @include "commands/artifact-list_more.mdx"

--- a/website/content/commands/artifact-push.mdx
+++ b/website/content/commands/artifact-push.mdx
@@ -25,7 +25,7 @@ local builds using "artifact list-builds" command.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/auth-method-delete.mdx
+++ b/website/content/commands/auth-method-delete.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint auth-method delete NAME`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/auth-method-inspect.mdx
+++ b/website/content/commands/auth-method-inspect.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint auth-method inspect NAME`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/auth-method-list.mdx
+++ b/website/content/commands/auth-method-list.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint auth-method list`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -41,7 +41,7 @@ Configure an OIDC auth method.
 - `-issuer=<string>` - Discovery URL of the OIDC provider that implements the .well-known/openid-configuration metadata endpoint.
 - `-issuer-ca-pem=<string>` - PEM-encoded certificates for connecting to the issuer. May be specified multiple times.
 - `-allowed-redirect-uri=<string>` - Allowed URI for auth redirection. This automatically has localhost (for CLI auth) and the server address configured. If you have additional external addresses, you can specify them here. May be specified multiple times.
-- `-claim-mapping=<key=value>` - Mapping of a claim to a variable value for the access selector. This can be specified multiple times. Example value: 'http://example.com/key=key'
+- `-claim-mapping=<key=value>` - Mapping of a claim to a variable value for the access selector. This can be specified multiple times. Example value: 'http://example.com/key=key'.
 - `-list-claim-mapping=<key=value>` - Same as claim-mapping but for list values. This can be repeated multiple times.
 
 @include "commands/auth-method-set-oidc_more.mdx"

--- a/website/content/commands/auth-method-set-oidc.mdx
+++ b/website/content/commands/auth-method-set-oidc.mdx
@@ -21,7 +21,7 @@ Configure an OIDC auth method.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/build.mdx
+++ b/website/content/commands/build.mdx
@@ -23,7 +23,7 @@ Build a new versioned artifact from source.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -40,6 +40,6 @@ Build a new versioned artifact from source.
 
 #### Command Options
 
-- `-push` - Push the artifact to the configured registry.
+- `-push` - Push the artifact to the configured registry. The default is true.
 
 @include "commands/build_more.mdx"

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -42,16 +42,16 @@ as well.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-json` - Output in JSON
-- `-raw` - Output in key=val
-- `-runner` - Show configuration that is set on runners. This will not show any configuration that is set on any applications. This only includes configuration set with the -runner flag.
+- `-json` - Output in JSON The default is false.
+- `-raw` - Output in key=val The default is false.
+- `-runner` - Show configuration that is set on runners. This will not show any configuration that is set on any applications. This only includes configuration set with the -runner flag. The default is false.
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 
 @include "commands/config-get_more.mdx"

--- a/website/content/commands/config-get.mdx
+++ b/website/content/commands/config-get.mdx
@@ -49,8 +49,8 @@ as well.
 
 #### Command Options
 
-- `-json` - Output in JSON The default is false.
-- `-raw` - Output in key=val The default is false.
+- `-json` - Output in JSON. The default is false.
+- `-raw` - Output in key=val. The default is false.
 - `-runner` - Show configuration that is set on runners. This will not show any configuration that is set on any applications. This only includes configuration set with the -runner flag. The default is false.
 - `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
 

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -29,16 +29,16 @@ Specify the "-app" flag to set a config variable for a specific app.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or 'app'.
+- `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or 'app'. The default is project.
 - `-workspace-scope=<string>` - Specify that the configuration is only available within a specific workspace. This configuration will only be set for deployments or operations (if -runner if set) when the workspace matches this.
 - `-label-scope=<string>` - If set, configuration will only be set if the deployment or operation (if -runner is set) has a matching label set.
-- `-runner` - Expose this configuration on runners. This can be used to set things such as credentials to cloud platforms for remote runners. This configuration will not be exposed to deployed applications. If this is specified in the context of a project, this will apply only to runners operating on jobs for the specific project or application.
+- `-runner` - Expose this configuration on runners. This can be used to set things such as credentials to cloud platforms for remote runners. This configuration will not be exposed to deployed applications. If this is specified in the context of a project, this will apply only to runners operating on jobs for the specific project or application. The default is false.
 
 @include "commands/config-set_more.mdx"

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -27,7 +27,7 @@ To use this command, you must specify a "-type" flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -30,7 +30,7 @@ you're configuring for details on what configuration fields are available.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -39,6 +39,6 @@ you're configuring for details on what configuration fields are available.
 
 - `-type=<string>` - Dynamic source type to configure, such as 'vault'.
 - `-config=<key=value>` - Configuration for the dynamic source type. This may be repeated. The fields available are dependent on the dynamic source type, so please check the documentation for that specific type for more information.
-- `-delete` - Delete the configuration for this source type. If this is set then the -config flag is ignored.
+- `-delete` - Delete the configuration for this source type. If this is set then the -config flag is ignored. The default is false.
 
 @include "commands/config-source-set_more.mdx"

--- a/website/content/commands/config-sync.mdx
+++ b/website/content/commands/config-sync.mdx
@@ -26,7 +26,7 @@ be deleted.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-clear.mdx
+++ b/website/content/commands/context-clear.mdx
@@ -29,7 +29,7 @@ the project.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-create.mdx
+++ b/website/content/commands/context-create.mdx
@@ -21,19 +21,19 @@ Creates a new context.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-set-default` - Set this context as the new default for the CLI.
+- `-set-default` - Set this context as the new default for the CLI. The default is true.
 - `-server-addr=<string>` - Address for the server.
 - `-server-auth-token=<string>` - Authentication token to use to connect to the server.
-- `-server-platform=<string>` - The current platform that Waypoint server is running on.
-- `-server-tls` - If true, will connect to the server over TLS.
-- `-server-tls-skip-verify` - If true, will not validate TLS cert presented by the server.
-- `-server-require-auth` - If true, will send authentication details.
+- `-server-platform=<string>` - The current platform that Waypoint server is running on. The default is n/a.
+- `-server-tls` - If true, will connect to the server over TLS. The default is true.
+- `-server-tls-skip-verify` - If true, will not validate TLS cert presented by the server. The default is false.
+- `-server-require-auth` - If true, will send authentication details. The default is false.
 
 @include "commands/context-create_more.mdx"

--- a/website/content/commands/context-delete.mdx
+++ b/website/content/commands/context-delete.mdx
@@ -21,13 +21,13 @@ Deletes a context. This will succeed if the context is already deleted.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-all` - Delete all contexts. If this is specified, NAME should not be specified in the command arguments.
+- `-all` - Delete all contexts. If this is specified, NAME should not be specified in the command arguments. The default is false.
 
 @include "commands/context-delete_more.mdx"

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -28,6 +28,6 @@ Output information about a waypoint context or general context info.
 
 #### Command Options
 
-- `-json` - Output information in JSON format The default is false.
+- `-json` - Output information in JSON format. The default is false.
 
 @include "commands/context-inspect_more.mdx"

--- a/website/content/commands/context-inspect.mdx
+++ b/website/content/commands/context-inspect.mdx
@@ -21,13 +21,13 @@ Output information about a waypoint context or general context info.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-json` - Output information in JSON format
+- `-json` - Output information in JSON format The default is false.
 
 @include "commands/context-inspect_more.mdx"

--- a/website/content/commands/context-list.mdx
+++ b/website/content/commands/context-list.mdx
@@ -21,7 +21,7 @@ Lists the contexts available to the CLI.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-rename.mdx
+++ b/website/content/commands/context-rename.mdx
@@ -24,7 +24,7 @@ exists. If the current default is FROM, the default will be set to TO.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-set.mdx
+++ b/website/content/commands/context-set.mdx
@@ -28,7 +28,7 @@ To restore this CLI context to use the default workspace, use
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-use.mdx
+++ b/website/content/commands/context-use.mdx
@@ -21,7 +21,7 @@ Set the default context for the CLI.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context-verify.mdx
+++ b/website/content/commands/context-verify.mdx
@@ -25,7 +25,7 @@ connection information is valid.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/context.mdx
+++ b/website/content/commands/context.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint context [options]`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -28,7 +28,7 @@ can be disabled by using the "-release=false" flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -45,6 +45,6 @@ can be disabled by using the "-release=false" flag.
 
 #### Command Options
 
-- `-release` - Release this deployment immediately.
+- `-release` - Release this deployment immediately. The default is true.
 
 @include "commands/deploy_more.mdx"

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -28,7 +28,7 @@ can be disabled by using the "-release=false" flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -45,6 +45,6 @@ can be disabled by using the "-release=false" flag.
 
 #### Command Options
 
-- `-release` - Release this deployment immediately.
+- `-release` - Release this deployment immediately. The default is true.
 
 @include "commands/deployment-deploy_more.mdx"

--- a/website/content/commands/deployment-destroy.mdx
+++ b/website/content/commands/deployment-destroy.mdx
@@ -26,7 +26,7 @@ by the user unless the force flag (-force) is specified.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -43,7 +43,7 @@ by the user unless the force flag (-force) is specified.
 
 #### Command Options
 
-- `-all` - Delete ALL deployments, including released.
-- `-force` - Yes to all confirmations.
+- `-all` - Delete ALL deployments, including released. The default is false.
+- `-force` - Yes to all confirmations. The default is false.
 
 @include "commands/deployment-destroy_more.mdx"

--- a/website/content/commands/deployment-list.mdx
+++ b/website/content/commands/deployment-list.mdx
@@ -21,25 +21,25 @@ Lists the deployments that were created.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-workspace-all` - List builds in all workspaces for this project and application.
-- `-verbose` (`-V`) - Display more details about each deployment.
-- `-url` (`-u`) - Display deployment URL.
-- `-json` - Output the deployment information as JSON.
-- `-long-ids` - Show long identifiers rather than sequence numbers.
+- `-workspace-all` - List builds in all workspaces for this project and application. The default is false.
+- `-verbose` (`-V`) - Display more details about each deployment. The default is false.
+- `-url` (`-u`) - Display deployment URL. The default is false.
+- `-json` - Output the deployment information as JSON. The default is false.
+- `-long-ids` - Show long identifiers rather than sequence numbers. The default is false.
 
 #### Filter Options
 
 - `-state=<string>` - Filter values to have the given status. One possible value from: error, running, success, unknown.
-- `-physical-state=<string>` - Show values in the given physical states. One possible value from: any, created, destroyed, pending.
+- `-physical-state=<string>` - Show values in the given physical states. One possible value from: any, created, destroyed, pending. The default is created.
 - `-order-by=<string>` - Order the values by which field. One possible value from: start-time, complete-time.
-- `-desc` - Sort the values in descending order.
+- `-desc` - Sort the values in descending order. The default is false.
 - `-limit=<uint>` - How many values to show.
 
 @include "commands/deployment-list_more.mdx"

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -32,7 +32,7 @@ you've used if you want to destroy everything.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -49,6 +49,6 @@ you've used if you want to destroy everything.
 
 #### Command Options
 
-- `-auto-approve` - Auto-approve destroying all resources. If unset, confirmation will be requested.
+- `-auto-approve` - Auto-approve destroying all resources. If unset, confirmation will be requested. The default is false.
 
 @include "commands/destroy_more.mdx"

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -41,9 +41,9 @@ The flags can change which plugins are listed and in which format.
 
 #### Command Options
 
-- `-builtin` - Show documentation on all builtin plugins The default is false.
-- `-markdown` - Show documentation in markdown format The default is false.
-- `-type=<string>` - Only show documentation for this type of plugin
-- `-plugin=<string>` - Only show documentation for plugins with this name
+- `-builtin` - Show documentation on all builtin plugins. The default is false.
+- `-markdown` - Show documentation in markdown format. The default is false.
+- `-type=<string>` - Only show documentation for this type of plugin.
+- `-plugin=<string>` - Only show documentation for plugins with this name.
 
 @include "commands/docs_more.mdx"

--- a/website/content/commands/docs.mdx
+++ b/website/content/commands/docs.mdx
@@ -24,7 +24,7 @@ The flags can change which plugins are listed and in which format.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -41,8 +41,8 @@ The flags can change which plugins are listed and in which format.
 
 #### Command Options
 
-- `-builtin` - Show documentation on all builtin plugins
-- `-markdown` - Show documentation in markdown format
+- `-builtin` - Show documentation on all builtin plugins The default is false.
+- `-markdown` - Show documentation in markdown format The default is false.
 - `-type=<string>` - Only show documentation for this type of plugin
 - `-plugin=<string>` - Only show documentation for plugins with this name
 

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -26,7 +26,7 @@ For example, you could run one of the following commands:
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -43,6 +43,6 @@ For example, you could run one of the following commands:
 
 #### Command Options
 
-- `-instance=<string>` - Start an exec session on this specific instance
+- `-instance=<string>` - Start an exec session on this specific instance.
 
 @include "commands/exec_more.mdx"

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -31,13 +31,13 @@ work for older and newer configuration formats.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-write` - Overwrite the input file. If this is false, the formatted output will be written to STDOUT. This has no effect when formatting from STDIN.
+- `-write` - Overwrite the input file. If this is false, the formatted output will be written to STDOUT. This has no effect when formatting from STDIN. The default is true.
 
 @include "commands/fmt_more.mdx"

--- a/website/content/commands/hostname-delete.mdx
+++ b/website/content/commands/hostname-delete.mdx
@@ -21,7 +21,7 @@ Delete a previously registered hostname.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/hostname-list.mdx
+++ b/website/content/commands/hostname-list.mdx
@@ -23,7 +23,7 @@ This will list all the registered hostnames for all applications.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/hostname-register.mdx
+++ b/website/content/commands/hostname-register.mdx
@@ -25,7 +25,7 @@ routing immediately.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/init.mdx
+++ b/website/content/commands/init.mdx
@@ -28,7 +28,7 @@ delete your configuration or any data in the server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -37,6 +37,6 @@ delete your configuration or any data in the server.
 
 - `-from-project=<string>` - Create a new application by fetching the given application from a remote source or from a local project folder or file on disk.
 - `-into=<string>` - Where to write the application fetched via -from-project
-- `-update` - Update the project configuration if it already exists. This can be used to update settings such as the remote runner data source.
+- `-update` - Update the project configuration if it already exists. This can be used to update settings such as the remote runner data source. The default is false.
 
 @include "commands/init_more.mdx"

--- a/website/content/commands/init.mdx
+++ b/website/content/commands/init.mdx
@@ -36,7 +36,7 @@ delete your configuration or any data in the server.
 #### Command Options
 
 - `-from-project=<string>` - Create a new application by fetching the given application from a remote source or from a local project folder or file on disk.
-- `-into=<string>` - Where to write the application fetched via -from-project
+- `-into=<string>` - Where to write the application fetched via -from-project.
 - `-update` - Update the project configuration if it already exists. This can be used to update settings such as the remote runner data source. The default is false.
 
 @include "commands/init_more.mdx"

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -53,7 +53,7 @@ and disable the UI, the command would be:
 
 #### Command Options
 
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
@@ -92,7 +92,7 @@ and disable the UI, the command would be:
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.
@@ -105,7 +105,7 @@ and disable the UI, the command would be:
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
-- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
+- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
 - `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-timestamp.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374441.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-timestamp.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value if not set will be 'install-' and then be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -46,85 +46,85 @@ and disable the UI, the command would be:
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
-- `-context-set-default` - Set the newly installed server as the default CLI context.
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374022.
+- `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 
 #### docker Options
 
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
+- `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 
 #### ecs Options
 
-- `-ecs-cluster=<string>` - Configures the Cluster to install into.
-- `-ecs-region=<string>` - Configures which AWS region to install into.
+- `-ecs-cluster=<string>` - Configures the Cluster to install into. The default is waypoint-server.
+- `-ecs-region=<string>` - Configures which AWS region to install into. The default is us-west-2.
 - `-ecs-subnets=<string>` - Subnets to install server into.
-- `-ecs-execution-role-name=<string>` - Configures the IAM Execution role name to use.
-- `-ecs-server-image=<string>` - Docker image for the Waypoint server.
-- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS.
-- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS.
-- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions.
+- `-ecs-execution-role-name=<string>` - Configures the IAM Execution role name to use. The default is waypoint-server-execution-role.
+- `-ecs-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS. The default is 512.
+- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS. The default is 1024.
+- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions. The default is waypoint-runner.
 - `-ecs-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS.
-- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS.
+- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS. The default is 2048.
+- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS. The default is 512.
 
 #### kubernetes Options
 
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost. The default is false.
 - `-k8s-annotate-service=<key=value>` - Annotations for the Service generated.
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
-- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
-- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
-- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes.
-- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes.
+- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation. The default is false.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
-- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions.
-- `-k8s-runner-service-account-init` - Create the service account if it does not exist.
+- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
+- `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.
-- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes.
+- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes. The default is 1Gi.
 
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
-- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth.
-- `-nomad-dc=<string>` - Datacenters to install to for Nomad.
-- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks.
-- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad.
+- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth. The default is false.
+- `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
+- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
+- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
-- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
-- `-nomad-region=<string>` - Region to install to for Nomad.
-- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task.
-- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
-- `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul.
+- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
+- `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
+- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task. The default is 600.
+- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
+- `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
-- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located.
-- `-nomad-consul-domain=<string>` - The domain where Consul is located.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
+- `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 - `-nomad-consul-token=<string>` - If set, the passed Consul token is stored in the job before sending to the Nomad servers. Overrides the CONSUL_HTTP_TOKEN environment variable if set.
 - `-nomad-host-volume=<string>` - Nomad host volume name, required for volume type 'host'.
 - `-nomad-csi-volume-provider=<string>` - Nomad CSI volume provider, required for volume type 'csi'.
-- `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes.
-- `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes.
-- `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system.
+- `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
+- `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
+- `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
 - `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
 - `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374022.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374441.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/job-cancel.mdx
+++ b/website/content/commands/job-cancel.mdx
@@ -21,7 +21,7 @@ Cancel a running job by id from Waypoint server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -38,6 +38,6 @@ Cancel a running job by id from Waypoint server.
 
 #### Command Options
 
-- `-dangerously-force` - Will forcefully cancel the job. This will immediately mark the job as complete in the server, regardless of the real job status. This may leave dangling resources or cause concurrency issues if the underlying job doesn't gracefully cancel. USE WITH CAUTION.
+- `-dangerously-force` - Will forcefully cancel the job. This will immediately mark the job as complete in the server, regardless of the real job status. This may leave dangling resources or cause concurrency issues if the underlying job doesn't gracefully cancel. USE WITH CAUTION. The default is false.
 
 @include "commands/job-cancel_more.mdx"

--- a/website/content/commands/job-get-stream.mdx
+++ b/website/content/commands/job-get-stream.mdx
@@ -21,7 +21,7 @@ Connects the local CLI to an active job stream.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/job-inspect.mdx
+++ b/website/content/commands/job-inspect.mdx
@@ -21,7 +21,7 @@ Inspect the details of a job by id in Waypoint server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -38,6 +38,6 @@ Inspect the details of a job by id in Waypoint server.
 
 #### Command Options
 
-- `-json` - Output the list of jobs as json.
+- `-json` - Output the list of jobs as json. The default is false.
 
 @include "commands/job-inspect_more.mdx"

--- a/website/content/commands/job-list.mdx
+++ b/website/content/commands/job-list.mdx
@@ -21,7 +21,7 @@ List all known jobs from Waypoint server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -41,8 +41,8 @@ List all known jobs from Waypoint server.
 - `-state=<string>` - List jobs that only match the requested state. Can be repeated multiple times. One possible value from: Success, Error, Running, Waiting, Queued, Unknown.
 - `-target-runner-id=<string>` - List jobs that were only assigned to the target runner by id.
 - `-target-runner-label=<key=value>` - List jobs that were only assigned to the target runner by labels. Can be repeated multiple times.
-- `-desc` - Output the list of jobs from newest to oldest.
-- `-json` - Output the list of jobs as json.
+- `-desc` - Output the list of jobs from newest to oldest. The default is false.
+- `-json` - Output the list of jobs as json. The default is false.
 - `-limit=<int>` - If set, will limit the number of jobs to list.
 
 @include "commands/job-list_more.mdx"

--- a/website/content/commands/k8s-bootstrap.mdx
+++ b/website/content/commands/k8s-bootstrap.mdx
@@ -39,7 +39,7 @@ should be no concern of data loss in the event of a bootstrap failure.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -47,8 +47,8 @@ should be no concern of data loss in the event of a bootstrap failure.
 #### Connection Options
 
 - `-server-addr=<string>` - Address for the server.
-- `-server-tls` - True if the server should be connected to via TLS.
-- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server.
+- `-server-tls` - True if the server should be connected to via TLS. The default is true.
+- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server. The default is false.
 
 #### Command Options
 
@@ -58,7 +58,7 @@ should be no concern of data loss in the event of a bootstrap failure.
 - `-odr-service-account=<string>` - The name of the Kubernetes service account to use for ODR.
 - `-odr-image-pull-policy=<string>` - The pull policy to use for the container image.
 - `-advertise-service=<string>` - The name of the service to advertise.
-- `-advertise-tls` - True if the advertise addr supports TLS.
-- `-advertise-tls-skip-verify` - True if the advertise addr TLS shouldn't be verified.
+- `-advertise-tls` - True if the advertise addr supports TLS. The default is true.
+- `-advertise-tls-skip-verify` - True if the advertise addr TLS shouldn't be verified. The default is false.
 
 @include "commands/k8s-bootstrap_more.mdx"

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -37,7 +37,7 @@ or file.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -45,16 +45,16 @@ or file.
 #### Connection Options
 
 - `-server-addr=<string>` - Address for the server.
-- `-server-tls` - True if the server should be connected to via TLS.
-- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server.
+- `-server-tls` - True if the server should be connected to via TLS. The default is true.
+- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server. The default is false.
 
 #### Command Options
 
 - `-auth-method=<string>` - Auth method to use for login. This will default to the only available auth method if only one exists.
 - `-token=<string>` - Auth with a token. This will force auth-method to 'token'. This works with both login and invite tokens.
-- `-from-kubernetes` - Perform the initial authentication after Waypoint is installed to Kubernetes. This requires kubectl to be configured with access to the Kubernetes cluster. The primary use case of this is to get the first token from a Waypoint installation. After that, future users should use a configured auth method or request a token from an administrator.
-- `-from-kubernetes-service=<string>` - The name of the Kubernetes service to get the server address from when using the -from-kubernetes flag.
-- `-from-kubernetes-secret=<string>` - The name of the Kubernetes secret that has the Waypoint token when using the -from-kubernetes flag.
+- `-from-kubernetes` - Perform the initial authentication after Waypoint is installed to Kubernetes. This requires kubectl to be configured with access to the Kubernetes cluster. The primary use case of this is to get the first token from a Waypoint installation. After that, future users should use a configured auth method or request a token from an administrator. The default is false.
+- `-from-kubernetes-service=<string>` - The name of the Kubernetes service to get the server address from when using the -from-kubernetes flag. The default is waypoint-ui.
+- `-from-kubernetes-secret=<string>` - The name of the Kubernetes secret that has the Waypoint token when using the -from-kubernetes flag. The default is waypoint-server-token.
 - `-from-kubernetes-namespace=<string>` - The name of the Kubernetes namespace that has the Waypoint token when using the -from-kubernetes flag.
 
 @include "commands/login_more.mdx"

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -28,7 +28,7 @@ to a specific deployment or filter out certain log messages.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/plugin.mdx
+++ b/website/content/commands/plugin.mdx
@@ -21,13 +21,13 @@ Runs a specified plugin directly.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-debug` - Set to true to run the plugin with support for debuggers like delve.
+- `-debug` - Set to true to run the plugin with support for debuggers like delve. The default is false.
 
 @include "commands/plugin_more.mdx"

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -32,7 +32,7 @@ some fields using flags by specifying the -waypoint-hcl flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -52,8 +52,8 @@ some fields using flags by specifying the -waypoint-hcl flag.
 - `-git-private-key-password=<string>` - Password for the private key specified by git-private-key-path if the key requires a password to decode. This is not required if the private key doesn't require a password.
 - `-git-recurse-submodules=<int>` - The maximum depth to recursively clone submodules. A value of zero disables cloning any submodules recursively.
 - `-poll` - Enable polling. This is only valid if a Git data source is supplied. This will watch the repo for changes and trigger a remote 'up'.
-- `-poll-interval=<string>` - Interval between polling if polling is enabled.
+- `-poll-interval=<string>` - Interval between polling if polling is enabled. The default is 30s.
 - `-app-status-poll` - Enable polling to continuously generate status reports for apps. This is only valid if a Git data source is supplied.
-- `-app-status-poll-interval=<string>` - Interval between polling to generate status reports if polling is enabled.
+- `-app-status-poll-interval=<string>` - Interval between polling to generate status reports if polling is enabled. The default is 5m.
 
 @include "commands/project-apply_more.mdx"

--- a/website/content/commands/project-apply.mdx
+++ b/website/content/commands/project-apply.mdx
@@ -43,7 +43,7 @@ some fields using flags by specifying the -waypoint-hcl flag.
 - `-waypoint-hcl=<string>` - Path to a waypoint.hcl file to associate with this project. This is only necessary if a waypoint.hcl is not committed alongside the project source code. If a waypoint.hcl file does not exist in the project source then this waypoint.hcl file will be used. This file will not be validated until an operation is run against the project; this is done on purpose since the waypoint.hcl file may depend on files in the source repository.
 - `-data-source=<string>` - The data source type to use (currently only supports 'git' or 'local'). Associated data source settings (such as flags starting with '-git') will not take effect unless the appropriate data source is set with this flag.
 - `-git-url=<string>` - URL of the Git repository to clone. This can be an HTTP or SSH URL.
-- `-git-path=<string>` - Path is a subdirectory within the checked out repository to go into for the project's configuration. This must be a relative path and may not contain '..'
+- `-git-path=<string>` - Path is a subdirectory within the checked out repository to go into for the project's configuration. This must be a relative path and may not contain '..'.
 - `-git-ref=<string>` - Git ref (i.e. branch, tag, commit) to clone on new operations.
 - `-git-auth-type=<string>` - Authentication type for Git. If set, must be one of 'basic' or 'ssh'. Basic auth is username/password and SSH uses an SSH key.
 - `-git-username=<string>` - Username for authentication when git-auth-type is 'basic'. For GitHub, this can be any value but it must be non-empty.

--- a/website/content/commands/project-inspect.mdx
+++ b/website/content/commands/project-inspect.mdx
@@ -28,13 +28,13 @@ or "waypoint init".
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-json` - Output project information as JSON.
+- `-json` - Output project information as JSON. The default is false.
 
 @include "commands/project-inspect_more.mdx"

--- a/website/content/commands/project-list.mdx
+++ b/website/content/commands/project-list.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint project list`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -36,6 +36,6 @@ Usage: `waypoint project list`
 
 #### Command Options
 
-- `-json` - Output the Project names as json.
+- `-json` - Output the Project names as json. The default is false.
 
 @include "commands/project-list_more.mdx"

--- a/website/content/commands/release-list.mdx
+++ b/website/content/commands/release-list.mdx
@@ -21,25 +21,25 @@ Lists the releases that were created if the platform includes a releaser.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-workspace-all` - List builds in all workspaces for this project and application.
-- `-verbose` (`-V`) - Display more details about each release.
-- `-url` (`-u`) - Display release URL.
-- `-json` - Output the release information as JSON.
-- `-long-ids` - Show long identifiers rather than sequence numbers.
+- `-workspace-all` - List builds in all workspaces for this project and application. The default is false.
+- `-verbose` (`-V`) - Display more details about each release. The default is false.
+- `-url` (`-u`) - Display release URL. The default is false.
+- `-json` - Output the release information as JSON. The default is false.
+- `-long-ids` - Show long identifiers rather than sequence numbers. The default is false.
 
 #### Filter Options
 
 - `-state=<string>` - Filter values to have the given status. One possible value from: error, running, success, unknown.
-- `-physical-state=<string>` - Show values in the given physical states. One possible value from: any, created, destroyed, pending.
+- `-physical-state=<string>` - Show values in the given physical states. One possible value from: any, created, destroyed, pending. The default is created.
 - `-order-by=<string>` - Order the values by which field. One possible value from: start-time, complete-time.
-- `-desc` - Sort the values in descending order.
+- `-desc` - Sort the values in descending order. The default is false.
 - `-limit=<uint>` - How many values to show.
 
 @include "commands/release-list_more.mdx"

--- a/website/content/commands/release.mdx
+++ b/website/content/commands/release.mdx
@@ -24,7 +24,7 @@ specified by ID using the '-deployment' flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -41,9 +41,9 @@ specified by ID using the '-deployment' flag.
 
 #### Command Options
 
-- `-repeat` - Re-release if deploy is already released.
+- `-repeat` - Re-release if deploy is already released. The default is false.
 - `-deployment=<string>` (`-d`) - Release the specified deployment.
-- `-prune` - Prune old unreleased deployments.
-- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0.
+- `-prune` - Prune old unreleased deployments. The default is true.
+- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0. The default is -1.
 
 @include "commands/release_more.mdx"

--- a/website/content/commands/runner-adopt.mdx
+++ b/website/content/commands/runner-adopt.mdx
@@ -30,7 +30,7 @@ the token they received during the adoption process.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -41,19 +41,19 @@ not generally recommended.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-enable-dynamic-config` - Allow dynamic config to be created when an exec plugin is used.
+- `-enable-dynamic-config` - Allow dynamic config to be created when an exec plugin is used. The default is false.
 - `-liveness-tcp-addr=<string>` - If this is set, the runner will open a TCP listener on this address when it is running. This can be used as a liveness probe endpoint. The TCP server serves no other purpose.
 - `-id=<string>` - If this is set, the runner will use the specified id.
 - `-cookie=<string>` - The cookie value of the server to validate API requests. This is required for runner adoption. If you do not already have a runner token, this must be set.
 - `-state-dir=<string>` - Directory to store state between restarts. This is optional. If this is set, then a runner can restart without re-triggering the adoption process.
 - `-label=<key=value>` - Labels to set for this runner in 'k=v' format. Can be specified multiple times.
-- `-concurrency=<int>` - The number of concurrent jobs that can be running at one time. This has no effect if `-odr` is set. A value of less than 1 will default to 1.
+- `-concurrency=<int>` - The number of concurrent jobs that can be running at one time. This has no effect if `-odr` is set. A value of less than 1 will default to 1. The default is 24.
 
 @include "commands/runner-agent_more.mdx"

--- a/website/content/commands/runner-agent.mdx
+++ b/website/content/commands/runner-agent.mdx
@@ -54,6 +54,6 @@ not generally recommended.
 - `-cookie=<string>` - The cookie value of the server to validate API requests. This is required for runner adoption. If you do not already have a runner token, this must be set.
 - `-state-dir=<string>` - Directory to store state between restarts. This is optional. If this is set, then a runner can restart without re-triggering the adoption process.
 - `-label=<key=value>` - Labels to set for this runner in 'k=v' format. Can be specified multiple times.
-- `-concurrency=<int>` - The number of concurrent jobs that can be running at one time. This has no effect if `-odr` is set. A value of less than 1 will default to 1. The default is 24.
+- `-concurrency=<int>` - The number of concurrent jobs that can be running at one time. This has no effect if `-odr` is set. The default value applied will be (total number of logical cpus available \* 3). A value of less than 1 will default to 1.
 
 @include "commands/runner-agent_more.mdx"

--- a/website/content/commands/runner-forget.mdx
+++ b/website/content/commands/runner-forget.mdx
@@ -26,7 +26,7 @@ seen this runner before and triggers the full adoption process again.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/runner-inspect.mdx
+++ b/website/content/commands/runner-inspect.mdx
@@ -19,13 +19,13 @@ Usage: `waypoint runner inspect <id>`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-json` - Output runner information as JSON. This includes more fields since this is the complete API structure.
+- `-json` - Output runner information as JSON. This includes more fields since this is the complete API structure. The default is false.
 
 @include "commands/runner-inspect_more.mdx"

--- a/website/content/commands/runner-list.mdx
+++ b/website/content/commands/runner-list.mdx
@@ -39,7 +39,7 @@ at any time, even after it is already adopted.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -56,7 +56,7 @@ at any time, even after it is already adopted.
 
 #### Command Options
 
-- `-pending` - List only runners pending adoption.
-- `-json` - Output runner configuration list information as JSON. This includes more fields since this is the complete API structure.
+- `-pending` - List only runners pending adoption. The default is false.
+- `-json` - Output runner configuration list information as JSON. This includes more fields since this is the complete API structure. The default is false.
 
 @include "commands/runner-list_more.mdx"

--- a/website/content/commands/runner-profile-delete.mdx
+++ b/website/content/commands/runner-profile-delete.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint runner profile delete <id>`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/runner-profile-inspect.mdx
+++ b/website/content/commands/runner-profile-inspect.mdx
@@ -19,13 +19,13 @@ Usage: `waypoint runner profile inspect <name>`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-json` - Output runner profile information as JSON. This includes more fields since this is the complete API structure.
+- `-json` - Output runner profile information as JSON. This includes more fields since this is the complete API structure. The default is false.
 
 @include "commands/runner-profile-inspect_more.mdx"

--- a/website/content/commands/runner-profile-list.mdx
+++ b/website/content/commands/runner-profile-list.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint runner profile list`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -27,7 +27,7 @@ lifecycle operation.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -35,12 +35,12 @@ lifecycle operation.
 #### Command Options
 
 - `-name=<string>` - The name of an existing runner profile to update.
-- `-oci-url=<string>` - The url for the OCI image to launch for the on-demand runner.
+- `-oci-url=<string>` - The url for the OCI image to launch for the on-demand runner. The default is hashicorp/waypoint-odr:latest.
 - `-env-var=<key=value>` - Environment variable to expose to the on-demand runner set in 'k=v' format. Typically used to introduce configuration for the plugins that the runner will execute. Can be specified multiple times.
 - `-env-vars=<string>` - DEPRECATED. Please see `-env-var`.
 - `-plugin-type=<string>` - The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.
 - `-plugin-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
-- `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner.
+- `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner. The default is false.
 - `-target-runner-id=<string>` - ID of the runner to target for this remote runner profile.
 - `-target-runner-label=<key=value>` - Labels on the runner to target for this remote runner profile. e.g. `-target-runner-label=k=v`. Can be specified multiple times.
 

--- a/website/content/commands/runner-reject.mdx
+++ b/website/content/commands/runner-reject.mdx
@@ -30,7 +30,7 @@ and then will not receive any further jobs.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/runner-token.mdx
+++ b/website/content/commands/runner-token.mdx
@@ -29,14 +29,14 @@ level of security to transfer a token around.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'.
+- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'. The default is 720h0m0s.
 - `-id=<string>` - Id to restrict this token to. If empty, all runner IDs are valid.
 - `-label=<key=value>` - Labels that must match the runner for this token to be valid. These are set in 'k=v' format and this flag can be repeated to set multiple labels. If no labels are set, runners with any labels are valid.
 

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -47,7 +47,7 @@ a CLI context by default.
 
 #### Command Options
 
-- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-1656374022.
+- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-1656374441.
 - `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty. The default is true.
 
 @include "commands/server-bootstrap_more.mdx"

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -47,7 +47,7 @@ a CLI context by default.
 
 #### Command Options
 
-- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-1656374441.
+- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-<timestamp>.
 - `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty. The default is true.
 
 @include "commands/server-bootstrap_more.mdx"

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -47,7 +47,7 @@ a CLI context by default.
 
 #### Command Options
 
-- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created. The default is bootstrap-<timestamp>.
+- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created. The default is bootstrap-timestamp.
 - `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty. The default is true.
 
 @include "commands/server-bootstrap_more.mdx"

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -34,7 +34,7 @@ a CLI context by default.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -42,12 +42,12 @@ a CLI context by default.
 #### Connection Options
 
 - `-server-addr=<string>` - Address for the server.
-- `-server-tls` - True if the server should be connected to via TLS.
-- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server.
+- `-server-tls` - True if the server should be connected to via TLS. The default is true.
+- `-server-tls-skip-verify` - True to skip verification of the TLS certificate advertised by the server. The default is false.
 
 #### Command Options
 
-- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created
-- `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty.
+- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-1656374022.
+- `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty. The default is true.
 
 @include "commands/server-bootstrap_more.mdx"

--- a/website/content/commands/server-bootstrap.mdx
+++ b/website/content/commands/server-bootstrap.mdx
@@ -47,7 +47,7 @@ a CLI context by default.
 
 #### Command Options
 
-- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created The default is bootstrap-<timestamp>.
+- `-context-create=<string>` - Create a CLI context for this bootstrapped server. The context name will be the value of this flag. If this is an empty string, a context will not be created. The default is bootstrap-<timestamp>.
 - `-context-set-default` - Set the newly bootstrapped server as the default CLI context. This only has an effect if -context-create is non-empty. The default is true.
 
 @include "commands/server-bootstrap_more.mdx"

--- a/website/content/commands/server-config-set.mdx
+++ b/website/content/commands/server-config-set.mdx
@@ -29,7 +29,7 @@ together in one call.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -40,7 +40,7 @@ together in one call.
   binaries to communicate back to the server. If this is blank, then
   the entrypoints will not communicate to the server. Features such as
   logs, exec, etc. will not work.
-- `-advertise-tls` - If true, the advertised address should be connected to with TLS.
-- `-advertise-tls-skip-verify` - Do not verify the TLS certificate presented by the server.
+- `-advertise-tls` - If true, the advertised address should be connected to with TLS. The default is true.
+- `-advertise-tls-skip-verify` - Do not verify the TLS certificate presented by the server. The default is false.
 
 @include "commands/server-config-set_more.mdx"

--- a/website/content/commands/server-cookie.mdx
+++ b/website/content/commands/server-cookie.mdx
@@ -32,7 +32,7 @@ to prevent unnecessary API noise to a cluster.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -53,7 +53,7 @@ and disable the UI, the command would be:
 
 #### Command Options
 
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
 - `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
@@ -92,7 +92,7 @@ and disable the UI, the command would be:
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.
@@ -105,7 +105,7 @@ and disable the UI, the command would be:
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
-- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
+- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
 - `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-timestamp.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374441.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-<timestamp>.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-timestamp.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value if not set will be 'install-' and then be suffixed with a timestamp at the time the command is executed.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -46,85 +46,85 @@ and disable the UI, the command would be:
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed.
-- `-context-set-default` - Set the newly installed server as the default CLI context.
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374022.
+- `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 
 #### docker Options
 
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
+- `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 
 #### ecs Options
 
-- `-ecs-cluster=<string>` - Configures the Cluster to install into.
-- `-ecs-region=<string>` - Configures which AWS region to install into.
+- `-ecs-cluster=<string>` - Configures the Cluster to install into. The default is waypoint-server.
+- `-ecs-region=<string>` - Configures which AWS region to install into. The default is us-west-2.
 - `-ecs-subnets=<string>` - Subnets to install server into.
-- `-ecs-execution-role-name=<string>` - Configures the IAM Execution role name to use.
-- `-ecs-server-image=<string>` - Docker image for the Waypoint server.
-- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS.
-- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS.
-- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions.
+- `-ecs-execution-role-name=<string>` - Configures the IAM Execution role name to use. The default is waypoint-server-execution-role.
+- `-ecs-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS. The default is 512.
+- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS. The default is 1024.
+- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions. The default is waypoint-runner.
 - `-ecs-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS.
-- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS.
+- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS. The default is 2048.
+- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS. The default is 512.
 
 #### kubernetes Options
 
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost. The default is false.
 - `-k8s-annotate-service=<key=value>` - Annotations for the Service generated.
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
-- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes.
-- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes.
-- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes.
-- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes.
+- `-k8s-cpu-request=<string>` - Configures the requested CPU amount for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes. The default is 0.
+- `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation. The default is false.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
-- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions.
-- `-k8s-runner-service-account-init` - Create the service account if it does not exist.
+- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
+- `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.
-- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes.
+- `-k8s-storage-request=<string>` - Configures the requested persistent volume size for the Waypoint server in Kubernetes. The default is 1Gi.
 
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
-- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth.
-- `-nomad-dc=<string>` - Datacenters to install to for Nomad.
-- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks.
-- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad.
+- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth. The default is false.
+- `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
+- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
+- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
-- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
-- `-nomad-region=<string>` - Region to install to for Nomad.
-- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task.
-- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
-- `-nomad-server-image=<string>` - Docker image for the Waypoint server.
-- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul.
+- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
+- `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
+- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task. The default is 600.
+- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
+- `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is true.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
-- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located.
-- `-nomad-consul-domain=<string>` - The domain where Consul is located.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
+- `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 - `-nomad-consul-token=<string>` - If set, the passed Consul token is stored in the job before sending to the Nomad servers. Overrides the CONSUL_HTTP_TOKEN environment variable if set.
 - `-nomad-host-volume=<string>` - Nomad host volume name, required for volume type 'host'.
 - `-nomad-csi-volume-provider=<string>` - Nomad CSI volume provider, required for volume type 'csi'.
-- `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes.
-- `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes.
-- `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system.
+- `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
+- `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
+- `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
 - `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
 - `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -54,7 +54,7 @@ and disable the UI, the command would be:
 #### Command Options
 
 - `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
-- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374022.
+- `-context-create=<string>` - Create a context with connection information for this installation. The default value will be suffixed with a timestamp at the time the command is executed. The default is install-1656374441.
 - `-context-set-default` - Set the newly installed server as the default CLI context. The default is true.
 - `-platform=<string>` - Platform to install the Waypoint server into.
 

--- a/website/content/commands/server-restore.mdx
+++ b/website/content/commands/server-restore.mdx
@@ -32,13 +32,13 @@ standard input. Using a name of '-' will force reading from standard input.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-exit` - After restoring, the server should exit so it can be restarted.
+- `-exit` - After restoring, the server should exit so it can be restarted. The default is false.
 
 @include "commands/server-restore_more.mdx"

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -37,8 +37,8 @@ environment.
 - `-listen-http=<string>` - Address to bind to for HTTP connections. Required for the UI. The default is 127.0.0.1:9702.
 - `-listen-http-insecure=<string>` - Address to bind to for insecure HTTP connections. This will not have TLS enabled. This will redirect users to the TLS port UNLESS there is an X-Forwarded-Proto header. This makes this port suitable for proxy backends.
 - `-tls-cert-file=<string>` - Path to a PEM-encoded certificate file for TLS. If this isn't set, a self-signed certificate will be generated. This file will be monitored for changes and will automatically reload on change.
-- `-tls-key-file=<string>` - Path to a PEM-encoded private key file for the TLS certificate specified with -tls-cert-file. This is required if -tls-cert-file is set. This file will be monitored for changes and will automatically reload on change
-- `-disable-ui` - Disable the embedded web interface The default is false.
+- `-tls-key-file=<string>` - Path to a PEM-encoded private key file for the TLS certificate specified with -tls-cert-file. This is required if -tls-cert-file is set. This file will be monitored for changes and will automatically reload on change.
+- `-disable-ui` - Disable the embedded web interface. The default is false.
 - `-url-enabled` - Enable the URL service. The default is true.
 - `-url-api-addr=<string>` - Address to Waypoint URL service API. The default is api.waypoint.run:443.
 - `-url-api-insecure` - True if TLS is not enabled for the Waypoint URL service API. The default is false.
@@ -51,10 +51,10 @@ environment.
   logs, exec, etc. will not work.
 - `-advertise-tls` - If true, the advertised address should be connected to with TLS. The default is true.
 - `-advertise-tls-skip-verify` - Do not verify the TLS certificate presented by the server. The default is false.
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
-- `-telemetry-oc-agent-addr=<string>` - Address of an OpenCensus agent or collector available to receive OpenCensus formatted telemetry, traces and stats (commonly port 55678). Example: localhost:55678
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms. The default is false.
+- `-telemetry-oc-agent-addr=<string>` - Address of an OpenCensus agent or collector available to receive OpenCensus formatted telemetry, traces and stats (commonly port 55678). Example: localhost:55678.
 - `-telemetry-oc-agent-insecure` - Disables client transport security for the OpenCensus agent exporter's gRPC connection. The default is false.
-- `-telemetry-dd-trace-addr=<string>` - Address of a DataDog agent available to accept traces (commonly port 8126). Example: localhost:8126
-- `-telemetry-oc-zpages-addr=<string>` - If set, Waypoint will run an OpenCensus zPages server at this address. Typically this is set to something like localhost:9999, where trace debug information could be viewed at http://localhost:9999/debug/tracez, and rpc stats at http://localhost:55679/debug/rpcz. More information at https://opencensus.io/zpages/
+- `-telemetry-dd-trace-addr=<string>` - Address of a DataDog agent available to accept traces (commonly port 8126). Example: localhost:8126.
+- `-telemetry-oc-zpages-addr=<string>` - If set, Waypoint will run an OpenCensus zPages server at this address. Typically this is set to something like localhost:9999, where trace debug information could be viewed at http://localhost:9999/debug/tracez, and rpc stats at http://localhost:55679/debug/rpcz. More information at https://opencensus.io/zpages/.
 
 @include "commands/server-run_more.mdx"

--- a/website/content/commands/server-run.mdx
+++ b/website/content/commands/server-run.mdx
@@ -25,7 +25,7 @@ environment.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -33,27 +33,27 @@ environment.
 #### Command Options
 
 - `-db=<string>` - Path to the database file.
-- `-listen-grpc=<string>` - Address to bind to for gRPC connections.
-- `-listen-http=<string>` - Address to bind to for HTTP connections. Required for the UI.
+- `-listen-grpc=<string>` - Address to bind to for gRPC connections. The default is 127.0.0.1:9701.
+- `-listen-http=<string>` - Address to bind to for HTTP connections. Required for the UI. The default is 127.0.0.1:9702.
 - `-listen-http-insecure=<string>` - Address to bind to for insecure HTTP connections. This will not have TLS enabled. This will redirect users to the TLS port UNLESS there is an X-Forwarded-Proto header. This makes this port suitable for proxy backends.
 - `-tls-cert-file=<string>` - Path to a PEM-encoded certificate file for TLS. If this isn't set, a self-signed certificate will be generated. This file will be monitored for changes and will automatically reload on change.
 - `-tls-key-file=<string>` - Path to a PEM-encoded private key file for the TLS certificate specified with -tls-cert-file. This is required if -tls-cert-file is set. This file will be monitored for changes and will automatically reload on change
-- `-disable-ui` - Disable the embedded web interface
-- `-url-enabled` - Enable the URL service.
-- `-url-api-addr=<string>` - Address to Waypoint URL service API.
-- `-url-api-insecure` - True if TLS is not enabled for the Waypoint URL service API.
-- `-url-control-addr=<string>` - Address to Waypoint URL service control API.
+- `-disable-ui` - Disable the embedded web interface The default is false.
+- `-url-enabled` - Enable the URL service. The default is true.
+- `-url-api-addr=<string>` - Address to Waypoint URL service API. The default is api.waypoint.run:443.
+- `-url-api-insecure` - True if TLS is not enabled for the Waypoint URL service API. The default is false.
+- `-url-control-addr=<string>` - Address to Waypoint URL service control API. The default is https://control.hzn.network.
 - `-url-control-token=<string>` - Token for the Waypoint URL server control API.
-- `-url-auto-app-hostname` - Whether apps automatically get a hostname on deploy.
+- `-url-auto-app-hostname` - Whether apps automatically get a hostname on deploy. The default is true.
 - `-advertise-addr=<string>` - Address to advertise for the server. This is used by the entrypoints
   binaries to communicate back to the server. If this is blank, then
   the entrypoints will not communicate to the server. Features such as
   logs, exec, etc. will not work.
-- `-advertise-tls` - If true, the advertised address should be connected to with TLS.
-- `-advertise-tls-skip-verify` - Do not verify the TLS certificate presented by the server.
-- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms
+- `-advertise-tls` - If true, the advertised address should be connected to with TLS. The default is true.
+- `-advertise-tls-skip-verify` - Do not verify the TLS certificate presented by the server. The default is false.
+- `-accept-tos` - Pass to accept the Terms of Service and Privacy Policy to use the Waypoint URL Service. This is required if the URL service is enabled and you're using the HashiCorp-provided URL service rather than self-hosting. See the privacy policy at https://hashicorp.com/privacy and the ToS at https://waypointproject.io/terms The default is false.
 - `-telemetry-oc-agent-addr=<string>` - Address of an OpenCensus agent or collector available to receive OpenCensus formatted telemetry, traces and stats (commonly port 55678). Example: localhost:55678
-- `-telemetry-oc-agent-insecure` - Disables client transport security for the OpenCensus agent exporter's gRPC connection.
+- `-telemetry-oc-agent-insecure` - Disables client transport security for the OpenCensus agent exporter's gRPC connection. The default is false.
 - `-telemetry-dd-trace-addr=<string>` - Address of a DataDog agent available to accept traces (commonly port 8126). Example: localhost:8126
 - `-telemetry-oc-zpages-addr=<string>` - If set, Waypoint will run an OpenCensus zPages server at this address. Typically this is set to something like localhost:9999, where trace debug information could be viewed at http://localhost:9999/debug/tracez, and rpc stats at http://localhost:55679/debug/rpcz. More information at https://opencensus.io/zpages/
 

--- a/website/content/commands/server-snapshot.mdx
+++ b/website/content/commands/server-snapshot.mdx
@@ -24,7 +24,7 @@ to standard out.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -37,24 +37,24 @@ command) will not be affected.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-auto-approve` - Auto-approve server uninstallation. If unset, confirmation will be requested.
-- `-delete-context` - Delete the context for the server once it's uninstalled.
+- `-auto-approve` - Auto-approve server uninstallation. If unset, confirmation will be requested. The default is false.
+- `-delete-context` - Delete the context for the server once it's uninstalled. The default is true.
 - `-platform=<string>` - Platform to uninstall the Waypoint server from.
-- `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
-- `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to uninstall.
-- `-ignore-runner-error` - Ignore any errors encountered while uninstalling runners. This allows the server to be uninstalled even if runner uninstallation fails. Note that this may leave runners dangling since future 'uninstall' runs will do nothing if the server is uninstalled.
+- `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name. The default is waypoint-server-snapshot.
+- `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to uninstall. The default is true.
+- `-ignore-runner-error` - Ignore any errors encountered while uninstalling runners. This allows the server to be uninstalled even if runner uninstallation fails. Note that this may leave runners dangling since future 'uninstall' runs will do nothing if the server is uninstalled. The default is false.
 
 #### ecs Options
 
-- `-ecs-cluster=<string>` - Configures the Cluster to uninstall.
-- `-ecs-region=<string>` - Configures which AWS region to uninstall from.
+- `-ecs-cluster=<string>` - Configures the Cluster to uninstall. The default is waypoint-server.
+- `-ecs-region=<string>` - Configures which AWS region to uninstall from. The default is us-west-2.
 
 #### kubernetes Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -28,68 +28,68 @@ manually installed runners will not be automatically upgraded.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-auto-approve` - Auto-approve server upgrade. If unset, confirmation will be requested.
+- `-auto-approve` - Auto-approve server upgrade. If unset, confirmation will be requested. The default is false.
 - `-context-name=<string>` - Waypoint server context to upgrade.
 - `-platform=<string>` - Platform to upgrade the Waypoint server from, defaults to the platform stored in the context.
-- `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name.
-- `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades.
+- `-snapshot-name=<string>` - Filename to write the snapshot to. If no name is specified, by default a timestamp will be appended to the default snapshot name. The default is waypoint-server-snapshot.
+- `-snapshot` - Enable or disable taking a snapshot of Waypoint server prior to upgrades. The default is true.
 
 #### docker Options
 
-- `-docker-server-image=<string>` - Docker image for the Waypoint server.
+- `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 
 #### ecs Options
 
-- `-ecs-cluster=<string>` - Configures the Cluster to upgrade.
-- `-ecs-server-image=<string>` - Docker image for the Waypoint server.
-- `-ecs-region=<string>` - Configures which AWS region to install into.
-- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS.
-- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS.
+- `-ecs-cluster=<string>` - Configures the Cluster to upgrade. The default is waypoint-server.
+- `-ecs-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
+- `-ecs-region=<string>` - Configures which AWS region to install into. The default is us-west-2.
+- `-ecs-cpu=<string>` - Configures the requested CPU amount for the Waypoint server task in ECS. The default is 512.
+- `-ecs-mem=<string>` - Configures the requested memory amount for the Waypoint server task in ECS. The default is 1024.
 - `-ecs-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions.
-- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS.
-- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS.
+- `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. If this is blank, an IAM role will be created automatically with the default permissions. The default is waypoint-runner.
+- `-ecs-odr-mem=<string>` - Configures the requested memory amount for the Waypoint On-Demand runner in ECS. The default is 2048.
+- `-ecs-odr-cpu=<string>` - Configures the requested CPU amount for the Waypoint On-Demand runner in ECS. The default is 512.
 
 #### kubernetes Options
 
-- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost.
+- `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost. The default is false.
 - `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
-- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation.
-- `-k8s-server-image=<string>` - Docker image for the Waypoint server.
+- `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation. The default is false.
+- `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
-- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions.
-- `-k8s-runner-service-account-init` - Create the service account if it does not exist.
+- `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
+- `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 
 #### nomad Options
 
 - `-nomad-annotate-service=<key=value>` - Annotations for the Service generated.
-- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth.
-- `-nomad-dc=<string>` - Datacenters to install to for Nomad.
-- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks.
-- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad.
+- `-nomad-auth-soft-fail` - Don't fail the Nomad task on an auth failure obtaining server image container. Attempt to continue without auth. The default is false.
+- `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
+- `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
+- `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
-- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad.
-- `-nomad-region=<string>` - Region to install to for Nomad.
-- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-server-memory=<string>` - MB of Memory to allocate to the server job task.
-- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz.
-- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
-- `-nomad-server-image=<string>` - Docker image for the Waypoint server.
+- `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
+- `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
+- `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-server-memory=<string>` - MB of Memory to allocate to the server job task. The default is 600.
+- `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
+- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
+- `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-host-volume=<string>` - Nomad host volume name.
-- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul.
+- `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is false.
 - `-nomad-consul-service-hostname=<string>` - If set, will use this hostname for Consul DNS rather than the default, i.e. "waypoint-server.service.consul".
-- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul.
-- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint.
-- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located.
-- `-nomad-consul-domain=<string>` - The domain where Consul is located.
+- `-nomad-consul-service-ui-tags=<string>` - Tags for the Waypoint UI service generated in Consul. The default is waypoint.
+- `-nomad-consul-service-backend-tags=<string>` - Tags for the Waypoint backend service generated in Consul. The 'first' tag will be used when crafting the Consul DNS hostname for accessing Waypoint. The default is waypoint.
+- `-nomad-consul-datacenter=<string>` - The datacenter where Consul is located. The default is dc1.
+- `-nomad-consul-domain=<string>` - The domain where Consul is located. The default is consul.
 
 @include "commands/server-upgrade_more.mdx"

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -65,7 +65,7 @@ manually installed runners will not be automatically upgraded.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
 - `-k8s-openshift` - Enables installing the Waypoint server on Kubernetes on Red Hat OpenShift. If set, auto-configures the installation. The default is false.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 
@@ -76,7 +76,7 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
-- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest')
+- `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
 - `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.

--- a/website/content/commands/status.mdx
+++ b/website/content/commands/status.mdx
@@ -26,7 +26,7 @@ data sourced projects.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -43,9 +43,9 @@ data sourced projects.
 
 #### Command Options
 
-- `-verbose` (`-V`) - Display more details.
-- `-json` - Output the status information as JSON.
-- `-all-projects` - Output status about every project in a workspace.
-- `-refresh` - Refresh application status for the requested app or apps in a project.
+- `-verbose` (`-V`) - Display more details. The default is false.
+- `-json` - Output the status information as JSON. The default is false.
+- `-all-projects` - Output status about every project in a workspace. The default is false.
+- `-refresh` - Refresh application status for the requested app or apps in a project. The default is false.
 
 @include "commands/status_more.mdx"

--- a/website/content/commands/task-cancel.mdx
+++ b/website/content/commands/task-cancel.mdx
@@ -21,7 +21,7 @@ Cancel an On-Demand Runner Task and all of the jobs associated with it.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/task-inspect.mdx
+++ b/website/content/commands/task-inspect.mdx
@@ -21,7 +21,7 @@ Inspect an On-Demand Runner Tasks and all of the jobs associated with it.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -38,7 +38,7 @@ Inspect an On-Demand Runner Tasks and all of the jobs associated with it.
 
 #### Command Options
 
-- `-json` - Output the list of jobs as json.
+- `-json` - Output the list of jobs as json. The default is false.
 - `-run-job-id=<string>` - Look up a Task by Run Job Id.
 
 @include "commands/task-inspect_more.mdx"

--- a/website/content/commands/task-list.mdx
+++ b/website/content/commands/task-list.mdx
@@ -22,7 +22,7 @@ Waypoint Job tuple made up of a StartTask, RunTask, and StopTask.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -39,8 +39,8 @@ Waypoint Job tuple made up of a StartTask, RunTask, and StopTask.
 
 #### Command Options
 
-- `-desc` - Output the list of Tasks from newest to oldest.
-- `-json` - Output the list of Tasks as json.
+- `-desc` - Output the list of Tasks from newest to oldest. The default is false.
+- `-json` - Output the list of Tasks as json. The default is false.
 - `-limit=<int>` - If set, will limit the number of Tasks to list.
 - `-state=<string>` - List Tasks that only match the requested state. Can be repeated multiple times. One possible value from: UNKNOWN, PENDING, STARTING, STARTED, RUNNING, COMPLETED, STOPPING, STOPPED, MIXED.
 

--- a/website/content/commands/token-exchange.mdx
+++ b/website/content/commands/token-exchange.mdx
@@ -26,7 +26,7 @@ the "waypoint user" set of commands. Everything that was possible with
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/token-invite.mdx
+++ b/website/content/commands/token-invite.mdx
@@ -26,13 +26,13 @@ the "waypoint user" set of commands. Everything that was possible with
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-lifetime=<duration>` - How long the invite token will valid for, starting now.
+- `-lifetime=<duration>` - How long the invite token will valid for, starting now. The default is 5m0s.
 
 @include "commands/token-invite_more.mdx"

--- a/website/content/commands/token-new.mdx
+++ b/website/content/commands/token-new.mdx
@@ -26,7 +26,7 @@ the "waypoint user" set of commands. Everything that was possible with
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/trigger-create.mdx
+++ b/website/content/commands/trigger-create.mdx
@@ -25,7 +25,7 @@ build artifact sequence number, it will use whatever the latest artifact sequenc
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -46,18 +46,18 @@ build artifact sequence number, it will use whatever the latest artifact sequenc
 - `-id=<string>` - If specified, will look up an existing trigger by this id and attempt to update the configuration.
 - `-description=<string>` - A human readable description about the trigger URL configuration.
 - `-trigger-tag=<string>` - A collection of tags to apply to the trigger URL configuration. Can be specified multiple times.
-- `-no-auth` - If set, the trigger URL configuration will not require authentication to initiate a request.
+- `-no-auth` - If set, the trigger URL configuration will not require authentication to initiate a request. The default is false.
 - `-op=<string>` - The operation the trigger should execute when requested. One possible value from: build, push, deploy, destroy-workspace, destroy-deployment, release, up, init, status-report-deploy, status-report-release.
 
 #### Operation Options
 
-- `-disable-push` - Disables pushing a build artifact to any configured registry for build operations.
+- `-disable-push` - Disables pushing a build artifact to any configured registry for build operations. The default is false.
 - `-build-id=<int>` - The sequence number (short id) for the build to use for a deployment operation.
 - `-deployment-id=<int>` - The sequence number (short id) for the deployment to use for a deployment operation.
 
 #### Release Operation Options
 
-- `-prune` - If true, will prune deployments that aren't released.
+- `-prune` - If true, will prune deployments that aren't released. The default is false.
 - `-prune-retain=<int>` - This sets the number of unreleased deployments to retain when pruning.
 
 @include "commands/trigger-create_more.mdx"

--- a/website/content/commands/trigger-delete.mdx
+++ b/website/content/commands/trigger-delete.mdx
@@ -21,7 +21,7 @@ Delete a trigger URL from Waypoint Server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/trigger-inspect.mdx
+++ b/website/content/commands/trigger-inspect.mdx
@@ -21,7 +21,7 @@ Inspect a registered trigger URL configuration.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -38,6 +38,6 @@ Inspect a registered trigger URL configuration.
 
 #### Command Options
 
-- `-json` - Output trigger URL configuration information as JSON. This includes more fields since this is the complete API structure.
+- `-json` - Output trigger URL configuration information as JSON. This includes more fields since this is the complete API structure. The default is false.
 
 @include "commands/trigger-inspect_more.mdx"

--- a/website/content/commands/trigger-list.mdx
+++ b/website/content/commands/trigger-list.mdx
@@ -21,7 +21,7 @@ List trigger URL configurations on Waypoint Server.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -39,7 +39,7 @@ List trigger URL configurations on Waypoint Server.
 #### Command Options
 
 - `-trigger-tag=<string>` - A collection of tags to filter on. If the requested tag does not match any defined trigger URL, it will be omitted from the results. Can be specified multiple times.
-- `-full` - Output the full list of options for a trigger configuration.
-- `-json` - Output trigger URL configuration list information as JSON. This includes more fields since this is the complete API structure.
+- `-full` - Output the full list of options for a trigger configuration. The default is false.
+- `-json` - Output trigger URL configuration list information as JSON. This includes more fields since this is the complete API structure. The default is false.
 
 @include "commands/trigger-list_more.mdx"

--- a/website/content/commands/trigger-update.mdx
+++ b/website/content/commands/trigger-update.mdx
@@ -25,7 +25,7 @@ build artifact sequence number, it will use whatever the latest artifact sequenc
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -46,18 +46,18 @@ build artifact sequence number, it will use whatever the latest artifact sequenc
 - `-id=<string>` - If specified, will look up an existing trigger by this id and attempt to update the configuration.
 - `-description=<string>` - A human readable description about the trigger URL configuration.
 - `-trigger-tag=<string>` - A collection of tags to apply to the trigger URL configuration. Can be specified multiple times.
-- `-no-auth` - If set, the trigger URL configuration will not require authentication to initiate a request.
+- `-no-auth` - If set, the trigger URL configuration will not require authentication to initiate a request. The default is false.
 - `-op=<string>` - The operation the trigger should execute when requested. One possible value from: build, push, deploy, destroy-workspace, destroy-deployment, release, up, init, status-report-deploy, status-report-release.
 
 #### Operation Options
 
-- `-disable-push` - Disables pushing a build artifact to any configured registry for build operations.
+- `-disable-push` - Disables pushing a build artifact to any configured registry for build operations. The default is false.
 - `-build-id=<int>` - The sequence number (short id) for the build to use for a deployment operation.
 - `-deployment-id=<int>` - The sequence number (short id) for the deployment to use for a deployment operation.
 
 #### Release Operation Options
 
-- `-prune` - If true, will prune deployments that aren't released.
+- `-prune` - If true, will prune deployments that aren't released. The default is false.
 - `-prune-retain=<int>` - This sets the number of unreleased deployments to retain when pruning.
 
 @include "commands/trigger-update_more.mdx"

--- a/website/content/commands/ui.mdx
+++ b/website/content/commands/ui.mdx
@@ -29,6 +29,6 @@ token invite page with an invite token for authentication.
 
 #### Command Options
 
-- `-authenticate` - Creates a new invite token and passes it to the UI for authorization The default is false.
+- `-authenticate` - Creates a new invite token and passes it to the UI for authorization. The default is false.
 
 @include "commands/ui_more.mdx"

--- a/website/content/commands/ui.mdx
+++ b/website/content/commands/ui.mdx
@@ -22,13 +22,13 @@ token invite page with an invite token for authentication.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-authenticate` - Creates a new invite token and passes it to the UI for authorization
+- `-authenticate` - Creates a new invite token and passes it to the UI for authorization The default is false.
 
 @include "commands/ui_more.mdx"

--- a/website/content/commands/up.mdx
+++ b/website/content/commands/up.mdx
@@ -21,7 +21,7 @@ Perform the build, deploy, and release steps.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
@@ -38,7 +38,7 @@ Perform the build, deploy, and release steps.
 
 #### Command Options
 
-- `-prune` - Prune old unreleased deployments.
-- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0.
+- `-prune` - Prune old unreleased deployments. The default is true.
+- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0. The default is -1.
 
 @include "commands/up_more.mdx"

--- a/website/content/commands/user-inspect.mdx
+++ b/website/content/commands/user-inspect.mdx
@@ -24,7 +24,7 @@ is specified via flags.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/user-invite.mdx
+++ b/website/content/commands/user-invite.mdx
@@ -29,14 +29,14 @@ via "waypoint login".
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'.
+- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'. The default is 24h0m0s.
 - `-username=<string>` - Invite a new user and provide a username hint. The user may still change their username after signing up. If this isn't specified, an invite token for your current user will be generated and no new user signup is performed.
 
 @include "commands/user-invite_more.mdx"

--- a/website/content/commands/user-modify.mdx
+++ b/website/content/commands/user-modify.mdx
@@ -24,7 +24,7 @@ Use "waypoint user inspect" to see the current attributes for a user.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/user-token.mdx
+++ b/website/content/commands/user-token.mdx
@@ -34,15 +34,15 @@ the "waypoint user" set of commands. Everything that was possible with
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
 #### Command Options
 
-- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'.
+- `-expires-in=<duration>` - The duration until the token expires. i.e. '5m'. The default is 720h0m0s.
 - `-username=<string>` - Username to generate the login token for. This defaults to the currently logged in user.
-- `-trigger-url-token` - Will generate a trigger auth token. This token can only be used for trigger URL actions.
+- `-trigger-url-token` - Will generate a trigger auth token. This token can only be used for trigger URL actions. The default is false.
 
 @include "commands/user-token_more.mdx"

--- a/website/content/commands/version.mdx
+++ b/website/content/commands/version.mdx
@@ -19,7 +19,7 @@ Usage: `waypoint version`
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/workspace-create.mdx
+++ b/website/content/commands/workspace-create.mdx
@@ -23,7 +23,7 @@ the -workspace flag.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/workspace-inspect.mdx
+++ b/website/content/commands/workspace-inspect.mdx
@@ -22,7 +22,7 @@ last known activity timestamp
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.

--- a/website/content/commands/workspace-list.mdx
+++ b/website/content/commands/workspace-list.mdx
@@ -22,7 +22,7 @@ context.
 
 #### Global Options
 
-- `-plain` - Plain output: no colors, no animation.
+- `-plain` - Plain output: no colors, no animation. The default is false.
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.


### PR DESCRIPTION
Prior to this commit, our docs CLI generator would not include the
default value for a flag when auto-generating our website docs. The CLI
docs include it, so now as of this commit, our website docs for the CLI
will also include it.