### PR TITLE
Fixes operation log flushing

### DIFF
--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -631,7 +631,11 @@ func (s *Service) RunnerJobStream(
 		}
 	}
 
-	defer logStreamWriter.Flush(ctx)
+	// We don't want the log stream writer to use the request context, because we want to
+	// ensure that flushing occurs even if it needs to happen after the request context
+	// is closed.
+	logStreamCtx := context.Background()
+	defer logStreamWriter.Flush(logStreamCtx)
 
 	// Start a goroutine that watches for job changes
 	jobCh := make(chan *serverstate.Job, 1)


### PR DESCRIPTION
All credit to @jgwhite and pairing buddies for finding and diagnosing this.

We're deferring the context cancellation (line 449) _and_ this flush method. If we pass that context into flush, flush will see the context cancel before it tries to do any work, and will likely exit early.

We really want to flush the logs, regardless of what happens to the parent context.