### PR TITLE
Explicitly returning ODR config when setting it in state

### DIFF
--- a/pkg/server/singleprocess/service_ondemand_runner.go
+++ b/pkg/server/singleprocess/service_ondemand_runner.go
@@ -25,8 +25,9 @@ func (s *Service) UpsertOnDemandRunnerConfig(
 			Target: &pb.Ref_Runner_Any{},
 		}
 	}
-	result := req.Config
-	if err := s.state(ctx).OnDemandRunnerConfigPut(result); err != nil {
+
+	result, err := s.state(ctx).OnDemandRunnerConfigPut(req.Config);
+	if err != nil {
 		return nil, hcerr.Externalize(log, err, "failed setting on-demand runner config", "id", result.Id, "name", result.Name)
 	}
 

--- a/pkg/server/singleprocess/service_ondemand_runner.go
+++ b/pkg/server/singleprocess/service_ondemand_runner.go
@@ -26,9 +26,9 @@ func (s *Service) UpsertOnDemandRunnerConfig(
 		}
 	}
 
-	result, err := s.state(ctx).OnDemandRunnerConfigPut(req.Config);
+	result, err := s.state(ctx).OnDemandRunnerConfigPut(req.Config)
 	if err != nil {
-		return nil, hcerr.Externalize(log, err, "failed setting on-demand runner config", "id", result.Id, "name", result.Name)
+		return nil, hcerr.Externalize(log, err, "failed setting on-demand runner config", "id", req.Config.Id, "name", req.Config.Name)
 	}
 
 	return &pb.UpsertOnDemandRunnerConfigResponse{Config: result}, nil

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -52,7 +52,7 @@ type Interface interface {
 	RunnerById(string, memdb.WatchSet) (*pb.Runner, error)
 	RunnerList() ([]*pb.Runner, error)
 
-	OnDemandRunnerConfigPut(*pb.OnDemandRunnerConfig) error
+	OnDemandRunnerConfigPut(*pb.OnDemandRunnerConfig) (*pb.OnDemandRunnerConfig, error)
 	OnDemandRunnerConfigGet(*pb.Ref_OnDemandRunnerConfig) (*pb.OnDemandRunnerConfig, error)
 	OnDemandRunnerConfigDelete(*pb.Ref_OnDemandRunnerConfig) error
 	OnDemandRunnerConfigList() ([]*pb.OnDemandRunnerConfig, error)

--- a/pkg/serverstate/statetest/test_runner_ondemand.go
+++ b/pkg/serverstate/statetest/test_runner_ondemand.go
@@ -27,12 +27,33 @@ func TestOnDemandRunnerConfig(t *testing.T, factory Factory, restartF RestartFac
 		defer s.Close()
 
 		// Set
-		ret, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{
+		_, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{
 			Id: "foo",
 		})
 		require.Error(err)
 		require.Equal(codes.NotFound, status.Code(err))
-		require.Equal(ret.Name, "foo")
+	})
+
+	t.Run("Set with no name", func(t *testing.T) {
+		require := require.New(t)
+
+		s := factory(t)
+		defer s.Close()
+
+		// Set
+		rec := serverptypes.TestOnDemandRunnerConfig(t, &pb.OnDemandRunnerConfig{
+			OciUrl:               "h/w:s",
+			EnvironmentVariables: map[string]string{"CONTAINER": "DOCKER", "FOO": "BAR"},
+			TargetRunner:         &pb.Ref_Runner{Target: &pb.Ref_Runner_Any{Any: &pb.Ref_RunnerAny{}}},
+			PluginConfig:         []byte(`{"foo":"bar"}`),
+			ConfigFormat:         pb.Hcl_JSON,
+			Default:              true,
+		})
+
+		result, err := s.OnDemandRunnerConfigPut(rec)
+		require.NoError(err)
+		require.NotEmpty(result.Id)
+		require.NotEmpty(result.Name)
 	})
 
 	t.Run("Put and Get", func(t *testing.T) {

--- a/pkg/serverstate/statetest/test_runner_ondemand.go
+++ b/pkg/serverstate/statetest/test_runner_ondemand.go
@@ -27,11 +27,12 @@ func TestOnDemandRunnerConfig(t *testing.T, factory Factory, restartF RestartFac
 		defer s.Close()
 
 		// Set
-		_, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{
+		ret, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{
 			Id: "foo",
 		})
 		require.Error(err)
 		require.Equal(codes.NotFound, status.Code(err))
+		require.Equal(ret.Name, "foo")
 	})
 
 	t.Run("Put and Get", func(t *testing.T) {
@@ -51,7 +52,7 @@ func TestOnDemandRunnerConfig(t *testing.T, factory Factory, restartF RestartFac
 			Default:              true,
 		})
 
-		err := s.OnDemandRunnerConfigPut(rec)
+		_, err := s.OnDemandRunnerConfigPut(rec)
 		require.NoError(err)
 
 		// Get exact
@@ -108,7 +109,7 @@ func TestOnDemandRunnerConfig(t *testing.T, factory Factory, restartF RestartFac
 		// Set
 		rec := serverptypes.TestOnDemandRunnerConfig(t, serverptypes.TestOnDemandRunnerConfig(t, nil))
 
-		err := s.OnDemandRunnerConfigPut(rec)
+		_, err := s.OnDemandRunnerConfigPut(rec)
 		require.NoError(err)
 
 		// Read
@@ -165,7 +166,7 @@ func TestOnDemandRunnerConfig_LabelTargeting(t *testing.T, factory Factory, rest
 		},
 	})
 
-	err := s.OnDemandRunnerConfigPut(rec)
+	_, err := s.OnDemandRunnerConfigPut(rec)
 	require.NoError(err)
 
 	resp, err := s.OnDemandRunnerConfigGet(&pb.Ref_OnDemandRunnerConfig{


### PR DESCRIPTION
For better or worse, currently, we don't require that a user set an ODR config's name. If they call OnDemandRunnerConfigPut with no name OR id, it's OK, we'll generate an ID and use it as the name, then we return that ODR profile with the name and ID set.

The problem is, our state function wasn't returning an ODR profile with the name set - it was mutating the input, and relying on the server handler to know about it. If someone else were implementing a new state backend, the would have no way of knowing it was important to set the name on the input, and likely wouldn't. This bit us in HCP.

Now, state returns and explicit OnDemandRunnerConfig. A much more clear API contract.