### PR TITLE
Fix Nomad upgrade of runner

### DIFF
--- a/.changelog/3804.txt
+++ b/.changelog/3804.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+upgrade: Nomad server upgrade upgrade now detects runners with the name
+`waypoint-runner` or `waypoint-static-runner`
+```

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -683,13 +683,23 @@ func (i *NomadInstaller) HasRunner(
 	if err != nil {
 		return false, err
 	}
+	var jobs []*api.JobListStub
 
-	jobs, _, err := client.Jobs().PrefixList(runnerName)
+	// Check for runner with job name pre-0.9
+	jobsWithOldRunnerName, _, err := client.Jobs().PrefixList(runnerName)
 	if err != nil {
 		return false, err
 	}
+	jobs = append(jobs, jobsWithOldRunnerName...)
+
+	// Check for runner with job name post-0.9
+	jobWithNewRunnerName, _, err := client.Jobs().PrefixList(runnerJobName)
+	if err != nil {
+		return false, err
+	}
+	jobs = append(jobs, jobWithNewRunnerName...)
 	for _, j := range jobs {
-		if j.Name == runnerName {
+		if j.Name == runnerJobName || j.Name == runnerName {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
`server upgrade`s for Nomad succeeded in upgrading the server, but failed to detect the runner because the old name for a runner's Nomad job, "waypoint-runner" was still being used. This PR corrects that by searching for a runner with the old name from before 0.9, "waypoint-runner", or the new name from after 0.9, "waypoint-static-runner".