### PR TITLE
Add OIDC Callback Server Port personalization

### DIFF
--- a/.changelog/3646.txt
+++ b/.changelog/3646.txt
@@ -1,0 +1,3 @@
+``release-note:improvement
+cli: Support OIDC Callback Server port customization via -oidc-callback-server-port, use 8087 as a default
+```

--- a/pkg/auth/oidc/cli.go
+++ b/pkg/auth/oidc/cli.go
@@ -30,7 +30,7 @@ func NewCallbackServer() (*CallbackServer, error) {
 		return nil, err
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:")
+	ln, err := net.Listen("tcp", "127.0.0.1:8087")
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/auth/oidc/cli.go
+++ b/pkg/auth/oidc/cli.go
@@ -23,14 +23,18 @@ type CallbackServer struct {
 // NewCallbackServer creates and starts a new local HTTP server for
 // OIDC authentication to redirect to. This is used to capture the
 // necessary information to complete the authentication.
-func NewCallbackServer() (*CallbackServer, error) {
+func NewCallbackServer(listenPort uint) (*CallbackServer, error) {
+	if listenPort < 1024 || listenPort > 65535 {
+		return nil, fmt.Errorf("invalid listen port: please specify a port between 1024 and 65535")
+	}
+
 	// Generate our nonce
 	nonce, err := oidc.NewID()
 	if err != nil {
 		return nil, err
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:8087")
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", listenPort))
 	if err != nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Fixes #3645

This PR switches from using a dynamic TCP port for the HTTP server that listens for the OIDC Callback in the CLI to using a static port (`8087`) or a custom one provided by the user via the `-oidc-callback-server-port` flag.

Example:

```
$ waypoint login -oidc-callback-server-port=8100
Complete the authentication by visiting your authentication provider.
Opening your browser window now. If the browser window does not launch,
please visit the URL below:
https://sso-provider.example.com/oauth/authorize?client_id=XYZ&nonce=my-nonce&redirect_uri=http%3A%2F%2F127.0.0.1%3A8100%2Foidc%2Fcallback&response_type=code&scope=openid+roles&state=st_dkdue3832
```