### PR TITLE
cli: Only display hint text if more than 0 default profiles on upgrade

### DIFF
--- a/.changelog/3688.txt
+++ b/.changelog/3688.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Only show runner profile default deletion hint if more than 0 default
+profiles are detected on upgrades.
+```

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -507,9 +507,11 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 				}
 			}
 
-			c.ui.Output("")
-			c.ui.Output(runnerMultiDefault, strings.Join(runnerDefaultNames[:], "\n"), strings.Join(runnerUnsetStr[:], "\n"), terminal.WithWarningStyle())
-			c.ui.Output("")
+			if len(runnerDefaultNames) > 0 {
+				c.ui.Output("")
+				c.ui.Output(runnerMultiDefault, strings.Join(runnerDefaultNames[:], "\n"), strings.Join(runnerUnsetStr[:], "\n"), terminal.WithWarningStyle())
+				c.ui.Output("")
+			}
 		}
 
 		// TODO(mitchellh): This creates a new auth token for the new runner.

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/waypoint/builtin/k8s"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/waypoint/builtin/k8s"
 
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
@@ -474,6 +475,9 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 					case "kubernetes":
 						// attempt to parse the runner profile config into the correct task launcher config struct
 						var result *k8s.TaskLauncherConfig
+						// NOTE(briancain): This is here due to a k8s task plugin bug. When
+						// we attempt to upgrade if we detect the previous mistake we warn
+						// users that certain key values in their plugin config are wrong.
 						if cfg.ConfigFormat == pb.Hcl_JSON {
 							err = json.Unmarshal(cfg.PluginConfig, result)
 							if err != nil {


### PR DESCRIPTION
Prior to this PR we would show a hint about removing multiple runner profile defaults even if none existed. This was a bug, so this PR fixes it to only show the warning if more than 0 profiles were detected on upgrades.

Fixes https://github.com/hashicorp/waypoint/issues/3663