### PR TITLE
inlinekeepalive client: ignore unavailable errors when determining compatibility

### DIFF
--- a/pkg/inlinekeepalive/client.go
+++ b/pkg/inlinekeepalive/client.go
@@ -113,8 +113,8 @@ func KeepaliveClientStreamInterceptor(sendInterval time.Duration) grpc.StreamCli
 
 			versionInfo, err := client.GetVersionInfo(ctx, &emptypb.Empty{})
 			if err != nil {
-				if status.Code(err) == codes.Canceled {
-					log.Trace("context canceled while determining if server is compatible with inline keepalives - will not send.")
+				if status.Code(err) == codes.Canceled || status.Code(err) == codes.Unavailable {
+					log.Trace("context canceled while determining if server is compatible with inline keepalives - will not send.", "err", err)
 					return
 				}
 				log.Warn("failed getting version info to determine if server is inline-keepalive compatible - will not send them", "err", err)


### PR DESCRIPTION
That's normal apparently in our integration tests, and this is causing one of those tests to fail. Won't argue with it.

We don’t _need_ to warn log anything there. If we hit that condition, we’ll never send the inline keepalive messages. The log is nice in case someone starts reporting the the RST_STREAM errors again - we can ask for this log and figure out what the problem was. This isn’t worth more than one more round of whack a mole though. If we find another case like this, we should switch this to debug/trace log.