### PR TITLE
ceb/config: Move reconnect log from Error to Warn

### DIFF
--- a/internal/ceb/config.go
+++ b/internal/ceb/config.go
@@ -320,7 +320,7 @@ func (ceb *CEB) recvConfig(
 			// If we get the unavailable error then the connection died.
 			// We restablish the connection.
 			if status.Code(err) == codes.Unavailable {
-				log.Error("ceb disconnected from server, attempting reconnect")
+				log.Warn("ceb disconnected from server, attempting reconnect")
 				err = reconnect()
 
 				// If we successfully reconnected, then exit this.


### PR DESCRIPTION
The ceb mentioning that it's attempting to reconnect at Error level can
get kind of noisey. Because the ceb is going to reconnect anyway and do
a final error log if it fails, we can move this reconnect message to a
warning instead.

Fixes #3644