### PR TITLE
Fix error check reference.ParseNomrmalizedNamed

### DIFF
--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -41,6 +41,9 @@ func (i *DockerRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) 
 
 	runnerImage := i.Config.RunnerImage
 	imageRef, err := reference.ParseNormalizedNamed(runnerImage)
+	if err != nil {
+		return err
+	}
 
 	imageList, err := cli.ImageList(ctx, types.ImageListOptions{
 		Filters: filters.NewArgs(filters.KeyValuePair{


### PR DESCRIPTION
* Fixes #3558

https://github.com/hashicorp/waypoint/blob/10585f14d3203a0a843fd726608031c42f4de3eb/internal/runnerinstall/docker.go#L43-L48

reference.FamiliarString does not check whether argument is nil as below.
Thus reference.ParseNormalizedNamed returns nil, err, then it must be checking error and return.

https://github.com/distribution/distribution/blob/8857a1948739db3520e2fb5211979aa62c3dd5da/reference/helpers.go#L27-L32