### PR TITLE
Set SG and subnet configs during ECS runner install

### DIFF
--- a/.changelog/3701.txt
+++ b/.changelog/3701.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Set the subnet and security group ID configs for the ECS task launcher plugin
+during an ECS runner install
+```

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -63,10 +63,10 @@ type TaskLauncherConfig struct {
 
 	// Subnets are the list of subnets for the cluster. These will match the
 	// subnets used for the Cluster
-	Subnets string `hcl:"subnets,optional"`
+	Subnets string `hcl:"subnets,required"`
 
 	// SecurityGroupId is the security group used for the Waypoint tasks.
-	SecurityGroupId string `hcl:"security_group_id,optional"`
+	SecurityGroupId string `hcl:"security_group_id,required"`
 
 	// LogGroup is the CloudWatch log group name to use.
 	LogGroup string `hcl:"log_group,optional"`

--- a/website/content/partials/components/task-aws-ecs.mdx
+++ b/website/content/partials/components/task-aws-ecs.mdx
@@ -20,6 +20,22 @@ Docker image for the Waypoint On-Demand Runners.
 Docker image for the Waypoint On-Demand Runners. This will
 default to the server image with the name (not label) suffixed with '-odr'.".
 
+#### security_group_id
+
+Security Group ID to place the On-Demand Runner task in.
+
+Security Group ID to place the On-Demand Runner task in. This defaults to the security group used for the Waypoint server.
+
+- Type: **string**
+
+#### subnets
+
+List of subnets to place the On-Demand Runner task in.
+
+List of subnets to place the On-Demand Runner task in. This defaults to the list of subnets configured for the Waypoint server and must be either identical or a subset of the subnets used by the Waypoint server.
+
+- Type: **string**
+
 ### Optional Parameters
 
 These parameters are used in the [`use` stanza](/docs/waypoint-hcl/use) for this plugin.
@@ -74,24 +90,6 @@ Configure the memory for the On-Demand runners. The default is 1024. See https:/
 AWS Region to use.
 
 AWS region to use. Defaults to the region used for the Waypoint Server.
-
-- Type: **string**
-- **Optional**
-
-#### security_group_id
-
-Security Group ID to place the On-Demand Runner task in.
-
-Security Group ID to place the On-Demand Runner task in. This defaults to the security group used for the Waypoint server.
-
-- Type: **string**
-- **Optional**
-
-#### subnets
-
-List of subnets to place the On-Demand Runner task in.
-
-List of subnets to place the On-Demand Runner task in. This defaults to the list of subnets configured for the Waypoint server and must be either identical or a subset of the subnets used by the Waypoint server.
 
 - Type: **string**
 - **Optional**


### PR DESCRIPTION
This PR updates the runner install for ECS to set the subnet and security group ID configurations for the ECS runner profile created during the installation of a runner during the runner install for ECS.

Closes #3514.

Example runner profile created by default:
```
waypoint runner profile inspect 01GAP2EV62V3J6WYMQW58VA9GH

» Runner profile:
                   Name: 01GAP2EV62V3J6WYMQW58VA9GH
                     ID: 01GAP2EV62V3J6WYMQW58VA9GH
                Default: true
                OCI URL: hashicorp/waypoint
            Plugin Type: aws-ecs
          Target Runner: *
  Environment Variables: map[]

» Additional Plugin Configuration:

{
	"cluster": "waypoint",
	"execution_role_name": "waypoint-runner-execution-role",
	"log_group": "waypoint-runner-logs",
	"odr_cpu": "512",
	"odr_memory": "2048",
	"region": "us-east-2",
	"security_group_id": "sg-asdf",
	"subnets": "subnet-asdf,subnet-asde,subnet-asdc",
	"task_role_name": "waypoint-runner"
}
```