### PR TITLE
Workspace scoped steps parsing: HCL parsing

### DIFF
--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -49,6 +49,9 @@ type hclStep struct {
 
 	// An optional embedded pipeline stanza
 	PipelineRaw *hclPipeline `hcl:"pipeline,block"`
+
+	// An optional embedded pipeline stanza
+	Workspace string `hcl:"workspace,optional"`
 }
 
 // Pipelines returns the id of all the defined pipelines
@@ -102,6 +105,7 @@ func (c *Config) Pipeline(id string, ctx *hcl.EvalContext) (*Pipeline, error) {
 			DependsOn: stepRaw.DependsOn,
 			ImageURL:  stepRaw.ImageURL,
 			Use:       stepRaw.Use,
+			Workspace: stepRaw.Workspace,
 		}
 
 		// Parse a nested pipeline step if defined
@@ -156,6 +160,7 @@ func (c *Config) Pipeline(id string, ctx *hcl.EvalContext) (*Pipeline, error) {
 					DependsOn: embedStepRaw.DependsOn,
 					ImageURL:  embedStepRaw.ImageURL,
 					Use:       embedStepRaw.Use,
+					Workspace: embedStepRaw.Workspace,
 				}
 				embSteps = append(embSteps, &s)
 			}
@@ -218,6 +223,12 @@ func (c *Config) buildPipelineProto(pl *hclPipeline) ([]*pb.Pipeline, error) {
 			Name:      step.Name,
 			DependsOn: step.DependsOn,
 			Image:     step.ImageURL,
+		}
+
+		if step.Workspace != "" {
+			s.Workspace = &pb.Ref_Workspace{
+				Workspace: step.Workspace,
+			}
 		}
 
 		// If no dependency was explictily set, we rely on the previous step

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -167,9 +167,11 @@ func TestPipeline(t *testing.T) {
 				steps := c.Steps
 				require.Len(steps, 3)
 				for _, step := range steps {
+					expected := ""
 					if step.Name == "testworkspace" {
-						require.Equal("testworkspace", step.Workspace)
+						expected = "testworkspace"
 					}
+					require.Equal(expected, step.Workspace)
 				}
 			},
 		},

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -348,9 +348,9 @@ func TestPipelineProtos(t *testing.T) {
 
 				require.Equal(pipelines[0].Name, "foo")
 
-				testStep := pipelines[0].Steps["testws"]
+				testStep := pipelines[0].Steps["testworkspace"]
 				require.NotNil(testStep.Workspace)
-				require.Equal("testws", testStep.Workspace.Workspace)
+				require.Equal("testworkspace", testStep.Workspace.Workspace)
 			},
 		},
 

--- a/internal/config/stages.go
+++ b/internal/config/stages.go
@@ -61,6 +61,9 @@ type Step struct {
 	Pipeline *Pipeline `hcl:"pipeline,block"`
 
 	ctx *hcl.EvalContext
+
+	// Optional workspace scoping
+	Workspace string `hcl:"workspace,optional"`
 }
 
 // Build are the build settings.

--- a/internal/config/testdata/pipelines/pipeline_step_workspace.hcl
+++ b/internal/config/testdata/pipelines/pipeline_step_workspace.hcl
@@ -1,0 +1,39 @@
+project = "foo"
+
+pipeline "foo" {
+  step "test" {
+    image_url = "example.com/test"
+
+    use "exec" {
+      command = "bar"
+    }
+  }
+  
+  step "testws" {
+    image_url = "example.com/test"
+    workspace = "testws"
+    use "exec" {
+      command = "bar"
+    }
+  }
+  
+  step "othertest" {
+    image_url = "example.com/test"
+    depends_on = ["test"]
+    use "exec" {
+      command = "bar"
+    }
+  }
+}
+
+app "web" {
+    config {
+        env = {
+            static = "hello"
+        }
+    }
+
+    build {}
+
+    deploy {}
+}

--- a/internal/config/testdata/pipelines/pipeline_step_workspace.hcl
+++ b/internal/config/testdata/pipelines/pipeline_step_workspace.hcl
@@ -9,9 +9,9 @@ pipeline "foo" {
     }
   }
   
-  step "testws" {
+  step "testworkspace" {
     image_url = "example.com/test"
-    workspace = "testws"
+    workspace = "testworkspace"
     use "exec" {
       command = "bar"
     }

--- a/internal/config/testdata/pipelines/pipeline_step_workspace_nested.hcl
+++ b/internal/config/testdata/pipelines/pipeline_step_workspace_nested.hcl
@@ -1,0 +1,78 @@
+project = "foo"
+
+pipeline "foo" {
+  step "test" {
+    image_url = "example.com/test"
+
+    use "exec" {
+      command = "bar"
+    }
+  }
+  
+  step "testworkspace" {
+    image_url = "example.com/test"
+    workspace = "testworkspace"
+    use "exec" {
+      command = "bar"
+    }
+  }
+
+  step "pipe_normal" {
+    pipeline "nested" {
+      step "test_nested" {
+        image_url = "example.com/test"
+
+        use "exec" {
+          command = "nested"
+        }
+      }
+    }
+  }
+  
+  step "pipe_changed" {
+    workspace = "testworkspace"
+    pipeline "nested" {
+      step "test_nested" {
+        image_url = "example.com/test"
+
+        use "exec" {
+          command = "nested"
+        }
+      }
+      step "test_nested_dontoverride" {
+        workspace = "dontoverride"
+        image_url = "example.com/test"
+
+        use "exec" {
+          command = "nested"
+        }
+      }
+      step "test_nested_overridejk" {
+        image_url = "example.com/test"
+
+        use "exec" {
+          command = "nested"
+        }
+      }
+    }
+  }
+  
+  step "normal" {
+    image_url = "example.com/test"
+    use "exec" {
+      command = "bar"
+    }
+  }
+}
+
+app "web" {
+    config {
+        env = {
+            static = "hello"
+        }
+    }
+
+    build {}
+
+    deploy {}
+}

--- a/internal/config/testdata/pipelines/pipeline_step_workspace_nested.hcl
+++ b/internal/config/testdata/pipelines/pipeline_step_workspace_nested.hcl
@@ -17,7 +17,7 @@ pipeline "foo" {
     }
   }
 
-  step "pipe_normal" {
+  step "pipe_nested" {
     pipeline "nested" {
       step "test_nested" {
         image_url = "example.com/test"
@@ -29,9 +29,9 @@ pipeline "foo" {
     }
   }
   
-  step "pipe_changed" {
+  step "pipe_nested_workspace" {
     workspace = "testworkspace"
-    pipeline "nested" {
+    pipeline "nested_workspace" {
       step "test_nested" {
         image_url = "example.com/test"
 
@@ -47,7 +47,7 @@ pipeline "foo" {
           command = "nested"
         }
       }
-      step "test_nested_overridejk" {
+      step "test_nested_override" {
         image_url = "example.com/test"
 
         use "exec" {


### PR DESCRIPTION
This PR adds HCL parsing for workspace scoped pipeline steps, and builds off of https://github.com/hashicorp/waypoint/pull/3805. 

This PR is a draft and will remain until #3805 is merged into the target branch [f-workspace-scoped-steps](https://github.com/hashicorp/waypoint/tree/f-workspace-scoped-steps). Right now it targets the `f-workspace-scoped-steps-service` branch, until #3805 is merged