### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /go/bin
+          at: /home/circleci/go/bin
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -194,11 +194,11 @@ jobs:
       - run:
           command: |
             go get github.com/kevinburke/go-bindata/...
-            PATH=/go/bin:$PATH make bin
-            cp waypoint /go/bin
+            PATH=/home/circleci/go/bin:$PATH make bin
+            cp waypoint /home/circleci/go/bin
       # save dev build to pass to downstream jobs
       - persist_to_workspace:
-          root: /go/bin
+          root: /home/circleci/go/bin
           paths:
             - waypoint
       - notify_main_failure
@@ -217,7 +217,7 @@ jobs:
       - run:
           command: |
             go get github.com/kevinburke/go-bindata/...
-            PATH=/go/bin:$PATH make bin/windows
+            PATH=/home/circleci/go/bin:$PATH make bin/windows
       - notify_main_failure
 
   integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.17
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.17
     middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
     website: &WEBSITE_IMAGE docker.mirror.hashicorp.services/node:14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Install golangci-lint
           command: |
             download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -x -s -- -d -b /go/bin/ v1.27.0
+            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go v1.27.0
       - run: go mod download
       - run:
           name: lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Install golangci-lint
           command: |
             download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go v1.27.0
+            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go v1.47.3
       - run: go mod download
       - run:
           name: lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - attach_workspace:
           at: /go/bin
       - setup_remote_docker:
-          docker_layer_cache: true
+          docker_layer_caching: true
       - run: &install_gotestsum
           name: Install gotestsum
           command: |
@@ -412,7 +412,7 @@ jobs:
     resource_class: xlarge
     environment:
       EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
-      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+      EMBER_TEST_PARALLEL: "true" #enables test parallelization with ember-exam
     steps:
       - checkout
       - md5uilib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ version: 2.1
 references:
   images:
     go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.17
-    middleman: &MIDDLEMAN_IMAGE docker.mirror.hashicorp.services/hashicorp/middleman-hashicorp:0.3.44
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
     website: &WEBSITE_IMAGE docker.mirror.hashicorp.services/node:14
 
@@ -13,7 +12,6 @@ references:
 
   cache:
     yarn: &YARN_CACHE_KEY waypoint-ui-v1-{{ checksum "ui/yarn.lock" }}-{{ checksum "uilib.md5" }}
-    rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "Gemfile.lock" }}
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: *TEST_RESULTS_DIR
@@ -23,7 +21,6 @@ references:
     GIT_COMMITTER_NAME: circleci-waypoint
     BASH_ENV: /home/circleci/project/.circleci/bash_env.sh
     DOCKER_BUILDKIT: 1
-    REBUILD_UI: &REBUILD_UI 1
 
 jobs:
   # Runs Go linters
@@ -42,7 +39,7 @@ jobs:
       - run: go mod download
       - run:
           name: lint
-          command: &lintcmd |
+          command: |
             golangci-lint run --build-tags="$GOTAGS" -v --concurrency 2 \
               --disable-all \
               --timeout 10m \
@@ -149,7 +146,7 @@ jobs:
           at: /go/bin
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: &install_gotestsum
+      - run:
           name: Install gotestsum
           command: |
             url=https://github.com/gotestyourself/gotestsum/releases/download

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -113,7 +113,7 @@ func (r *Runner) AcceptExact(ctx context.Context, id string) error {
 
 var testRecvDelay time.Duration
 
-//nolint:lostcancel
+//nolint:govet,lostcancel
 func (r *Runner) accept(ctx context.Context, id string) error {
 	if r.readState(&r.stateExit) > 0 {
 		return ErrClosed

--- a/internal/server/boltdbstate/instance_test.go
+++ b/internal/server/boltdbstate/instance_test.go
@@ -1,3 +1,4 @@
+//nolint:govet,copylocks
 package boltdbstate
 
 import (
@@ -83,7 +84,6 @@ func TestInstancesByApp(t *testing.T) {
 	require.Len(list, 1)
 
 	// Should not for other app
-	//nolint:copylocks
 	ref2 := *ref
 	ref2.Application = "NO"
 	list, err = s.InstancesByApp(&ref2, nil, nil)
@@ -130,7 +130,6 @@ func TestInstancesByAppWorkspace(t *testing.T) {
 	require.Len(list, 1)
 
 	// Should not for other app
-	//nolint:copylocks
 	ref2 := *refWs
 	ref2.Workspace = "NO"
 	list, err = s.InstancesByApp(ref, &ref2, nil)

--- a/internal/server/boltdbstate/instance_test.go
+++ b/internal/server/boltdbstate/instance_test.go
@@ -1,4 +1,3 @@
-//nolint:govet,copylocks
 package boltdbstate
 
 import (
@@ -84,6 +83,7 @@ func TestInstancesByApp(t *testing.T) {
 	require.Len(list, 1)
 
 	// Should not for other app
+	//nolint:govet,copylocks
 	ref2 := *ref
 	ref2.Application = "NO"
 	list, err = s.InstancesByApp(&ref2, nil, nil)
@@ -130,6 +130,7 @@ func TestInstancesByAppWorkspace(t *testing.T) {
 	require.Len(list, 1)
 
 	// Should not for other app
+	//nolint:govet,copylocks
 	ref2 := *refWs
 	ref2.Workspace = "NO"
 	list, err = s.InstancesByApp(ref, &ref2, nil)

--- a/pkg/serverstate/statetest/test_instance.go
+++ b/pkg/serverstate/statetest/test_instance.go
@@ -1,4 +1,3 @@
-//nolint:govet,copylocks
 package statetest
 
 import (
@@ -165,7 +164,8 @@ func TestInstance(t *testing.T, factory Factory, restartF RestartFactory) {
 		require.Len(list, 1)
 
 		// Should not for other app
-		ref2 := *app //nolint:copylocks
+		//nolint:govet,copylocks
+		ref2 := *app
 		ref2.Application = "NO"
 		list, err = s.InstancesByApp(&ref2, nil, nil)
 		require.NoError(err)
@@ -227,6 +227,7 @@ func TestInstance(t *testing.T, factory Factory, restartF RestartFactory) {
 		require.Len(list, 1)
 
 		// Should not for other app
+		//nolint:govet,copylocks
 		ref2 := *wsRef
 		ref2.Workspace = "NO"
 		list, err = s.InstancesByApp(app, &ref2, nil)

--- a/pkg/serverstate/statetest/test_instance.go
+++ b/pkg/serverstate/statetest/test_instance.go
@@ -1,3 +1,4 @@
+//nolint:govet,copylocks
 package statetest
 
 import (
@@ -164,8 +165,7 @@ func TestInstance(t *testing.T, factory Factory, restartF RestartFactory) {
 		require.Len(list, 1)
 
 		// Should not for other app
-		//nolint:copylocks
-		ref2 := *app
+		ref2 := *app //nolint:copylocks
 		ref2.Application = "NO"
 		list, err = s.InstancesByApp(&ref2, nil, nil)
 		require.NoError(err)
@@ -227,7 +227,6 @@ func TestInstance(t *testing.T, factory Factory, restartF RestartFactory) {
 		require.Len(list, 1)
 
 		// Should not for other app
-		//nolint:copylocks
 		ref2 := *wsRef
 		ref2.Workspace = "NO"
 		list, err = s.InstancesByApp(app, &ref2, nil)


### PR DESCRIPTION
We already use the [next-gen](https://circleci.com/docs/circleci-images#next-gen-language-images) image in our release build, we must have just skipped updating the circleci config here.

This also updates golangci-lint to the latest version, and updated the syntax to continue intentionally ignoring the items that had comments explaining why they should be ignored.