### PR TITLE
ui: bump google-protobuf to 3.21.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -136,10 +136,10 @@
   "dependencies": {
     "@hashicorp/design-system-components": "^1.0.3",
     "@hashicorp/ember-flight-icons": "^2.0.10",
-    "@types/google-protobuf": "^3.7.2",
+    "@types/google-protobuf": "^3.15.6",
     "api-common-protos": "link:./lib/api-common-protos",
     "ember-cli-typescript-blueprints": "^3.0.0",
-    "google-protobuf": "^3.12.2",
+    "google-protobuf": "^3.21.0",
     "grpc-web": "link:./lib/grpc-web",
     "opaqueany": "link:./lib/opaqueany",
     "waypoint-client": "link:./lib/waypoint-client",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2437,10 +2437,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google-protobuf@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.2.tgz#cd8a360c193ce4d672575a20a79f49ba036d38d2"
-  integrity sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ==
+"@types/google-protobuf@^3.15.6":
+  version "3.15.6"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.6.tgz#674a69493ef2c849b95eafe69167ea59079eb504"
+  integrity sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==
 
 "@types/htmlbars-inline-precompile@*":
   version "1.0.1"
@@ -9153,10 +9153,10 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-google-protobuf@^3.12.2:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.12.2.tgz#50ce9f9b6281235724eb243d6a83e969a2176e53"
-  integrity sha512-4CZhpuRr1d6HjlyrxoXoocoGFnRYgKULgMtikMddA9ztRyYR59Aondv2FioyxWVamRo0rF2XpYawkTCBEQOSkA==
+google-protobuf@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.0.tgz#8dfa3fca16218618d373d414d3c1139e28034d6e"
+  integrity sha512-byR7MBTK4tZ5PZEb+u5ZTzpt4SfrTxv5682MjPlHN16XeqgZE2/8HOIWeiXe8JKnT9OVbtBGhbq8mtvkK8cd5g==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.9"


### PR DESCRIPTION
## Why the change?

We recently (#3720) regenerated the waypoint-pb (protobuf types) and waypoint-client (grpc-web client) libraries using protoc 3.17.3. It seems like this latest generated code requires a more up-to-date version of the google-protobuf dependency.

## How do I test this?

1. Check out the branch
2. `(cd ui && make build)`
3. `make static-assets`
4. `make bin`
5. `./waypoint server run -accept-tos`
6. Run the bootstrap command it gives you
7. `./waypoint ui -authenticate`
8. Verify you see no errors in the JS console
9. Verify the version info shows up in the footer