### PR TITLE
Test getting instances by deployment

### DIFF
--- a/pkg/serverstate/statetest/test_status_report.go
+++ b/pkg/serverstate/statetest/test_status_report.go
@@ -104,8 +104,7 @@ func TestStatusReport(t *testing.T, factory Factory, restartF RestartFactory) {
 			require.Equal(ts.AsTime(), resp.Status.CompleteTime.AsTime())
 		}
 
-		// Add another and see Latset change
-		// Add
+		// Add another and see Latest change
 		err = s.StatusReportPut(false, serverptypes.TestStatusReport(t, &pb.StatusReport{
 			Id:          "d2",
 			Application: app,


### PR DESCRIPTION
We didn't have test coverage on this function! I could have added more sub-tests to the big parent, but in this case I decided that duplicating some of the setup was worth it to get a clean initial testing state.