### PR TITLE
Add additional OAuth2 hooks and handling

### DIFF
--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -611,6 +611,13 @@ func (s *Service) newToken(
 		return "", err
 	}
 
+	if s.processToken != nil {
+		body, err = s.processToken(ctx, body)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	return s.encodeToken(ctx, keyId, metadata, body)
 }
 

--- a/pkg/server/singleprocess/service.go
+++ b/pkg/server/singleprocess/service.go
@@ -36,6 +36,11 @@ type Service struct {
 	// with EncodeId), and returns only the waypoint-relevant ID.
 	decodeId func(encodedId string) (id string, err error)
 
+	// processToken allows an implementation the ability to alter a to be
+	// generated token before it's generated. This can be used to alter semantics
+	// about the token, such as adding labels, metadata, or additional info
+	processToken func(ctx context.Context, token *pb.Token) (*pb.Token, error)
+
 	logStreamProvider logstream.Provider
 
 	// urlConfig is not nil if the URL service is enabled. This is guaranteed
@@ -98,6 +103,7 @@ func New(opts ...Option) (pb.WaypointServer, error) {
 	s.encodeId = cfg.idEncoder
 	s.decodeId = cfg.idDecoder
 	s.features = cfg.features
+	s.processToken = cfg.processToken
 
 	if !cfg.oidcDisabled {
 		s.oidcCache = wpoidc.NewProviderCache()
@@ -256,6 +262,8 @@ type config struct {
 	idEncoder func(ctx context.Context, id string) (encodedId string, err error)
 	idDecoder func(encodedId string) (id string, err error)
 
+	processToken func(ctx context.Context, token *pb.Token) (*pb.Token, error)
+
 	serverConfig         *serverconfig.Config
 	log                  hclog.Logger
 	superuser            bool
@@ -399,6 +407,16 @@ func WithServerConfigSkipInit() Option {
 func WithFeatures(features ...pb.ServerFeaturesFeature) Option {
 	return func(s *Service, cfg *config) error {
 		cfg.features = features
+		return nil
+	}
+}
+
+// WithTokenProcessor installs a function that will be called just before
+// a new token is encoded. This allows customization of that Token to include
+// additional information.
+func WithTokenProcessor(fn func(context.Context, *pb.Token) (*pb.Token, error)) Option {
+	return func(s *Service, cfg *config) error {
+		cfg.processToken = fn
 		return nil
 	}
 }

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -430,6 +430,7 @@ func (s *Service) onDemandRunnerStartJob(
 	// the user of the token to be the user that queued the original job, which is
 	// the correct behavior.
 	token, err := s.newToken(ctx, 60*time.Minute, DefaultKeyId, nil, &pb.Token{
+		// TODO(emp) should this be a Token_Runner_?
 		Kind: &pb.Token_Login_{Login: &pb.Token_Login{
 			UserId: encodedDefaultUserId,
 		}},


### PR DESCRIPTION
The CEB was not perform the OAuth2 exchange, so that's fixed here.

Also, the hook allows HCP Waypoint to inject OAuth2 to a token before it's encoded.