### PR TITLE
internal/core: Ensure proto message is proper type before return

### DIFF
--- a/internal/core/app_build.go
+++ b/internal/core/app_build.go
@@ -59,7 +59,11 @@ func (a *App) Build(ctx context.Context, optFuncs ...BuildOption) (
 	if err != nil {
 		return nil, nil, err
 	}
-	build := msg.(*pb.Build)
+	build, ok := msg.(*pb.Build)
+	if !ok {
+		return nil, nil, status.Error(codes.Internal,
+			"app_build failed to convert the operation message into a Build proto message")
+	}
 
 	// If we're not pushing, then we're done!
 	if !opts.Push {

--- a/internal/core/app_deploy.go
+++ b/internal/core/app_deploy.go
@@ -50,7 +50,12 @@ func (a *App) Deploy(ctx context.Context, push *pb.PushedArtifact) (*pb.Deployme
 		return nil, err
 	}
 
-	return msg.(*pb.Deployment), nil
+	result, ok := msg.(*pb.Deployment)
+	if !ok {
+		return nil, status.Error(codes.Internal, "app_deploy failed to convert the operation message into a Deployment proto")
+	}
+
+	return result, nil
 }
 
 // deployEvalContext sets the HCL evaluation context for `deploy` blocks.

--- a/internal/core/app_push.go
+++ b/internal/core/app_push.go
@@ -64,7 +64,12 @@ func (a *App) PushBuild(ctx context.Context, optFuncs ...PushBuildOption) (*pb.P
 		return nil, err
 	}
 
-	return msg.(*pb.PushedArtifact), nil
+	result, ok := msg.(*pb.PushedArtifact)
+	if !ok {
+		return nil, status.Error(codes.Internal, "app_push failed to convert the operation message into a PushedArtifact proto")
+	}
+
+	return result, nil
 }
 
 // PushBuildOption is used to configure a Build

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -84,7 +84,12 @@ func (a *App) Release(ctx context.Context, target *pb.Deployment) (
 		release = result.(component.Release)
 	}
 
-	return releasepb.(*pb.Release), release, nil
+	result, ok := releasepb.(*pb.Release)
+	if !ok {
+		return nil, nil, status.Error(codes.Internal, "app_release failed to convert the operation message into a Release proto")
+	}
+
+	return result, release, nil
 }
 
 // createReleaser creates the releaser component instance by trying to

--- a/internal/core/app_release.go
+++ b/internal/core/app_release.go
@@ -84,12 +84,12 @@ func (a *App) Release(ctx context.Context, target *pb.Deployment) (
 		release = result.(component.Release)
 	}
 
-	result, ok := releasepb.(*pb.Release)
+	releaseResult, ok := releasepb.(*pb.Release)
 	if !ok {
 		return nil, nil, status.Error(codes.Internal, "app_release failed to convert the operation message into a Release proto")
 	}
 
-	return result, release, nil
+	return releaseResult, release, nil
 }
 
 // createReleaser creates the releaser component instance by trying to


### PR DESCRIPTION
Prior to this commit, if any of the following plugins
build,deploy,artifactpush, or release did not properly return the
expected protobuf message, the internal core funcs would attempt to
convert the proto mesage without ensuring it was the proper expected
type. If this ever happened, the core func would panic and break
completely. This commit fixes that with some extra guarding to first
check if we can properly convert the message to our expected proto type,
and if not, return an internal error code rather than panicing.