### PR TITLE
Destroy Failed Deployments

### DIFF
--- a/.changelog/3602.txt
+++ b/.changelog/3602.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-cli: Update deployment destroy to proceed with deleting resources for failed
-deployments
+cli: `deployment destroy` will now attempt to destroy any known resources for failed
+deployments. Previously, `destroy` would skip unsuccessful deployments.
 ```

--- a/.changelog/3602.txt
+++ b/.changelog/3602.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Update deployment destroy to proceed with deleting resources for failed
+deployments
+```

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -63,7 +63,8 @@ func (c *DeploymentDestroyCommand) Run(args []string) int {
 		for _, deployment := range deployments {
 			// Can't destroy a deployment that was not successful
 			if deployment.Status.GetState() != pb.Status_SUCCESS {
-				continue
+				c.ui.Output("The deployment was not successful - destroy may not completely destroy "+
+					"all resources", terminal.WithWarningStyle())
 			}
 
 			// Get our app client

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -76,9 +76,11 @@ func (c *DeploymentDestroyCommand) Run(args []string) int {
 					Deployment: deployment,
 				},
 			}); err != nil {
-				c.ui.Output("Error destroying the deployment: %s", err.Error(), terminal.WithErrorStyle())
-				return ErrSentinel
+				c.ui.Output("Error destroying deployment %d: %s", deployment.Sequence, err.Error(), terminal.WithErrorStyle())
 			}
+		}
+		if err != nil {
+			return ErrSentinel
 		}
 		return nil
 	})

--- a/internal/cli/deployment_destroy.go
+++ b/internal/cli/deployment_destroy.go
@@ -63,8 +63,8 @@ func (c *DeploymentDestroyCommand) Run(args []string) int {
 		for _, deployment := range deployments {
 			// Can't destroy a deployment that was not successful
 			if deployment.Status.GetState() != pb.Status_SUCCESS {
-				c.ui.Output("The deployment was not successful - destroy may not completely destroy "+
-					"all resources", terminal.WithWarningStyle())
+				c.ui.Output("Deployment %d was not successful - destroy may not completely destroy "+
+					"all resources", deployment.Sequence, terminal.WithWarningStyle())
 			}
 
 			// Get our app client


### PR DESCRIPTION
Update `waypoint deployment destroy` to continue with deleting the specified deployment from the database, while also warning the user that the resources created from the failed deployment may not be fully destroyed.

Addresses #533.