### PR TITLE
internal/config: Detail that default use expected to not be ws scoped

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -241,12 +241,12 @@ func (c *App) Validate() (ValidationResults, error) {
 
 	if c.BuildRaw == nil || c.BuildRaw.Use == nil || c.BuildRaw.Use.Type == "" {
 		results = append(results, ValidationResult{Error: fmt.Errorf(
-			"build stage with a default 'use' stanza is required")})
+			"build stage with a default non-workspace scoped 'use' stanza is required")})
 	}
 
 	if c.DeployRaw == nil || c.DeployRaw.Use == nil || c.DeployRaw.Use.Type == "" {
 		results = append(results, ValidationResult{Error: fmt.Errorf(
-			"deploy stage with a default 'use' stanza is required")})
+			"deploy stage with a default non-workspace scoped 'use' stanza is required")})
 	}
 
 	for _, scope := range c.BuildRaw.WorkspaceScoped {


### PR DESCRIPTION
The config validation error was a little vague as to the fact that it
expects a non workspace scoped use stanza to exist as the default rather
than using a workspace for all `use` stanzas and using the "default"
workspace as the default use stanza.