### PR TITLE
k8s runner profile should use odr img, not server

### DIFF
--- a/.changelog/3800.txt
+++ b/.changelog/3800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/runner: Default to odr oci image url for runner profiles created via runner install
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -66,7 +66,7 @@ func (c *RunnerInstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "odr-image",
 			Usage:   "Docker image for the on-demand runners.",
-			Default: "hashicorp/waypoint-odr:latest",
+			Default: installutil.DefaultRunnerImage,
 			Target:  &c.runnerProfileOdrImage,
 		})
 

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
@@ -256,7 +257,7 @@ func (c *RunnerProfileSetCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "oci-url",
 			Target:  &c.flagOCIUrl,
-			Default: "hashicorp/waypoint-odr:latest",
+			Default: installutil.DefaultRunnerImage,
 			Usage:   "The url for the OCI image to launch for the on-demand runner.",
 		})
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/waypoint/internal/installutil"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/waypoint/internal/installutil"
 
 	"github.com/hashicorp/waypoint/builtin/k8s"
 
@@ -432,7 +433,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 		} else {
 			ociUrl := odr.OciUrl
 			if ociUrl == "" {
-				ociUrl = "hashicorp/waypoint-odr:latest"
+				ociUrl = installutil.DefaultRunnerImage
 			}
 			odr = &pb.OnDemandRunnerConfig{
 				Id:                   oldRunnerConfig.Config.Id,

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -9,10 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/waypoint/internal/installutil"
-
-	"github.com/hashicorp/waypoint/builtin/k8s"
-
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,9 +16,11 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/k8s"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/clisnapshot"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/runnerinstall"
 	"github.com/hashicorp/waypoint/internal/serverinstall"

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -2,6 +2,7 @@ package installutil
 
 import (
 	"fmt"
+
 	"github.com/distribution/distribution/v3/reference"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
@@ -29,6 +30,10 @@ func DefaultODRImage(serverImage string) (string, error) {
 }
 
 const DefaultServerImage = "hashicorp/waypoint:latest"
+
+// When we have a serverImage value to give to DefaultODRImage,
+// we should use that. When we don't, we can use this value
+const DefaultRunnerImage = "hashicorp/waypoint-odr:latest"
 
 func DefaultRunnerName(id string) string {
 	return "waypoint-" + id + "-runner"

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -8,15 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/waypoint/builtin/k8s"
-	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"github.com/hashicorp/waypoint/internal/clierrors"
-	"github.com/hashicorp/waypoint/internal/installutil"
-	helminstallutil "github.com/hashicorp/waypoint/internal/installutil/helm"
-	k8sinstallutil "github.com/hashicorp/waypoint/internal/installutil/k8s"
-	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/mitchellh/mapstructure"
 	dockerparser "github.com/novln/docker-parser"
 	"helm.sh/helm/v3/pkg/action"
@@ -25,6 +16,15 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"github.com/hashicorp/waypoint/builtin/k8s"
+	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/installutil"
+	helminstallutil "github.com/hashicorp/waypoint/internal/installutil/helm"
+	k8sinstallutil "github.com/hashicorp/waypoint/internal/installutil/k8s"
+	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
 type K8sRunnerInstaller struct {

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/waypoint/builtin/k8s"
-	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/waypoint/builtin/k8s"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -260,7 +261,7 @@ func (i *K8sRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-runner-image",
 		Target:  &i.Config.RunnerImage,
-		Default: installutil.DefaultServerImage,
+		Default: installutil.DefaultRunnerImage,
 		Usage:   "Docker image for the Waypoint runner.",
 	})
 

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -73,7 +73,7 @@ the install, the command would be:
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint runner to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-helm-version=<string>` - The version of the Helm chart to use for the Waypoint runner install. The required version number format is: 'vX.Y.Z'.
 - `-k8s-namespace=<string>` - The namespace in the Kubernetes cluster into which the Waypoint runner will be installed. The default is default.
-- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint:latest.
+- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint-odr:latest.
 - `-k8s-cpu-request=<string>` - Requested amount of CPU for Waypoint runner. The default is 250m.
 - `-k8s-mem-request=<string>` - Requested amount of memory for Waypoint runner. The default is 256Mi.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.


### PR DESCRIPTION
My runner profile created via running `waypoint runner install` did not use the ODR image by default.

Before:
```
$ wd runner install -k8s-context=secondary -server-tls-skip-verify -- -label=environment=secondary
...

$ wd runner profile list
Runner profiles
                  NAME                  | PLUGIN TYPE |                OCI URL                 |            TARGET RUNNER            | DEFAULT
----------------------------------------+-------------+----------------------------------------+-------------------------------------+----------
  01GBWMDG7YRX1A7HRPQKWNSX2S            | kubernetes  | docker.io/hashicorp/waypoint-odr:0.9.1 | *                                   | yes
  kubernetes-bootstrap-profile          | kubernetes  | hashicorp/waypoint-odr:latest          | *                                   | yes
  kubernetes-01GBWN6ZBQP6GH4R4GGWRG9W8M | kubernetes  | hashicorp/waypoint:latest              | labels: {"environment":"secondary"} |
```

After:
```
$ wd runner install -k8s-context=secondary -server-tls-skip-verify -- -label=environment=secondary2
...

$ wd runner profile list
Runner profiles
                  NAME                  | PLUGIN TYPE |                OCI URL                 |            TARGET RUNNER             | DEFAULT
----------------------------------------+-------------+----------------------------------------+--------------------------------------+----------
  01GBWMDG7YRX1A7HRPQKWNSX2S            | kubernetes  | docker.io/hashicorp/waypoint-odr:0.9.1 | *                                    | yes
  kubernetes-bootstrap-profile          | kubernetes  | hashicorp/waypoint-odr:latest          | *                                    | yes
  kubernetes-01GBWN6ZBQP6GH4R4GGWRG9W8M | kubernetes  | hashicorp/waypoint:latest              | labels: {"environment":"secondary"}  |
  kubernetes-01GBZ9Q7ZPMHJKVR5XJJHQX96S | kubernetes  | hashicorp/waypoint-odr:latest          | labels: {"environment":"secondary2"} |
```