### PR TITLE
Add values required for the updated Destroy interface

### DIFF
--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/go-argmapper"
 	"github.com/mitchellh/mapstructure"
 	"google.golang.org/grpc/codes"
@@ -272,10 +273,8 @@ func (op *deployDestroyOperation) Do(ctx context.Context, log hclog.Logger, app 
 		return nil, nil // Fail silently for now, this will be fixed in v0.2
 	}
 
-	baseArgs := []argmapper.Arg{plugin.ArgNamedAny("deployment", op.Deployment.Deployment)}
 	declaredResourcesResp := &component.DeclaredResourcesResp{}
 	destroyedResourcesResp := &component.DestroyedResourcesResp{}
-	args := append(baseArgs, argmapper.Typed(declaredResourcesResp), argmapper.Typed(destroyedResourcesResp))
 
 	// We don't need the result, we just need the declared and destroyed resources
 	// which we can access without the result since they were passed by reference
@@ -284,7 +283,9 @@ func (op *deployDestroyOperation) Do(ctx context.Context, log hclog.Logger, app 
 		nil,
 		op.Component,
 		destroyer.DestroyFunc(),
-		args...,
+		plugin.ArgNamedAny("deployment", op.Deployment.Deployment),
+		argmapper.Typed(declaredResourcesResp),
+		argmapper.Typed(destroyedResourcesResp),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The destroy plugin interface requires (Declared|Destroyed)ResourceResp now, but release was not updated to provide these values. This simply provides them but doesn't use them. This prevents calling a Release plugins Destroy method from failing to execute (which was failing because argmapper was looking for these values)