### PR TITLE
`runner install` fixes

### DIFF
--- a/.changelog/3772.txt
+++ b/.changelog/3772.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+internal/runnerinstall: Fix order of error checking and make error message more specific
+```

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -137,7 +137,7 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 		Id:         c.id,
 	})
 	if err != nil {
-		s.Update("Unable to uninstall runner", terminal.StatusError)
+		s.Update("Unable to uninstall runner")
 		s.Abort()
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -128,6 +128,8 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 	defer sg.Wait()
 
 	s := sg.Add("Uninstalling runner...")
+	defer func() { s.Abort() }()
+
 	err := p.Uninstall(ctx, &runnerinstall.InstallOpts{
 		Log:        log,
 		UI:         c.ui,
@@ -135,9 +137,10 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 		Id:         c.id,
 	})
 	if err != nil {
-		c.ui.Output("Error uninstalling runner: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
+		s.Update("Error uninstalling runner")
+		s.Status(terminal.StatusError)
+		s.Done()
+		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}
 	s.Update("Runner %q uninstalled successfully", c.id)

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -137,6 +137,8 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 		Id:         c.id,
 	})
 	if err != nil {
+		s.Update("Unable to uninstall runner", terminal.StatusError)
+		s.Abort()
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -137,9 +137,6 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 		Id:         c.id,
 	})
 	if err != nil {
-		s.Update("Error uninstalling runner")
-		s.Status(terminal.StatusError)
-		s.Done()
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}

--- a/internal/installutil/k8s/k8s.go
+++ b/internal/installutil/k8s/k8s.go
@@ -46,7 +46,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 		namespace, _, err := newCmdConfig.Namespace()
 		if err != nil {
 			return nil, fmt.Errorf(
-				"Error getting namespace from client config: %s",
+				"error getting namespace from client config: %s",
 				clierrors.Humanize(err),
 			)
 		}
@@ -57,7 +57,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 	clientconfig, err := newCmdConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf(
-			"Error initializing kubernetes client: %s",
+			"error initializing kubernetes client: %s",
 			clierrors.Humanize(err),
 		)
 	}
@@ -65,7 +65,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 	clientset, err := kubernetes.NewForConfig(clientconfig)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"Error initializing kubernetes client: %s",
+			"error initializing kubernetes client: %s",
 			clierrors.Humanize(err),
 		)
 	}

--- a/internal/installutil/k8s/k8s.go
+++ b/internal/installutil/k8s/k8s.go
@@ -103,7 +103,7 @@ func (i *K8sInstaller) CleanPVC(ctx context.Context, ui terminal.UI, log hclog.L
 			metav1.DeleteOptions{},
 			listOptions,
 		); err != nil {
-			s.Update("Unable to delete PVCs", terminal.StatusError)
+			s.Update("Unable to delete PVCs")
 			s.Abort()
 			return err
 		}
@@ -122,7 +122,7 @@ func (i *K8sInstaller) CleanPVC(ctx context.Context, ui terminal.UI, log hclog.L
 			}
 		})
 		if err != nil {
-			s.Update("Unable to delete PVCs", terminal.StatusError)
+			s.Update("Unable to delete PVCs")
 			s.Abort()
 			return err
 		}

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -280,7 +280,7 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	sg := ui.StepGroup()
 	defer sg.Wait()
 
-	s := sg.Add("Uninstalling Runner...")
+	s := sg.Add("Finding runner in ECS services...")
 	defer func() { s.Abort() }()
 
 	sess, err := utils.GetSession(&utils.SessionConfig{

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/mitchellh/mapstructure"
 	dockerparser "github.com/novln/docker-parser"
 	"helm.sh/helm/v3/pkg/action"
@@ -17,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -330,7 +330,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	// Move to: B) Decide which uninstall path we use based on if there is a runner
 	// with the naming patterns we get with our 0.9.0+ helm installer
 	if len(listK8sClient.Items) == 0 && len(listHelmClient.Items) == 0 {
-		return fmt.Errorf("runner with ID %q not found in namespace %q", opts.Id, i.Config.Namespace)
+		return fmt.Errorf("runner with ID %q not found in namespace %q with context %q", opts.Id, i.Config.Namespace, i.Config.K8sContext)
 	} else if len(listHelmClient.Items) > 0 {
 		err = i.uninstallWithHelm(ctx, opts)
 	} else {

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -314,7 +314,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
 	})
 	if err != nil {
-		return fmt.Errorf("could not list deployments in namespace %q: %s", i.Config.Namespace, err)
+		return fmt.Errorf("could not list deployments in namespace %q with context %q: %s", i.Config.Namespace, i.Config.K8sContext, err)
 	}
 
 	// Search for runner with 0.9+ tag format, installed with helm
@@ -323,7 +323,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", strings.ToLower(opts.Id)),
 	})
 	if err != nil {
-		return fmt.Errorf("could not list pods in namespace %q: %s", i.Config.Namespace, err)
+		return fmt.Errorf("could not list pods in namespace %q with context %q: %s", i.Config.Namespace,  i.Config.K8sContext, err)
 	}
 
 	// If both lists are empty, the runner is not here at all

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -314,15 +314,16 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
 	})
 	if err != nil {
-		return fmt.Errorf("could not find deployments in namespace %q: %s", i.Config.Namespace, err)
+		return fmt.Errorf("could not list deployments in namespace %q: %s", i.Config.Namespace, err)
 	}
 
 	// Search for runner with 0.9+ tag format, installed with helm
-	listHelmClient, err := deploymentClient.List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", opts.Id),
+	podClient := clientset.CoreV1().Pods(i.Config.Namespace)
+	listHelmClient, err := podClient.List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", strings.ToLower(opts.Id)),
 	})
 	if err != nil {
-		return fmt.Errorf("could not find deployments in namespace %q: %s", i.Config.Namespace, err)
+		return fmt.Errorf("could not list pods in namespace %q: %s", i.Config.Namespace, err)
 	}
 
 	// If both lists are empty, the runner is not here at all

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -313,24 +313,14 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
 	})
 	if err != nil {
-		// TODO: don't include the error here, because the function that
-		// calls this one also outputs the error
-		ui.Output(
-			"Error looking up deployments: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return err
+		return fmt.Errorf("could not find deployments in namespace %q: %s", i.Config.Namespace, err)
 	}
 
 	listHelmClient, err := deploymentClient.List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", opts.Id),
 	})
 	if err != nil {
-		ui.Output(
-			"Error looking up deployments: %s", clierrors.Humanize(err),
-			terminal.WithErrorStyle(),
-		)
-		return err
+		return fmt.Errorf("could not find deployments in namespace %q: %s", i.Config.Namespace, err)
 	}
 
 	if len(listK8sClient.Items) == 0 && len(listHelmClient.Items) == 0 {

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -323,7 +323,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", strings.ToLower(opts.Id)),
 	})
 	if err != nil {
-		return fmt.Errorf("could not list pods in namespace %q with context %q: %s", i.Config.Namespace,  i.Config.K8sContext, err)
+		return fmt.Errorf("could not list pods in namespace %q with context %q: %s", i.Config.Namespace, i.Config.K8sContext, err)
 	}
 
 	// If both lists are empty, the runner is not here at all

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -314,7 +314,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
 	})
 	if err != nil {
-		return fmt.Errorf("could not list deployments in namespace %q with context %q: %s", i.Config.Namespace, i.Config.K8sContext, err)
+		return fmt.Errorf("could not list deployments in namespace %q with current context: %s", i.Config.Namespace, err)
 	}
 
 	// Search for runner with 0.9+ tag format, installed with helm
@@ -323,14 +323,14 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=waypoint-%s", strings.ToLower(opts.Id)),
 	})
 	if err != nil {
-		return fmt.Errorf("could not list pods in namespace %q with context %q: %s", i.Config.Namespace, i.Config.K8sContext, err)
+		return fmt.Errorf("could not list pods in namespace %q with current context: %s", i.Config.Namespace, err)
 	}
 
 	// If both lists are empty, the runner is not here at all
 	// Move to: B) Decide which uninstall path we use based on if there is a runner
 	// with the naming patterns we get with our 0.9.0+ helm installer
 	if len(listK8sClient.Items) == 0 && len(listHelmClient.Items) == 0 {
-		return fmt.Errorf("runner with ID %q not found in namespace %q with context %q", opts.Id, i.Config.Namespace, i.Config.K8sContext)
+		return fmt.Errorf("runner with ID %q not found in namespace %q with current context", opts.Id, i.Config.Namespace)
 	} else if len(listHelmClient.Items) > 0 {
 		err = i.uninstallWithHelm(ctx, opts)
 	} else {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/3681

This is largely a code cleanup PR. The main issue was that if I installed a runner on Cluster A, then switched my kube context to Cluster B, and then tried to uninstall that runner, I would get the waypoint error message "No runners installed" because the code path would go through the `k8sUninstall` function.
This improvement first checks if the runner is on the currently-active cluster before choosing the uninstall method, and returning the appropriate error message.

Per the comments in this PR:
```
	// Our checks here follow the logic of:
 	// Up until v0.8.2, we installed runners with the k8s client,
 	// and the Label was "app=waypoint-runner" and the Name "waypoint-runner-random-id"
 	// As of 0.9.0, we install runners with helm, with a Label following the
 	// pattern ("app.kubernetes.io/instance=waypoint-%s", runnerId)
 	// and the Name ("waypoint-"+strings.ToLower(runnerId))
 	//
 	// Therefore we need to ascertain A) if the runner exists on the cluster at
 	// all (it might not be if the user is auth'd to the wrong cluster), and then B)
 	// if the name/label matches the Helm pattern or the k8s client pattern so
 	// we know how to uninstall it
```

Previous to this update, if the runner wasn't found on the cluster, we'd still remove the runner from Waypoint and then tell the user that no runners were installed:
```
❯ wd runner uninstall -platform=kubernetes -id=01GBD70R1TYVKH5T41HHYE9D49
✓ Runner "01GBD70R1TYVKH5T41HHYE9D49" uninstalled successfully
✓ Runner "01GBD70R1TYVKH5T41HHYE9D49" forgotten on server
✓ No runners installed.
```

After this update, the error messages are more specific and timely (we don't list the specific context because if the user hasn't set it with the `-k8s-context` flag then we don't have it; but we include this note just as a troubleshooting hint for the user):
```
❯ wd runner uninstall -platform=kubernetes -id=01GBTCZCF74K88V3DBB1MGXR25
❌ Unable to uninstall runner
! runner with ID "01GBTCZCF74K88V3DBB1MGXR25" not found in namespace "default"
  with current context
```