### PR TITLE
Fixing inlinekeepalive early stream exit warning

### DIFF
--- a/pkg/inlinekeepalive/server.go
+++ b/pkg/inlinekeepalive/server.go
@@ -114,7 +114,10 @@ func KeepaliveServerStreamInterceptor(sendInterval time.Duration) grpc.StreamSer
 
 		// Only send keepalives if this is a server stream - not allowed otherwise
 		if info.IsServerStream && isClientCompatible(ctx) {
-			go ServeKeepalives(ctx, log, ss, sendInterval, sendMx)
+			go func() {
+				ServeKeepalives(ctx, log, ss, sendInterval, sendMx)
+				log.Trace("stopped sending inline keepalives")
+			}()
 		}
 
 		return handler(srv, &KeepaliveServerStream{


### PR DESCRIPTION
Prior to this, if a stream were to exit very quickly, we would fail our call to the server's GetVersionInfo due to context cancelled, and log a warning. This is actually fine - we can just stop setting up the inlinekeepalive logic, because there's no stream anymore!