### PR TITLE
Validating fields that can be used as path tokens

### DIFF
--- a/pkg/server/ptypes/application.go
+++ b/pkg/server/ptypes/application.go
@@ -33,7 +33,7 @@ func TestApplication(t testing.T, src *pb.Application) *pb.Application {
 func ValidateUpsertApplicationRequest(v *pb.UpsertApplicationRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
 		validation.Field(&v.Project, validation.Required),
-		validation.Field(&v.Name, validation.Required),
+		validation.Field(&v.Name, validation.Required, validation.By(validatePathToken)),
 	))
 }
 

--- a/pkg/server/ptypes/auth_method.go
+++ b/pkg/server/ptypes/auth_method.go
@@ -50,7 +50,7 @@ func ValidateAuthMethod(v *pb.AuthMethod) error {
 // ValidateAuthMethodRules
 func ValidateAuthMethodRules(v *pb.AuthMethod) []*validation.FieldRules {
 	return []*validation.FieldRules{
-		validation.Field(&v.Name, validation.Required, validation.By(isNotToken)),
+		validation.Field(&v.Name, validation.Required, validation.By(isNotToken), validation.By(validatePathToken)),
 		validation.Field(&v.AccessSelector, validation.By(isBExpr)),
 
 		validation.Field(&v.Method, validation.Required),

--- a/pkg/server/ptypes/ondemand_runner.go
+++ b/pkg/server/ptypes/ondemand_runner.go
@@ -56,6 +56,7 @@ func ValidateOnDemandRunnerConfigRules(p *pb.OnDemandRunnerConfig) []*validation
 	return []*validation.FieldRules{
 		validation.Field(&p.PluginType, validation.Required),
 		validation.Field(&p.PluginConfig, isPluginHcl(p)),
+		validation.Field(&p.Name, validation.By(validatePathToken)),
 	}
 }
 

--- a/pkg/server/ptypes/project.go
+++ b/pkg/server/ptypes/project.go
@@ -56,7 +56,12 @@ func ValidateProject(p *pb.Project) error {
 // ValidateProjectRules
 func ValidateProjectRules(p *pb.Project) []*validation.FieldRules {
 	return []*validation.FieldRules{
-		validation.Field(&p.Name, validation.Required),
+
+		validation.Field(&p.Name,
+			validation.Required,
+			validation.By(validatePathToken),
+		),
+
 		validation.Field(&p.WaypointHcl, isWaypointHcl(p)),
 
 		validationext.StructField(&p.DataSource, func() []*validation.FieldRules {

--- a/pkg/server/ptypes/ref.go
+++ b/pkg/server/ptypes/ref.go
@@ -1,7 +1,11 @@
 package ptypes
 
 import (
+	"errors"
+	"strings"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
@@ -17,4 +21,17 @@ func ValidateRefOperationRules(v *pb.Ref_Operation) []*validation.FieldRules {
 	return []*validation.FieldRules{
 		validation.Field(&v.Target, validation.Required),
 	}
+}
+
+// validatePathToken Validates a field that can be used as a GRPC Gateway path token
+// Check the route in gateway.yml to see which fields are path tokens.
+func validatePathToken(pathToken interface{}) error {
+	s, _ := pathToken.(string)
+
+	// A path token cannot contain ../, as grpc gateway will interpret that
+	// as a path traversal.
+	if strings.Contains(s, "../") {
+		return errors.New("name cannot contain '../'")
+	}
+	return nil
 }

--- a/pkg/server/ptypes/runner.go
+++ b/pkg/server/ptypes/runner.go
@@ -48,7 +48,7 @@ func TestRunner(t testing.T, src *pb.Runner) *pb.Runner {
 // ValidateAdoptRunnerRequest
 func ValidateAdoptRunnerRequest(v *pb.AdoptRunnerRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,
-		validation.Field(&v.RunnerId, validation.Required),
+		validation.Field(&v.RunnerId, validation.Required, validation.By(validatePathToken)),
 	))
 }
 

--- a/pkg/server/ptypes/workspace.go
+++ b/pkg/server/ptypes/workspace.go
@@ -63,7 +63,7 @@ func ValidateUpsertWorkspaceRequest(v *pb.UpsertWorkspaceRequest) error {
 		validation.Field(&v.Workspace, validation.Required),
 		validationext.StructField(&v.Workspace, func() []*validation.FieldRules {
 			return append(ValidateWorkspaceRules(v.Workspace),
-				validation.Field(&v.Workspace.Name, validation.Required),
+				validation.Field(&v.Workspace.Name, validation.Required, validation.By(validatePathToken)),
 			)
 		}),
 	))

--- a/pkg/serverhandler/handlertest/test_service_project.go
+++ b/pkg/serverhandler/handlertest/test_service_project.go
@@ -16,6 +16,7 @@ func init() {
 		TestServiceProject,
 		TestServiceProject_GetApplication,
 		TestServiceProject_UpsertApplication,
+		TestServiceProject_InvalidName,
 	}
 }
 
@@ -209,4 +210,22 @@ func TestServiceProject_UpsertApplication(t *testing.T, factory Factory) {
 			require.NotNil(resp)
 		}
 	})
+}
+
+func TestServiceProject_InvalidName(t *testing.T, factory Factory) {
+	ctx := context.Background()
+	require := require.New(t)
+	client, _ := factory(t)
+
+	// GRPC Gateway interprets ../ as a path traversal, and therefore we cannot allow
+	// '../' in any fields we use as path tokens.
+	project := ptypes.TestProject(t, &pb.Project{
+		Name: "../../",
+	})
+
+	// Create a project
+	_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{
+		Project: project,
+	})
+	require.Error(err)
 }


### PR DESCRIPTION
Fields that can be used as GRPC gateway path tokens need some additional validation. For now, we ensure they don't contain a path traversal.