### PR TITLE
ui: allow dependabot to update all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
     directory: /ui
     schedule:
       interval: weekly
-    allow:
-      - dependency-name: '@hashicorp/*'
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Why the change?

Dependabot does a good job with our security and design system updates, I thought it might be worth giving it a spin with all ui dependencies.