### PR TITLE
Default Runner Profile Plugin Configuration w/`runner install`

### DIFF
--- a/.changelog/3699.txt
+++ b/.changelog/3699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Set plugin configuration on runner profile created during `runner install`
+```

--- a/.changelog/3701.txt
+++ b/.changelog/3701.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Set the subnet and security group ID configs for the ECS task launcher plugin
+during an ECS runner install
+```

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -63,10 +63,10 @@ type TaskLauncherConfig struct {
 
 	// Subnets are the list of subnets for the cluster. These will match the
 	// subnets used for the Cluster
-	Subnets string `hcl:"subnets,optional"`
+	Subnets string `hcl:"subnets,required"`
 
 	// SecurityGroupId is the security group used for the Waypoint tasks.
-	SecurityGroupId string `hcl:"security_group_id,optional"`
+	SecurityGroupId string `hcl:"security_group_id,required"`
 
 	// LogGroup is the CloudWatch log group name to use.
 	LogGroup string `hcl:"log_group,optional"`

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -546,7 +546,7 @@ func installRunner(
 	// If this installation platform supports an out-of-the-box ODR
 	// config then we set that up. This enables on-demand runners to
 	// work immediately.
-	if odc, ok := p.(serverinstall.OnDemandRunnerConfigProvider); ok {
+	if odc, ok := p.(installutil.OnDemandRunnerConfigProvider); ok {
 		s = sg.Add("Registering on-demand runner configuration...")
 
 		if odrConfig == nil {
@@ -554,10 +554,6 @@ func installRunner(
 		}
 
 		odrConfig.Name = odrConfig.PluginType + "-bootstrap-profile"
-		if err != nil {
-			ui.Output("Error getting version: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
-			return 1
-		}
 
 		_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
 			Config: odrConfig,

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"os"
 	"sort"
 	"strings"
@@ -411,7 +412,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 	s.Update("Previous runner uninstalled")
 	s.Done()
 
-	if odc, ok := p.(serverinstall.OnDemandRunnerConfigProvider); ok {
+	if odc, ok := p.(installutil.OnDemandRunnerConfigProvider); ok {
 		odr := odc.OnDemandRunnerConfig()
 
 		runnerConfigName := odr.PluginType + "-bootstrap-profile"

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -3,6 +3,7 @@ package installutil
 import (
 	"fmt"
 	"github.com/distribution/distribution/v3/reference"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
 // DefaultODRImage returns the default Waypoint ODR image based on the
@@ -31,4 +32,10 @@ const DefaultServerImage = "hashicorp/waypoint:latest"
 
 func DefaultRunnerName(id string) string {
 	return "waypoint-" + id + "-runner"
+}
+
+// An optional interface that the installer can implement to request
+// an ondemand runner be registered.
+type OnDemandRunnerConfigProvider interface {
+	OnDemandRunnerConfig() *pb.OnDemandRunnerConfig
 }

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/waypoint/internal/installutil"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"os"
 	"time"
 
@@ -210,5 +211,14 @@ func (d DockerRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 	return nil
 }
 
-func (d DockerRunnerInstaller) UninstallFlags(set *flag.Set) {
+func (d DockerRunnerInstaller) UninstallFlags(set *flag.Set) {}
+
+func (i *DockerRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
+	// TODO: Add options for plugin config here
+	return &pb.OnDemandRunnerConfig{
+		Name:       "docker",
+		OciUrl:     i.Config.RunnerImage,
+		PluginType: "docker",
+		Default:    true,
+	}
 }

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -701,11 +701,7 @@ func (i *ECSRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	}
 
 	if i.Config.Subnets != nil {
-		var subnets []string
-		for _, s := range i.Config.Subnets {
-			subnets = append(subnets, s)
-		}
-		cfgMap["subnets"] = strings.Join(subnets, ",")
+		cfgMap["subnets"] = strings.Join(i.Config.Subnets, ",")
 		// TODO: set security group
 	}
 

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -1516,7 +1516,7 @@ func (i *ECSInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 	}
 
 	return &pb.OnDemandRunnerConfig{
-		Name:         "ecs",
+		Name:         "aws-ecs",
 		OciUrl:       i.config.OdrImage,
 		PluginType:   "aws-ecs",
 		Default:      true,

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -107,12 +107,6 @@ type InstallRunnerOpts struct {
 	Id string
 }
 
-// An optional interface that the installer can implement to request
-// an ondemand runner be registered.
-type OnDemandRunnerConfigProvider interface {
-	OnDemandRunnerConfig() *pb.OnDemandRunnerConfig
-}
-
 var Platforms = map[string]Installer{
 	"ecs":        &ECSInstaller{},
 	"kubernetes": &K8sInstaller{},

--- a/website/content/partials/components/task-aws-ecs.mdx
+++ b/website/content/partials/components/task-aws-ecs.mdx
@@ -20,6 +20,22 @@ Docker image for the Waypoint On-Demand Runners.
 Docker image for the Waypoint On-Demand Runners. This will
 default to the server image with the name (not label) suffixed with '-odr'.".
 
+#### security_group_id
+
+Security Group ID to place the On-Demand Runner task in.
+
+Security Group ID to place the On-Demand Runner task in. This defaults to the security group used for the Waypoint server.
+
+- Type: **string**
+
+#### subnets
+
+List of subnets to place the On-Demand Runner task in.
+
+List of subnets to place the On-Demand Runner task in. This defaults to the list of subnets configured for the Waypoint server and must be either identical or a subset of the subnets used by the Waypoint server.
+
+- Type: **string**
+
 ### Optional Parameters
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
@@ -74,24 +90,6 @@ Configure the memory for the On-Demand runners. The default is 1024. See https:/
 AWS Region to use.
 
 AWS region to use. Defaults to the region used for the Waypoint Server.
-
-- Type: **string**
-- **Optional**
-
-#### security_group_id
-
-Security Group ID to place the On-Demand Runner task in.
-
-Security Group ID to place the On-Demand Runner task in. This defaults to the security group used for the Waypoint server.
-
-- Type: **string**
-- **Optional**
-
-#### subnets
-
-List of subnets to place the On-Demand Runner task in.
-
-List of subnets to place the On-Demand Runner task in. This defaults to the list of subnets configured for the Waypoint server and must be either identical or a subset of the subnets used by the Waypoint server.
 
 - Type: **string**
 - **Optional**


### PR DESCRIPTION
This PR updates each of the concrete implementations of the `RunnerInstaller` interface to implement the `OnDemandRunnerConfigProvider` interface, which has been refactored into the `internal/installutil` package (making it available to implementations of both `Installer` and `RunnerInstaller`). The benefit of this is that runners installed with the `runner install` command will have plugin configuration set for the task launcher plugin of their platform, rather than none being set. Though many task launcher plugins report their configurations as optional, some are in fact required, so this PR will help installers of runners get their remote operations up and running more smoothly.

The default plugin configuration for each platform doesn't yet achieve full parity with that of the server install. For example, the runner install for ECS currently doesn't set the security group for the runner profile created along with it, whereas the server install does set this field.

Closes #3686 and #3685.