### PR TITLE
chore(docs): add `kubectl delete rolebinding`

### DIFF
--- a/website/content/docs/troubleshooting.mdx
+++ b/website/content/docs/troubleshooting.mdx
@@ -65,6 +65,7 @@ $ kubectl delete sts waypoint-server
 $ kubectl delete pvc data-waypoint-server-0
 $ kubectl delete svc waypoint
 $ kubectl delete deploy waypoint-runner
+$ kubectl delete rolebinding waypoint-runner-rolebinding
 ```
 
 ## Pack Builder No Such Image


### PR DESCRIPTION
This adds an additional `kubectl` command to cleanup the role binding when "resetting"
- `kubectl delete rolebinding waypoint-runner-rolebinding`

```console
└─ χ waypoint server install \
  -accept-tos -platform=kubernetes
✓ Inspecting Kubernetes cluster
❌ Installing Waypoint Helm chart...
! Error installing server into kubernetes: rendered manifests contain a resource that already
exists. Unable to continue
  with install: RoleBinding "waypoint-runner-rolebinding" in namespace "default"
  exists and cannot be imported into the current release: invalid ownership
  metadata; label validation error: missing key "app.kubernetes.io/managed-by":
  must be set to "Helm"; annotation validation error: missing key
  "meta.helm.sh/release-name": must be set to "waypoint"; annotation validation
  error: missing key "meta.helm.sh/release-namespace": must be set to "default"
```