### PR TITLE
Remove PR template

### DIFF
--- a/ui/pull_request_template.md
+++ b/ui/pull_request_template.md
@@ -1,3 +1,0 @@
-## ✅ Reviewer's checklist
-
-- [ ] +1 Percy, if applicable


### PR DESCRIPTION
PR template firing only for changes to child /ui directory isn't a feature GitHub offers right now

Delete template as it will not fire, so it's less confusing

Resolves: https://github.com/hashicorp/waypoint/issues/3332