### PR TITLE
Move token encoding logic to server state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
       - run:
           name: Setup k3s
           command: |
-            curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--docker --disable=traefik --write-kubeconfig-mode 664" sh -
+            curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.23.8+k3s2" INSTALL_K3S_EXEC="--docker --disable=traefik --write-kubeconfig-mode 664" sh -
             sleep 5
       - run:
           name: Get k3s nodes

--- a/internal/server/boltdbstate/state.go
+++ b/internal/server/boltdbstate/state.go
@@ -127,20 +127,19 @@ func (s *State) TokenEncrypt(token []byte, keyId string, metadata map[string]str
 }
 
 func (s *State) TokenDecrypt(ciphertext []byte) (*pb.TokenTransport, *pb.Token, error) {
-	var err error
 	if subtle.ConstantTimeCompare(ciphertext[:len(tokenMagic)], []byte(tokenMagic)) != 1 {
-		return nil, nil, errors.Wrapf(err, "bad magic")
+		return nil, nil, errors.Errorf("bad magic")
 	}
 
 	var tt pb.TokenTransport
-	err = proto.Unmarshal(ciphertext[len(tokenMagic):], &tt)
+	err := proto.Unmarshal(ciphertext[len(tokenMagic):], &tt)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	key, err := s.HMACKeyGet(tt.KeyId)
 	if err != nil || key == nil {
-		return nil, nil, errors.Wrapf(err, "unknown key")
+		return nil, nil, errors.Errorf("unknown key")
 	}
 
 	// Hash the token body using the HMAC key so that we can compare
@@ -153,7 +152,7 @@ func (s *State) TokenDecrypt(ciphertext []byte) (*pb.TokenTransport, *pb.Token, 
 	h.Write(tt.Body)
 	sum := h.Sum(nil)
 	if subtle.ConstantTimeCompare(sum, tt.Signature) != 1 {
-		return nil, nil, errors.Wrapf(err, "bad signature")
+		return nil, nil, errors.Errorf("bad signature")
 	}
 
 	// Decode the actual token structure

--- a/internal/server/boltdbstate/state.go
+++ b/internal/server/boltdbstate/state.go
@@ -133,7 +133,7 @@ func (s *State) TokenDecrypt(ciphertext []byte) (*pb.TokenTransport, *pb.Token, 
 	}
 
 	var tt pb.TokenTransport
-	err = proto.Unmarshal(ciphertext, &tt)
+	err = proto.Unmarshal(ciphertext[len(tokenMagic):], &tt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/boltdbstate/state.go
+++ b/internal/server/boltdbstate/state.go
@@ -3,12 +3,15 @@
 package boltdbstate
 
 import (
+	"bytes"
+	"crypto/subtle"
 	"fmt"
 	"reflect"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/crypto/blake2b"
 	"google.golang.org/protobuf/proto"

--- a/internal/server/boltdbstate/state.go
+++ b/internal/server/boltdbstate/state.go
@@ -81,10 +81,10 @@ type State struct {
 }
 
 const (
-	// tokenMagic is used as a byte sequence prepended to the encoded TokenTransport to identify
+	// TokenMagic is used as a byte sequence prepended to the encoded TokenTransport to identify
 	// the token as valid before attempting to decode it. This is mostly a nicity to improve
 	// understanding of the token data and error messages.
-	tokenMagic = "wp24"
+	TokenMagic = "wp24"
 )
 
 // Hashes token in OSS with HMAC
@@ -120,19 +120,19 @@ func (s *State) TokenEncrypt(token []byte, keyId string, metadata map[string]str
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(tokenMagic)
+	buf.WriteString(TokenMagic)
 	buf.Write(ttData)
 
 	return buf.Bytes(), nil
 }
 
 func (s *State) TokenDecrypt(ciphertext []byte) (*pb.TokenTransport, *pb.Token, error) {
-	if subtle.ConstantTimeCompare(ciphertext[:len(tokenMagic)], []byte(tokenMagic)) != 1 {
+	if subtle.ConstantTimeCompare(ciphertext[:len(TokenMagic)], []byte(TokenMagic)) != 1 {
 		return nil, nil, errors.Errorf("bad magic")
 	}
 
 	var tt pb.TokenTransport
-	err := proto.Unmarshal(ciphertext[len(tokenMagic):], &tt)
+	err := proto.Unmarshal(ciphertext[len(TokenMagic):], &tt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -41,10 +41,6 @@ const (
 	// the token as valid before attempting to decode it. This is mostly a nicity to improve
 	// understanding of the token data and error messages.
 	tokenMagic = "wp24"
-
-	// hmacKeySize is the size in bytes that the HMAC keys should be. Each key will contain this number of bytes
-	// of data from rand.Reader
-	hmacKeySize = 32
 )
 
 var (
@@ -415,41 +411,14 @@ func (s *Service) decodeToken(ctx context.Context, token string) (*pb.TokenTrans
 // keyId controls which key is used to sign the key (key values are generated lazily).
 // metadata is attached to the token transport as configuration style information
 func (s *Service) encodeToken(ctx context.Context, keyId string, metadata map[string]string, body *pb.Token) (string, error) {
-	// Get the key material
-	key, err := s.state(ctx).HMACKeyCreateIfNotExist(keyId, hmacKeySize)
-	if err != nil {
-		return "", err
-	}
-
-	// Proto encode the body, this is what we sign.
-	bodyData, err := proto.Marshal(body)
-	if err != nil {
-		return "", err
-	}
-
-	// Sign it
-	h, err := blake2b.New256(key.Key)
-	if err != nil {
-		return "", err
-	}
-	h.Write(bodyData)
-
-	// Build our wrapper which is not signed or encrypted.
-	var tt pb.TokenTransport
-	tt.Body = bodyData
-	tt.KeyId = keyId
-	tt.Metadata = metadata
-	tt.Signature = h.Sum(nil)
-
-	// Marshal the wrapper and base58 encode it.
-	ttData, err := proto.Marshal(&tt)
+	ct, err := s.state(ctx).TokenEncrypt(keyId, body, metadata)
 	if err != nil {
 		return "", err
 	}
 
 	var buf bytes.Buffer
 	buf.WriteString(tokenMagic)
-	buf.Write(ttData)
+	buf.Write(ct)
 
 	return base58.Encode(buf.Bytes()), nil
 }

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -1,10 +1,8 @@
 package singleprocess
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/subtle"
 	"io"
 	"strings"
 	"time"
@@ -12,7 +10,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/mr-tron/base58"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/blake2b"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"

--- a/pkg/server/singleprocess/auth_test.go
+++ b/pkg/server/singleprocess/auth_test.go
@@ -279,7 +279,7 @@ func TestServiceAuth(t *testing.T) {
 		require.NoError(err)
 
 		var buf bytes.Buffer
-		buf.WriteString(tokenMagic)
+		buf.WriteString("wp24")
 		buf.Write(ttData)
 
 		rogue := base58.Encode(buf.Bytes())

--- a/pkg/server/singleprocess/auth_test.go
+++ b/pkg/server/singleprocess/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/hashicorp/waypoint/internal/server/boltdbstate"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 )
@@ -279,7 +280,7 @@ func TestServiceAuth(t *testing.T) {
 		require.NoError(err)
 
 		var buf bytes.Buffer
-		buf.WriteString("wp24")
+		buf.WriteString(boltdbstate.TokenMagic)
 		buf.Write(ttData)
 
 		rogue := base58.Encode(buf.Bytes())

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -23,6 +23,8 @@ type Interface interface {
 	HMACKeyEmpty() bool
 	HMACKeyCreateIfNotExist(id string, size int) (*pb.HMACKey, error)
 	HMACKeyGet(id string) (*pb.HMACKey, error)
+	TokenEncrypt(tokenPlaintext string) (tokenCiphertext string, err error)
+	TokenDecrypt(tokenCiphertext string) (tokenPlaintext string, err error)
 
 	ServerConfigSet(*pb.ServerConfig) error
 	ServerConfigGet() (*pb.ServerConfig, error)

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -23,8 +23,8 @@ type Interface interface {
 	HMACKeyEmpty() bool
 	HMACKeyCreateIfNotExist(id string, size int) (*pb.HMACKey, error)
 	HMACKeyGet(id string) (*pb.HMACKey, error)
-	TokenEncrypt(tokenPlaintext string) (tokenCiphertext string, err error)
-	TokenDecrypt(tokenCiphertext string) (tokenPlaintext string, err error)
+	TokenEncrypt(keyId string, token *pb.Token, metadata map[string]string) (ciphertext []byte, err error)
+	TokenDecrypt(ciphertext string) (token string, err error)
 
 	ServerConfigSet(*pb.ServerConfig) error
 	ServerConfigGet() (*pb.ServerConfig, error)

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -23,8 +23,8 @@ type Interface interface {
 	HMACKeyEmpty() bool
 	HMACKeyCreateIfNotExist(id string, size int) (*pb.HMACKey, error)
 	HMACKeyGet(id string) (*pb.HMACKey, error)
-	TokenEncrypt(keyId string, token *pb.Token, metadata map[string]string) (ciphertext []byte, err error)
-	TokenDecrypt(ciphertext string) (token string, err error)
+	TokenEncrypt(token []byte, keyId string, metadata map[string]string) (ciphertext []byte, err error)
+	TokenDecrypt(ciphertext []byte) (tt *pb.TokenTransport, token *pb.Token, err error)
 
 	ServerConfigSet(*pb.ServerConfig) error
 	ServerConfigGet() (*pb.ServerConfig, error)


### PR DESCRIPTION
Moving the token encoding logic over to the server from Auth since it will be handled differently in HCP.

Context:

To prevent users from tampering with tokens, we include a secure hash in every token we create. We create an HMAC key for the server and store it in the database, and use that to create and validate tokens. In HCP, we outsource this cryptographic security to Vault. Therefore, we need to move the hashing logic out of the shared server code. This will kill two birds with one stone, and solve a problem with encrypting/decrypting HMAC keys in HCP.