### PR TITLE
website: fix link from input vars to “literal expressions”

### DIFF
--- a/website/content/docs/waypoint-hcl/variables/input.mdx
+++ b/website/content/docs/waypoint-hcl/variables/input.mdx
@@ -390,7 +390,7 @@ implicit type of the `default` value), you will receive an error.
 
 When variable values are provided in a variable definitions file, you can use
 Waypoint's usual syntax for
-[literal expressions](/docs/language/expressions/types.html#literal-expressions)
+[literal expressions](/docs/waypoint-hcl/syntax/expressions#literal-expressions)
 to assign complex-typed values, like lists and maps.
 
 Some special rules apply to the `-var` command line option and to environment


### PR DESCRIPTION
Current state:

https://user-images.githubusercontent.com/34030/186507556-7c600445-47c2-41fe-9de3-e970c34ecffb.mp4

