### PR TITLE
runner img should be server and other fixups

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -375,12 +375,12 @@ func (c *InstallCommand) Run(args []string) int {
 	s.Update("Server installed and configured!")
 	s.Done()
 
-	if c.flagRunner {
-		// we pass nil for the ODR config because it's a fresh install
-		if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil); code > 0 {
-			return code
-		}
-	}
+	// if c.flagRunner {
+	// 	// we pass nil for the ODR config because it's a fresh install
+	// 	if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil); code > 0 {
+	// 		return code
+	// 	}
+	// }
 
 	// Close and success
 	c.ui.Output(outInstallSuccess,

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -375,12 +375,12 @@ func (c *InstallCommand) Run(args []string) int {
 	s.Update("Server installed and configured!")
 	s.Done()
 
-	// if c.flagRunner {
-	// 	// we pass nil for the ODR config because it's a fresh install
-	// 	if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil); code > 0 {
-	// 		return code
-	// 	}
-	// }
+	if c.flagRunner {
+		// we pass nil for the ODR config because it's a fresh install
+		if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil); code > 0 {
+			return code
+		}
+	}
 
 	// Close and success
 	c.ui.Output(outInstallSuccess,

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -66,7 +66,7 @@ func (c *RunnerInstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "odr-image",
 			Usage:   "Docker image for the on-demand runners.",
-			Default: installutil.DefaultRunnerImage,
+			Default: installutil.DefaultOdrImage,
 			Target:  &c.runnerProfileOdrImage,
 		})
 

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -257,7 +257,7 @@ func (c *RunnerProfileSetCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "oci-url",
 			Target:  &c.flagOCIUrl,
-			Default: installutil.DefaultRunnerImage,
+			Default: installutil.DefaultOdrImage,
 			Usage:   "The url for the OCI image to launch for the on-demand runner.",
 		})
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -431,7 +431,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 		} else {
 			ociUrl := odr.OciUrl
 			if ociUrl == "" {
-				ociUrl = installutil.DefaultRunnerImage
+				ociUrl = installutil.DefaultOdrImage
 			}
 			odr = &pb.OnDemandRunnerConfig{
 				Id:                   oldRunnerConfig.Config.Id,

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -33,7 +33,7 @@ const DefaultServerImage = "hashicorp/waypoint:latest"
 
 // When we have a serverImage value to give to DefaultODRImage,
 // we should use that. When we don't, we can use this value
-const DefaultRunnerImage = "hashicorp/waypoint-odr:latest"
+const DefaultOdrImage = "hashicorp/waypoint-odr:latest"
 
 func DefaultRunnerName(id string) string {
 	return "waypoint-" + id + "-runner"

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -117,7 +117,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 
 	odrImage := i.Config.OdrImage
 	if odrImage == "" {
-		odrImage, err = installutil.DefaultODRImage(i.Config.ServerImage)
+		odrImage, err = installutil.DefaultODRImage(i.Config.RunnerImage)
 		if err != nil {
 			opts.UI.Output("Error getting default ODR image: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 			return err

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -238,7 +238,7 @@ func (i *K8sRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-runner-image",
 		Target:  &i.Config.RunnerImage,
-		Default: installutil.DefaultRunnerImage,
+		Default: installutil.DefaultServerImage,
 		Usage:   "Docker image for the Waypoint runner.",
 	})
 

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -117,7 +117,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 
 	odrImage := i.Config.OdrImage
 	if odrImage == "" {
-		odrImage, err = installutil.DefaultODRImage(i.Config.RunnerImage)
+		odrImage, err = installutil.DefaultODRImage(i.Config.ServerImage)
 		if err != nil {
 			opts.UI.Output("Error getting default ODR image: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
 			return err

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -238,7 +238,7 @@ func (i *K8sRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "k8s-runner-image",
 		Target:  &i.Config.RunnerImage,
-		Default: installutil.DefaultServerImage,
+		Default: defaultRunnerImage,
 		Usage:   "Docker image for the Waypoint runner.",
 	})
 

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -670,7 +670,7 @@ func (i *K8sInstaller) InstallRunner(
 		Config: k8sinstallutil.K8sConfig{
 			K8sContext:           i.Config.K8sContext,
 			Namespace:            i.Config.Namespace,
-			ServerImage:          i.Config.ServerImage,
+			RunnerImage:          i.Config.ServerImage,
 			CpuRequest:           i.Config.CpuRequest,
 			MemRequest:           i.Config.MemRequest,
 			CreateServiceAccount: true,

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -670,7 +670,7 @@ func (i *K8sInstaller) InstallRunner(
 		Config: k8sinstallutil.K8sConfig{
 			K8sContext:           i.Config.K8sContext,
 			Namespace:            i.Config.Namespace,
-			RunnerImage:          i.Config.ServerImage,
+			ServerImage:          i.Config.ServerImage,
 			CpuRequest:           i.Config.CpuRequest,
 			MemRequest:           i.Config.MemRequest,
 			CreateServiceAccount: true,
@@ -965,7 +965,8 @@ func (i *K8sInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:   "k8s-odr-image",
 		Target: &i.Config.OdrImage,
-		Usage:  "Docker image for the Waypoint On-Demand Runners",
+		Usage: "Docker image for the Waypoint On-Demand Runners. This will " +
+			"default to the server image with the name (not label) suffixed with '-odr'.",
 	})
 
 	set.StringVar(&flag.StringVar{
@@ -1032,7 +1033,8 @@ func (i *K8sInstaller) UpgradeFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:   "k8s-odr-image",
 		Target: &i.Config.OdrImage,
-		Usage:  "Docker image for the Waypoint On-Demand Runners",
+		Usage: "Docker image for the Waypoint On-Demand Runners. This will " +
+			"default to the server image with the name (not label) suffixed with '-odr'.",
 	})
 
 	set.StringVar(&flag.StringVar{

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -93,7 +93,7 @@ and disable the UI, the command would be:
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -73,7 +73,7 @@ the install, the command would be:
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint runner to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-helm-version=<string>` - The version of the Helm chart to use for the Waypoint runner install. The required version number format is: 'vX.Y.Z'.
 - `-k8s-namespace=<string>` - The namespace in the Kubernetes cluster into which the Waypoint runner will be installed. The default is default.
-- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint-odr:latest.
+- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint.
 - `-k8s-cpu-request=<string>` - Requested amount of CPU for Waypoint runner. The default is 250m.
 - `-k8s-mem-request=<string>` - Requested amount of memory for Waypoint runner. The default is 256Mi.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -93,7 +93,7 @@ and disable the UI, the command would be:
 - `-k8s-pull-secret=<string>` - Secret to use to access the Waypoint server image on Kubernetes.
 - `-k8s-secret-file=<string>` - Use the Kubernetes Secret in the given path to access the Waypoint server image.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 - `-k8s-storageclassname=<string>` - Name of the StorageClass required by the volume claim to install the Waypoint server image to.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -65,7 +65,7 @@ manually installed runners will not be automatically upgraded.
 - `-k8s-context=<string>` - The Kubernetes context to upgrade the Waypoint server to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-namespace=<string>` - Namespace to install the Waypoint server into for Kubernetes. The default is default.
 - `-k8s-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
-- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners.
+- `-k8s-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
 - `-k8s-runner-service-account=<string>` - Service account to assign to the on-demand runner. If this is blank, a service account will be created automatically with the correct permissions. The default is waypoint-runner.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
 


### PR DESCRIPTION
1. changed the name of the var `const DefaultRunnerImage = "hashicorp/waypoint-odr:latest"` to `DefaultOdrImage`
2. updated the k8s server install `odr-image` flag description to match the other platforms
3. reverted back the change made in https://github.com/hashicorp/waypoint/pull/3800/files that changed the default flag value for RunnerInstall `k8s-runner-image` (it has been `hashicorp/waypoint`; I changed it in PR-3800 to be `hashicorp/waypoint-odr`; I have now realized that is wrong based on the current structure of our code and in this PR revert it back to `hashicorp/waypoint` for now; will open an issue for a larger code refactor)