### PR TITLE
cli: Warn if local invocation of `waypoint pipeline run`

### DIFF
--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -39,7 +39,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		c.ui.Output("Both pipeline name and ID were specified, using pipeline ID", terminal.WithWarningStyle())
 	}
 
-	if *c.flagLocal == true {
+	if *c.flagLocal {
 		// TODO(briancain): Remove this warning when local support for Pipelines is introduced.
 		// GitHub: https://github.com/hashicorp/waypoint/issues/3813
 		c.ui.Output("At the moment, the initial Tech Preview of Custom Pipelines does not allow "+

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -39,6 +39,16 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		c.ui.Output("Both pipeline name and ID were specified, using pipeline ID", terminal.WithWarningStyle())
 	}
 
+	if *c.flagLocal == true {
+		// TODO(briancain): Remove this warning when local support for Pipelines is introduced.
+		// GitHub: https://github.com/hashicorp/waypoint/issues/3813
+		c.ui.Output("At the moment, the initial Tech Preview of Custom Pipelines does not allow "+
+			"for executing pipelines with a local runner. The CLI will attempt to run the "+
+			"requested pipeline but it will likely fail if the project was not configured "+
+			"to run remotely.",
+			terminal.WithWarningStyle())
+	}
+
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
 		// setup pipeline name to be used for UI printing
 		pipelineIdent := pipelineName


### PR DESCRIPTION
Prior to this commit, the CLI would attempt to run a pipeline locally if the `-local` flag was used. Currently the MVP of pipelines does not support this, so we should show a big warning as such prior to running the pipeline so that users aren't confused when they see an error about the project not being setup to run remotely.

Fixes [#3811](https://github.com/hashicorp/waypoint/issues/3811)