### PR TITLE
updating the waypoint destroy help description

### DIFF
--- a/.changelog/3580.txt
+++ b/.changelog/3580.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Fix incorrect description for `destroy -h` command.
+```

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -91,7 +91,9 @@ func (c *DestroyCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint destroy [options]
 
-  Delete all resources created for all apps or projects in the current workspace.
+  Delete all resources created for all apps or project in the current workspace.
+  Specify the -app to select a given app to delete resources for in a given 
+  workspace.
 
   The workspace can continue to be used after this call, this just deletes
   all the resources created for all apps in the workspace up to this point.

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -91,17 +91,17 @@ func (c *DestroyCommand) Help() string {
 	return formatHelp(`
 Usage: waypoint destroy [options]
 
-  Delete all resources created for an app or project in the current workspace.
+  Delete all resources created for all apps or projects in the current workspace.
 
   The workspace can continue to be used after this call, this just deletes
-  all the resources created for this app up to this point.
+  all the resources created for all apps in the workspace up to this point.
 
   This functionality must be supported by the plugins in use and is dependent
   on their behavior. The expected behavior is that any physical resources created
   as part of deploys and releases are destroyed. For example, any load balancers,
   VMs, containers, etc.
 
-  This targets one app in one workspace. You must call this for each workspace
+  This targets apps in one workspace. You must call this for each workspace
   you've used if you want to destroy everything.
 
 ` + c.Flags().Help())

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -17,7 +17,9 @@ Delete all the resources created
 
 Usage: `waypoint destroy [options]`
 
-Delete all resources created for all apps or projects in the current workspace.
+Delete all resources created for all apps or project in the current workspace.
+Specify the -app to select a given app to delete resources for in a given
+workspace.
 
 The workspace can continue to be used after this call, this just deletes
 all the resources created for all apps in the workspace up to this point.

--- a/website/content/commands/destroy.mdx
+++ b/website/content/commands/destroy.mdx
@@ -17,17 +17,17 @@ Delete all the resources created
 
 Usage: `waypoint destroy [options]`
 
-Delete all resources created for an app or project in the current workspace.
+Delete all resources created for all apps or projects in the current workspace.
 
 The workspace can continue to be used after this call, this just deletes
-all the resources created for this app up to this point.
+all the resources created for all apps in the workspace up to this point.
 
 This functionality must be supported by the plugins in use and is dependent
 on their behavior. The expected behavior is that any physical resources created
 as part of deploys and releases are destroyed. For example, any load balancers,
 VMs, containers, etc.
 
-This targets one app in one workspace. You must call this for each workspace
+This targets apps in one workspace. You must call this for each workspace
 you've used if you want to destroy everything.
 
 #### Global Options


### PR DESCRIPTION
Updating the `waypoint destroy -h` description, as previously it read only destroying resources for one app, when in fact it destroys all apps/resources in the workspace. See below:

```
$ waypoint up -w=test

$ kubectl get po
NAME                                                 READY   STATUS    RESTARTS   AGE
example-nodejs-metrics-sidecar-v7-6758bf9764-qvctl   2/2     Running   0          76s
test-example-nodejs-v7-54c9fb8448-mw4nw              1/1     Running   0          20s
waypoint-runner-0                                    1/1     Running   0          3h5m
waypoint-server-0                                    1/1     Running   0          3h5m

$ waypoint destroy -w=test -auto-approve
  Performing operation locally

» Destroying releases for application 'example-nodejs-metrics-sidecar'...
✓ Running release destroy v7
✓ Kubernetes client connected to https://kubernetes.docker.internal:6443 with namespace default
✓ Service deleted

» Destroying deployments for application 'example-nodejs-metrics-sidecar'...
✓ Running deployment destroy v7
✓ Kubernetes client connected to https://kubernetes.docker.internal:6443 with namespace default
✓ Deployment deleted
Destroy successful!
  Performing operation locally

» Destroying releases for application 'test-example-nodejs'...
✓ Running release destroy v7
✓ Kubernetes client connected to https://kubernetes.docker.internal:6443 with namespace default
✓ Service deleted

» Destroying deployments for application 'test-example-nodejs'...
✓ Running deployment destroy v7
✓ Kubernetes client connected to https://kubernetes.docker.internal:6443 with namespace default
✓ Deployment deleted
Destroy successful!

$ kubectl get po
NAME                READY   STATUS    RESTARTS   AGE
waypoint-runner-0   1/1     Running   0          3h7m
waypoint-server-0   1/1     Running   0          3h7m
```