### PR TITLE
ui: Fix header spacing on build/release detail pages

### DIFF
--- a/.changelog/3614.txt
+++ b/.changelog/3614.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Fix header spacing on build/release detail pages
+```

--- a/ui/app/components/panel-header.hbs
+++ b/ui/app/components/panel-header.hbs
@@ -15,7 +15,7 @@
 }}
 <header data-test-panel-header class="panel-header {{if vars.icon "icon-header"}}">
   {{#if vars.icon}}
-    <IconTile @icon={{vars.icon}} />
+    <Hds::IconTile @icon={{vars.icon}} @size="large" />
   {{/if}}
   <div class={{if vars.icon "icon-header--title"}}>
     <h1>{{t vars.title}}

--- a/ui/app/styles/components/navigation/panel-header.scss
+++ b/ui/app/styles/components/navigation/panel-header.scss
@@ -1,8 +1,10 @@
 .panel-header {
   display: flex;
   align-items: center;
+  justify-items: center;
   flex-wrap: wrap;
   color: rgb(var(--text-muted));
+  margin-top: scale.$base; // Align with non-detail pages e.g. page-header
   
   h1 {
     display: flex;
@@ -12,6 +14,7 @@
     flex-direction: row;
     align-items: center;
     @include Typography.Interface(M);
+    margin-bottom: 0; // Override h1 margin
 
     .badge {
       margin-left: scale.$sm-3;

--- a/ui/tests/acceptance/percy-test.ts
+++ b/ui/tests/acceptance/percy-test.ts
@@ -59,4 +59,25 @@ module('Acceptance | Percy', function (hooks) {
     await snapshot('Application list');
     assert.ok(true);
   });
+
+  test('Builds and releases pages', async function (assert) {
+    let project = this.server.create('project', { name: 'acme-project' });
+    let application = this.server.create('application', { name: 'acme-app', project });
+    let build = this.server.create('build', 'random', { application });
+    let release = this.server.create('release', 'random', { application });
+
+    await visit(`/default/${project.name}/app/${application.name}/builds`);
+    await snapshot('Builds page');
+
+    await visit(`/default/${project.name}/app/${application.name}/build/${build.id}`);
+    await snapshot('Build detail page');
+
+    await visit(`/default/${project.name}/app/${application.name}/releases`);
+    await snapshot('Releases page');
+
+    await visit(`/default/${project.name}/app/${application.name}/release/seq/${release.sequence}`);
+    await snapshot('Release detail page');
+
+    assert.ok(true);
+  });
 });


### PR DESCRIPTION
- Swap out IconTile for Hds::IconTile
  - Fix visual alignment bug along the way, to have panel-header match page-header
- Add Percy test

Resolves: https://github.com/hashicorp/waypoint/issues/3504
Resolves part of: https://github.com/hashicorp/waypoint/issues/3313 (IconTile swapped out everywhere except for /onboarding, which could use some Percy-ing)