### PR TITLE
CI: add e2e tests for Docker platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,32 @@ jobs:
           command: ./ci/integration.sh
       - notify_main_failure
 
+  e2e-docker:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: go version
+      - run:
+          name: Install go
+          command: |
+            curl -SL --fail -o /tmp/golang.tar.gz https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local/ -xzf /tmp/golang.tar.gz
+            rm -rf /tmp/golang.tar.gz
+            go version
+      - run:
+          name: Execute Integration Tests
+          command: |
+            echo "===> Set env vars"
+            export E2E_PLATFORM=Docker
+            export WP_BINARY="$(pwd)/waypoint"
+            echo "===> Run tests"
+            ./test-e2e/run-test.sh
+      - notify_main_failure
+
   image-release:
     docker:
       # Use a modern Circle image as we just need up-to-date Docker here
@@ -441,90 +467,97 @@ jobs:
 
 workflows:
   version: 2
-  go-tests:
-    jobs:
-      - lint
-      - check-vendor:
-          requires:
-            - lint
-      - go-test:
-          requires:
-            - lint
-      - dev-build:
-          requires:
-            - lint
-          filters:
-            branches:
-              ignore:
-                - main
-      - dev-build-windows:
-          requires:
-            - lint
-          filters:
-            branches:
-              ignore:
-                - main
+  # go-tests:
+  #   jobs:
+  #     - lint
+  #     - check-vendor:
+  #         requires:
+  #           - lint
+  #     - go-test:
+  #         requires:
+  #           - lint
+  #     - dev-build:
+  #         requires:
+  #           - lint
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
+  #     - dev-build-windows:
+  #         requires:
+  #           - lint
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
 
-  integration:
+  # integration:
+  #   jobs:
+  #     - lint
+  #     - frontend-cache:
+  #         requires:
+  #           - lint
+  #     - ember-build-prod:
+  #         requires:
+  #           - frontend-cache
+  #     - build-static-assets:
+  #         requires:
+  #           - ember-build-prod
+  #     - dev-build:
+  #         requires:
+  #           - build-static-assets
+  #     - publish-static-assets:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+  #         requires:
+  #           - build-static-assets
+  #     - integration:
+  #         requires:
+  #           - dev-build
+  #     - image-release:
+  #         requires:
+  #           - integration
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+
+  e2e:
     jobs:
-      - lint
-      - frontend-cache:
-          requires:
-            - lint
-      - ember-build-prod:
-          requires:
-            - frontend-cache
-      - build-static-assets:
-          requires:
-            - ember-build-prod
-      - dev-build:
-          requires:
-            - build-static-assets
-      - publish-static-assets:
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - build-static-assets
-      - integration:
+      - dev-build
+      - e2e-docker:
           requires:
             - dev-build
-      - image-release:
-          requires:
-            - integration
-          filters:
-            branches:
-              only:
-                - main
 
-  website-mdx:
-    jobs:
-      - generate-website-mdx:
-          filters:
-            branches:
-              ignore:
-                - main
-      - check-website-mdx:
-          requires:
-            - generate-website-mdx
-          filters:
-            branches:
-              ignore:
-                - main
+  # website-mdx:
+  #   jobs:
+  #     - generate-website-mdx:
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
+  #     - check-website-mdx:
+  #         requires:
+  #           - generate-website-mdx
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - main
 
-  frontend:
-    jobs:
-      - frontend-cache
-      - frontend-lint:
-          requires:
-            - frontend-cache
-      - ember-build-tests:
-          requires:
-            - frontend-lint
-      - ember-test:
-          requires:
-            - ember-build-tests
+  # frontend:
+  #   jobs:
+  #     - frontend-cache
+  #     - frontend-lint:
+  #         requires:
+  #           - frontend-cache
+  #     - ember-build-tests:
+  #         requires:
+  #           - frontend-lint
+  #     - ember-test:
+  #         requires:
+  #           - ember-build-tests
 
 commands:
   md5uilib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,97 +469,97 @@ jobs:
 
 workflows:
   version: 2
-  # go-tests:
-  #   jobs:
-  #     - lint
-  #     - check-vendor:
-  #         requires:
-  #           - lint
-  #     - go-test:
-  #         requires:
-  #           - lint
-  #     - dev-build:
-  #         requires:
-  #           - lint
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - main
-  #     - dev-build-windows:
-  #         requires:
-  #           - lint
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - main
-
-  # integration:
-  #   jobs:
-  #     - lint
-  #     - frontend-cache:
-  #         requires:
-  #           - lint
-  #     - ember-build-prod:
-  #         requires:
-  #           - frontend-cache
-  #     - build-static-assets:
-  #         requires:
-  #           - ember-build-prod
-  #     - dev-build:
-  #         requires:
-  #           - build-static-assets
-  #     - publish-static-assets:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
-  #         requires:
-  #           - build-static-assets
-  #     - integration:
-  #         requires:
-  #           - dev-build
-  #     - image-release:
-  #         requires:
-  #           - integration
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
-
-  e2e:
+  go-tests:
     jobs:
-      - dev-build
-      - e2e-docker:
+      - lint
+      - check-vendor:
+          requires:
+            - lint
+      - go-test:
+          requires:
+            - lint
+      - dev-build:
+          requires:
+            - lint
+          filters:
+            branches:
+              ignore:
+                - main
+      - dev-build-windows:
+          requires:
+            - lint
+          filters:
+            branches:
+              ignore:
+                - main
+
+  integration:
+    jobs:
+      - lint
+      - frontend-cache:
+          requires:
+            - lint
+      - ember-build-prod:
+          requires:
+            - frontend-cache
+      - build-static-assets:
+          requires:
+            - ember-build-prod
+      - dev-build:
+          requires:
+            - build-static-assets
+      - publish-static-assets:
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - build-static-assets
+      - integration:
           requires:
             - dev-build
+      - image-release:
+          requires:
+            - integration
+          filters:
+            branches:
+              only:
+                - main
+      - e2e-docker:
+          requires:
+            - image-release
+          filters:
+            branches:
+              only:
+                - main
 
-  # website-mdx:
-  #   jobs:
-  #     - generate-website-mdx:
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - main
-  #     - check-website-mdx:
-  #         requires:
-  #           - generate-website-mdx
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - main
+  website-mdx:
+    jobs:
+      - generate-website-mdx:
+          filters:
+            branches:
+              ignore:
+                - main
+      - check-website-mdx:
+          requires:
+            - generate-website-mdx
+          filters:
+            branches:
+              ignore:
+                - main
 
-  # frontend:
-  #   jobs:
-  #     - frontend-cache
-  #     - frontend-lint:
-  #         requires:
-  #           - frontend-cache
-  #     - ember-build-tests:
-  #         requires:
-  #           - frontend-lint
-  #     - ember-test:
-  #         requires:
-  #           - ember-build-tests
+  frontend:
+    jobs:
+      - frontend-cache
+      - frontend-lint:
+          requires:
+            - frontend-cache
+      - ember-build-tests:
+          requires:
+            - frontend-lint
+      - ember-test:
+          requires:
+            - ember-build-tests
 
 commands:
   md5uilib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ references:
     BASH_ENV: /home/circleci/project/.circleci/bash_env.sh
     DOCKER_BUILDKIT: 1
 
+  e2e-env: &e2e-env
+    WP_SERVERIMAGE_UPGRADE: blah
+
 jobs:
   # Runs Go linters
   lint:
@@ -247,6 +250,8 @@ jobs:
     # things, whereas k3s does not like the updated docker things; le sigh
     machine:
       image: ubuntu-2204:current
+    environment:
+      <<: *e2e-env
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ references:
     BASH_ENV: /home/circleci/project/.circleci/bash_env.sh
     DOCKER_BUILDKIT: 1
 
-  e2e-env: &e2e-env
-    WP_SERVERIMAGE_UPGRADE: blah
-
 jobs:
   # Runs Go linters
   lint:
@@ -251,7 +248,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
     environment:
-      <<: *e2e-env
+      E2E_PLATFORM: "Docker"
     steps:
       - checkout
       - attach_workspace:
@@ -268,13 +265,8 @@ jobs:
             rm -rf /tmp/golang.tar.gz
             go version
       - run:
-          name: Execute Integration Tests
-          command: |
-            echo "===> Set env vars"
-            export E2E_PLATFORM=Docker
-            export WP_BINARY="$(pwd)/waypoint"
-            echo "===> Run tests"
-            ./test-e2e/run-test.sh
+          name: Execute E2E Docker Tests
+          command: ./test-e2e/run-test.sh
       - notify_main_failure
 
   image-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,15 +242,20 @@ jobs:
       - notify_main_failure
 
   e2e-docker:
+    # we use the latest version of ubuntu on circleci here, as opposed to the 2004
+    # version that our integration test uses, because we need the updated docker
+    # things, whereas k3s does not like the updated docker things; le sigh
     machine:
       image: ubuntu-2204:current
     steps:
       - checkout
       - attach_workspace:
           at: .
+      # This is just to remind ourselves of what version of Go is default
+      # on this machine image; currently it's 1.18, but we should use 1.17
       - run: go version
       - run:
-          name: Install go
+          name: Install go v1.17.6
           command: |
             curl -SL --fail -o /tmp/golang.tar.gz https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	dockerTestDir = fmt.Sprintf("%s/docker/go", examplesRootDir)
-	// dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
+	dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
 )
 
 func TestWaypointDockerInstall(t *testing.T) {
@@ -59,36 +59,36 @@ func TestWaypointDockerUp(t *testing.T) {
 	}
 }
 
-// func TestWaypointDockerMultiAppUp(t *testing.T) {
-// 	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
-// 	stdout, stderr, err := wp.RunRaw("init")
+func TestWaypointDockerMultiAppUp(t *testing.T) {
+	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+	stdout, stderr, err := wp.RunRaw("init")
 
-// 	if err != nil {
-// 		t.Errorf("unexpected error initializing waypoint project: %s", err)
-// 	}
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
 
-// 	if stderr != "" {
-// 		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
-// 	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
 
-// 	if !strings.Contains(stdout, "Project initialized!") {
-// 		t.Errorf("No success message detected after initializing project:\n%s", stdout)
-// 	}
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
 
-// 	stdout, stderr, err = wp.RunRaw("up")
+	stdout, stderr, err = wp.RunRaw("up")
 
-// 	if err != nil {
-// 		t.Errorf("unexpected error deploying waypoint project: %s", err)
-// 	}
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
 
-// 	if stderr != "" {
-// 		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
-// 	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
 
-// 	if !strings.Contains(stdout, "The deploy was successful!") {
-// 		t.Errorf("No success message detected after deploying project:\n%s", stdout)
-// 	}
-// }
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
 
 func TestWaypointDockerUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
@@ -124,36 +124,36 @@ func TestWaypointDockerUpAfterUpgrade(t *testing.T) {
 	}
 }
 
-// func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
-// 	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
-// 	stdout, stderr, err := wp.RunRaw("init")
+func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
+	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+	stdout, stderr, err := wp.RunRaw("init")
 
-// 	if err != nil {
-// 		t.Errorf("unexpected error initializing waypoint project: %s", err)
-// 	}
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
 
-// 	if stderr != "" {
-// 		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
-// 	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
 
-// 	if !strings.Contains(stdout, "Project initialized!") {
-// 		t.Errorf("No success message detected after initializing project:\n%s", stdout)
-// 	}
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
 
-// 	stdout, stderr, err = wp.RunRaw("up")
+	stdout, stderr, err = wp.RunRaw("up")
 
-// 	if err != nil {
-// 		t.Errorf("unexpected error deploying waypoint project: %s", err)
-// 	}
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
 
-// 	if stderr != "" {
-// 		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
-// 	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
 
-// 	if !strings.Contains(stdout, "The deploy was successful!") {
-// 		t.Errorf("No success message detected after deploying project:\n%s", stdout)
-// 	}
-// }
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
 
 func TestWaypointDockerDestroy(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -8,12 +8,12 @@ import (
 
 var (
 	dockerTestDir = fmt.Sprintf("%s/docker/go", examplesRootDir)
-	dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
+	// dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
 )
 
 func TestWaypointDockerInstall(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
-	stdout, stderr, err := wp.RunRaw("install", "-platform=docker", "-accept-tos", fmt.Sprintf("-docker-server-image=%s", wpServerImage))
+	stdout, stderr, err := wp.RunRaw("install", "-platform=docker", "-accept-tos", fmt.Sprintf("-docker-server-image=%s", wpServerImage), fmt.Sprintf("-docker-odr-image=%s", wpOdrImage))
 
 	if err != nil {
 		t.Errorf("unexpected error installing server to docker: %s", err)
@@ -59,40 +59,40 @@ func TestWaypointDockerUp(t *testing.T) {
 	}
 }
 
-func TestWaypointDockerMultiAppUp(t *testing.T) {
-	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
-	stdout, stderr, err := wp.RunRaw("init")
+// func TestWaypointDockerMultiAppUp(t *testing.T) {
+// 	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+// 	stdout, stderr, err := wp.RunRaw("init")
 
-	if err != nil {
-		t.Errorf("unexpected error initializing waypoint project: %s", err)
-	}
+// 	if err != nil {
+// 		t.Errorf("unexpected error initializing waypoint project: %s", err)
+// 	}
 
-	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
-	}
+// 	if stderr != "" {
+// 		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+// 	}
 
-	if !strings.Contains(stdout, "Project initialized!") {
-		t.Errorf("No success message detected after initializing project:\n%s", stdout)
-	}
+// 	if !strings.Contains(stdout, "Project initialized!") {
+// 		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+// 	}
 
-	stdout, stderr, err = wp.RunRaw("up")
+// 	stdout, stderr, err = wp.RunRaw("up")
 
-	if err != nil {
-		t.Errorf("unexpected error deploying waypoint project: %s", err)
-	}
+// 	if err != nil {
+// 		t.Errorf("unexpected error deploying waypoint project: %s", err)
+// 	}
 
-	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
-	}
+// 	if stderr != "" {
+// 		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+// 	}
 
-	if !strings.Contains(stdout, "The deploy was successful!") {
-		t.Errorf("No success message detected after deploying project:\n%s", stdout)
-	}
-}
+// 	if !strings.Contains(stdout, "The deploy was successful!") {
+// 		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+// 	}
+// }
 
 func TestWaypointDockerUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
-	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=docker", "-auto-approve", fmt.Sprintf("-docker-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=docker", "-auto-approve", fmt.Sprintf("-docker-server-image=%s", wpServerImageUpgrade), fmt.Sprintf("-docker-odr-image=%s", wpOdrImageUpgrade), "-snapshot=false")
 
 	if err != nil {
 		t.Errorf("unexpected error upgrading server in docker: %s", err)
@@ -124,36 +124,36 @@ func TestWaypointDockerUpAfterUpgrade(t *testing.T) {
 	}
 }
 
-func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
-	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
-	stdout, stderr, err := wp.RunRaw("init")
+// func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
+// 	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+// 	stdout, stderr, err := wp.RunRaw("init")
 
-	if err != nil {
-		t.Errorf("unexpected error initializing waypoint project: %s", err)
-	}
+// 	if err != nil {
+// 		t.Errorf("unexpected error initializing waypoint project: %s", err)
+// 	}
 
-	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
-	}
+// 	if stderr != "" {
+// 		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+// 	}
 
-	if !strings.Contains(stdout, "Project initialized!") {
-		t.Errorf("No success message detected after initializing project:\n%s", stdout)
-	}
+// 	if !strings.Contains(stdout, "Project initialized!") {
+// 		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+// 	}
 
-	stdout, stderr, err = wp.RunRaw("up")
+// 	stdout, stderr, err = wp.RunRaw("up")
 
-	if err != nil {
-		t.Errorf("unexpected error deploying waypoint project: %s", err)
-	}
+// 	if err != nil {
+// 		t.Errorf("unexpected error deploying waypoint project: %s", err)
+// 	}
 
-	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
-	}
+// 	if stderr != "" {
+// 		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+// 	}
 
-	if !strings.Contains(stdout, "The deploy was successful!") {
-		t.Errorf("No success message detected after deploying project:\n%s", stdout)
-	}
-}
+// 	if !strings.Contains(stdout, "The deploy was successful!") {
+// 		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+// 	}
+// }
 
 func TestWaypointDockerDestroy(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	dockerTestDir = fmt.Sprintf("%s/docker/go", examplesRootDir)
+	dockerTestDir         = fmt.Sprintf("%s/docker/go", examplesRootDir)
 	dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
 )
 

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	dockerTestDir = fmt.Sprintf("%s/docker/go", examplesRootDir)
+	dockerMultiAppTestDir = fmt.Sprintf("%s/docker/go-multiapp", examplesRootDir)
 )
 
 func TestWaypointDockerInstall(t *testing.T) {
@@ -58,6 +59,37 @@ func TestWaypointDockerUp(t *testing.T) {
 	}
 }
 
+func TestWaypointDockerMultiAppUp(t *testing.T) {
+	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+	stdout, stderr, err := wp.RunRaw("init")
+
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
+
+	stdout, stderr, err = wp.RunRaw("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
 func TestWaypointDockerUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
 	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=docker", "-auto-approve", fmt.Sprintf("-docker-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
@@ -78,6 +110,37 @@ func TestWaypointDockerUpgrade(t *testing.T) {
 func TestWaypointDockerUpAfterUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
 	stdout, stderr, err := wp.RunRaw("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
+	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+	stdout, stderr, err := wp.RunRaw("init")
+
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
+
+	stdout, stderr, err = wp.RunRaw("up")
 
 	if err != nil {
 		t.Errorf("unexpected error deploying waypoint project: %s", err)

--- a/test-e2e/ecs_smoke_test.go
+++ b/test-e2e/ecs_smoke_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	ecsTestDir = fmt.Sprintf("%s/ecs/nodejs", examplesRootDir)
+	// this one uses python instead of node just for kicks
+	ecsTestDir = fmt.Sprintf("%s/aws/aws-ecs/python", examplesRootDir)
 )
 
 func TestWaypointEcsInstall(t *testing.T) {

--- a/test-e2e/ecs_smoke_test.go
+++ b/test-e2e/ecs_smoke_test.go
@@ -13,7 +13,7 @@ var (
 
 func TestWaypointEcsInstall(t *testing.T) {
 	wp := NewBinary(t, wpBinary, ecsTestDir)
-	stdout, stderr, err := wp.RunRaw("install", "-platform=ecs", "-accept-tos", fmt.Sprintf("-ecs-server-image=%s", wpServerImage))
+	stdout, stderr, err := wp.RunRaw("install", "-platform=ecs", "-accept-tos", fmt.Sprintf("-ecs-server-image=%s", wpServerImage), fmt.Sprintf("-ecs-odr-image=%s", wpOdrImage))
 
 	if err != nil {
 		t.Errorf("unexpected error installing server to ecs: %s", err)
@@ -61,7 +61,7 @@ func TestWaypointEcsUp(t *testing.T) {
 
 func TestWaypointEcsUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, ecsTestDir)
-	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=ecs", "-auto-approve", fmt.Sprintf("-ecs-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=ecs", "-auto-approve", fmt.Sprintf("-ecs-server-image=%s", wpServerImageUpgrade), fmt.Sprintf("-ecs-odr-image=%s", wpOdrImageUpgrade), "-snapshot=false")
 
 	if err != nil {
 		t.Errorf("unexpected error upgrading server in ecs: %s", err)

--- a/test-e2e/ecs_smoke_test.go
+++ b/test-e2e/ecs_smoke_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	ecsTestDir = fmt.Sprintf("%s/ecs/nodejs", examplesRootDir)
+)
+
+func TestWaypointEcsInstall(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("install", "-platform=ecs", "-accept-tos", fmt.Sprintf("-ecs-server-image=%s", wpServerImage))
+
+	if err != nil {
+		t.Errorf("unexpected error installing server to ecs: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output installing server to ecs: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
+		t.Errorf("No success message detected after ecs server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointEcsUp(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("init")
+
+	if err != nil {
+		t.Errorf("unexpected error initializing waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Project initialized!") {
+		t.Errorf("No success message detected after initializing project:\n%s", stdout)
+	}
+
+	stdout, stderr, err = wp.RunRaw("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointEcsUpgrade(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=ecs", "-auto-approve", fmt.Sprintf("-ecs-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error upgrading server in ecs: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output upgrading server in ecs: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
+		t.Errorf("No success message detected after ecs server install:\n%s", stdout)
+	}
+}
+
+func TestWaypointEcsUpAfterUpgrade(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("up")
+
+	if err != nil {
+		t.Errorf("unexpected error deploying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "The deploy was successful!") {
+		t.Errorf("No success message detected after deploying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointEcsDestroy(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("destroy")
+
+	if err != nil {
+		t.Errorf("unexpected error destroying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Destroy successful!") {
+		t.Errorf("No success message detected after destroying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointEcsUninstall(t *testing.T) {
+	wp := NewBinary(t, wpBinary, ecsTestDir)
+	stdout, stderr, err := wp.RunRaw("server", "uninstall", "-platform=ecs", "-auto-approve", "-snapshot=false")
+
+	if err != nil {
+		t.Errorf("unexpected error uninstalling waypoint server: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {
+		t.Errorf("No success message detected after uninstalling server:\n%s", stdout)
+	}
+}

--- a/test-e2e/k8s_smoke_test.go
+++ b/test-e2e/k8s_smoke_test.go
@@ -12,7 +12,7 @@ var (
 
 func TestWaypointKubernetesInstall(t *testing.T) {
 	wp := NewBinary(t, wpBinary, kubernetesTestDir)
-	stdout, stderr, err := wp.RunRaw("install", "-platform=kubernetes", "-accept-tos", fmt.Sprintf("-k8s-server-image=%s", wpServerImage))
+	stdout, stderr, err := wp.RunRaw("install", "-platform=kubernetes", "-accept-tos", fmt.Sprintf("-k8s-server-image=%s", wpServerImage), fmt.Sprintf("-k8s-odr-image=%s", wpOdrImage))
 
 	if err != nil {
 		t.Errorf("unexpected error installing server to kubernetes: %s", err)
@@ -60,7 +60,7 @@ func TestWaypointKubernetesUp(t *testing.T) {
 
 func TestWaypointKubernetesUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, kubernetesTestDir)
-	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=kubernetes", "-auto-approve", fmt.Sprintf("-k8s-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=kubernetes", "-auto-approve", fmt.Sprintf("-k8s-server-image=%s", wpServerImageUpgrade), fmt.Sprintf("-k8s-odr-image=%s", wpOdrImageUpgrade), "-snapshot=false")
 
 	if err != nil {
 		t.Errorf("unexpected error upgrading server in kubernetes: %s", err)

--- a/test-e2e/nomad_smoke_test.go
+++ b/test-e2e/nomad_smoke_test.go
@@ -12,7 +12,7 @@ var (
 
 func TestWaypointNomadInstall(t *testing.T) {
 	wp := NewBinary(t, wpBinary, nomadTestDir)
-	stdout, stderr, err := wp.RunRaw("install", "-platform=nomad", "-accept-tos", fmt.Sprintf("-nomad-server-image=%s", wpServerImage))
+	stdout, stderr, err := wp.RunRaw("install", "-platform=nomad", "-accept-tos", fmt.Sprintf("-nomad-server-image=%s", wpServerImage), fmt.Sprintf("-nomad-odr-image=%s", wpOdrImage))
 
 	if err != nil {
 		t.Errorf("unexpected error installing server to nomad: %s", err)
@@ -60,7 +60,7 @@ func TestWaypointNomadUp(t *testing.T) {
 
 func TestWaypointNomadUpgrade(t *testing.T) {
 	wp := NewBinary(t, wpBinary, nomadTestDir)
-	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=nomad", "-auto-approve", fmt.Sprintf("-nomad-server-image=%s", wpServerImageUpgrade), "-snapshot=false")
+	stdout, stderr, err := wp.RunRaw("server", "upgrade", "-platform=nomad", "-auto-approve", fmt.Sprintf("-nomad-server-image=%s", wpServerImageUpgrade), fmt.Sprintf("-nomad-odr-image=%s", wpOdrImageUpgrade), "-snapshot=false")
 
 	if err != nil {
 		t.Errorf("unexpected error upgrading server in nomad: %s", err)

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -26,11 +26,6 @@ if [ "${E2E_PLATFORM}" != "Docker" ] && [ "${E2E_PLATFORM}" != "Kubernetes" ] &&
   exit 1
 fi
 
-if [ -z "$WP_SERVERIMAGE_UPGRADE" ]; then
-  echo "Env var 'WP_SERVERIMAGE_UPGRADE' must be set (e.g. 'hashicorp/waypoint:latest')"
-  exit 1
-fi
-
 # For running script outside of `test-e2e` folder
 TESTDIR="${WP_TESTE2E_DIR:-$(pwd)}"
 

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -20,6 +20,11 @@ spin()
 echo "Beginning Waypoint end-to-end tests..."
 echo
 
+if [ "${E2E_PLATFORM}" != "Docker" ] && [ "${E2E_PLATFORM}" != "Kubernetes" ] && [ "${E2E_PLATFORM}" != "Ecs" ] && [ "${E2E_PLATFORM}" != "Nomad" ]; then
+  echo "Environment variable 'E2E_PLATFORM' must be one of: 'Docker', 'Kubernetes', 'Ecs', 'Nomad'"
+  exit 1
+fi
+
 # For running script outside of `test-e2e` folder
 TESTDIR="${WP_TESTE2E_DIR:-$(pwd)}"
 
@@ -77,7 +82,7 @@ fi
 # Test env vars
 export WP_BINARY="$TESTDIR/waypoint"
 export WP_SERVERIMAGE="hashicorp/waypoint:latest"
-export WP_SERVERIMAGE_UPGRADE="waypoint:dev"
+export WP_SERVERIMAGE_UPGRADE="hashicorp/waypoint:latest"
 
 # 
 
@@ -91,11 +96,21 @@ echo
 if [ -z "$CI_ENV" ]; then
   spin &
   SPIN_PID=$!
-  trap "kill -9 $SPIN_PID" `seq 0 15`
+  trap 'kill -9 $SPIN_PID' $(seq 0 15)
 fi
 
-go test -v "github.com/hashicorp/waypoint/test-e2e"
+# Run Docker tests
+go test -v "github.com/hashicorp/waypoint/test-e2e" -run "$E2E_PLATFORM"
 testResult=$?
+
+# Set up Nomad
+# Run Nomad tests
+
+# Set up K8S/K3S
+# Run K8S tests
+
+# Set up ECS
+# Run ECS tests
 
 if [[ "$testResult" -eq 0 ]]; then
   echo

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -26,6 +26,11 @@ if [ "${E2E_PLATFORM}" != "Docker" ] && [ "${E2E_PLATFORM}" != "Kubernetes" ] &&
   exit 1
 fi
 
+if [ -z "$WP_SERVERIMAGE_UPGRADE" ]; then
+  echo "Env var 'WP_SERVERIMAGE_UPGRADE' must be set (e.g. 'hashicorp/waypoint:latest')"
+  exit 1
+fi
+
 # For running script outside of `test-e2e` folder
 TESTDIR="${WP_TESTE2E_DIR:-$(pwd)}"
 
@@ -50,7 +55,9 @@ export OUTDIR="build/${GOOS}_${GOARCH}"
 # Test env vars
 export WP_BINARY="${WP_BINARY:-$TESTDIR/waypoint}"
 export WP_SERVERIMAGE="hashicorp/waypoint:latest"
-export WP_SERVERIMAGE_UPGRADE="hashicorp/waypoint:latest"
+export WP_ODRIMAGE="hashicorp/waypoint-odr:latest"
+export WP_SERVERIMAGE_UPGRADE="ghcr.io/hashicorp/waypoint/alpha:latest"
+export WP_ODRIMAGE_UPGRADE="ghcr.io/hashicorp/waypoint/alpha-odr:latest"
 
 if [ -z "$WP_EXAMPLES_PATH" ]; then
   echo "WP_EXAMPLES_PATH unset; setting to ${TESTDIR}/waypoint-examples"

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -52,12 +52,8 @@ export GOARCH="$(go env GOARCH)"
 export GOEXE="$(go env GOEXE)"
 export OUTDIR="build/${GOOS}_${GOARCH}"
 
-# Test env vars
+# Target working directory for the binary location if not specified
 export WP_BINARY="${WP_BINARY:-$TESTDIR/waypoint}"
-export WP_SERVERIMAGE="hashicorp/waypoint:latest"
-export WP_ODRIMAGE="hashicorp/waypoint-odr:latest"
-export WP_SERVERIMAGE_UPGRADE="ghcr.io/hashicorp/waypoint/alpha:latest"
-export WP_ODRIMAGE_UPGRADE="ghcr.io/hashicorp/waypoint/alpha-odr:latest"
 
 if [ -z "$WP_EXAMPLES_PATH" ]; then
   echo "WP_EXAMPLES_PATH unset; setting to ${TESTDIR}/waypoint-examples"

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -34,9 +34,6 @@ echo
 
 make tools
 
-echo "Skipping for now"
-echo
-
 # TODO: install packages for building waypoint and running supported platforms:
 # - git, curl, (probably more)
 # - golang

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # Waypoint end to end test runner
 
@@ -31,6 +32,8 @@ TESTDIR="${WP_TESTE2E_DIR:-$(pwd)}"
 echo "==> Installing dependencies..."
 echo
 
+make tools
+
 echo "Skipping for now"
 echo
 
@@ -47,17 +50,26 @@ export GOARCH="$(go env GOARCH)"
 export GOEXE="$(go env GOEXE)"
 export OUTDIR="build/${GOOS}_${GOARCH}"
 
+# Test env vars
+export WP_BINARY="${WP_BINARY:-$TESTDIR/waypoint}"
+export WP_SERVERIMAGE="hashicorp/waypoint:latest"
+export WP_SERVERIMAGE_UPGRADE="hashicorp/waypoint:latest"
+
 if [ -z "$WP_EXAMPLES_PATH" ]; then
   echo "WP_EXAMPLES_PATH unset; setting to ${TESTDIR}/waypoint-examples"
   export WP_EXAMPLES_PATH="${TESTDIR}/waypoint-examples"
 fi
 
-echo "==> Building waypoint binary..."
-echo
-
-echo "Skipping for now"
-echo "Assuming waypoint is available on the path"
-echo
+echo "==> Checking if Waypoint binary is built..."
+if [ -f "${WP_BINARY}" ]; then
+  "${WP_BINARY}" version
+  echo
+else
+  echo "==> Building waypoint binary..."
+  echo
+  make
+  echo
+fi
 
 # TODO: build waypoint OR download a package, add a switch for this
 #   - add param for installing a certain waypoint server, allow install from alpha package
@@ -78,11 +90,6 @@ else
   echo "==> Using existing waypoint-examples repo for test..."
   echo
 fi
-
-# Test env vars
-export WP_BINARY="$TESTDIR/waypoint"
-export WP_SERVERIMAGE="hashicorp/waypoint:latest"
-export WP_SERVERIMAGE_UPGRADE="hashicorp/waypoint:latest"
 
 # 
 

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -20,7 +20,7 @@ import (
 // Test config settings used by the tests
 var (
 	wpBinary             = Getenv("WP_BINARY", "waypoint")
-	wpServerImage        = Getenv("WP_SERVERIMAGE", "hashicorp/waypoint:0.2.0")
+	wpServerImage        = Getenv("WP_SERVERIMAGE", "hashicorp/waypoint:latest")
 	wpServerImageUpgrade = Getenv("WP_SERVERIMAGE_UPGRADE", "hashicorp/waypoint:latest")
 
 	examplesRootDir = Getenv("WP_EXAMPLES_PATH", "waypoint-examples")

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -21,7 +21,9 @@ import (
 var (
 	wpBinary             = Getenv("WP_BINARY", "waypoint")
 	wpServerImage        = Getenv("WP_SERVERIMAGE", "hashicorp/waypoint:latest")
-	wpServerImageUpgrade = Getenv("WP_SERVERIMAGE_UPGRADE", "hashicorp/waypoint:latest")
+	wpOdrImage           = Getenv("WP_ODRIMAGE", "hashicorp/waypoint-odr:latest")
+	wpServerImageUpgrade = Getenv("WP_SERVERIMAGE_UPGRADE", "ghcr.io/hashicorp/waypoint/alpha:latest")
+	wpOdrImageUpgrade    = Getenv("WP_ODRIMAGE_UPGRADE", "ghcr.io/hashicorp/waypoint/alpha-odr:latest")
 
 	examplesRootDir = Getenv("WP_EXAMPLES_PATH", "waypoint-examples")
 )


### PR DESCRIPTION
This fixes up a few things in our bash setup for e2e to run in CI, and adds support initially for the Docker platform.
Other platforms will be tracked in #3597. This base test case would have caught some of the edge cases we've missed in recent pre-release testing, so it's good to get this in as a starting point.

Since I've now set these to run only on `main` after an image is built off of `main`, look at [the second-to-last workflow](https://app.circleci.com/pipelines/github/hashicorp/waypoint/17223/workflows/b069f1e5-7c28-434f-b5aa-1a3c4d6f6b48) for the example run.