### PR TITLE
Runner install - extra arguments

### DIFF
--- a/.changelog/3746.txt
+++ b/.changelog/3746.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+install/runner: Allow additional arguments for `waypoint runner agent` command
+to be supplied to `waypoint runner install` CLI
+```

--- a/.changelog/3746.txt
+++ b/.changelog/3746.txt
@@ -2,3 +2,7 @@
 install/runner: Allow additional arguments for `waypoint runner agent` command
 to be supplied to `waypoint runner install` CLI
 ```
+```release-note:improvement
+cli: Internal-only labels on runners are hidden from CLI output for `waypoint runner
+list` and `waypoint runner inspect`
+```

--- a/internal/cli/runner_inspect.go
+++ b/internal/cli/runner_inspect.go
@@ -85,6 +85,11 @@ func (c *RunnerInspectCommand) Run(args []string) int {
 		stateStr = "unknown"
 	}
 
+	// Omit label that the user didn't set from the output
+	if _, ok := resp.Labels["waypoint.hashicorp.com/runner-hash"]; ok {
+		delete(resp.Labels, "waypoint.hashicorp.com/runner-hash")
+	}
+
 	c.ui.Output("Runner:", terminal.WithHeaderStyle())
 	c.ui.NamedValues([]terminal.NamedValue{
 		{

--- a/internal/cli/runner_inspect.go
+++ b/internal/cli/runner_inspect.go
@@ -86,9 +86,7 @@ func (c *RunnerInspectCommand) Run(args []string) int {
 	}
 
 	// Omit label that the user didn't set from the output
-	if _, ok := resp.Labels["waypoint.hashicorp.com/runner-hash"]; ok {
-		delete(resp.Labels, "waypoint.hashicorp.com/runner-hash")
-	}
+	delete(resp.Labels, "waypoint.hashicorp.com/runner-hash")
 
 	c.ui.Output("Runner:", terminal.WithHeaderStyle())
 	c.ui.NamedValues([]terminal.NamedValue{

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -223,8 +223,8 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 			TlsSkipVerify: c.serverTlsSkipVerify,
 			RequireAuth:   c.serverRequireAuth,
 		},
-		Id:             id,
-		RunnerRunFlags: secondaryArgs,
+		Id:               id,
+		RunnerAgentFlags: secondaryArgs,
 	})
 	if err != nil {
 		c.ui.Output("Error installing runner: %s", clierrors.Humanize(err),

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -18,14 +18,15 @@ import (
 type RunnerInstallCommand struct {
 	*baseCommand
 
-	platform              []string `hcl:"platform,optional"`
-	skipAdopt             bool     `hcl:"skip_adopt,optional"`
-	serverUrl             string   `hcl:"server_url,required"`
-	id                    string   `hcl:"id,optional"`
-	runnerProfileOdrImage string   `hcl:"odr_image,optional"`
-	serverTls             bool     `hcl:"server_tls,optional"`
-	serverTlsSkipVerify   bool     `hcl:"server_tls_skip_verify,optional"`
-	serverRequireAuth     bool     `hcl:"server_require_auth,optional"`
+	platform              []string          `hcl:"platform,optional"`
+	skipAdopt             bool              `hcl:"skip_adopt,optional"`
+	serverUrl             string            `hcl:"server_url,required"`
+	id                    string            `hcl:"id,optional"`
+	runnerProfileOdrImage string            `hcl:"odr_image,optional"`
+	serverTls             bool              `hcl:"server_tls,optional"`
+	serverTlsSkipVerify   bool              `hcl:"server_tls_skip_verify,optional"`
+	serverRequireAuth     bool              `hcl:"server_require_auth,optional"`
+	labels                map[string]string `hcl:"labels,optional"`
 }
 
 func (c *RunnerInstallCommand) AutocompleteArgs() complete.Predictor {
@@ -98,6 +99,12 @@ func (c *RunnerInstallCommand) Flags() *flag.Sets {
 			Name:   "id",
 			Usage:  "If this is set, the runner will use the specified id.",
 			Target: &c.id,
+		})
+
+		f.StringMapVar(&flag.StringMapVar{
+			Name:   "label",
+			Target: &c.labels,
+			Usage:  "Labels to set for this runner in 'k=v' format. Can be specified multiple times.",
 		})
 
 		for _, name := range sortedPlatformNames {
@@ -214,7 +221,8 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 			TlsSkipVerify: c.serverTlsSkipVerify,
 			RequireAuth:   c.serverRequireAuth,
 		},
-		Id: id,
+		Id:     id,
+		Labels: c.labels,
 	})
 	if err != nil {
 		c.ui.Output("Error installing runner: %s", clierrors.Humanize(err),

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -18,15 +18,14 @@ import (
 type RunnerInstallCommand struct {
 	*baseCommand
 
-	platform              []string          `hcl:"platform,optional"`
-	skipAdopt             bool              `hcl:"skip_adopt,optional"`
-	serverUrl             string            `hcl:"server_url,required"`
-	id                    string            `hcl:"id,optional"`
-	runnerProfileOdrImage string            `hcl:"odr_image,optional"`
-	serverTls             bool              `hcl:"server_tls,optional"`
-	serverTlsSkipVerify   bool              `hcl:"server_tls_skip_verify,optional"`
-	serverRequireAuth     bool              `hcl:"server_require_auth,optional"`
-	labels                map[string]string `hcl:"labels,optional"`
+	platform              []string `hcl:"platform,optional"`
+	skipAdopt             bool     `hcl:"skip_adopt,optional"`
+	serverUrl             string   `hcl:"server_url,required"`
+	id                    string   `hcl:"id,optional"`
+	runnerProfileOdrImage string   `hcl:"odr_image,optional"`
+	serverTls             bool     `hcl:"server_tls,optional"`
+	serverTlsSkipVerify   bool     `hcl:"server_tls_skip_verify,optional"`
+	serverRequireAuth     bool     `hcl:"server_require_auth,optional"`
 }
 
 func (c *RunnerInstallCommand) AutocompleteArgs() complete.Predictor {
@@ -99,12 +98,6 @@ func (c *RunnerInstallCommand) Flags() *flag.Sets {
 			Name:   "id",
 			Usage:  "If this is set, the runner will use the specified id.",
 			Target: &c.id,
-		})
-
-		f.StringMapVar(&flag.StringMapVar{
-			Name:   "label",
-			Target: &c.labels,
-			Usage:  "Labels to set for this runner in 'k=v' format. Can be specified multiple times.",
 		})
 
 		for _, name := range sortedPlatformNames {
@@ -209,6 +202,15 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 		}
 	}
 
+	// collect any args after a `--` break to pass forward as secondary flags
+	var secondaryArgs []string
+	for i, f := range args {
+		if f == "--" {
+			secondaryArgs = args[(i + 1):]
+			break
+		}
+	}
+
 	s = sg.Add("Installing runner...")
 	err = p.Install(ctx, &runnerinstall.InstallOpts{
 		Log:        log,
@@ -221,8 +223,8 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 			TlsSkipVerify: c.serverTlsSkipVerify,
 			RequireAuth:   c.serverRequireAuth,
 		},
-		Id:     id,
-		Labels: c.labels,
+		Id:             id,
+		RunnerRunFlags: secondaryArgs,
 	})
 	if err != nil {
 		c.ui.Output("Error installing runner: %s", clierrors.Humanize(err),

--- a/internal/cli/runner_list.go
+++ b/internal/cli/runner_list.go
@@ -87,9 +87,8 @@ func (c *RunnerListCommand) Run(args []string) int {
 		if stateStr == "" {
 			stateStr = "unknown"
 		}
-		if _, ok := r.Labels["waypoint.hashicorp.com/runner-hash"]; ok {
-			delete(r.Labels, "waypoint.hashicorp.com/runner-hash")
-		}
+		// Omit label that the user didn't set from the output
+		delete(r.Labels, "waypoint.hashicorp.com/runner-hash")
 
 		var labelStr string
 		for k, v := range r.Labels {

--- a/internal/cli/runner_list.go
+++ b/internal/cli/runner_list.go
@@ -87,6 +87,9 @@ func (c *RunnerListCommand) Run(args []string) int {
 		if stateStr == "" {
 			stateStr = "unknown"
 		}
+		if _, ok := r.Labels["waypoint.hashicorp.com/runner-hash"]; ok {
+			delete(r.Labels, "waypoint.hashicorp.com/runner-hash")
+		}
 
 		var labelStr string
 		for k, v := range r.Labels {

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -108,7 +108,7 @@ func (i *DockerRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) 
 		User:         "root",
 		Image:        runnerImage,
 		Env:          opts.AdvertiseClient.Env(),
-		Cmd:          []string{"runner", "agent", "-id=" + opts.Id, "-cookie=" + opts.Cookie, "-vv"},
+		Cmd:          append([]string{"runner", "agent", "-id=" + opts.Id, "-cookie=" + opts.Cookie, "-vv"}, opts.RunnerRunFlags...),
 		Labels: map[string]string{
 			"waypoint-type": "runner",
 		},

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -108,7 +108,7 @@ func (i *DockerRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) 
 		User:         "root",
 		Image:        runnerImage,
 		Env:          opts.AdvertiseClient.Env(),
-		Cmd:          append([]string{"runner", "agent", "-id=" + opts.Id, "-cookie=" + opts.Cookie, "-vv"}, opts.RunnerRunFlags...),
+		Cmd:          append([]string{"runner", "agent", "-id=" + opts.Id, "-cookie=" + opts.Cookie, "-vv"}, opts.RunnerAgentFlags...),
 		Labels: map[string]string{
 			"waypoint-type": "runner",
 		},

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -188,7 +188,7 @@ func (i *ECSRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			runSvcArn, err = launchRunner(
 				ctx, ui, log, sess,
 				opts.AdvertiseClient.Env(),
-				opts.RunnerRunFlags,
+				opts.RunnerAgentFlags,
 				executionRole,
 				taskRole,
 				logGroup,

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -188,6 +188,7 @@ func (i *ECSRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			runSvcArn, err = launchRunner(
 				ctx, ui, log, sess,
 				opts.AdvertiseClient.Env(),
+				opts.RunnerRunFlags,
 				executionRole,
 				taskRole,
 				logGroup,
@@ -358,7 +359,7 @@ func launchRunner(
 	ui terminal.UI,
 	log hclog.Logger,
 	sess *session.Session,
-	env []string,
+	env, extraArgs []string,
 	executionRoleArn, taskRoleArn, logGroup, region, cpu, memory, runnerImage, cluster, cookie, id string,
 	netInfo *awsinstallutil.NetworkInformation,
 	efsInfo *awsinstallutil.EfsInformation,
@@ -394,9 +395,15 @@ func launchRunner(
 			Value: aws.String(value),
 		})
 	}
+
+	var args []*string
+	for _, arg := range extraArgs {
+		args = append(args, aws.String(arg))
+	}
+
 	def := ecs.ContainerDefinition{
 		Essential: aws.Bool(true),
-		Command: []*string{
+		Command: append([]*string{
 			aws.String("runner"),
 			aws.String("agent"),
 			aws.String("-id=" + id),
@@ -404,7 +411,7 @@ func launchRunner(
 			aws.String("-cookie=" + cookie),
 			aws.String("-state-dir=/data/runner"),
 			aws.String("-vv"),
-		},
+		}, args...),
 		Name:  aws.String(runnerName),
 		Image: aws.String(runnerImage),
 		PortMappings: []*ecs.PortMapping{

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -179,7 +179,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			"enabled": false,
 		},
 		"runner": map[string]interface{}{
-			"agentArgs": opts.RunnerRunFlags,
+			"agentArgs": opts.RunnerAgentFlags,
 			"id":        opts.Id,
 			"image": map[string]interface{}{
 				"repository": runnerImageRef.Repository(),

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -174,17 +174,12 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 		}
 	}
 
-	var labels []string
-	for labelKey, labelValue := range opts.Labels {
-		labels = append(labels, "-label="+labelKey+"="+labelValue)
-	}
-
 	values := map[string]interface{}{
 		"server": map[string]interface{}{
 			"enabled": false,
 		},
 		"runner": map[string]interface{}{
-			"agentArgs": labels,
+			"agentArgs": opts.RunnerRunFlags,
 			"id":        opts.Id,
 			"image": map[string]interface{}{
 				"repository": runnerImageRef.Repository(),

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -174,12 +174,18 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 		}
 	}
 
+	var labels []string
+	for labelKey, labelValue := range opts.Labels {
+		labels = append(labels, "-label="+labelKey+"="+labelValue)
+	}
+
 	values := map[string]interface{}{
 		"server": map[string]interface{}{
 			"enabled": false,
 		},
 		"runner": map[string]interface{}{
-			"id": opts.Id,
+			"agentArgs": labels,
+			"id":        opts.Id,
 			"image": map[string]interface{}{
 				"repository": runnerImageRef.Repository(),
 				"tag":        runnerImageRef.Tag(),

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -172,7 +172,7 @@ func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 			"-state-dir=/data/runner",
 			"-cookie=" + opts.Cookie,
 			"-vv",
-		}, opts.RunnerRunFlags...),
+		}, opts.RunnerAgentFlags...),
 		"auth_soft_fail": c.AuthSoftFail,
 	}
 

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -165,14 +165,14 @@ func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 	task := api.NewTask("runner", "docker")
 	task.Config = map[string]interface{}{
 		"image": c.RunnerImage,
-		"args": []string{
+		"args": append([]string{
 			"runner",
 			"agent",
 			"-id=" + opts.Id,
 			"-state-dir=/data/runner",
 			"-cookie=" + opts.Cookie,
 			"-vv",
-		},
+		}, opts.RunnerRunFlags...),
 		"auth_soft_fail": c.AuthSoftFail,
 	}
 

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -53,7 +53,7 @@ type InstallOpts struct {
 	// Unique ID for the runner.
 	Id string
 
-	// TODO: Description
+	// Flags which will be supplied to the `waypoint runner agent` command
 	RunnerRunFlags []string
 }
 

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -52,6 +52,11 @@ type InstallOpts struct {
 
 	// Unique ID for the runner.
 	Id string
+
+	// Labels is the set of labels which can be applied to the runner. They will
+	// be used via the `label` flag on the `runner agent` command in the runner
+	// container
+	Labels map[string]string
 }
 
 var Platforms = map[string]RunnerInstaller{

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -53,10 +53,8 @@ type InstallOpts struct {
 	// Unique ID for the runner.
 	Id string
 
-	// Labels is the set of labels which can be applied to the runner. They will
-	// be used via the `label` flag on the `runner agent` command in the runner
-	// container
-	Labels map[string]string
+	// TODO: Description
+	RunnerRunFlags []string
 }
 
 var Platforms = map[string]RunnerInstaller{

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -54,7 +54,7 @@ type InstallOpts struct {
 	Id string
 
 	// Flags which will be supplied to the `waypoint runner agent` command
-	RunnerRunFlags []string
+	RunnerAgentFlags []string
 }
 
 var Platforms = map[string]RunnerInstaller{


### PR DESCRIPTION
Allow extra arguments to be supplied to the `runner agent` command, run by the container installed with `runner install`.

Set the extra arguments on the k8s w/Helm, AWS ECS, Docker and Nomad runner installs.