### PR TITLE
WIP: workspace scoped step jobs

### DIFF
--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -390,12 +390,21 @@ func (s *Service) buildStepJobs(
 			// step's jobs aren't scheduled prior to any dependencies.
 			parentStepDep := map[string][]string{pipeline.Id: job.DependsOn}
 
-			// TODO: add the parent step workspace ref. Note this only works now
-			// because we are limiting nested pipelines to 1 layer.
 			embedJobs, embedRun, embedStepIds, err := s.buildStepJobs(ctx, log, req,
 				visitedPipelines, nodeStepRef, parentStepDep, embeddedPipeline, pipelineRun)
 			if err != nil {
 				return nil, nil, nil, err
+			}
+
+			// Add the parent step workspace ref.
+			// **Note** this only works now because we are limiting nested
+			// pipelines to 1 layer.
+			if step.Workspace != nil {
+				for _, jobReq := range embedJobs {
+					jobReq.Job.Workspace = &pb.Ref_Workspace{
+						Workspace: step.Workspace.Workspace,
+					}
+				}
 			}
 
 			// add the nested jobs

--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -298,6 +298,12 @@ func (s *Service) buildStepJobs(
 			RunSequence:  pipelineRun.Sequence,
 		}
 
+		if step.Workspace != nil {
+			job.Workspace = &pb.Ref_Workspace{
+				Workspace: step.Workspace.Workspace,
+			}
+		}
+
 		// Queue the right job depending on the Step type. We will queue a Waypoint
 		// operation if the type is a reserved built in step.
 		switch o := step.Kind.(type) {
@@ -384,6 +390,8 @@ func (s *Service) buildStepJobs(
 			// step's jobs aren't scheduled prior to any dependencies.
 			parentStepDep := map[string][]string{pipeline.Id: job.DependsOn}
 
+			// TODO: add the parent step workspace ref. Note this only works now
+			// because we are limiting nested pipelines to 1 layer.
 			embedJobs, embedRun, embedStepIds, err := s.buildStepJobs(ctx, log, req,
 				visitedPipelines, nodeStepRef, parentStepDep, embeddedPipeline, pipelineRun)
 			if err != nil {


### PR DESCRIPTION
This PR updates how steps are used to create jobs, by reading the new workspace reference and updating the job definition to use that workspace. 

This PR is a continuation of the work started in https://github.com/hashicorp/waypoint/pull/3802 and is currently built off of and targeting that branch.

Currently Waypoint only allows a single layer of nesting pipelines. If the `step` that embeds a pipeline has a `workspace` set, that workspace will be set on all the embedded jobs that get created. 