### PR TITLE
Ecs upgrade runner

### DIFF
--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -251,6 +251,7 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 	runnerOpts := &runnerinstall.InstallOpts{
 		Log: log,
 		UI:  c.ui,
+		Id:  "static",
 	}
 
 	// Upgrade in place

--- a/internal/installutil/adoption.go
+++ b/internal/installutil/adoption.go
@@ -35,9 +35,7 @@ LOOP:
 		// If it's found, adopt it. Otherwise, try until deadline.
 		runners, err := client.ListRunners(ctx, &pb.ListRunnersRequest{})
 		if err != nil {
-			ui.Output(runnerFailedToConnectToServer, clierrors.Humanize(err),
-				terminal.WithErrorStyle(),
-			)
+			ui.Output(runnerFailedToConnectToServer, terminal.WithErrorStyle())
 			return err
 		}
 		for _, myRunner := range runners.Runners {

--- a/internal/installutil/aws/ecs.go
+++ b/internal/installutil/aws/ecs.go
@@ -691,7 +691,7 @@ func DeleteEcsResources(
 	return nil
 }
 
-func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, log hclog.Logger) (*ecs.DescribeServicesOutput, *ecs.Service, error) {
+func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, log hclog.Logger) (*ecs.Service, error) {
 	var services *ecs.DescribeServicesOutput
 	var foundService *ecs.Service
 	for _, serviceName := range serviceNames {
@@ -701,19 +701,19 @@ func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, log hc
 		})
 		services = ss
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if ss != nil && len(ss.Services) > 0 {
 			foundService = ss.Services[0]
 			if len(ss.Services) != 1 {
 				log.Debug("Unable to uninstall runner; expected 1 service named %s, found %d", serviceName, len(ss.Services))
-				return nil, nil, fmt.Errorf("expected 1 service named %s, found %d", serviceName, len(ss.Services))
+				return nil, fmt.Errorf("expected 1 service named %s, found %d", serviceName, len(ss.Services))
 			}
 			break
 		}
 	}
 	if len(services.Failures) > 0 {
-		return nil, nil, fmt.Errorf("could not find service named %q or %q, service is %q", serviceNames[0], serviceNames[1], *services.Failures[0].Reason)
+		return nil, fmt.Errorf("could not find service named %q or %q, service is %q", serviceNames[0], serviceNames[1], *services.Failures[0].Reason)
 	}
-	return services, foundService, nil
+	return foundService, nil
 }

--- a/internal/installutil/aws/ecs.go
+++ b/internal/installutil/aws/ecs.go
@@ -691,7 +691,9 @@ func DeleteEcsResources(
 	return nil
 }
 
-func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, services *ecs.DescribeServicesOutput, foundService *ecs.Service, log hclog.Logger) (*ecs.DescribeServicesOutput, *ecs.Service, error) {
+func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, log hclog.Logger) (*ecs.DescribeServicesOutput, *ecs.Service, error) {
+	var services *ecs.DescribeServicesOutput
+	var foundService *ecs.Service
 	for _, serviceName := range serviceNames {
 		ss, err := ecsSvc.DescribeServices(&ecs.DescribeServicesInput{
 			Cluster:  aws.String(cluster),

--- a/internal/installutil/aws/ecs.go
+++ b/internal/installutil/aws/ecs.go
@@ -704,14 +704,14 @@ func FindServices(serviceNames []string, ecsSvc *ecs.ECS, cluster string, servic
 		if ss != nil && len(ss.Services) > 0 {
 			foundService = ss.Services[0]
 			if len(ss.Services) != 1 {
-				log.Debug("Unable to uninstall runner; expected 1 runner service named %s, found %d", serviceName, len(ss.Services))
-				return nil, nil, fmt.Errorf("expected 1 runner service named %s, found %d", serviceName, len(ss.Services))
+				log.Debug("Unable to uninstall runner; expected 1 service named %s, found %d", serviceName, len(ss.Services))
+				return nil, nil, fmt.Errorf("expected 1 service named %s, found %d", serviceName, len(ss.Services))
 			}
 			break
 		}
 	}
 	if len(services.Failures) > 0 {
-		return nil, nil, fmt.Errorf("could not find runner named %q or %q, service is %q", serviceNames[0], serviceNames[1], *services.Failures[0].Reason)
+		return nil, nil, fmt.Errorf("could not find service named %q or %q, service is %q", serviceNames[0], serviceNames[1], *services.Failures[0].Reason)
 	}
 	return services, foundService, nil
 }

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -28,3 +28,7 @@ func DefaultODRImage(serverImage string) (string, error) {
 }
 
 const DefaultServerImage = "hashicorp/waypoint:latest"
+
+func DefaultRunnerName(id string) string {
+	return "waypoint-" + id + "-runner"
+}

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -3,6 +3,7 @@ package runnerinstall
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"os"
 	"time"
 
@@ -163,7 +164,7 @@ func (d DockerRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 
 	s.Update("Finding runner container")
 	containerNames := []string{
-		defaultRunnerName(opts.Id),
+		installutil.DefaultRunnerName(opts.Id),
 		DefaultRunnerTagName,
 	}
 	var foundContainer types.Container

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -287,7 +287,7 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	}
 	var foundService *ecs.Service
 	var services *ecs.DescribeServicesOutput
-	services, foundService, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.Config.Cluster, log)
+	foundService, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.Config.Cluster, log)
 	if err != nil {
 		opts.UI.Output("Could not get list of ECS services: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -3,6 +3,7 @@ package runnerinstall
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/waypoint/internal/clierrors"
 	"strconv"
 	"strings"
 	"time"
@@ -287,7 +288,7 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	var services *ecs.DescribeServicesOutput
 	services, foundService, err = installutil.FindServices(serviceNames, ecsSvc, i.Config.Cluster, services, foundService, log)
 	if err != nil {
-		s.Update("Could not get list of ECS services")
+		opts.UI.Output("Could not get list of ECS services: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err
 	}
 	clusterArn := foundService.ClusterArn

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -287,7 +287,7 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	}
 	var foundService *ecs.Service
 	var services *ecs.DescribeServicesOutput
-	services, foundService, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.Config.Cluster, services, foundService, log)
+	services, foundService, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.Config.Cluster, log)
 	if err != nil {
 		opts.UI.Output("Could not get list of ECS services: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return err

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -3,6 +3,7 @@ package runnerinstall
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"strconv"
 	"strings"
 	"time"
@@ -114,7 +115,7 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 	// Name AND ID of the Nomad job will be waypoint-runner-ID
 	// Name is cosmetic, but ID must be unique
-	jobRef := defaultRunnerName(opts.Id)
+	jobRef := installutil.DefaultRunnerName(opts.Id)
 	job := api.NewServiceJob(jobRef, jobRef, c.Region, 50)
 	job.Namespace = &c.Namespace
 	job.Datacenters = c.Datacenters
@@ -130,7 +131,7 @@ func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 	volumeRequest := api.VolumeRequest{ReadOnly: false}
 	if c.CsiVolumeProvider != "" {
 		volumeRequest.Type = "csi"
-		volumeRequest.Source = defaultRunnerName(opts.Id)
+		volumeRequest.Source = installutil.DefaultRunnerName(opts.Id)
 		volumeRequest.AccessMode = "single-node-writer"
 		volumeRequest.AttachmentMode = "file-system"
 	} else {
@@ -305,7 +306,7 @@ func (i *NomadRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 	s = sg.Add("Locate existing Waypoint runner...")
 	var waypointRunnerJobName string
 	possibleRunnerJobNames := []string{
-		defaultRunnerName(opts.Id),
+		installutil.DefaultRunnerName(opts.Id),
 		DefaultRunnerTagName,
 	}
 	for _, runnerJobName := range possibleRunnerJobNames {

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -61,10 +61,6 @@ var Platforms = map[string]RunnerInstaller{
 	"docker":     &DockerRunnerInstaller{},
 }
 
-func defaultRunnerName(id string) string {
-	return "waypoint-" + id + "-runner"
-}
-
 const (
 	DefaultRunnerTagName = "waypoint-runner"
 )

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -947,7 +947,7 @@ func (i *ECSInstaller) HasRunner(
 	}
 	serviceNames := []string{
 		defaultRunnerTagName,
-		awsinstallutil.DefaultStaticRunnerName,
+		installutil.DefaultRunnerName("static"),
 	}
 	ecsSvc := ecs.New(sess)
 	var foundService *ecs.Service

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -950,14 +950,17 @@ func (i *ECSInstaller) HasRunner(
 		installutil.DefaultRunnerName("static"),
 	}
 	ecsSvc := ecs.New(sess)
-	var services *ecs.DescribeServicesOutput
-	services, _, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.config.Cluster, log)
+	foundService, err := awsinstallutil.FindServices(serviceNames, ecsSvc, i.config.Cluster, log)
+	if foundService == nil {
+		opts.UI.Output("No runner ECS service found to upgrade", terminal.WithWarningStyle())
+		return false, nil
+	}
 	if err != nil {
 		opts.UI.Output("Could not get list of ECS services: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return false, err
 	}
 
-	return len(services.Services) > 0, nil
+	return true, nil
 }
 
 func (i *ECSInstaller) InstallFlags(set *flag.Set) {

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -950,9 +950,8 @@ func (i *ECSInstaller) HasRunner(
 		installutil.DefaultRunnerName("static"),
 	}
 	ecsSvc := ecs.New(sess)
-	var foundService *ecs.Service
 	var services *ecs.DescribeServicesOutput
-	services, foundService, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.config.Cluster, services, foundService, log)
+	services, _, err = awsinstallutil.FindServices(serviceNames, ecsSvc, i.config.Cluster, log)
 	if err != nil {
 		opts.UI.Output("Could not get list of ECS services: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return false, err


### PR DESCRIPTION
This PR updates the `server upgrade` command to set the runner ID to `static`, which is the ID of the runner installed with the Waypoint server (using `waypoint install`) starting in 0.9. The ECS upgrade process requires this to be set in order to properly search the name of the ECS service to uninstall for the static runner as part of the upgrade.

A small refactor has also been done for querying services in ECS by creating a new helper function in `internal/installutil/aws`.