### PR TITLE
cli: Show noop job operation type in task and job CLIs

### DIFF
--- a/internal/cli/job_inspect.go
+++ b/internal/cli/job_inspect.go
@@ -72,6 +72,8 @@ func (c *JobInspectCommand) Run(args []string) int {
 	var op string
 	// Job_Noop seems to be missing the isJob_operation method
 	switch resp.Operation.(type) {
+	case *pb.Job_Noop_:
+		op = "Noop"
 	case *pb.Job_Build:
 		op = "Build"
 	case *pb.Job_Push:

--- a/internal/cli/job_inspect.go
+++ b/internal/cli/job_inspect.go
@@ -70,7 +70,6 @@ func (c *JobInspectCommand) Run(args []string) int {
 	}
 
 	var op string
-	// Job_Noop seems to be missing the isJob_operation method
 	switch resp.Operation.(type) {
 	case *pb.Job_Noop_:
 		op = "Noop"

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -174,8 +174,9 @@ func (c *JobListCommand) Run(args []string) int {
 
 	for _, j := range jobs {
 		var op string
-		// Job_Noop seems to be missing the isJob_operation method
 		switch j.Operation.(type) {
+		case *pb.Job_Noop_:
+			op = "Noop"
 		case *pb.Job_Build:
 			op = "Build"
 		case *pb.Job_Push:

--- a/internal/cli/task_inspect.go
+++ b/internal/cli/task_inspect.go
@@ -167,8 +167,9 @@ func (c *TaskInspectCommand) FormatJob(job *pb.Job) error {
 	}
 
 	var op string
-	// Job_Noop seems to be missing the isJob_operation method
 	switch job.Operation.(type) {
+	case *pb.Job_Noop_:
+		op = "Noop"
 	case *pb.Job_Build:
 		op = "Build"
 	case *pb.Job_Push:

--- a/internal/cli/task_list.go
+++ b/internal/cli/task_list.go
@@ -104,6 +104,8 @@ func (c *TaskListCommand) Run(args []string) int {
 		var op string
 		// Job_Noop seems to be missing the isJob_operation method
 		switch t.TaskJob.Operation.(type) {
+		case *pb.Job_Noop_:
+			op = "Noop"
 		case *pb.Job_Build:
 			op = "Build"
 		case *pb.Job_Push:

--- a/internal/cli/task_list.go
+++ b/internal/cli/task_list.go
@@ -102,7 +102,6 @@ func (c *TaskListCommand) Run(args []string) int {
 
 	for _, t := range tasks {
 		var op string
-		// Job_Noop seems to be missing the isJob_operation method
 		switch t.TaskJob.Operation.(type) {
 		case *pb.Job_Noop_:
 			op = "Noop"


### PR DESCRIPTION
This operation was initially left off the job and task CLIs because no jobs used the operation. Now, the pipelines exec step uses a `noop` job to execute commands in the spawned resource, so we should show the noop job operation type too so it doesn't show up as "Unknown" in the job and task CLIs.