### PR TITLE
fix(tfc): `ConfigSourcer` refresh_interval

### DIFF
--- a/.changelog/3524.txt
+++ b/.changelog/3524.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/tfc: fix HCL field, `refresh_interval`
+```

--- a/builtin/tfc/config_sourcer.go
+++ b/builtin/tfc/config_sourcer.go
@@ -443,7 +443,7 @@ config {
 
 	doc.SetField(
 		"skip_verify",
-		"Do not validate the TLS cert presented by the Vault server.",
+		"Do not validate the TLS cert presented by the Terraform Cloud server.",
 		docs.Summary(
 			"This is not recommended unless absolutely necessary.",
 		),
@@ -474,5 +474,5 @@ type sourceConfig struct {
 	Token           string `hcl:"token"`
 	BaseURL         string `hcl:"base_url,optional"`
 	SkipVerify      bool   `hcl:"skip_verify,optional"`
-	RefreshInterval string `hcl:"refresh_internal,optional"`
+	RefreshInterval string `hcl:"refresh_interval,optional"`
 }

--- a/builtin/tfc/config_sourcer.go
+++ b/builtin/tfc/config_sourcer.go
@@ -443,7 +443,7 @@ config {
 
 	doc.SetField(
 		"skip_verify",
-		"Do not validate the TLS cert presented by the Terraform Cloud server.",
+		"Do not validate the TLS cert presented by Terraform Cloud.",
 		docs.Summary(
 			"This is not recommended unless absolutely necessary.",
 		),

--- a/website/content/partials/components/configsourcer-terraform-cloud.mdx
+++ b/website/content/partials/components/configsourcer-terraform-cloud.mdx
@@ -98,7 +98,7 @@ The format of this value is the Go time duration format. Specifically a whole nu
 
 ##### skip_verify
 
-Do not validate the TLS cert presented by the Terraform Cloud server.
+Do not validate the TLS cert presented by Terraform Cloud.
 
 This is not recommended unless absolutely necessary.
 

--- a/website/content/partials/components/configsourcer-terraform-cloud.mdx
+++ b/website/content/partials/components/configsourcer-terraform-cloud.mdx
@@ -66,12 +66,6 @@ parameters used for `dynamic` are in the previous section.
 
 #### Required Source Parameters
 
-##### refresh_interval
-
-How often the outputs should be fetch.
-
-The format of this value is the Go time duration format. Specifically a whole number followed by: s for seconds, m for minutes, h for hours. The minimum value for this setting is 60 seconds, with no specified maximum.
-
 ##### token
 
 The Terraform Cloud API token.
@@ -92,14 +86,19 @@ This is provided to allow users to query values from Terraform Enterprise instal
 - **Optional**
 - Default: https://api.terraform.io
 
-##### refresh_internal
+##### refresh_interval
+
+How often the outputs should be fetch.
+
+The format of this value is the Go time duration format. Specifically a whole number followed by: s for seconds, m for minutes, h for hours. The minimum value for this setting is 60 seconds, with no specified maximum.
 
 - Type: **string**
 - **Optional**
+- Default: 10m0s
 
 ##### skip_verify
 
-Do not validate the TLS cert presented by the Vault server.
+Do not validate the TLS cert presented by the Terraform Cloud server.
 
 This is not recommended unless absolutely necessary.
 


### PR DESCRIPTION
This fixes the `refresh_interval` HCL parsing for the `terraform-cloud` `ConfigSourcer`

**Disclaimer**: I haven't successfully gotten any working end-to-end usage of `dynamic("terraform-cloud", ...` so I haven't verified this change, but this looks like an obvious typo/bug