### PR TITLE
Docs/ecs install

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -137,7 +137,11 @@ func (c *InstallCommand) Run(args []string) int {
 			sr.Status(terminal.StatusError)
 			// dont return the error yet
 		} else {
-			sr.Update("Successfully connected to Waypoint server in %s!", strings.ToUpper(c.platform))
+			p := strings.Title(c.platform)
+			if p == "Ecs" {
+				p = strings.ToUpper(p)
+			}
+			sr.Update("Successfully connected to Waypoint server in %s!", p)
 			sr.Status(terminal.StatusOK)
 			sr.Done()
 			break

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -137,7 +137,7 @@ func (c *InstallCommand) Run(args []string) int {
 			sr.Status(terminal.StatusError)
 			// dont return the error yet
 		} else {
-			sr.Update("Successfully connected to Waypoint server in %s!", strings.Title(c.platform))
+			sr.Update("Successfully connected to Waypoint server in %s!", strings.ToUpper(c.platform))
 			sr.Status(terminal.StatusOK)
 			sr.Done()
 			break

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -69,8 +69,8 @@ expected host for a Consul service, i.e. `waypoint-server.service.dc1.consul`.
 When running the install helper, the CLI should show the Consul DNS backed hostname of Waypoint
 server at the end of an install:
 
-```shell
-waypoint@hashicorp:waypoint λ waypoint install -platform=nomad -accept-tos -nomad-host-volume="waypoint"
+```shell-session
+$ waypoint install -platform=nomad -accept-tos -nomad-host-volume="waypoint"
 ✓ Waypoint server ready
 ✓ The CLI has been configured to automatically install a Consul service for
 the Waypoint service backend and ui service in Nomad.
@@ -123,19 +123,19 @@ The main components installed are:
 - EC2 Security Group: authorizing traffic in to the cluster, as well as enabling access to the EFS FileSystem from the Cluster
 - CloudWatch Log Groups: a log group is created for each of the Waypoint server and runner services
 - IAM Execution role
-- Network load balancer: required to enable both HTTP and gRPC connections\*
+- Network load balancer: required to enable both HTTP and gRPC connections (see `NOTE`)
 - Load balancing target groups: a target group is created for each of the Waypoint server and runner services
 - ECS Cluster: a cluster dedicated to running the Waypoint server and runner
 - ECS server service: runs the Waypoint server task
 - ECS runner service: runs the default Waypoint runner task
 - ECS Task Definitions: for both the server and runner
 
-~> **NOTE**: \* A Network Load Balancer is required because user-supplied TLS certificates are not yet supported.
+~> **NOTE**: A Network Load Balancer is required because user-supplied TLS certificates are not yet supported.
 
-And example ECS install should give output similar to the below.
+An example ECS install should result in output similar to the below:
 
-```shell
-❯ waypoint install --platform=ecs -accept-tos                                                                                                                                     21:27:12
+```shell-session
+$ waypoint install -platform=ecs -accept-tos
 ✓ Networking setup
 ✓ Created new ECS cluster: waypoint-server
 ✓ EFS ready

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -111,7 +111,26 @@ an IP address from the Nomad allocation after the Waypoint install helper finish
 
 ### AWS ECS Platform
 
-This section still needs to be filled out.
+Waypoint supports installing the server in AWS ECS. Several AWS resources are created
+as part of the install. The default cluster name is `waypoint-server`; this can
+be changed by specifying the value for the flag `-ecs-cluster`. The resources
+are tagged with `waypoint-server` as the tag name; this is not able to be changed
+as Waypoint needs a way to track all the resources that are part of the server install.
+
+The main components installed are:
+
+- EFS Filesystem: used for persisting the Waypoint server database
+- EC2 Security Group: authorizing traffic in to the cluster, as well as enabling access to the EFS FileSystem from the Cluster
+- CloudWatch Log Groups: a log group is created for each of the Waypoint server and runner services
+- IAM Execution role
+- Network load balancer: required to enable both HTTP and gRPC connections\*
+- Load balancing target groups: a target group is created for each of the Waypoint server and runner services
+- ECS Cluster: a cluster dedicated to running the Waypoint server and runner
+- ECS server service: runs the Waypoint server task
+- ECS runner service: runs the default Waypoint runner task
+- ECS Task Definitions: for both the server and runner
+
+~> **NOTE**: \* A Network Load Balancer is required because user-supplied TLS certificates are not yet supported.
 
 ### Docker Platform
 

--- a/website/content/docs/server/install.mdx
+++ b/website/content/docs/server/install.mdx
@@ -132,6 +132,45 @@ The main components installed are:
 
 ~> **NOTE**: \* A Network Load Balancer is required because user-supplied TLS certificates are not yet supported.
 
+And example ECS install should give output similar to the below.
+
+```shell
+❯ waypoint install --platform=ecs -accept-tos                                                                                                                                     21:27:12
+✓ Networking setup
+✓ Created new ECS cluster: waypoint-server
+✓ EFS ready
+✓ Found existing IAM role to use: waypoint-server-execution-role
+✓ Created CloudWatchLogs group to store logs in: waypoint-server-logs
+✓ Network load balancer created
+✓ Created ECS Service (waypoint, cluster-name: waypoint-server)
+✓ Waiting for target group to be healthy...
+✓ Service launched!
+✓ Server installed and configured!
+✓ Successfully connected to Waypoint server in ECS!
+✓ Installing runner...
+✓ Registered ondemand runner!
+✓ Found existing IAM role to use: waypoint-server-execution-role
+✓ Found existing IAM role to use: waypoint-runner
+✓ Created CloudWatchLogs group to store logs in: waypoint-runner-logs
+✓ Runner service created
+Waypoint server successfully installed and configured!
+
+The CLI has been configured to connect to the server automatically. This
+connection information is saved in the CLI context named "install-1656552433".
+Use the "waypoint context" CLI to manage CLI contexts.
+
+The server has been configured to advertise the following address for
+entrypoint communications. This must be a reachable address for all your
+deployments. If this is incorrect, manually set it using the CLI command
+"waypoint server config-set".
+
+To launch and authenticate into the Web UI, run:
+waypoint ui -authenticate
+
+Advertise Address: waypoint-server-nlb-xyz123.elb.us-west-2.amazonaws.com:9701
+Web UI Address: https://waypoint-server-nlb-xyz123.elb.us-west-2.amazonaws.com:9702
+```
+
 ### Docker Platform
 
 Waypoint supports running the Waypoint server directly in Docker. Generally, this flow

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -123,7 +123,7 @@ in the future.
 
 4. When ready, run the upgrade command for your given platform. For example:
 
-```shell
+```shell-session
 waypoint server upgrade -platform=kubernetes -auto-approve
 ```
 


### PR DESCRIPTION
This add docs for the ECS server install, using the list of created resources from #1564 and including a note about how we tag resources, and how that is separate from the cluster name.
Closes #2658 