### PR TITLE
Base init load fix

### DIFF
--- a/.changelog/3657.txt
+++ b/.changelog/3657.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Fix issue where the CLI would exit with no error or action taken if a local
+  waypoint.hcl file was invalid
+```

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -52,7 +52,7 @@ func (c *baseCommand) initConfigLoad(path string) (*configpkg.Config, configpkg.
 		Workspace: c.refWorkspace.Workspace,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, []configpkg.ValidationResult{{Error: err}}, err
 	}
 
 	// Validate
@@ -60,7 +60,6 @@ func (c *baseCommand) initConfigLoad(path string) (*configpkg.Config, configpkg.
 	if err != nil {
 		return nil, results, err
 	}
-
 	return cfg, results, nil
 }
 

--- a/internal/cli/testdata/invalid.hcl
+++ b/internal/cli/testdata/invalid.hcl
@@ -1,0 +1,17 @@
+project = "test-project"
+app "web" {
+    build {
+        use "docker" {}
+    }
+
+    # Deploy to Docker
+    deploy {
+        use "docker" {}
+    }
+}
+
+variable "port" {
+  type = number
+  default = 1
+  default = 2
+}

--- a/internal/cli/testdata/valid.hcl
+++ b/internal/cli/testdata/valid.hcl
@@ -1,0 +1,17 @@
+project = "test-project"
+app "web" {
+    build {
+        use "docker" {}
+    }
+
+    # Deploy to Docker
+    deploy {
+        use "docker" {}
+    }
+}
+
+variable "port" {
+  type = number
+  default = 1
+  # default = 2
+}


### PR DESCRIPTION
Fixed a regression introduced in or around https://github.com/hashicorp/waypoint/pull/3605 when if a **local** `waypoint.hcl` file in the current directory had a validation error, the resulting error would not be converted to a validation result, and was then swallowed and never shown to the user. 

The result would be an empty reply from the CLI with no operation or messages:

```terminal
$> waypoint up


$> waypoint deployment list


$> waypoint deployment list -vvv
2022-08-08T17:02:19.550-0500 [INFO]  waypoint: waypoint version: full_string="v0.9.0-313-g1a48c27c4 (1a48c27c4+CHANGES)" version=v0.9.0-313-g1a48c27c4 prerelease="" metadata="" revision=1a48c27c4+CHANGES
2022-08-08T17:02:19.550-0500 [TRACE] waypoint: starting interrupt listener for context cancellation
2022-08-08T17:02:19.550-0500 [TRACE] waypoint: interrupt listener goroutine started
2022-08-08T17:02:19.550-0500 [DEBUG] waypoint: home configuration directory: path=/Users/clint/Library/Preferences/waypoint

2022-08-08T17:02:19.552-0500 [TRACE] waypoint: stopping signal listeners and cancelling the context

$>
```

This *should* only be present in the situation where the local file in the current directory has a validation error. If the `waypoint.hcl` file a remote repo contained the invalid HCL, the remote runners correctly surfaced the error to the user. 

Updated output after this change using a file with 2 `default` values specified in a single `waypoint.hcl` variable block:

```
$> waypoint deployment list
» The following validation issues were detected:
! /Users/clint/go-src/github.com/catsby/waypoint-webapp-go/waypoint.hcl:154,3-10: Attribute redefined; The argument "default" was already set at /Users/clint/go-src/github.com/catsby/waypoint-webapp-go/waypoint.hcl:153,3-10. Each argument may be set only
once.
```

~CHANGELOG entry coming~ added