### PR TITLE
core/install: Add --nomad-csi-volume-name flag to install

### DIFF
--- a/.changelog/3546.txt
+++ b/.changelog/3546.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+CLI: Nomad CSI volumes names can be specified during installation and upgrades for both Waypoint runners and Waypoint server installations
+```
+

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -292,7 +292,7 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:   "nomad-csi-volume",
 		Target: &i.Config.CsiVolume,
-		Usage:  fmt.Sprintf("The name of the volume to initialize within the CSI provider. The default is %s.", defaultRunnerName("<runner_id>")),
+		Usage:  fmt.Sprintf("The name of the volume to initialize within the CSI provider. The default is %s.", defaultRunnerName("[runner_id]")),
 	})
 }
 

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -75,14 +75,14 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 			return fmt.Errorf("choose either CSI or host volume, not both")
 		}
 		if i.Config.CsiVolumeName == "" {
-			i.Config.CsiVolumeName = "waypoint-" + opts.Id + "-runner"
+			i.Config.CsiVolumeName = defaultRunnerName(opts.Id)
 		}
 
 		s = sg.Add("Creating persistent volume")
 		err = nomadutil.CreatePersistentVolume(
 			ctx,
 			client,
-			"waypoint-"+opts.Id+"-runner",
+			defaultRunnerName(opts.Id),
 			i.Config.CsiVolumeName,
 			i.Config.CsiPluginId,
 			i.Config.CsiVolumeProvider,

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -43,7 +43,7 @@ type NomadConfig struct {
 	CsiExternalId        string            `hcl:"nomad_csi_external_id,optional"`
 	CsiPluginId          string            `hcl:"nomad_csi_plugin_id,required"`
 	CsiSecrets           map[string]string `hcl:"nomad_csi_secrets,optional"`
-	CsiVolumeName        string            `hcl:"nomad_csi_volume_name,optional"`
+	CsiVolume            string            `hcl:"nomad_csi_volume,optional"`
 
 	NomadHost string `hcl:"nomad_host,optional"`
 }
@@ -74,8 +74,8 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 		if i.Config.HostVolume != "" {
 			return fmt.Errorf("choose either CSI or host volume, not both")
 		}
-		if i.Config.CsiVolumeName == "" {
-			i.Config.CsiVolumeName = defaultRunnerName(opts.Id)
+		if i.Config.CsiVolume == "" {
+			i.Config.CsiVolume = defaultRunnerName(opts.Id)
 		}
 
 		s = sg.Add("Creating persistent volume")
@@ -83,7 +83,7 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 			ctx,
 			client,
 			defaultRunnerName(opts.Id),
-			i.Config.CsiVolumeName,
+			i.Config.CsiVolume,
 			i.Config.CsiPluginId,
 			i.Config.CsiVolumeProvider,
 			i.Config.CsiFS,

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -290,9 +290,9 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:   "nomad-csi-volume-name",
-		Target: &i.Config.CsiVolumeName,
-		Usage:  "The name of the volume to initialize within the CSI provider.",
+		Name:   "nomad-csi-volume",
+		Target: &i.Config.CsiVolume,
+		Usage:  fmt.Sprintf("The name of the volume to initialize within the CSI provider. The default is %s.", defaultRunnerName("<runner_id>")),
 	})
 }
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -67,7 +67,7 @@ type nomadConfig struct {
 	csiTopologies        map[string]string `hcl:"nomad_csi_topologies,optional"`
 	csiSecrets           map[string]string `hcl:"nomad_csi_secrets,optional"`
 	csiParams            map[string]string `hcl:"csi_parameters,optional"`
-	csiVolumeName        string            `hcl:"nomad_csi_volume_name,optional"`
+	csiVolume            string            `hcl:"nomad_csi_volume,optional"`
 	nomadHost            string            `hcl:"nomad_host,optional"`
 
 	runnerResourcesCPU         string `hcl:"runner_resources_cpu,optional"`
@@ -76,7 +76,7 @@ type nomadConfig struct {
 	runnerCsiVolumeProvider    string `hcl:"runner_csi_volume_provider,optional"`
 	runnerCsiVolumeCapacityMin int64  `hcl:"runner_csi_volume_capacity_min,optional"`
 	runnerCsiVolumeCapacityMax int64  `hcl:"runner_csi_volume_capacity_max,optional"`
-	runnerCsiVolumeName        string `hcl:"runner_csi_volume_name,optional"`
+	runnerCsiVolume            string `hcl:"runner_csi_volume,optional"`
 }
 
 var (
@@ -214,7 +214,7 @@ func (i *NomadInstaller) Install(
 			ctx,
 			client,
 			"waypoint-server",
-			i.config.csiVolumeName,
+			i.config.csiVolume,
 			i.config.csiPluginId,
 			i.config.csiVolumeProvider,
 			i.config.csiFS,
@@ -647,7 +647,7 @@ func (i *NomadInstaller) InstallRunner(
 			CsiExternalId:         i.config.csiExternalId,
 			CsiPluginId:           i.config.csiPluginId,
 			CsiSecrets:            i.config.csiSecrets,
-			CsiVolumeName:         i.config.runnerCsiVolumeName,
+			CsiVolume:             i.config.runnerCsiVolume,
 			NomadHost:             i.config.nomadHost,
 		},
 	}
@@ -1166,8 +1166,8 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:   "nomad-runner-csi-volume-name",
-		Target: &i.config.runnerCsiVolumeName,
+		Name:   "nomad-runner-csi-volume",
+		Target: &i.config.runnerCsiVolume,
 		Usage:  "The name of the volume to initialize for the Waypoint runner within the CSI provider.",
 	})
 
@@ -1309,8 +1309,8 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:   "nomad-csi-volume-name",
-		Target: &i.config.csiVolumeName,
+		Name:   "nomad-csi-volume",
+		Target: &i.config.csiVolume,
 		Usage:  "The name of the volume to initialize for Waypoint server within the CSI provider.",
 	})
 }
@@ -1413,8 +1413,8 @@ func (i *NomadInstaller) UpgradeFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:   "nomad-runner-csi-volume-name",
-		Target: &i.config.runnerCsiVolumeName,
+		Name:   "nomad-runner-csi-volume",
+		Target: &i.config.runnerCsiVolume,
 		Usage:  "The name of the volume to initialize for the Waypoint runner within the CSI provider.",
 	})
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -205,9 +205,6 @@ func (i *NomadInstaller) Install(
 		if i.config.hostVolume != "" {
 			return nil, fmt.Errorf("choose either CSI or host volume, not both")
 		}
-		if i.config.csiVolumeName == "" {
-			i.config.csiVolumeName = "waypoint-server"
-		}
 
 		s.Update("Creating persistent volume")
 		err = nomad.CreatePersistentVolume(
@@ -1309,9 +1306,10 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:   "nomad-csi-volume",
-		Target: &i.config.csiVolume,
-		Usage:  "The name of the volume to initialize for Waypoint server within the CSI provider.",
+		Name:    "nomad-csi-volume",
+		Target:  &i.config.csiVolume,
+		Usage:   "The name of the volume to initialize for Waypoint server within the CSI provider.",
+		Default: "waypoint-server",
 	})
 }
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -115,7 +115,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
-- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
+- `-nomad-runner-csi-volume=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
@@ -136,6 +136,6 @@ and disable the UI, the command would be:
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
-- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider.
+- `-nomad-csi-volume=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider. The default is waypoint-server.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -115,6 +115,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
+- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
@@ -135,5 +136,6 @@ and disable the UI, the command would be:
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
+- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider.
 
 @include "commands/install_more.mdx"

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -82,6 +82,6 @@ unless the '-skip-adopt' flag is set to true.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-secrets=<key=value>` - Credentials for publishing volume for Waypoint runner.
-- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize within the CSI provider.
+- `-nomad-csi-volume=<string>` - The name of the volume to initialize within the CSI provider. The default is waypoint-<runner_id>-runner.
 
 @include "commands/runner-install_more.mdx"

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -82,5 +82,6 @@ unless the '-skip-adopt' flag is set to true.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-secrets=<key=value>` - Credentials for publishing volume for Waypoint runner.
+- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize within the CSI provider.
 
 @include "commands/runner-install_more.mdx"

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -82,6 +82,6 @@ unless the '-skip-adopt' flag is set to true.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-secrets=<key=value>` - Credentials for publishing volume for Waypoint runner.
-- `-nomad-csi-volume=<string>` - The name of the volume to initialize within the CSI provider. The default is waypoint-<runner_id>-runner.
+- `-nomad-csi-volume=<string>` - The name of the volume to initialize within the CSI provider. The default is waypoint-[runner_id]-runner.
 
 @include "commands/runner-install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -115,7 +115,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
-- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
+- `-nomad-runner-csi-volume=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
@@ -136,6 +136,6 @@ and disable the UI, the command would be:
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
-- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider.
+- `-nomad-csi-volume=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider. The default is waypoint-server.
 
 @include "commands/server-install_more.mdx"

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -115,6 +115,7 @@ and disable the UI, the command would be:
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
+- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
@@ -135,5 +136,6 @@ and disable the UI, the command would be:
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
+- `-nomad-csi-volume-name=<string>` - The name of the volume to initialize for Waypoint server within the CSI provider.
 
 @include "commands/server-install_more.mdx"

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -84,7 +84,7 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
-- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
+- `-nomad-runner-csi-volume=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -84,6 +84,7 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.
 - `-nomad-runner-csi-volume-provider=<string>` - Name of the CSI volume provider to use for the Waypoint runner.
+- `-nomad-runner-csi-volume-name=<string>` - The name of the volume to initialize for the Waypoint runner within the CSI provider.
 - `-nomad-runner-csi-volume-capacity-min=<int>` - Waypoint runner Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-runner-csi-volume-capacity-max=<int>` - Waypoint runner Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.


### PR DESCRIPTION
This commit allows users to specify their own volume names within their
CSI provider. Some cases where the upstream provider is incompatible
with the default name because of limitations on their end make it so
that waypoint is unable to be used within those providers. In my testing
the DigitalOcean CSI provider doesn't handle capitalization of the
volume's name specifically within the runner ID. I suspect other 
providers may have different requirements which we should be able to 
work around since there is not an explicit requirement in the CSI spec 
for the names of volumes within a provider.