### PR TITLE
use fixed status on release and build mock data

### DIFF
--- a/ui/tests/acceptance/percy-test.ts
+++ b/ui/tests/acceptance/percy-test.ts
@@ -67,8 +67,8 @@ module('Acceptance | Percy', function (hooks) {
   test('Builds and releases pages', async function (assert) {
     let project = this.server.create('project', { name: 'acme-project' });
     let application = this.server.create('application', { name: 'acme-app', project });
-    let build = this.server.create('build', 'random', { application });
-    let release = this.server.create('release', 'random', { application });
+    let build = this.server.create('build', 'random', 'minutes-old-success', { application });
+    let release = this.server.create('release', 'random', 'minutes-old-success', { application });
 
     await visit(`/default/${project.name}/app/${application.name}/builds`);
     await snapshot('Builds page');

--- a/ui/tests/acceptance/percy-test.ts
+++ b/ui/tests/acceptance/percy-test.ts
@@ -67,8 +67,8 @@ module('Acceptance | Percy', function (hooks) {
   test('Builds and releases pages', async function (assert) {
     let project = this.server.create('project', { name: 'acme-project' });
     let application = this.server.create('application', { name: 'acme-app', project });
-    let build = this.server.create('build', 'random', 'minutes-old-success', { application });
-    let release = this.server.create('release', 'random', 'minutes-old-success', { application });
+    let build = this.server.create('build', 'minutes-old-success', { application });
+    let release = this.server.create('release', 'minutes-old-success', { application });
 
     await visit(`/default/${project.name}/app/${application.name}/builds`);
     await snapshot('Builds page');


### PR DESCRIPTION
The data used for the percy visual acceptance test was using randomized `status` on the build and release objects, so those were not consistent with the baseline from test to test, This assigns a fixed status to both. Once this is merged, we should approve it as the baseline. 