### PR TITLE
Bug/syncing install cli outputs

### DIFF
--- a/.changelog/3729.txt
+++ b/.changelog/3729.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix order of CLI outputs during install
+```

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -125,6 +125,7 @@ func (c *InstallCommand) Run(args []string) int {
 	retries := 0
 	maxRetries := 12
 	sr := sg.Add("Attempting to make connection to server...") // stepgroup for retry ui
+	defer func() { sr.Abort() }()
 
 	for {
 		log.Info("connecting to the server so we can set the server config", "addr", contextConfig.Server.Address)
@@ -174,6 +175,16 @@ func (c *InstallCommand) Run(args []string) int {
 			terminal.WithErrorStyle(),
 		)
 		return 1
+	} else {
+		// Close the step here, so that the order of resolved steps makes sense to
+		// the user in case we fail on the "Retrieving initial auth token..." series
+		// Prior to this change, if we failed to retrieve the auth token, the resolved
+		// step with the error message would appear _before_ the above "Successfully connected
+		// to Waypoint server!" message and that is confusing
+		s.Update("Configured server connection")
+		s.Status(terminal.StatusOK)
+		s.Done()
+		s = sg.Add("")
 	}
 
 	client := pb.NewWaypointClient(conn)

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -152,10 +152,11 @@ func (i *K8sInstaller) Install(
 	if isKind {
 		s.Update(warnK8SKind)
 		s.Status(terminal.StatusWarn)
+		s.Done()
+		s = sg.Add("")
 	}
-	s.Done()
 
-	s = sg.Add("Getting Helm configs...")
+	s.Update("Getting Helm configs...")
 	defer func() { s.Abort() }()
 	settings, err := helminstallutil.SettingsInit()
 	if err != nil {


### PR DESCRIPTION
Fixes #3721

Also got rid of the extraneous "Inspecting Kubernetes cluster" success message. This step is only inspecting the cluster to see if it's a `kind` cluster or not so it can provide a warning; it's not informative of the larger install process and does not need to be part of the output.

Before:
```
 ❯ waypoint server install -platform=kubernetes -accept-tos
✓ Inspecting Kubernetes cluster
✓ Waypoint server installed with Helm!
❌ Retrieving initial auth token...
✓ Successfully connected to Waypoint server in Kubernetes!
! Error attempting to authenticate to bootstrapped server:
```

After:
```
❯ wd server install -platform=kubernetes --accept-tos                                                                                                                     11:15:58
✓ Waypoint server installed with Helm!
✓ Configured server connection
✓ Successfully connected to Waypoint server in Kubernetes!
❌ Retrieving initial auth token...
! Error attempting to authenticate to bootstrapped server:
```