### PR TITLE
Delete runner profiles by name

### DIFF
--- a/.changelog/3803.txt
+++ b/.changelog/3803.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+cli: `runner profile delete` deletes by name rather than the user-invisible ID.
+```
+
+```release-note:bug
+cli: `runner profile apply` does not create entries with duplicate names. 
+```

--- a/.changelog/3803.txt
+++ b/.changelog/3803.txt
@@ -3,5 +3,5 @@ cli: `runner profile delete` deletes by name rather than the user-invisible ID.
 ```
 
 ```release-note:bug
-cli: `runner profile apply` does not create entries with duplicate names. 
+cli: `runner profile set` does not create entries with duplicate names. 
 ```

--- a/website/content/commands/runner-profile-delete.mdx
+++ b/website/content/commands/runner-profile-delete.mdx
@@ -15,7 +15,7 @@ Delete a runner profile.
 
 ## Usage
 
-Usage: `waypoint runner profile delete <id>`
+Usage: `waypoint runner profile delete <name>`
 
 #### Global Options
 
@@ -23,5 +23,9 @@ Usage: `waypoint runner profile delete <id>`
 - `-app=<string>` (`-a`) - App to target. Certain commands require a single app target for Waypoint configurations with multiple apps. If you have a single app, then this can be ignored.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
+
+#### Command Options
+
+- `-id=<string>` - The id of the runner profile to delete.
 
 @include "commands/runner-profile-delete_more.mdx"


### PR DESCRIPTION
Closes https://github.com/hashicorp/waypoint/issues/3481

This allows runner profiles to be deleted by name, not ID. We don't surface IDs to users, so it's not useful to delete them by ID.

I also found that we were able to create multiple runner profiles with the same name. This PR fixes that, adds a test around it, and still allows users to delete runner profiles by `id` (via a flag) if they find themselves with duplicate-named runners as an emergency backdoor.