### PR TITLE
serverinstall/k8s: Actually set on-demand runner image with Helm

### DIFF
--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -194,7 +194,13 @@ func (i *K8sInstaller) Install(
 
 	imageRef, err := dockerparser.Parse(i.Config.ServerImage)
 	if err != nil {
-		ui.Output("Error parsing image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
+		ui.Output("Error parsing server image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
+		return nil, err
+	}
+
+	odrImageRef, err := dockerparser.Parse(i.Config.OdrImage)
+	if err != nil {
+		ui.Output("Error parsing on-demand runner image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return nil, err
 	}
 
@@ -218,6 +224,16 @@ func (i *K8sInstaller) Install(
 		},
 		"runner": map[string]interface{}{
 			"enabled": false,
+			"image": map[string]interface{}{
+				"repository": odrImageRef.Repository(),
+				"tag":        odrImageRef.Tag(),
+			},
+			"odr": map[string]interface{}{
+				"image": map[string]interface{}{
+					"repository": odrImageRef.Repository(),
+					"tag":        odrImageRef.Tag(),
+				},
+			},
 		},
 	}
 

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -478,7 +478,13 @@ func (i *K8sInstaller) Upgrade(
 
 	imageRef, err := dockerparser.Parse(i.Config.ServerImage)
 	if err != nil {
-		ui.Output("Error parsing image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
+		ui.Output("Error parsing server image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
+		return nil, err
+	}
+
+	odrImageRef, err := dockerparser.Parse(i.Config.OdrImage)
+	if err != nil {
+		ui.Output("Error parsing on-demand runner image ref: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 		return nil, err
 	}
 
@@ -492,6 +498,16 @@ func (i *K8sInstaller) Upgrade(
 		},
 		"runner": map[string]interface{}{
 			"enabled": false,
+			"image": map[string]interface{}{
+				"repository": odrImageRef.Repository(),
+				"tag":        odrImageRef.Tag(),
+			},
+			"odr": map[string]interface{}{
+				"image": map[string]interface{}{
+					"repository": odrImageRef.Repository(),
+					"tag":        odrImageRef.Tag(),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Prior to this commit, Helm would never properly set the right on-demand runner image specified by the CLI install flags. This commit fixes that by ensuring those values are properly set with the Helm chart yaml prior to the install.

I don't know if this requires a changelog because the bug might of been introduced after the last release.