### PR TITLE
ui: tidy page titles

### DIFF
--- a/ui/app/templates/workspace/projects/project/app/builds.hbs
+++ b/ui/app/templates/workspace/projects/project/app/builds.hbs
@@ -1,4 +1,4 @@
-{{page-title (concat @model.application.application "Builds")}}
+{{page-title "Builds"}}
 {{#if @model.builds}}
   <Table class="table--artifact-list">
     <colgroup>

--- a/ui/app/templates/workspace/projects/project/app/deployments.hbs
+++ b/ui/app/templates/workspace/projects/project/app/deployments.hbs
@@ -1,4 +1,4 @@
-{{page-title (concat @model.application.application "Deployments")}}
+{{page-title "Deployments"}}
 {{#let (not-eq this.target.currentRouteName 'workspace.projects.project.app.deployments.deployment.resource') as |isNotResourcePage|}}
   <div class={{if (and isNotResourcePage this.deploymentsByGeneration) "grid grid--menu-with-panel"}}>
   {{#if isNotResourcePage}}

--- a/ui/app/templates/workspace/projects/project/app/exec.hbs
+++ b/ui/app/templates/workspace/projects/project/app/exec.hbs
@@ -1,3 +1,3 @@
-{{page-title (concat @model.application.application "Exec")}}
+{{page-title "Exec"}}
 
 <Exec @deploymentId={{@model.releases.firstObject.deploymentId}}/>

--- a/ui/app/templates/workspace/projects/project/app/logs.hbs
+++ b/ui/app/templates/workspace/projects/project/app/logs.hbs
@@ -1,3 +1,3 @@
-{{page-title (concat @model.application.application "Logs")}}
+{{page-title "Logs"}}
 
 <LogStream @req={{@model.request}}></LogStream>

--- a/ui/app/templates/workspace/projects/project/app/releases.hbs
+++ b/ui/app/templates/workspace/projects/project/app/releases.hbs
@@ -1,4 +1,4 @@
-{{page-title (concat @model.application.application "Releases")}}
+{{page-title "Releases"}}
 {{#if @model.releases}}
   <Table class="table--artifact-list">
     <colgroup>

--- a/ui/app/templates/workspace/projects/project/app/resources.hbs
+++ b/ui/app/templates/workspace/projects/project/app/resources.hbs
@@ -1,3 +1,4 @@
+{{page-title "Resources"}}
 {{#if @model.resources.length}}
   <ResourcesTableExtended
     @resources={{@model.resources}}


### PR DESCRIPTION
## Why the change?

There were a bunch of places where we were concatenating the name of the current application onto the name of the page. The is an issue for two reasons:

1. ember-page-title takes care of the application name automatically because it is added an the parent `app` template
2. For many of those pages, `@model.application.application` didn’t resolve to anything

## What does it look like?

### Before

![CleanShot 2022-08-25 at 12 14 23@2x](https://user-images.githubusercontent.com/34030/186639546-881fc6c5-bc37-4b56-aaf6-d30fe8b22688.png)

### After

<img width="1360" alt="CleanShot 2022-08-25 at 12 15 28@2x" src="https://user-images.githubusercontent.com/34030/186639568-259ec785-8967-438c-ac07-25435a390300.png">

## How do I test it?

1. [Visit the review app](https://waypoint-4dp1ntxk0-hashicorp.vercel.app)
2. Authenticate with any random string
3. Verify the page titles for [deployments](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/deployments), [builds](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/builds), [releases](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/releases), [logs](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/logs), [resources](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/resources), and [exec](https://waypoint-4dp1ntxk0-hashicorp.vercel.app/default/marketing-public/app/wp-matrix/exec) are correct

## Why no changelog entry?

This is super minor and I very much doubt it will have affected anyone’s experience of using Waypoint UI.