### PR TITLE
`WatchTask` for Nomad Task Launcher

### DIFF
--- a/.changelog/3797.txt
+++ b/.changelog/3797.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/nomad: Store Nomad on-demand runner logs in the job system
+```

--- a/.changelog/3797.txt
+++ b/.changelog/3797.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-plugin/nomad: Store Nomad on-demand runner logs in the job system
+plugin/nomad: Implement WatchTask plugin for Nomad task launcher. Store Nomad on-demand runner logs in the job system.
 ```

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -3,7 +3,6 @@ package nomad
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -307,7 +306,7 @@ func (p *TaskLauncher) WatchTask(
 
 	if len(allocs) != 1 {
 		log.Error("Invalid # of allocs for ODR job.")
-		return nil, errors.New("there should be one allocation in the job")
+		return nil, status.Error(codes.Internal, "there should be one allocation in the job")
 	}
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 	if err != nil {
@@ -316,7 +315,7 @@ func (p *TaskLauncher) WatchTask(
 	}
 	tg := alloc.GetTaskGroup()
 	if len(tg.Tasks) != 1 {
-		return nil, errors.New("there should be one task in the allocation")
+		return nil, status.Error(codes.Internal, "there should be one task in the allocation")
 	}
 	task := tg.Tasks[0]
 
@@ -339,7 +338,7 @@ func (p *TaskLauncher) WatchTask(
 		}
 		allocTask, ok := alloc.TaskStates[task.Name]
 		if !ok {
-			return nil, errors.New("ODR task not in alloc")
+			return nil, status.Error(codes.Unknown, "ODR task not in alloc")
 		}
 		state = allocTask.State
 	}

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -363,7 +363,6 @@ func (p *TaskLauncher) WatchTask(
 					case err := <-errChan:
 						log.Error("Error reading logs from alloc: %q", err.Error())
 						return nil, err
-
 					}
 				}
 			}

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -310,7 +310,7 @@ func (p *TaskLauncher) WatchTask(
 	}
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 	if err != nil {
-		log.Error("Failed to get info for alloc "+allocs[0].ID+". Error: %s", err.Error())
+		log.Error("Failed to get info for alloc.", "alloc_id", allocs[0].ID, "err", err.Error())
 		return nil, err
 	}
 	tg := alloc.GetTaskGroup()
@@ -329,11 +329,11 @@ func (p *TaskLauncher) WatchTask(
 		select {
 		case <-ticker.C:
 		case <-ctx.Done(): // cancelled
-			return nil, status.Errorf(codes.Aborted, "Context cancelled from timeout waiting for ODR task to start %s", ctx.Err())
+			return nil, status.Errorf(codes.Aborted, "Context cancelled from timeout waiting for ODR task to start: %s", ctx.Err())
 		}
 		alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 		if err != nil {
-			log.Error("Failed to get info for alloc "+allocs[0].ID+". Error: %s", err.Error())
+		log.Error("Failed to get info for alloc waiting for task to start", "alloc_id", allocs[0].ID, "err", err.Error())
 			return nil, err
 		}
 		allocTask, ok := alloc.TaskStates[task.Name]
@@ -349,7 +349,7 @@ func (p *TaskLauncher) WatchTask(
 		follow = false
 	}
 
-	log.Debug("Getting logs for alloc: " + alloc.Name + ", task: " + task.Name)
+	log.Debug("Getting logs for alloc", "alloc_name", alloc.Name, "task_name", task.Name)
 	ch := make(chan struct{})
 	logStream, errChan := client.AllocFS().Logs(alloc, follow, task.Name, "stderr", "", 0, ch, queryOpts)
 READ_LOGS:
@@ -360,7 +360,7 @@ READ_LOGS:
 				// check if task is dead, if it is dead, return
 				alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 				if err != nil {
-					log.Error("Failed to get info for alloc "+allocs[0].ID+". Error: %s", err.Error())
+		log.Error("Failed to get info for alloc to stream logs", "alloc_id", allocs[0].ID, "err", err.Error())
 					return nil, err
 				}
 				allocTask, ok := alloc.TaskStates[task.Name]
@@ -380,7 +380,7 @@ READ_LOGS:
 			log.Info(message)
 			ui.Output(message)
 		case err := <-errChan:
-			log.Error("Error reading logs from alloc: %q", err.Error())
+			log.Error("Error reading logs from alloc", "err", err.Error())
 			return nil, err
 		}
 	}

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -305,8 +305,8 @@ func (p *TaskLauncher) WatchTask(
 	}
 
 	if len(allocs) != 1 {
-		log.Error("Invalid # of allocs for ODR job.")
-		return nil, status.Error(codes.Internal, "there should be one allocation in the job")
+		log.Error("Invalid # of allocs for ODR job", "total_allocs", len(allocs))
+		return nil, status.Errorf(codes.Internal, "Invalid # of allocs for ODR job: %d", len(allocs))
 	}
 	alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 	if err != nil {
@@ -333,7 +333,7 @@ func (p *TaskLauncher) WatchTask(
 		}
 		alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 		if err != nil {
-		log.Error("Failed to get info for alloc waiting for task to start", "alloc_id", allocs[0].ID, "err", err.Error())
+			log.Error("Failed to get info for alloc waiting for task to start", "alloc_id", allocs[0].ID, "err", err.Error())
 			return nil, err
 		}
 		allocTask, ok := alloc.TaskStates[task.Name]
@@ -360,7 +360,7 @@ READ_LOGS:
 				// check if task is dead, if it is dead, return
 				alloc, _, err := client.Allocations().Info(allocs[0].ID, queryOpts)
 				if err != nil {
-		log.Error("Failed to get info for alloc to stream logs", "alloc_id", allocs[0].ID, "err", err.Error())
+					log.Error("Failed to get info for alloc to stream logs", "alloc_id", allocs[0].ID, "err", err.Error())
 					return nil, err
 				}
 				allocTask, ok := alloc.TaskStates[task.Name]

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -5,17 +5,18 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/api"
+	"github.com/oklog/ulid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
-	"github.com/oklog/ulid"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 )
 
 // TaskLauncher implements the TaskLauncher plugin interface to support


### PR DESCRIPTION
Closes #3714.

The task launcher Nomad plugin will use the Nomad API to stream logs from the Nomad allocation which is running the Waypoint on-demand runner container. These logs will be available in the log output of the static runner. This means that long after the ODR job is purged from Nomad, the ODR's logs are consumable from the static runner, which runs indefinitely, making troubleshooting of remote operations easier since previously, the ODR logs were unavailable (unless the operator quickly got the ODR's logs with `nomad logs` or in the Nomad UI before it was purged).