### PR TITLE
serverinstall/k8s: Prevent double runner profiles with Helm install

### DIFF
--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -521,7 +521,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 		// TODO(mitchellh): This creates a new auth token for the new runner.
 		// In the future, we need to invalidate the old token. We don't have
 		// the functionality to do this today.
-		return installRunner(ctx, installOpts.Log, client, c.ui, p, advertiseAddr, odr)
+		return installRunner(ctx, installOpts.Log, client, c.ui, p, advertiseAddr, odr, true)
 	}
 	return 0
 }

--- a/internal/server/boltdbstate/ondemand_runner.go
+++ b/internal/server/boltdbstate/ondemand_runner.go
@@ -188,13 +188,13 @@ func (s *State) onDemandRunnerGet(
 	b := dbTxn.Bucket(onDemandRunnerBucket)
 
 	if ref.Id != "" {
-		s.log.Info("looking up ondemand runner config by id", "id", ref.Id)
+		s.log.Info("looking up on-demand runner config by id", "id", ref.Id)
 		return &result, dbGet(b, []byte(strings.ToLower(ref.Id)), &result)
 	}
 
 	// Look for one by name if possible.
 	if ref.Name != "" {
-		s.log.Info("looking up ondemand runner config by name", "name", ref.Name)
+		s.log.Info("looking up on-demand runner config by name", "name", ref.Name)
 		iter, err := memTxn.Get(
 			onDemandRunnerIndexTableName,
 			onDemandRunnerIndexName+"_prefix",
@@ -207,7 +207,7 @@ func (s *State) onDemandRunnerGet(
 		next := iter.Next()
 		if next == nil {
 			// Indicates that there isn't one of the given name.
-			return nil, status.Errorf(codes.NotFound, "ondemand runner config not found")
+			return nil, status.Errorf(codes.NotFound, "on-demand runner config not found: %v", ref)
 		}
 
 		idx := next.(*onDemandRunnerIndexRecord)

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -101,7 +101,7 @@ type ecsConfig struct {
 func (i *ECSInstaller) Install(
 	ctx context.Context,
 	opts *InstallOpts,
-) (*InstallResults, error) {
+) (*InstallResults, string, error) {
 	ui := opts.UI
 	log := opts.Log
 
@@ -122,15 +122,15 @@ func (i *ECSInstaller) Install(
 	// for more information on valid combinations
 	mem, err := strconv.Atoi(i.config.Memory)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	cpu, err := strconv.Atoi(i.config.CPU)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if err := utils.ValidateEcsMemCPUPair(mem, cpu); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// we need to validate the given ODR mem/cpu at install time to verify the
@@ -138,14 +138,14 @@ func (i *ECSInstaller) Install(
 	// post-install
 	odrMem, err := strconv.Atoi(i.config.OdrMemory)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	odrCpu, err := strconv.Atoi(i.config.OdrCPU)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := utils.ValidateEcsMemCPUPair(odrMem, odrCpu); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	lf := &Lifecycle{
@@ -191,7 +191,7 @@ func (i *ECSInstaller) Install(
 	}
 
 	if err := lf.Execute(log, ui); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// Set our connection information
@@ -215,7 +215,7 @@ func (i *ECSInstaller) Install(
 		Context:       &contextConfig,
 		AdvertiseAddr: &advertiseAddr,
 		HTTPAddr:      httpAddr,
-	}, nil
+	}, "", nil
 }
 
 // Launch takes the previously created resource and launches the Waypoint server

--- a/internal/serverinstall/serverinstall.go
+++ b/internal/serverinstall/serverinstall.go
@@ -2,6 +2,7 @@ package serverinstall
 
 import (
 	"context"
+
 	"github.com/hashicorp/waypoint/internal/runnerinstall"
 
 	"github.com/hashicorp/go-hclog"
@@ -20,7 +21,8 @@ type Installer interface {
 	HasRunner(context.Context, *InstallOpts) (bool, error)
 
 	// Install expects the Waypoint server to be installed.
-	Install(context.Context, *InstallOpts) (*InstallResults, error)
+	// Returns InstallResults, a bootstrap token (if platform sets one up), or an error
+	Install(context.Context, *InstallOpts) (*InstallResults, string, error)
 
 	// InstallRunner expects a Waypoint runner to be installed.
 	InstallRunner(context.Context, *runnerinstall.InstallOpts) error


### PR DESCRIPTION
Prior to this commit, the CLI installer would set up two runner profiles: The first one coming from Helm, and the second one coming from our runnerInstall function setting up the bootstrap profile.

Because Helm already sets up a profile, we use that runner profile instead of the bootstrap profile so that we don't install with multiple default runnerp profiles.

Fixes #3832