### PR TITLE
bug: do not reset runner profile default if flag not specified

### DIFF
--- a/.changelog/3702.txt
+++ b/.changelog/3702.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Do not set runner profile defaultness to false if default flag not specified.
+```
+

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -27,7 +28,7 @@ type RunnerProfileSetCommand struct {
 	flagEnvVars            []string
 	flagPluginType         string
 	flagPluginConfig       string
-	flagDefault            bool
+	flagDefault            *bool
 	flagTargetRunnerId     string
 	flagTargetRunnerLabels map[string]string
 }
@@ -188,7 +189,9 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 
 	od.OciUrl = c.flagOCIUrl
 	od.EnvironmentVariables = map[string]string{}
-	od.Default = c.flagDefault
+	if c.flagDefault != nil {
+		od.Default = *c.flagDefault
+	}
 
 	if c.flagEnvVars != nil {
 		//TODO(XX): Deprecate -env-vars and this logic
@@ -287,10 +290,9 @@ func (c *RunnerProfileSetCommand) Flags() *flag.Sets {
 				"the environment the plugin will launch the on-demand runner in.",
 		})
 
-		f.BoolVar(&flag.BoolVar{
-			Name:    "default",
-			Target:  &c.flagDefault,
-			Default: false,
+		f.BoolPtrVar(&flag.BoolPtrVar{
+			Name:   "default",
+			Target: &c.flagDefault,
 			Usage: "Indicates that this remote runner profile should be the default for any project that doesn't " +
 				"otherwise specify its own remote runner.",
 		})

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -41,7 +41,7 @@ lifecycle operation.
 - `-env-vars=<string>` - DEPRECATED. Please see `-env-var`.
 - `-plugin-type=<string>` - The type of the plugin to launch for the on-demand runner, such as aws-ecs, kubernetes, etc.
 - `-plugin-config=<string>` - Path to an hcl file that contains the configuration for the plugin. This is only necessary when the plugin's defaults need to be adjusted for the environment the plugin will launch the on-demand runner in.
-- `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner. The default is false.
+- `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner.
 - `-target-runner-id=<string>` - ID of the runner to target for this remote runner profile.
 - `-target-runner-label=<key=value>` - Labels on the runner to target for this remote runner profile. e.g. `-target-runner-label=k=v`. Can be specified multiple times.
 


### PR DESCRIPTION
This fixes a bug wherein if the default flag was not specified, waypoint would set default to false.

Bug behavior:
```
$ waypoint runner profile list
Runner profiles
         NAME        | PLUGIN TYPE |                   OCI URL                   |               TARGET RUNNER               | DEFAULT  
---------------------+-------------+---------------------------------------------+-------------------------------------------+----------
  docker             | docker      | hashicorp/waypoint-odr:latest               | *                                         | yes      

$ waypoint runner profile set -name=docker -plugin-type=docker -oci-url=hashicorp/waypoint-odr:latest

$ waypoint runner profile list
Runner profiles
         NAME        | PLUGIN TYPE |                   OCI URL                   |               TARGET RUNNER               | DEFAULT  
---------------------+-------------+---------------------------------------------+-------------------------------------------+----------
  docker             | docker      | hashicorp/waypoint-odr:latest               | *                                         |          

```

Notice I did not tell it to stop defaulting that profile, yet it's no longer the default


New behavior:
```
$ waypoint runner profile list
Runner profiles
         NAME        | PLUGIN TYPE |                   OCI URL                   |               TARGET RUNNER               | DEFAULT  
---------------------+-------------+---------------------------------------------+-------------------------------------------+----------
  docker             | docker      | hashicorp/waypoint-odr:latest               | *                                         | yes      

$ waypoint runner profile set -name=docker -plugin-type=docker -oci-url=hashicorp/waypoint-odr:latest

$ waypoint runner profile list
Runner profiles
         NAME        | PLUGIN TYPE |                   OCI URL                   |               TARGET RUNNER               | DEFAULT  
---------------------+-------------+---------------------------------------------+-------------------------------------------+----------
  docker             | docker      | hashicorp/waypoint-odr:latest               | *                                         | yes         

```

Thanks to @benedikt for the bug report