### PR TITLE
Fix installing runner without specifying labels

### DIFF
--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -4,6 +4,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/posener/complete"
+	empty "google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"
@@ -12,8 +15,6 @@ import (
 	"github.com/hashicorp/waypoint/pkg/server"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/serverconfig"
-	"github.com/posener/complete"
-	empty "google.golang.org/protobuf/types/known/emptypb"
 )
 
 type RunnerInstallCommand struct {
@@ -294,7 +295,7 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 				PluginType: platform[0],
 			}
 		}
-		if targetLabels != nil {
+		if len(targetLabels) != 0 {
 			odrConfig.TargetRunner = &pb.Ref_Runner{
 				Target: &pb.Ref_Runner_Labels{
 					Labels: &pb.Ref_RunnerLabels{

--- a/pkg/server/ptypes/ondemand_runner.go
+++ b/pkg/server/ptypes/ondemand_runner.go
@@ -57,6 +57,19 @@ func ValidateOnDemandRunnerConfigRules(p *pb.OnDemandRunnerConfig) []*validation
 		validation.Field(&p.PluginType, validation.Required),
 		validation.Field(&p.PluginConfig, isPluginHcl(p)),
 		validation.Field(&p.Name, validation.By(validatePathToken)),
+		validation.Field(&p.TargetRunner, validation.By(func(i interface{}) error {
+			targetRunner, _ := i.(*pb.Ref_Runner)
+			if targetRunner == nil {
+				return nil
+			}
+			switch runner := targetRunner.Target.(type) {
+			case *pb.Ref_Runner_Labels:
+				if len(runner.Labels.Labels) == 0 {
+					return errors.New("profile targets a runner with labels, but does not specify any labels")
+				}
+			}
+			return nil
+		})),
 	}
 }
 


### PR DESCRIPTION
This fixes a bug where if you tried a runner install with no targeting, it would attempt to target by labels but not include any actual labels, resulting in an invalid runner profile.

This fixes the cli, and also introduces a new validator on the server for the condition.