### PR TITLE
builtin/pack: Only show warning if on unsupported arch

### DIFF
--- a/builtin/pack/builder.go
+++ b/builtin/pack/builder.go
@@ -352,7 +352,7 @@ func (b *Builder) Build(
 	if err != nil {
 		return nil, err
 	}
-	if serverInfo.Architecture != "amd64" {
+	if serverInfo.Architecture != "amd64" && serverInfo.Architecture != "x86_64" {
 		ui.Output(
 			"Warning! Buildpacks are known to have issues on architectures "+
 				"other than amd64. The architecure being reported by the Docker "+


### PR DESCRIPTION
Prior to this commit, we would warn if *any* architecture didn't match
`amd64`. This is a bit confusing, because the arch reported could be
`x86_64` which is technically supported.

Instead, this commit updates the pack builder to warn if arm
architectures are detected, which are currently unsupported by the
heroku pack builder.