### PR TITLE
ui: remove `@ember-decorators/component`

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,6 @@
     "test:ember:percy:ci": "percy exec ember test --path=dist"
   },
   "devDependencies": {
-    "@ember-decorators/component": "^6.1.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.2",
     "@ember/test-helpers": "^2.6.0",


### PR DESCRIPTION
Pretty sure we don’t use this directly anymore.

No change to `yarn.lock` because of the following chain:

```
❯ yarn why @ember-decorators/component
yarn why v1.22.18
[1/4] 🤔  Why do we have the module "@ember-decorators/component"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@ember-decorators/component@6.1.1"
info Reasons this module exists
   - "ember-toggle#ember-decorators" depends on it
   - Hoisted from "ember-toggle#ember-decorators#@ember-decorators#component"
```