### PR TITLE
e2e updates

### DIFF
--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -50,7 +50,7 @@ func TestWaypointAvailable(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output getting version: %s", err)
+		t.Errorf("unexpected stderr output getting version: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint v") {

--- a/test-e2e/cli_smoke.test.go
+++ b/test-e2e/cli_smoke.test.go
@@ -14,7 +14,7 @@ func TestWaypointInstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output getting version: %s", err)
+		t.Errorf("unexpected stderr output getting version: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint v") {

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -157,16 +157,14 @@ func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
 
 func TestWaypointDockerDestroy(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
-	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve", "-vvv")
+	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve")
 
 	if err != nil {
 		t.Errorf("unexpected error destroying waypoint project: %s", err)
 	}
 
 	if stderr != "" {
-		// t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
-		fmt.Println("got a stderr")
-		fmt.Println(stderr)
+		t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {
@@ -176,16 +174,14 @@ func TestWaypointDockerDestroy(t *testing.T) {
 
 func TestWaypointDockerDestroyMultiApp(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
-	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve", "-vvv")
+	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve")
 
 	if err != nil {
 		t.Errorf("unexpected error destroying waypoint project: %s", err)
 	}
 
 	if stderr != "" {
-		// t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
-		fmt.Println("got a stderr")
-		fmt.Println(stderr)
+		t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -133,7 +133,7 @@ func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -147,7 +147,7 @@ func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {

--- a/test-e2e/docker_smoke_test.go
+++ b/test-e2e/docker_smoke_test.go
@@ -20,7 +20,7 @@ func TestWaypointDockerInstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output installing server to docker: %s", err)
+		t.Errorf("unexpected stderr output installing server to docker: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
@@ -37,7 +37,7 @@ func TestWaypointDockerUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -51,7 +51,7 @@ func TestWaypointDockerUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -68,7 +68,7 @@ func TestWaypointDockerMultiAppUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -82,7 +82,7 @@ func TestWaypointDockerMultiAppUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -99,7 +99,7 @@ func TestWaypointDockerUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output upgrading server in docker: %s", err)
+		t.Errorf("unexpected stderr output upgrading server in docker: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
@@ -116,7 +116,7 @@ func TestWaypointDockerUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -157,14 +157,35 @@ func TestWaypointDockerMultiAppUpAfterUpgrade(t *testing.T) {
 
 func TestWaypointDockerDestroy(t *testing.T) {
 	wp := NewBinary(t, wpBinary, dockerTestDir)
-	stdout, stderr, err := wp.RunRaw("destroy")
+	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve", "-vvv")
 
 	if err != nil {
 		t.Errorf("unexpected error destroying waypoint project: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+		// t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
+		fmt.Println("got a stderr")
+		fmt.Println(stderr)
+	}
+
+	if !strings.Contains(stdout, "Destroy successful!") {
+		t.Errorf("No success message detected after destroying project:\n%s", stdout)
+	}
+}
+
+func TestWaypointDockerDestroyMultiApp(t *testing.T) {
+	wp := NewBinary(t, wpBinary, dockerMultiAppTestDir)
+	stdout, stderr, err := wp.RunRaw("destroy", "-auto-approve", "-vvv")
+
+	if err != nil {
+		t.Errorf("unexpected error destroying waypoint project: %s", err)
+	}
+
+	if stderr != "" {
+		// t.Errorf("unexpected stderr output destroying waypoint project: %v", stderr)
+		fmt.Println("got a stderr")
+		fmt.Println(stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {
@@ -181,7 +202,7 @@ func TestWaypointDockerUninstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {

--- a/test-e2e/ecs_smoke_test.go
+++ b/test-e2e/ecs_smoke_test.go
@@ -20,7 +20,7 @@ func TestWaypointEcsInstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output installing server to ecs: %s", err)
+		t.Errorf("unexpected stderr output installing server to ecs: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
@@ -37,7 +37,7 @@ func TestWaypointEcsUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -51,7 +51,7 @@ func TestWaypointEcsUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -68,7 +68,7 @@ func TestWaypointEcsUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output upgrading server in ecs: %s", err)
+		t.Errorf("unexpected stderr output upgrading server in ecs: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
@@ -85,7 +85,7 @@ func TestWaypointEcsUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -102,7 +102,7 @@ func TestWaypointEcsDestroy(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {
@@ -119,7 +119,7 @@ func TestWaypointEcsUninstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {

--- a/test-e2e/k8s_smoke_test.go
+++ b/test-e2e/k8s_smoke_test.go
@@ -19,7 +19,7 @@ func TestWaypointKubernetesInstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output installing server to kubernetes: %s", err)
+		t.Errorf("unexpected stderr output installing server to kubernetes: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
@@ -36,7 +36,7 @@ func TestWaypointKubernetesUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -50,7 +50,7 @@ func TestWaypointKubernetesUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -67,7 +67,7 @@ func TestWaypointKubernetesUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output upgrading server in kubernetes: %s", err)
+		t.Errorf("unexpected stderr output upgrading server in kubernetes: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
@@ -84,7 +84,7 @@ func TestWaypointKubernetesUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -101,7 +101,7 @@ func TestWaypointKubernetesDestroy(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {
@@ -118,7 +118,7 @@ func TestWaypointKubernetesUninstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {

--- a/test-e2e/nomad_smoke_test.go
+++ b/test-e2e/nomad_smoke_test.go
@@ -19,7 +19,7 @@ func TestWaypointNomadInstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output installing server to nomad: %s", err)
+		t.Errorf("unexpected stderr output installing server to nomad: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully installed and configured!") {
@@ -36,7 +36,7 @@ func TestWaypointNomadUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output initializing waypoint project: %s", err)
+		t.Errorf("unexpected stderr output initializing waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Project initialized!") {
@@ -50,7 +50,7 @@ func TestWaypointNomadUp(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -67,7 +67,7 @@ func TestWaypointNomadUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output upgrading server in nomad: %s", err)
+		t.Errorf("unexpected stderr output upgrading server in nomad: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint has finished upgrading the server") {
@@ -84,7 +84,7 @@ func TestWaypointNomadUpAfterUpgrade(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output deploying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output deploying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "The deploy was successful!") {
@@ -101,7 +101,7 @@ func TestWaypointNomadDestroy(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output destroying waypoint project: %s", err)
+		t.Errorf("unexpected stderr output destroying waypoint project: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Destroy successful!") {
@@ -118,7 +118,7 @@ func TestWaypointNomadUninstall(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", err)
+		t.Errorf("unexpected stderr output uninstalling waypoint server: %s", stderr)
 	}
 
 	if !strings.Contains(stdout, "Waypoint server successfully uninstalled") {

--- a/test-e2e/run-test.sh
+++ b/test-e2e/run-test.sh
@@ -95,7 +95,7 @@ echo
 # TODO: allow for running all platforms, or only certain ones
 
 # only spin for local devs running on machine to show tests aren't frozen
-if [ -z "$CI_ENV" ]; then
+if [ -z "$CI" ]; then
   spin &
   SPIN_PID=$!
   trap 'kill -9 $SPIN_PID' $(seq 0 15)
@@ -130,6 +130,6 @@ if [[ "$testResult" -eq 0 ]]; then
 fi
 
 # must be at end of script
-if [ -z "$CI_ENV" ]; then
+if [ -z "$CI" ]; then
   kill -9 $SPIN_PID
 fi


### PR DESCRIPTION
Ignore the branch name; there was no bug with the tests -- they found a real bug!

But this does fix the fact that when it found the bug, we weren't seeing the error message from `stderr`. Plus updating the `CI` env var so that we don't see the spinner output `|\-/|\-/|\-/|\-/---` prefixing the test results.

As these only run on main; see [this run](https://app.circleci.com/pipelines/github/hashicorp/waypoint/17378/workflows/557a7efd-a414-4c1b-8d73-d765526f2a93/jobs/186773) for the results of this PR.