### PR TITLE
Add flags to Nomad server upgrade command for the bootstrap runner

### DIFF
--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -1383,6 +1383,33 @@ func (i *NomadInstaller) UpgradeFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
+		Name:   "nomad-runner-host-volume",
+		Target: &i.config.runnerHostVolume,
+		Usage:  "Name of the host volume to use for the Waypoint runner.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:   "nomad-runner-csi-volume-provider",
+		Target: &i.config.runnerCsiVolumeProvider,
+		Usage:  "Name of the CSI volume provider to use for the Waypoint runner.",
+	})
+
+	// TODO: Update default values for runner - less space is needed for runner compared to server
+	set.Int64Var(&flag.Int64Var{
+		Name:    "nomad-runner-csi-volume-capacity-min",
+		Target:  &i.config.runnerCsiVolumeCapacityMin,
+		Usage:   "Waypoint runner Nomad CSI volume capacity minimum, in bytes.",
+		Default: defaultCSIVolumeCapacityMin,
+	})
+
+	set.Int64Var(&flag.Int64Var{
+		Name:    "nomad-runner-csi-volume-capacity-max",
+		Target:  &i.config.runnerCsiVolumeCapacityMax,
+		Usage:   "Waypoint runner Nomad CSI volume capacity maximum, in bytes.",
+		Default: defaultCSIVolumeCapacityMax,
+	})
+
+	set.StringVar(&flag.StringVar{
 		Name:    "nomad-server-image",
 		Target:  &i.config.serverImage,
 		Usage:   "Docker image for the Waypoint server.",

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -82,6 +82,10 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-server-memory=<string>` - MB of Memory to allocate to the server job task. The default is 600.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
+- `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
+- `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
+- `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
+- `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-nomad-host-volume=<string>` - Nomad host volume name.
 - `-nomad-consul-service` - Create service for Waypoint UI and Server in Consul. The default is false.


### PR DESCRIPTION
The bootstrap runner's persistent volume is required and configurable with the `waypoint install` command in 0.9. Flags to configure the volume are added to the `waypoint server upgrade` command to ensure the runner's upgrade alongside the server is successful.