### PR TITLE
core/cli: Update profile set to use defaults on init only

### DIFF
--- a/.changelog/3854.txt
+++ b/.changelog/3854.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli: Setting configurations in a runner profile no longer resets unspecified configuration
+```
+
+```release-note:improvement
+cli: A new `-runner-target-any` flag has been added to runner profile set to allow users to specify targeting any runner.
+```

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -130,7 +130,7 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 			},
 		}
 		if c.flagTargetRunnerAny != nil {
-			c.ui.Output("Both -target-runner-id and -target-runner-any detected, only one can be set at a time. ID takes priority.",
+			c.ui.Output("Both -target-runner-label and -target-runner-any detected, only one can be set at a time. Labels take priority.",
 				terminal.WithWarningStyle())
 		}
 	} else if od.TargetRunner == nil || (c.flagTargetRunnerAny != nil && *c.flagTargetRunnerAny) {

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -133,7 +133,7 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 			c.ui.Output("Both -target-runner-id and -target-runner-any detected, only one can be set at a time. ID takes priority.",
 				terminal.WithWarningStyle())
 		}
-	} else if c.flagTargetRunnerAny != nil && *c.flagTargetRunnerAny {
+	} else if od.TargetRunner == nil || (c.flagTargetRunnerAny != nil && *c.flagTargetRunnerAny) {
 		od.TargetRunner = &pb.Ref_Runner{Target: &pb.Ref_Runner_Any{}}
 	}
 

--- a/internal/pkg/flag/flag_string_ptr.go
+++ b/internal/pkg/flag/flag_string_ptr.go
@@ -1,0 +1,65 @@
+package flag
+
+import (
+	"github.com/posener/complete"
+)
+
+// -- StringPtrVar and stringValue
+type StringPtrVar struct {
+	Name       string
+	Aliases    []string
+	Usage      string
+	Default    string
+	Hidden     bool
+	EnvVar     string
+	Target     **string
+	Completion complete.Predictor
+	SetHook    func(val string)
+}
+
+func (f *Set) StringPtrVar(i *StringPtrVar) {
+	f.VarFlag(&VarFlag{
+		Name:       i.Name,
+		Aliases:    i.Aliases,
+		Default:    i.Default,
+		Usage:      i.Usage,
+		EnvVar:     i.EnvVar,
+		Value:      newStringPtr(i, i.Target, i.Hidden),
+		Completion: i.Completion,
+	})
+}
+
+type stringPtrValue struct {
+	v      *StringPtrVar
+	hidden bool
+	target **string
+}
+
+func newStringPtr(v *StringPtrVar, target **string, hidden bool) *stringPtrValue {
+	return &stringPtrValue{
+		v:      v,
+		hidden: hidden,
+		target: target,
+	}
+}
+
+func (s *stringPtrValue) Set(val string) error {
+	*s.target = &val
+
+	if s.v.SetHook != nil {
+		s.v.SetHook(val)
+	}
+
+	return nil
+}
+
+func (s *stringPtrValue) String() string {
+	if *s.target != nil {
+		return **s.target
+	}
+	return s.v.Default
+}
+
+func (s *stringPtrValue) Get() interface{} { return s.target }
+func (s *stringPtrValue) Example() string  { return "string" }
+func (s *stringPtrValue) Hidden() bool     { return s.hidden }

--- a/internal/pkg/flag/flag_string_ptr_test.go
+++ b/internal/pkg/flag/flag_string_ptr_test.go
@@ -1,0 +1,75 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringPtrVar(t *testing.T) {
+	cases := map[string]struct {
+		input     *string
+		expected  *string
+		omitValue bool // e.g. -poll instead of -poll=true
+		shouldErr bool
+	}{
+		"omitted": {
+			expected: nil,
+		},
+		// specifying -flag without a value should fail
+		"no value set": {
+			omitValue: true,
+			shouldErr: true,
+		},
+		"value passed in": {
+			input:    strPtr("blammo"),
+			expected: strPtr("blammo"),
+		},
+		// empty is equivilant to a user supplying -flag="", and not a scenario
+		// where the flag is simply omittied.
+		"empty string as input": {
+			input:    strPtr(""),
+			expected: strPtr(""),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var valA *string
+			var valB string
+			sets := NewSets()
+			{
+				set := sets.NewSet("A")
+				set.StringPtrVar(&StringPtrVar{
+					Name:   "a",
+					Target: &valA,
+				})
+			}
+			{
+				// borrowed from string_slice_test, just to have another input
+				set := sets.NewSet("B")
+				set.StringVar(&StringVar{
+					Name:   "b",
+					Target: &valB,
+				})
+			}
+
+			var err error
+			inputs := []string{"-b=somevalueB"}
+			if c.input != nil {
+				inputs = append(inputs, "-a="+*c.input)
+			}
+			if c.omitValue == true {
+				inputs = append(inputs, "-a")
+			}
+			err = sets.Parse(inputs)
+			if c.shouldErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, c.expected, valA)
+		})
+	}
+}

--- a/website/content/commands/runner-profile-set.mdx
+++ b/website/content/commands/runner-profile-set.mdx
@@ -44,5 +44,6 @@ lifecycle operation.
 - `-default` - Indicates that this remote runner profile should be the default for any project that doesn't otherwise specify its own remote runner.
 - `-target-runner-id=<string>` - ID of the runner to target for this remote runner profile.
 - `-target-runner-label=<key=value>` - Labels on the runner to target for this remote runner profile. e.g. `-target-runner-label=k=v`. Can be specified multiple times.
+- `-target-runner-any` - Set profile to target any available runner.
 
 @include "commands/runner-profile-set_more.mdx"


### PR DESCRIPTION
This commit modifies `runner profile set` to use profile defaults only when setting up an initial profile instead of resetting the profile to defaults when updating an existing profile.

Fixes #3853