### PR TITLE
Fix fix typo

### DIFF
--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -516,7 +516,7 @@ func (b *Builder) Documentation() (*docs.Documentation, error) {
 	doc.Description(`
 Create a Docker image using CloudNative Buildpacks.
 
-**This plugin must either be run via Docker or inside an ondemand runner.**
+**This plugin must either be run via Docker or inside an ondemand runner**.
 `)
 
 	doc.Example(`

--- a/website/content/partials/components/builder-pack.mdx
+++ b/website/content/partials/components/builder-pack.mdx
@@ -2,7 +2,7 @@
 
 Create a Docker image using CloudNative Buildpacks.
 
-**This plugin must either be run via Docker or inside an ondemand runner.**
+**This plugin must either be run via Docker or inside an ondemand runner**.
 
 ### Interface
 


### PR DESCRIPTION
Fixes the typo fixed in #3532 that broke the `make gen/website-mdx` comparisons.
This is grammatically incorrect but what our tool enforces. If we leave the `.` inside the `**` then the website gen checker gets mad that there is a line that doesn't end with a `.`.