### PR TITLE
website: remove section on `project apply -runner-profile=...`

### DIFF
--- a/website/content/docs/runner/profiles.mdx
+++ b/website/content/docs/runner/profiles.mdx
@@ -163,13 +163,3 @@ $ waypoint runner profile delete 01G65VD1SSB3HYJ3FS9K629A3B
 
 » Runner profile deleted
 ```
-
-## Using Profiles for Projects
-
-Projects can be configured to use specific runner profiles, rather than the default. To force a particular project
-to build using an on-demand runner on ECS, for example, add a new runner profile as described
-[above](/docs/runner/profiles#adding-a-new-runner-profile), and then use `waypoint project apply` to set the `-runner-profile`:
-
-```shell-session
-$ waypoint project apply -runner-profile=ecs <your-project-name>
-```


### PR DESCRIPTION
Seems this feature may have been planned but never implemented.

<img width="1263" alt="CleanShot 2022-08-31 at 11 42 07@2x" src="https://user-images.githubusercontent.com/34030/187724913-44c76317-ae67-40fc-923c-0f2761fbd99d.png">
