### PR TITLE
chore: add hcl `replace`

### DIFF
--- a/.changelog/3522.txt
+++ b/.changelog/3522.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Adds string `replace` function for HCL configs
+```

--- a/pkg/config/funcs/doc.go
+++ b/pkg/config/funcs/doc.go
@@ -50,7 +50,7 @@ func Docs() map[string]string {
 		"range":           "generate a list of numbers",
 		"regex":           "match the given string against the given regular expression pattern, returning captures if defined",
 		"regexall":        "same as regex but look for all matches of the given pattern rather than just the first",
-		"replace":         "`replace` searches a given string for another given substring, and replaces each occurrence with a given replacement string.",
+		"replace":         "searches a given string for another given substring, and replaces each occurrence with a given replacement string.",
 		"reverse":         "reverse the order of the elements in the list",
 		"selectormatch":   "applies a selector to a map and returns true if the selector matches",
 		"selectorlookup":  "applies a map of selectors to a map of labels. The value for the first matching selector is returned. If none match, the default is returned.",

--- a/pkg/config/funcs/doc.go
+++ b/pkg/config/funcs/doc.go
@@ -50,6 +50,7 @@ func Docs() map[string]string {
 		"range":           "generate a list of numbers",
 		"regex":           "match the given string against the given regular expression pattern, returning captures if defined",
 		"regexall":        "same as regex but look for all matches of the given pattern rather than just the first",
+		"replace":         "`replace` searches a given string for another given substring, and replaces each occurrence with a given replacement string.",
 		"reverse":         "reverse the order of the elements in the list",
 		"selectormatch":   "applies a selector to a map and returns true if the selector matches",
 		"selectorlookup":  "applies a map of selectors to a map of labels. The value for the first matching selector is returned. If none match, the default is returned.",

--- a/pkg/config/funcs/stdlib.go
+++ b/pkg/config/funcs/stdlib.go
@@ -40,6 +40,7 @@ func Stdlib() map[string]function.Function {
 		"range":           stdlib.RangeFunc,
 		"regex":           stdlib.RegexFunc,
 		"regexall":        stdlib.RegexAllFunc,
+		"replace":         stdlib.ReplaceFunc,
 		"reverse":         stdlib.ReverseListFunc,
 		"setintersection": stdlib.SetIntersectionFunc,
 		"setproduct":      stdlib.SetProductFunc,

--- a/website/content/partials/funcs.mdx
+++ b/website/content/partials/funcs.mdx
@@ -388,7 +388,7 @@ same as regex but look for all matches of the given pattern rather than just the
 replace(str, substr, replace) string
 ```
 
-`replace` searches a given string for another given substring, and replaces each occurrence with a given replacement string.
+searches a given string for another given substring, and replaces each occurrence with a given replacement string.
 
 ## `reverse`
 

--- a/website/content/partials/funcs.mdx
+++ b/website/content/partials/funcs.mdx
@@ -382,6 +382,14 @@ regexall(pattern, string) list of dynamic
 
 same as regex but look for all matches of the given pattern rather than just the first
 
+## `replace`
+
+```hcl
+replace(str, substr, replace) string
+```
+
+`replace` searches a given string for another given substring, and replaces each occurrence with a given replacement string.
+
 ## `reverse`
 
 ```hcl


### PR DESCRIPTION
# Description

This adds the `replace` function from https://github.com/zclconf/go-cty

This achieves parity with https://www.terraform.io/language/functions/replace#replace-function