### PR TITLE
Hide dynamic Mirage content from Percy diffs

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -116,7 +116,7 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 We use [Percy](https://percy.io) for visual regression testing.
 
-All the Percy snapshotting happens in [percy-test.ts](./tests/acceptance/percy-test.ts). The aim is to have a test for every significant state in this file. We keep it all in one file, rather than weaving Percy snapshotting through the rest of the test suite. We think this makes it more maintainable.
+All the Percy snapshotting happens in [percy-test.ts](./tests/acceptance/percy-test.ts). The aim is to have a test for every significant state in the UI in this file. We keep it all in one file, rather than weaving Percy snapshotting through the rest of the test suite. We think this makes it more maintainable.
 
 We are incrementally adding Percy tests, so it’s rather minimal at the moment. If you’d like to add a Percy test, please go ahead.
 
@@ -128,7 +128,10 @@ yarn ember:test:percy
 
 This is exactly the same command we run in CI. You will need to set the env var `PERCY_TOKEN` with a valid Percy token.
 
-If you need access to our Percy account, please ask someone from @hashicorp/waypoint-frontend.
+#### Percy troubleshooting
+
+- If you need access to our Percy account (for approvals), please ask someone from @hashicorp/waypoint-frontend.
+- Percy should only trigger visual diffs for changes to the UI. If you notice an unexpected Percy snapshot, that part of the UI may need the class `hide-in-percy` added to the Mirage test. It's safe to approve the Percy snapshot and tag @hashicorp/waypoint-frontend to fix the frontend Mirage tests in a separate PR.
 
 ### Building
 

--- a/ui/app/components/app-item/build.hbs
+++ b/ui/app/components/app-item/build.hbs
@@ -10,7 +10,7 @@
   </th>
   {{#let (or @build.pushedArtifact @build) as |operation|}}
     <td>
-      <span data-test-status class="table__icon-text-cell-span">
+      <span data-test-status class="table__icon-text-cell-span hide-in-percy">
         {{#if operation.status}}
           <FlightIcon
             data-test-status-icon
@@ -54,7 +54,7 @@
         }}
       {{/if}}
     </td>
-    <td data-test-provider>
+    <td data-test-provider class="hide-in-percy">
       <span class="table__icon-text-cell-span">
         <FlightIcon
           data-test-icon-type={{icon-for-component operation.component.name}}

--- a/ui/app/components/app-item/release.hbs
+++ b/ui/app/components/app-item/release.hbs
@@ -11,7 +11,7 @@
   </th>
   {{#let (or @release.pushedArtifact @release) as |operation|}}
     <td>
-      <span data-test-status class="table__icon-text-cell-span">
+      <span data-test-status class="table__icon-text-cell-span hide-in-percy">
         {{#if operation.status}}
           <FlightIcon
             data-test-status-icon
@@ -55,7 +55,7 @@
         }}
       {{/if}}
     </td>
-    <td data-test-provider>
+    <td data-test-provider class="hide-in-percy">
       <span class="table__icon-text-cell-span">
         <FlightIcon
           data-test-icon-type={{icon-for-component operation.component.name}}

--- a/ui/app/components/operation-status-indicator.hbs
+++ b/ui/app/components/operation-status-indicator.hbs
@@ -25,7 +25,7 @@
 
 --}}
 <div class="operation-status-indicator">
-  <span class="icon-text-group">
+  <span class="icon-text-group hide-in-percy">
     <FlightIcon
       data-test-icon-type={{icon-for-component @operation.component.name}}
       @name={{icon-for-component @operation.component.name}}


### PR DESCRIPTION
Also, flesh out Percy docs
- I believe no changelog needed: not a user-facing change. Fixes flaky diffs for from Percy visual regression testing for dev team.
- (Aside: We could component-ize icon with adjacent text, and Percy it separately, but it's not super important right now)

Resolves https://github.com/hashicorp/waypoint/issues/3631

I went ahead and added folks from @hashicorp/waypoint-frontend, @hashicorp/waypoint-ecosystem and @hashicorp/waypoint-backend to the HashiCorp Percy account, so that you can approve Percy diffs on PRs if you do indeed change the `ui/` at all. After this PR is merged to `main`, the dynamic content will be hidden and other open PRs will need to rebase, so as not to bring in "incorrect" snapshots to `main`, that will cause more flaky Percy diffs.

***

- [x] For the reviewer: Please +1 the Percy also as part of code review

I personally like to review with this option clicked, but YMMV:

<img width="1753" alt="image" src="https://user-images.githubusercontent.com/1372946/182504771-527ce8ed-896c-4da6-9a40-e281431a9c0e.png">
