### PR TITLE
ui: Make it clearer that remote runners are required for GitOps

### DIFF
--- a/.changelog/3615.txt
+++ b/.changelog/3615.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Make it clearer that remote runners are required for GitOps 
+```

--- a/ui/app/components/app-form/project-repository-settings.hbs
+++ b/ui/app/components/app-form/project-repository-settings.hbs
@@ -1,6 +1,20 @@
 <form class="pds-form" {{on "submit" this.saveSettings}}>
 
   <div part="fields" class="card">
+    <Hds::Alert @type='inline' @color='warning' class='card-alert' as |A|>
+      <A.Title>
+        {{t 'runner-alert.title'}}
+      </A.Title>
+      <A.Description>
+        {{t 'runner-alert.description'}}
+      </A.Description>
+      <A.Link::Standalone
+        @icon='external-link'
+        @iconPosition='trailing'
+        @text={{t 'runner-alert.link'}}
+        @href='https://developer.hashicorp.com/waypoint/docs/runner'
+      />
+    </Hds::Alert>
     <div class="card-header">
       <h4>{{t "form.project_git_settings.git_title"}}</h4>
     </div>

--- a/ui/app/styles/components/card.scss
+++ b/ui/app/styles/components/card.scss
@@ -109,3 +109,7 @@
 .card-header {
   font-size: scale.$sm-1;
 }
+
+.card-alert {
+  margin: scale.$sm--3 0 scale.$lg--1 0;
+}

--- a/ui/tests/acceptance/percy-test.ts
+++ b/ui/tests/acceptance/percy-test.ts
@@ -41,13 +41,17 @@ module('Acceptance | Percy', function (hooks) {
     assert.ok(true);
   });
 
-  test('populated projects list', async function (assert) {
-    this.server.create('project', { name: 'acme-project' });
+  test('project snapshots', async function (assert) {
+    let myProject = this.server.create('project', { name: 'acme-project' });
     this.server.create('project', { name: 'acme-marketing' });
     this.server.create('project', { name: 'acme-anvils' });
 
     await visit('/default');
     await snapshot('Populated projects list');
+
+    await visit(`/default/${myProject.name}/settings`);
+    await snapshot('Project settings: Git repository form');
+
     assert.ok(true);
   });
 

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -314,3 +314,8 @@ image-ref:
 
 workspace-switcher:
   error: Failed to load workspaces
+
+runner-alert: 
+  title: Remote runner required
+  description: In order to connect to a repository, you must install a remote runner first.
+  link: Waypoint Runners documentation


### PR DESCRIPTION
Brings OSS to parity with HCP

Resolves: https://github.com/hashicorp/waypoint/issues/3034

Note: Additional changes to this feature in HCP / OSS may be coming down the road, but this is an iterative improvement to the UX.