### PR TITLE
Fixing panic in ecs task config

### DIFF
--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -11,13 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/oklog/ulid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
+	"github.com/hashicorp/waypoint/builtin/aws/utils"
 )
 
 // TaskLauncher implements the TaskLauncher plugin interface to support
@@ -63,10 +63,10 @@ type TaskLauncherConfig struct {
 
 	// Subnets are the list of subnets for the cluster. These will match the
 	// subnets used for the Cluster
-	Subnets string `hcl:"subnets,required"`
+	Subnets string `hcl:"subnets"`
 
 	// SecurityGroupId is the security group used for the Waypoint tasks.
-	SecurityGroupId string `hcl:"security_group_id,required"`
+	SecurityGroupId string `hcl:"security_group_id"`
 
 	// LogGroup is the CloudWatch log group name to use.
 	LogGroup string `hcl:"log_group,optional"`


### PR DESCRIPTION
`required` is not a valid hcl tag. In hcl, it looks like the absence of an "optional" tag indicates that a field is required.

Currently, we're panicing here when we attempt to parse this config: https://github.com/hashicorp/hcl/blob/main/gohcl/schema.go#L176

Fixes change introduced here: https://github.com/hashicorp/waypoint/commit/4a08b1bdb6f427712d2a005c09c72636e5e27762

This fix has been tested by hand.

Runner panic stacktrace:

```
2022-09-02T17:49:04.872-04:00	panic: invalid hcl field tag kind "required" on string "Subnets"

2022-09-02T17:49:04.872-04:00	goroutine 44 [running]:

2022-09-02T17:49:04.873-04:00	github.com/hashicorp/hcl/v2/gohcl.getFieldTags({0x3b2d2c0, 0xc000f6ae40})

2022-09-02T17:49:04.873-04:00	/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.10.1-0.20210621220818-327f3ce2570e/gohcl/schema.go:176 +0x625

2022-09-02T17:49:04.873-04:00	github.com/hashicorp/hcl/v2/gohcl.ImpliedBodySchema({0xc000f6ae40, 0xc0004ab5f0})

2022-09-02T17:49:04.873-04:00	/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.10.1-0.20210621220818-327f3ce2570e/gohcl/schema.go:36 +0xe9

2022-09-02T17:49:04.873-04:00	github.com/hashicorp/hcl/v2/gohcl.decodeBodyToStruct({0x3a8e8a0, 0xc000c7d9e0}, 0xc0004ab560, {0xc000f6ae40, 0xc0004ab560, 0x9a2100})

2022-09-02T17:49:04.873-04:00	/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.10.1-0.20210621220818-327f3ce2570e/gohcl/decode.go:52 +0x85

2022-09-02T17:49:04.873-04:00	github.com/hashicorp/hcl/v2/gohcl.decodeBodyToValue({0x3a8e8a0, 0xc000c7d9e0}, 0xe2682a, {0xc000f6ae40, 0xc0004ab560, 0x7f17228425b0})

2022-09-02T17:49:04.873-04:00	/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.10.1-0.20210621220818-327f3ce2570e/gohcl/decode.go:43 +0xa5

2022-09-02T17:49:04.873-04:00	github.com/hashicorp/hcl/v2/gohcl.DecodeBody({0x3a8e8a0, 0xc000c7d9e0}, 0xc0009e9e30, {0xc000235680, 0xc0004ab560})

2022-09-02T17:49:04.874-04:00	/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.10.1-0.20210621220818-327f3ce2570e/gohcl/decode.go:36 +0x105

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint-plugin-sdk/component.Configure({0x2fdca40, 0xc0009e9e30}, {0x3a8e8a0, 0xc000c7d9e0}, 0xb)

2022-09-02T17:49:04.874-04:00	/go/pkg/mod/github.com/hashicorp/waypoint-plugin-sdk@v0.0.0-20220502215818-69a3eeb201d8/component/configure.go:63 +0xb6

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/plugin.Open({0x3a8de20, 0xc00023d140}, {0x3b1cdf0, 0xc000bd2d80}, 0xc00066e150)

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/plugin/invoke.go:157 +0x15d

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).executeStartTaskOp(0xc000942c40, {0x3a8de20, 0xc00023d140}, {0x3b1cdf0, 0xc000bd2d80}, {0x93, 0x12b}, 0x467733)

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/operation_task.go:34 +0x169

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).prepareAndExecuteJob(0xc001133ef0, {0x3a8de20, 0xc00023d140}, {0x3b1cdf0, 0xc000bd2d80}, {0x3ae56e8, 0xc00064e6c0}, 0xc000c94428, {0x3ae5690, 0xc00064e660}, ...)

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/accept.go:556 +0x2ba

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).accept(0xc00094cfc0, {0x3a8de20, 0xc000cee600}, {0x0, 0x0})

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/accept.go:465 +0x1a70

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).Accept(...)

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/accept.go:110

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).AcceptMany(0xc00094cfc0, {0x3a8de20, 0xc000cee600})

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/accept.go:55 +0x45

2022-09-02T17:49:04.874-04:00	github.com/hashicorp/waypoint/internal/runner.(*Runner).AcceptParallel.func1()

2022-09-02T17:49:04.874-04:00	/tmp/wp-src/internal/runner/accept.go:43 +0x6f

2022-09-02T17:49:04.874-04:00	created by github.com/hashicorp/waypoint/internal/runner.(*Runner).AcceptParallel

2022-09-02T17:49:04.875-04:00	/tmp/wp-src/internal/runner/accept.go:40 +0x185
```