### PR TITLE
core/runner: Fix server panic when runner is forgotten

### DIFF
--- a/.changelog/3756.txt
+++ b/.changelog/3756.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/runner: Server no longer panics when a runner stopped after it is forgotten.
+```

--- a/internal/server/boltdbstate/runner.go
+++ b/internal/server/boltdbstate/runner.go
@@ -304,8 +304,7 @@ func (s *State) runnerSetAdoptionState(
 func (s *State) runnerOffline(dbTxn *bolt.Tx, memTxn *memdb.Txn, id string) error {
 	r, err := s.runnerById(dbTxn, id)
 	if status.Code(err) == codes.NotFound {
-		r = nil
-		err = nil
+		return nil
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Before this commit when Waypoint was determining whether or not to
remove a Runner from boltdb it was possible for runner to be nil at the
time we attempted to determine what type of Runner the Runner was. This
caused the server to panic as soon as the runner became unavailable.

This commit fixes the panic by avoiding the runner from being set to nil
by instead initializing an empty runner variable so that if a runner is
not found the type can still be determined and the runner cleaned up.

Fixes #3448