### PR TITLE
config/pipeline: Auto-prune deployments on release by default

### DIFF
--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -305,7 +305,7 @@ func (c *Config) buildPipelineProto(pl *hclPipeline) ([]*pb.Pipeline, error) {
 		case "release":
 			var releaseBody struct {
 				DeploymentRef       uint64 `hcl:"deployment_ref,optional"` // 0 or "unset" means latest
-				Prune               bool   `hcl:"prune,optional"`
+				Prune               *bool  `hcl:"prune,optional"`          // nil means unset, we default to "true"
 				PruneRetain         int32  `hcl:"prune_retain,optional"`
 				PruneRetainOverride bool   `hcl:"prune_retain_override,optional"`
 			}
@@ -330,10 +330,16 @@ func (c *Config) buildPipelineProto(pl *hclPipeline) ([]*pb.Pipeline, error) {
 				}
 			}
 
+			// unset, so default to true
+			if releaseBody.Prune == nil {
+				b := true
+				releaseBody.Prune = &b
+			}
+
 			s.Kind = &pb.Pipeline_Step_Release_{
 				Release: &pb.Pipeline_Step_Release{
 					Deployment:          deployRef,
-					Prune:               releaseBody.Prune,
+					Prune:               *releaseBody.Prune,
 					PruneRetain:         releaseBody.PruneRetain,
 					PruneRetainOverride: releaseBody.PruneRetainOverride,
 				},


### PR DESCRIPTION
This commit updates a built-in step Release to auto-prune deployments by
default. This matches the behavior of our CLIs `waypoint deploy` and
`waypoint release`.

Fixes #3779