### PR TITLE
Rae/working runner install branch

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -530,6 +530,7 @@ func installRunner(
 		)
 		return 1
 	}
+	s.Update("Runner %q installed", id)
 	s.Done()
 
 	err = installutil.AdoptRunner(ctx, ui, client, id, advertiseAddr.Addr)

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -229,11 +229,13 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 
 	// TODO(demophoon): Remove when we can handle automatic snapshot backup and
 	// restore for kubernetes servers.
-	upgradeFrom, _ := version.NewVersion(initServerVersion)
-	postHelmVersion, _ := version.NewVersion("v0.9.0")
-	if upgradeFrom.LessThan(postHelmVersion) {
-		c.ui.Output(upgradeToHelmRefused, terminal.WithErrorStyle())
-		return 1
+	if strings.ToLower(c.platform) == "kubernetes" {
+		upgradeFrom, _ := version.NewVersion(initServerVersion)
+		postHelmVersion, _ := version.NewVersion("v0.9.0")
+		if upgradeFrom.LessThan(postHelmVersion) {
+			c.ui.Output(upgradeToHelmRefused, terminal.WithErrorStyle())
+			return 1
+		}
 	}
 
 	c.ui.Output("Waypoint server will now upgrade from version %q",

--- a/internal/installutil/adoption.go
+++ b/internal/installutil/adoption.go
@@ -47,11 +47,8 @@ LOOP:
 		}
 		time.Sleep(5 * time.Second)
 	}
-	s.Update("Runner detected by server")
-	s.Status(terminal.StatusOK)
-	s.Done()
+	s.Update("Runner detected by server; adopting runner...")
 
-	s = sg.Add("Adopting runner...")
 	_, err := client.AdoptRunner(ctx, &pb.AdoptRunnerRequest{
 		RunnerId: id,
 		Adopt:    true,

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -163,8 +163,8 @@ func (d DockerRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 
 	s.Update("Finding runner container")
 	containerNames := []string{
-		"waypoint-" + opts.Id + "-runner",
-		runnerName,
+		defaultRunnerName(opts.Id),
+		DefaultRunnerTagName,
 	}
 	var foundContainer types.Container
 	for _, containerName := range containerNames {

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	defaultRunnerLogGroup = "waypoint-runner-logs"
-	defaultRunnerTagName  = "waypoint-runner"
 	defaultTaskRuntime    = "FARGATE"
 	defaultRunnerTagValue = "runner-component"
 )
@@ -281,8 +280,8 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	// We check for the serviceName before v0.9 and v0.9+
 	ecsSvc := ecs.New(sess)
 	serviceNames := []string{
-		"waypoint-runner-" + opts.Id,
-		"waypoint-runner",
+		defaultRunnerName(opts.Id),
+		DefaultRunnerTagName,
 	}
 	var foundService *ecs.Service
 	var services *ecs.DescribeServicesOutput
@@ -425,7 +424,7 @@ func launchRunner(
 			{
 				ContainerPath: aws.String("/data/runner"),
 				ReadOnly:      aws.Bool(false),
-				SourceVolume:  aws.String(defaultRunnerTagName),
+				SourceVolume:  aws.String(DefaultRunnerTagName),
 			},
 		},
 	}
@@ -438,13 +437,13 @@ func launchRunner(
 		ExecutionRoleArn:        aws.String(executionRoleArn),
 		Cpu:                     aws.String(cpu),
 		Memory:                  aws.String(memory),
-		Family:                  aws.String(runnerName),
+		Family:                  aws.String(DefaultRunnerTagName),
 		TaskRoleArn:             &taskRoleArn,
 		NetworkMode:             aws.String("awsvpc"),
 		RequiresCompatibilities: []*string{aws.String(defaultTaskRuntime)},
 		Tags: []*ecs.Tag{
 			{
-				Key:   aws.String(defaultRunnerTagName),
+				Key:   aws.String(DefaultRunnerTagName),
 				Value: aws.String(defaultRunnerTagValue),
 			},
 			{
@@ -461,7 +460,7 @@ func launchRunner(
 					FileSystemId:      efsInfo.FileSystemID,
 					TransitEncryption: aws.String(ecs.EFSTransitEncryptionEnabled),
 				},
-				Name: aws.String(defaultRunnerTagName),
+				Name: aws.String(DefaultRunnerTagName),
 			},
 		},
 	}
@@ -527,7 +526,7 @@ func launchRunner(
 		Cluster:              clusterArn,
 		DesiredCount:         aws.Int64(1),
 		LaunchType:           aws.String(defaultTaskRuntime),
-		ServiceName:          aws.String(runnerName + "-" + id),
+		ServiceName:          aws.String(DefaultRunnerTagName + "-" + id),
 		EnableECSManagedTags: aws.Bool(true),
 		TaskDefinition:       aws.String(taskDefArn),
 		NetworkConfiguration: &ecs.NetworkConfiguration{
@@ -539,7 +538,7 @@ func launchRunner(
 		},
 		Tags: []*ecs.Tag{
 			{
-				Key:   aws.String(defaultRunnerTagName),
+				Key:   aws.String(DefaultRunnerTagName),
 				Value: aws.String(defaultRunnerTagValue),
 			},
 			{
@@ -549,7 +548,7 @@ func launchRunner(
 		},
 	}
 
-	s.Update("Creating ECS Service (%s)", runnerName)
+	s.Update("Creating ECS Service (%s)", DefaultRunnerTagName)
 	svc, err := installutil.CreateService(createServiceInput, ecsSvc)
 	if err != nil {
 		return nil, err
@@ -645,7 +644,7 @@ func (i *ECSRunnerInstaller) setupTaskRole(
 		RoleName:                 aws.String(roleName),
 		Tags: []*iam.Tag{
 			{
-				Key:   aws.String(defaultRunnerTagName),
+				Key:   aws.String(DefaultRunnerTagName),
 				Value: aws.String(defaultRunnerTagValue),
 			},
 			{

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -178,7 +178,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			},
 			"serviceAccount": map[string]interface{}{
 				"create": i.Config.CreateServiceAccount,
-				"name":   runnerName,
+				"name":   DefaultRunnerTagName,
 			},
 
 			"pullPolicy": "always",
@@ -306,7 +306,7 @@ func (i *K8sRunnerInstaller) uninstallWithK8s(ctx context.Context, opts *Install
 
 	deploymentClient := clientset.AppsV1().Deployments(i.Config.Namespace)
 	if list, err := deploymentClient.List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", runnerName),
+		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
 	}); err != nil {
 		ui.Output(
 			"Error looking up deployments: %s", clierrors.Humanize(err),
@@ -354,7 +354,7 @@ func (i *K8sRunnerInstaller) uninstallWithK8s(ctx context.Context, opts *Install
 		w, err := deploymentClient.Watch(
 			ctx,
 			metav1.ListOptions{
-				LabelSelector: "app=" + runnerName,
+				LabelSelector: "app=" + DefaultRunnerTagName,
 			},
 		)
 		if err != nil {
@@ -370,7 +370,7 @@ func (i *K8sRunnerInstaller) uninstallWithK8s(ctx context.Context, opts *Install
 			ctx,
 			metav1.DeleteOptions{},
 			metav1.ListOptions{
-				LabelSelector: "app=" + runnerName,
+				LabelSelector: "app=" + DefaultRunnerTagName,
 			},
 		); err != nil {
 			ui.Output(

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -184,7 +184,6 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			"pullPolicy": "always",
 		},
 	}
-	s.Done()
 
 	s = sg.Add("Installing Waypoint Helm chart with runner options: " + c.Name())
 	_, err = client.RunWithContext(ctx, c, values)

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -444,11 +444,7 @@ func (i *K8sRunnerInstaller) uninstallWithHelm(ctx context.Context, opts *Instal
 	if strings.ToLower(runnerCfg.Id) != strings.ToLower(opts.Id) {
 		return errors.New("Runner not found")
 	}
-	s.Update("Runner %q found", opts.Id)
-	s.Status(terminal.StatusOK)
-	s.Done()
-
-	s = sg.Add("Uninstalling Runner...")
+	s.Update("Runner %q found; uninstalling runner...", opts.Id)
 	client := action.NewUninstall(actionConfig)
 	client.DryRun = false
 	client.DisableHooks = false
@@ -460,7 +456,7 @@ func (i *K8sRunnerInstaller) uninstallWithHelm(ctx context.Context, opts *Instal
 	if err != nil {
 		return err
 	}
-	s.Update("Runner Uninstalled")
+	s.Update("Runner %q uninstalled", opts.Id)
 	s.Status(terminal.StatusOK)
 	s.Done()
 

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -185,7 +185,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 		},
 	}
 
-	s = sg.Add("Installing Waypoint Helm chart with runner options: " + c.Name())
+	s.Update("Installing Waypoint Helm chart with runner options: " + c.Name())
 	_, err = client.RunWithContext(ctx, c, values)
 	if err != nil {
 		return err

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -2,6 +2,7 @@ package runnerinstall
 
 import (
 	"context"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -59,3 +60,11 @@ var Platforms = map[string]RunnerInstaller{
 	"nomad":      &NomadRunnerInstaller{},
 	"docker":     &DockerRunnerInstaller{},
 }
+
+func defaultRunnerName(id string) string {
+	return "waypoint-" + id + "-runner"
+}
+
+const (
+	DefaultRunnerTagName = "waypoint-runner"
+)

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -560,6 +560,7 @@ func (i *ECSInstaller) Upgrade(
 	}
 
 	s.Update("Waiting until service is stable")
+	// WaitUntil waits for ~10 minutes
 	err = ecsSvc.WaitUntilServicesStable(&ecs.DescribeServicesInput{
 		Cluster:  &clusterArn,
 		Services: []*string{serverSvc.ServiceName},

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -248,7 +248,7 @@ func (i *K8sInstaller) Install(
 		},
 	}
 
-	s = sg.Add("Installing Waypoint Helm chart...")
+	s.Update("Installing Waypoint Helm chart...")
 	_, err = client.RunWithContext(ctx, c, values)
 	if err != nil {
 		return nil, err

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -4,21 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/waypoint/internal/installutil"
 	helminstallutil "github.com/hashicorp/waypoint/internal/installutil/helm"
 	"github.com/hashicorp/waypoint/internal/runnerinstall"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	"net"
-	"strings"
-	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/k8s"
@@ -612,9 +613,7 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 	if err != nil {
 		return err
 	}
-	s.Update("Helm action initialized")
-	s.Status(terminal.StatusOK)
-	s.Done()
+	s.Update("Helm action initialized, creating new Helm uninstall object...")
 
 	chartNS := ""
 	if v := i.config.namespace; v != "" {
@@ -625,18 +624,14 @@ func (i *K8sInstaller) Uninstall(ctx context.Context, opts *InstallOpts) error {
 		chartNS = "default"
 	}
 
-	s = sg.Add("Creating new Helm uninstall object...")
 	client := action.NewUninstall(actionConfig)
 	client.DryRun = false
 	client.DisableHooks = false
 	client.Wait = true
 	client.Timeout = 300 * time.Second
 	client.Description = ""
-	s.Update("Helm uninstall created")
-	s.Status(terminal.StatusOK)
-	s.Done()
+	s.Update("Helm uninstall created; uninstalling Helm chart...")
 
-	s = sg.Add("Uninstalling Helm chart...")
 	_, err = client.Run("waypoint")
 	if err != nil {
 		return err

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -166,7 +166,6 @@ func (i *K8sInstaller) Install(
 	if err != nil {
 		return nil, err
 	}
-	s.Done()
 
 	chartNS := ""
 	if v := i.config.namespace; v != "" {
@@ -248,7 +247,6 @@ func (i *K8sInstaller) Install(
 			"enabled": false,
 		},
 	}
-	s.Done()
 
 	s = sg.Add("Installing Waypoint Helm chart...")
 	_, err = client.RunWithContext(ctx, c, values)
@@ -472,7 +470,6 @@ func (i *K8sInstaller) Upgrade(
 			"enabled": false,
 		},
 	}
-	s.Done()
 
 	s = sg.Add("Installing Waypoint Helm chart...")
 	_, err = client.RunWithContext(ctx, "waypoint", c, values)


### PR DESCRIPTION
- wraps the k8s-specific version check in an `if`
- removes some superfluous CLI output messages
- fix ecs runner search since we changed the name between 0.8.2 and this upcoming version
- consolidate usage of `waypoint-runner` hardcoded name in `runner install` pkg