### PR TITLE
ui: make `<ContainerImageTag>` JSON parsing more resilient

### DIFF
--- a/.changelog/3786.txt
+++ b/.changelog/3786.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Make UI more resilient to invalid state JSON
+```

--- a/ui/app/components/container-image-tag/index.ts
+++ b/ui/app/components/container-image-tag/index.ts
@@ -13,11 +13,20 @@ export default class extends Component<Args> {
 
   get states(): unknown {
     return this.args.statusReport.resourcesList
-      ? this.args.statusReport.resourcesList.map((r) => JSON.parse(r.stateJson ?? '{}'))
+      ? this.args.statusReport.resourcesList.map(stateFromResource)
       : [];
   }
 
   get imageRefs(): ReturnType<typeof findImageRefs> {
     return findImageRefs(this.states);
+  }
+}
+
+function stateFromResource(resource: StatusReport.Resource.AsObject): unknown {
+  try {
+    return JSON.parse(resource.stateJson);
+  } catch (error) {
+    console.error('Could not pass stateJson for resource', resource);
+    return {};
   }
 }


### PR DESCRIPTION
This is a guess at a fix. A deeper fix would involve inspect the state JSON that caused the UI crash. This change will at least log the rogue resource data out in the console.

Addresses #3782 