### PR TITLE
k8s: `server install` bug with helm/bootstrap race condition

### DIFF
--- a/.changelog/3744.txt
+++ b/.changelog/3744.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/install/k8s: Fixes the k8s installer race condition with the bootstrap token
+```

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -210,7 +210,7 @@ func (c *InstallCommand) Run(args []string) int {
 		contextConfig.Server.AuthToken = tokenResp.Token
 	} else {
 		// try default context in case server was started again from install
-		defaultCtx, err := c.contextStorage.Default()
+		defaultCtxName, err := c.contextStorage.Default()
 		if err != nil {
 			c.ui.Output(
 				"Error getting default context to use existing auth token: %s\n\n%s\n\n%s",
@@ -222,12 +222,12 @@ func (c *InstallCommand) Run(args []string) int {
 			return 1
 		}
 
-		if defaultCtx != "" {
-			defaultCtxConfig, err := c.contextStorage.Load(defaultCtx)
+		if defaultCtxName != "" {
+			defaultCtxConfig, err := c.contextStorage.Load(defaultCtxName)
 			if err != nil {
 				c.ui.Output(
 					"Error loading the context %q to use existing auth token: %s\n\n%s\n\n%s",
-					defaultCtx,
+					defaultCtxName,
 					clierrors.Humanize(err),
 					errInstallToken,
 					errInstallRunning,

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -194,6 +194,7 @@ func (c *InstallCommand) Run(args []string) int {
 	// We need our bootstrap token immediately
 	var callOpts []grpc.CallOption
 	tokenResp, err := client.BootstrapToken(ctx, &empty.Empty{})
+	var token string
 	if err != nil && status.Code(err) != codes.PermissionDenied {
 		c.ui.Output(
 			"Error getting the initial token: %s\n\n%s",
@@ -203,11 +204,30 @@ func (c *InstallCommand) Run(args []string) int {
 		)
 		return 1
 	}
-
+	// If we're not using the k8s install path, then we set the token
+	// based on the tokenResp
 	if tokenResp != nil {
+		token = tokenResp.Token
+	}
+	// Our k8s installer uses the helm chart behind the scenes, which bootstraps
+	// the server; therefore we need to get the token that was created and we
+	// expect this error type
+	if tokenResp == nil && status.Code(err) == codes.PermissionDenied && c.platform == "kubernetes" {
+		loginCmd := LoginCommand{
+			flagK8S:            true,
+			flagK8STokenSecret: "waypoint-server-token",
+		}
+		var exitCode int
+		token, exitCode = loginCmd.loginK8S(ctx)
+		if exitCode > 0 {
+			return exitCode
+		}
+	}
+
+	if token != "" {
 		log.Debug("token received, setting on context")
 		contextConfig.Server.RequireAuth = true
-		contextConfig.Server.AuthToken = tokenResp.Token
+		contextConfig.Server.AuthToken = token
 	} else {
 		// try default context in case server was started again from install
 		defaultCtxName, err := c.contextStorage.Default()

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -11,6 +11,7 @@ import (
 	dockerparser "github.com/novln/docker-parser"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -362,6 +363,45 @@ func (i *K8sInstaller) Install(
 		return nil, err
 	}
 	s.Done()
+
+	s = sg.Add("Waiting for the bootstrap process to finish...")
+	var bootJobName string
+	err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+		// the label we use for LabelSelector is set here
+		// https://github.com/hashicorp/waypoint-helm/blob/d2f6de6e9010b94da84f37eeaca4a8190a439060/templates/bootstrap-job.yaml#L8
+		jobs, err := clientset.BatchV1().Jobs(i.config.namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/instance=waypoint",
+		})
+		if err != nil {
+			return false, nil
+		}
+		// the job we are searching for is prefixed with `waypoint-bootstrap`
+		// per our Helm chart; if that naming ever changes, this will also need to be updated
+		// https://github.com/hashicorp/waypoint-helm/blob/d2f6de6e9010b94da84f37eeaca4a8190a439060/templates/bootstrap-job.yaml#L5
+		jobPrefix := "waypoint-bootstrap-"
+		var bootJob *batchv1.Job
+		for _, j := range jobs.Items {
+			if strings.Contains(j.Name, jobPrefix) {
+				bootJob = &j
+				bootJobName = j.Name
+				break
+			}
+		}
+		if bootJob.Status.Succeeded == 1 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		log.Error("no bootstrap job found, returning", "job_name", bootJobName)
+		s.Update("No bootstrap job found")
+		s.Status(terminal.WarningStyle)
+		s.Done()
+		return nil, err
+	}
+	s.Update("Server bootstrap complete!")
+	s.Done()
+	s = sg.Add("")
 
 	s.Update("Waypoint server installed with Helm!")
 	s.Status(terminal.StatusOK)

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -8,12 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/waypoint/internal/installutil"
-	helminstallutil "github.com/hashicorp/waypoint/internal/installutil/helm"
-	"github.com/hashicorp/waypoint/internal/runnerinstall"
+	dockerparser "github.com/novln/docker-parser"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
-
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,11 +22,13 @@ import (
 	"github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/installutil"
+	helminstallutil "github.com/hashicorp/waypoint/internal/installutil/helm"
 	k8sinstallutil "github.com/hashicorp/waypoint/internal/installutil/k8s"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/runnerinstall"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/serverconfig"
-	dockerparser "github.com/novln/docker-parser"
 )
 
 //

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -375,7 +375,7 @@ func (i *K8sInstaller) Install(
 		if err != nil {
 			return false, nil
 		}
-		// the job we are searching for is prefixed with `waypoint-bootstrap`
+		// NOTE(krantzinator): the job we are searching for is prefixed with `waypoint-bootstrap`
 		// per our Helm chart; if that naming ever changes, this will also need to be updated
 		// https://github.com/hashicorp/waypoint-helm/blob/d2f6de6e9010b94da84f37eeaca4a8190a439060/templates/bootstrap-job.yaml#L5
 		jobPrefix := "waypoint-bootstrap-"
@@ -393,7 +393,7 @@ func (i *K8sInstaller) Install(
 		return false, nil
 	})
 	if err != nil {
-		log.Error("no bootstrap job found, returning", "job_name", bootJobName)
+		log.Error("no bootstrap job found, returning", "job_name", bootJobName, "err", err)
 		s.Update("No bootstrap job found")
 		s.Status(terminal.WarningStyle)
 		s.Done()


### PR DESCRIPTION
This is the fix for the k8s install. We need to make sure that we use the token that helm bootstrapped to finish the server configuration.
✅ Upgrade from 0.9.1 to the branch `fixes-to-k8s-installers` in the last child PR but off of this PR works! (#3773)



We should probably have some kind of checker in `internal/cli/k8s_bootstrap.go` that waits for the bootstrap job to successfully finish before proceeding, to avoid unnecessary errors in the logs (a server install where the default installer "wins" the race for bootstrapping, but then helm still tries to bootstrap and we get logged errors that are irrelevant), and other potential side effects.
The server logs do still include the error message `waypoint.server.grpc: /hashicorp.waypoint.Waypoint/BootstrapToken response: error="rpc error: code = PermissionDenied desc = server is already bootstrapped" duration=63.741µs
2022/08/31 13:59:59 http: TLS handshake error from 10.100.2.244:9852: EOF`. However, the server is still installed, bootstrapped, and functional, so I have not worked on this further, and quite frankly, don't want to 😄.

Fixes #3722
Fixes #3707

Child PRs:
#3772 
#3773 