### PR TITLE
k8s: consolidate down to installutil pkg

### DIFF
--- a/builtin/k8s/helm/platform.go
+++ b/builtin/k8s/helm/platform.go
@@ -89,13 +89,9 @@ func (p *Platform) Deploy(
 		return nil, err
 	}
 
-	chartNS := ""
-	if v := p.config.Namespace; v != "" {
-		chartNS = v
-	}
-	if chartNS == "" {
-		// If all else fails, default the namespace to "default"
-		chartNS = "default"
+	if p.config.Namespace == "" {
+		// default the namespace to "default"
+		p.config.Namespace = "default"
 	}
 
 	// From here on out, we will always return a partial deployment if we error.
@@ -115,7 +111,7 @@ func (p *Platform) Deploy(
 		client.Devel = p.config.Devel
 		client.DependencyUpdate = false
 		client.Timeout = 300 * time.Second
-		client.Namespace = chartNS
+		client.Namespace = p.config.Namespace
 		client.ReleaseName = p.config.Name
 		client.GenerateName = false
 		client.NameTemplate = ""
@@ -151,7 +147,7 @@ func (p *Platform) Deploy(
 	client.Devel = p.config.Devel
 	client.DependencyUpdate = false
 	client.Timeout = 300 * time.Second
-	client.Namespace = chartNS
+	client.Namespace = p.config.Namespace
 	client.Atomic = false
 	client.SkipCRDs = false
 	client.SubNotes = true

--- a/internal/installutil/adoption.go
+++ b/internal/installutil/adoption.go
@@ -25,9 +25,6 @@ LOOP:
 	for {
 		select {
 		case <-timer.C:
-			ui.Output("Cancelled.",
-				terminal.WithErrorStyle(),
-			)
 			return errors.New("runner not detected by server after 5 minutes")
 		default:
 		}

--- a/internal/installutil/helm/helm.go
+++ b/internal/installutil/helm/helm.go
@@ -3,6 +3,9 @@ package helm
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint/builtin/k8s"
@@ -17,8 +20,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
-	"net/url"
-	"strings"
 )
 
 // restClientGetter is a RESTClientGetter interface implementation for the
@@ -91,7 +92,6 @@ func ActionInit(log hclog.Logger, kubeConfigPath string, context string) (*actio
 	if err != nil {
 		return nil, err
 	}
-
 	driver := "secret"
 
 	// For logging, we'll debug log to a custom named logger.

--- a/internal/installutil/k8s/k8s.go
+++ b/internal/installutil/k8s/k8s.go
@@ -143,7 +143,7 @@ func CleanPVC(ctx context.Context, ui terminal.UI, log hclog.Logger, listOptions
 			}
 		})
 		if err != nil {
-			s.Update("Unable to delete PVCs")
+			s.Update("Deleted PVCs not cleaned up after 10 minutes")
 			s.Abort()
 			return err
 		}

--- a/internal/installutil/k8s/k8s.go
+++ b/internal/installutil/k8s/k8s.go
@@ -16,22 +16,43 @@ import (
 )
 
 type K8sConfig struct {
-	namespace string `hcl:"namespace,optional"`
+	KubeconfigPath       string `hcl:"kubeconfig,optional"`
+	K8sContext           string `hcl:"context,optional"`
+	Version              string `hcl:"version,optional"`
+	Namespace            string `hcl:"namespace,optional"`
+	RunnerImage          string `hcl:"runner_image,optional"`
+	CpuRequest           string `hcl:"runner_cpu_request,optional"`
+	MemRequest           string `hcl:"runner_mem_request,optional"`
+	CreateServiceAccount bool   `hcl:"odr_service_account_init,optional"`
+	OdrImage             string `hcl:"odr_image"`
 
-	k8sContext string `hcl:"k8s_context,optional"`
-}
+	// Required for backwards compatibility
+	ImagePullPolicy string `hcl:"image_pull_policy,optional"`
+	CpuLimit        string `hcl:"cpu_limit,optional"`
+	MemLimit        string `hcl:"mem_limit,optional"`
+	ImagePullSecret string `hcl:"image_pull_secret,optional"`
+	
+	// Used for serverinstall
+	ServerImage        string            `hcl:"server_image,optional"`
+	ServiceAnnotations map[string]string `hcl:"service_annotations,optional"`
 
-type K8sInstaller struct {
-	config K8sConfig
+	OdrServiceAccount     string `hcl:"odr_service_account,optional"`
+	OdrServiceAccountInit bool   `hcl:"odr_service_account_init,optional"`
+
+	AdvertiseInternal bool   `hcl:"advertise_internal,optional"`
+	StorageClassName  string `hcl:"storageclassname,optional"`
+	StorageRequest    string `hcl:"storage_request,optional"`
+	SecretFile        string `hcl:"secret_file,optional"`
+	KubeConfigPath    string `hcl:"kubeconfig_path,optional"`
 }
 
 // newClient creates a new K8S client based on the configured settings.
-func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
+func NewClient(config K8sConfig) (*kubernetes.Clientset, error) {
 	// Build our K8S client.
 	configOverrides := &clientcmd.ConfigOverrides{}
-	if i.config.k8sContext != "" {
+	if config.K8sContext != "" {
 		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: i.config.k8sContext,
+			CurrentContext: config.K8sContext,
 		}
 	}
 	newCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
@@ -42,7 +63,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 	// Discover the current target namespace in the user's config so if they
 	// run kubectl commands waypoint will show up. If we use the default namespace
 	// they might not see the objects we've created.
-	if i.config.namespace == "" {
+	if config.Namespace == "" {
 		namespace, _, err := newCmdConfig.Namespace()
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -51,7 +72,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 			)
 		}
 
-		i.config.namespace = namespace
+		config.Namespace = namespace
 	}
 
 	clientconfig, err := newCmdConfig.ClientConfig()
@@ -75,7 +96,7 @@ func (i *K8sInstaller) NewClient() (*kubernetes.Clientset, error) {
 
 // Takes list options and cleans up any PVCs found in the query of resources from the kubernetes api.
 // Useful for cleaning up PVCs left behind by statefulsets deployed via helm.
-func (i *K8sInstaller) CleanPVC(ctx context.Context, ui terminal.UI, log hclog.Logger, listOptions metav1.ListOptions) error {
+func CleanPVC(ctx context.Context, ui terminal.UI, log hclog.Logger, listOptions metav1.ListOptions, config K8sConfig) error {
 
 	sg := ui.StepGroup()
 	defer sg.Wait()
@@ -83,11 +104,11 @@ func (i *K8sInstaller) CleanPVC(ctx context.Context, ui terminal.UI, log hclog.L
 	s := sg.Add("Deleting PVCs...")
 	defer func() { s.Abort() }()
 
-	clientset, err := i.NewClient()
+	clientset, err := NewClient(config)
 	if err != nil {
 		return err
 	}
-	pvcClient := clientset.CoreV1().PersistentVolumeClaims(i.config.namespace)
+	pvcClient := clientset.CoreV1().PersistentVolumeClaims(config.Namespace)
 	if list, err := pvcClient.List(ctx, listOptions); err != nil {
 		return err
 	} else if len(list.Items) > 0 {

--- a/internal/installutil/k8s/k8s.go
+++ b/internal/installutil/k8s/k8s.go
@@ -31,7 +31,7 @@ type K8sConfig struct {
 	CpuLimit        string `hcl:"cpu_limit,optional"`
 	MemLimit        string `hcl:"mem_limit,optional"`
 	ImagePullSecret string `hcl:"image_pull_secret,optional"`
-	
+
 	// Used for serverinstall
 	ServerImage        string            `hcl:"server_image,optional"`
 	ServiceAnnotations map[string]string `hcl:"service_annotations,optional"`

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -59,13 +59,9 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 		return err
 	}
 
-	chartNS := ""
-	if v := i.Config.Namespace; v != "" {
-		chartNS = v
-	}
-	if chartNS == "" {
-		// If all else fails, default the namespace to "default"
-		chartNS = "default"
+	// If all else fails, default the namespace to "default"
+	if i.Config.Namespace == "" {
+		i.Config.Namespace = "default"
 	}
 
 	// This setup for Helm install matches the setup for the Helm platform plugin
@@ -78,7 +74,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 	client.Devel = true
 	client.DependencyUpdate = false
 	client.Timeout = 300 * time.Second
-	client.Namespace = chartNS
+	client.Namespace = i.Config.Namespace
 	client.ReleaseName = "waypoint-" + strings.ToLower(opts.Id)
 	client.GenerateName = false
 	client.NameTemplate = ""

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -146,7 +146,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			if k8sErrors.IsNotFound(err) {
 				err = nil
 			} else {
-				opts.UI.Output("Error getting service account: %s", clierrors.Humanize(err), terminal.StatusError)
+				opts.UI.Output(fmt.Sprintf("Error getting service account: %s", clierrors.Humanize(err)), terminal.StatusError)
 				return err
 			}
 		} else {

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -341,7 +341,7 @@ func (i *K8sInstaller) Install(
 	err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
 		// the label we use for LabelSelector is set here
 		// https://github.com/hashicorp/waypoint-helm/blob/d2f6de6e9010b94da84f37eeaca4a8190a439060/templates/bootstrap-job.yaml#L8
-		jobs, err := clientset.BatchV1().Jobs(i.config.namespace).List(ctx, metav1.ListOptions{
+		jobs, err := clientset.BatchV1().Jobs(i.Config.Namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/instance=waypoint",
 		})
 		if err != nil {

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -479,7 +479,7 @@ func (i *K8sInstaller) Upgrade(
 		},
 	}
 
-	s = sg.Add("Installing Waypoint Helm chart...")
+	s.Update("Installing Waypoint Helm chart...")
 	_, err = client.RunWithContext(ctx, "waypoint", c, values)
 	if err != nil {
 		return nil, err

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -144,13 +144,9 @@ func (i *K8sInstaller) Install(
 		return nil, err
 	}
 
-	chartNS := ""
-	if v := i.Config.Namespace; v != "" {
-		chartNS = v
-	}
-	if chartNS == "" {
+	if i.Config.Namespace == "" {
 		// If all else fails, default the namespace to "default"
-		chartNS = "default"
+		i.Config.Namespace = "default"
 	}
 
 	client := action.NewInstall(actionConfig)
@@ -162,7 +158,7 @@ func (i *K8sInstaller) Install(
 	client.Devel = true
 	client.DependencyUpdate = false
 	client.Timeout = 300 * time.Second
-	client.Namespace = chartNS
+	client.Namespace = i.Config.Namespace
 	client.ReleaseName = "waypoint"
 	client.GenerateName = false
 	client.NameTemplate = ""
@@ -244,7 +240,7 @@ func (i *K8sInstaller) Install(
 		}
 
 		s.Update("Getting waypoint-ui service...")
-		svc, err := clientset.CoreV1().Services(chartNS).Get(
+		svc, err := clientset.CoreV1().Services(i.Config.Namespace).Get(
 			ctx, "waypoint-ui", metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -422,13 +418,9 @@ func (i *K8sInstaller) Upgrade(
 		return nil, err
 	}
 
-	chartNS := ""
-	if v := i.Config.Namespace; v != "" {
-		chartNS = v
-	}
-	if chartNS == "" {
+	if i.Config.Namespace == "" {
 		// If all else fails, default the namespace to "default"
-		chartNS = "default"
+		i.Config.Namespace = "default"
 	}
 
 	client := action.NewUpgrade(actionConfig)
@@ -439,7 +431,7 @@ func (i *K8sInstaller) Upgrade(
 	client.Devel = true
 	client.DependencyUpdate = false
 	client.Timeout = 300 * time.Second
-	client.Namespace = chartNS
+	client.Namespace = i.Config.Namespace
 	client.Atomic = false
 	client.SkipCRDs = false
 	client.SubNotes = true
@@ -505,7 +497,7 @@ func (i *K8sInstaller) Upgrade(
 		}
 
 		s.Update("Getting waypoint-ui service...")
-		svc, err := clientset.CoreV1().Services(chartNS).Get(
+		svc, err := clientset.CoreV1().Services(i.Config.Namespace).Get(
 			ctx, "waypoint-ui", metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -677,7 +677,10 @@ func (i *K8sInstaller) InstallRunner(
 			OdrImage:             i.Config.OdrImage,
 		},
 	}
-
+	// parachute in case we remove the flag defaults one day
+	if runnerInstaller.Config.Namespace == "" {
+		runnerInstaller.Config.Namespace = "default"
+	}
 	err := runnerInstaller.Install(ctx, opts)
 	if err != nil {
 		return err
@@ -696,6 +699,11 @@ func (i *K8sInstaller) UninstallRunner(
 			K8sContext:     i.Config.K8sContext,
 			Namespace:      i.Config.Namespace,
 		},
+	}
+
+	// parachute in case we remove the flag defaults one day
+	if runnerUninstaller.Config.Namespace == "" {
+		runnerUninstaller.Config.Namespace = "default"
 	}
 
 	err := runnerUninstaller.Uninstall(ctx, opts)
@@ -925,7 +933,7 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 		Name:    "k8s-namespace",
 		Target:  &i.Config.Namespace,
 		Usage:   "Namespace to install the Waypoint server into for Kubernetes.",
-		Default: "",
+		Default: "default",
 	})
 
 	set.StringVar(&flag.StringVar{
@@ -1011,7 +1019,7 @@ func (i *K8sInstaller) UpgradeFlags(set *flag.Set) {
 		Name:    "k8s-namespace",
 		Target:  &i.Config.Namespace,
 		Usage:   "Namespace to install the Waypoint server into for Kubernetes.",
-		Default: "",
+		Default: "default",
 	})
 
 	set.StringVar(&flag.StringVar{
@@ -1056,7 +1064,7 @@ func (i *K8sInstaller) UninstallFlags(set *flag.Set) {
 		Name:    "k8s-namespace",
 		Target:  &i.Config.Namespace,
 		Usage:   "Namespace in Kubernetes to uninstall the Waypoint server from.",
-		Default: "",
+		Default: "default",
 	})
 }
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -88,7 +88,7 @@ and disable the UI, the command would be:
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes. The default is 0.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes. The default is default.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -88,7 +88,7 @@ and disable the UI, the command would be:
 - `-k8s-mem-request=<string>` - Configures the requested memory amount for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-cpu-limit=<string>` - Configures the CPU limit for the Waypoint server in Kubernetes. The default is 0.
 - `-k8s-mem-limit=<string>` - Configures the memory limit for the Waypoint server in Kubernetes. The default is 0.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes. The default is default.
 - `-k8s-pull-policy=<string>` - Set the pull policy for the Waypoint server image.
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.

--- a/website/content/commands/server-uninstall.mdx
+++ b/website/content/commands/server-uninstall.mdx
@@ -59,6 +59,6 @@ command) will not be affected.
 #### kubernetes Options
 
 - `-k8s-context=<string>` - The Kubernetes context to unisntall the Waypoint server from. If left unset, Waypoint will use the current Kubernetes context.
-- `-k8s-namespace=<string>` - Namespace in Kubernetes to uninstall the Waypoint server from.
+- `-k8s-namespace=<string>` - Namespace in Kubernetes to uninstall the Waypoint server from. The default is default.
 
 @include "commands/server-uninstall_more.mdx"

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -63,7 +63,7 @@ manually installed runners will not be automatically upgraded.
 
 - `-k8s-advertise-internal` - Advertise the internal service address rather than the external. This is useful if all your deployments will be able to access the private service address. This will default to false but will be automatically set to true if the external host is detected to be localhost. The default is false.
 - `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
-- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes.
+- `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes. The default is default.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.


### PR DESCRIPTION
Fixes #3752 

Basically we were not propagating the value of the `k8s-context` or `namespace` flags down to k8sinstallutil.config. This moves the k8s configs from `runnerinstall` and `serverinstall` into the central location of k8sinstallutil, and changes the methods in the install util from methods to functions so ease the confusion of how these things relate together.
Now the values of those flags are being used by our installers.