### PR TITLE
server: Track embedded step refs for pipelines with noop job

### DIFF
--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -124,7 +124,6 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		step.Done()
 
 		successful := steps
-
 		for _, jobId := range resp.AllJobIds {
 			job, err := c.project.Client().GetJob(c.Ctx, &pb.GetJobRequest{
 				JobId: jobId,

--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -425,7 +425,7 @@ func (s *Service) buildStepJobs(
 				}
 			}
 
-			// Steps of type Pipline Refs are now noop jobs. This is currently a work around to ensure that
+			// Steps of type Pipeline Refs are now noop jobs. This is currently a work around to ensure that
 			// if a step parent is *Also* an embedded pipeline, we should not run until
 			// that pipeline is complete. To accomplish this, we make a Noop job depend
 			// on all of the embedded pipeline jobs.

--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -227,7 +227,7 @@ func (s *Service) buildStepJobs(
 	// Generate job IDs for each of the steps. We need to know the IDs in
 	// advance to set up the dependency chain.
 	stepIds := map[string]string{}
-	for name, _ := range pipeline.Steps {
+	for name := range pipeline.Steps {
 		nodeId, ok := nodeStepRef.stepRefs[nodePipelineStepRef{pipeline: pipeline.Id, step: name}]
 		if !ok {
 			return nil, nil, nil, status.Errorf(codes.Internal,

--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -267,7 +267,6 @@ func (s *Service) buildStepJobs(
 				return nil, nil, nil, status.Errorf(codes.Internal,
 					"no step ID was found for nodeDepId from pipeline %q and step name %q!!",
 					pipeline.Name, nodeDepId)
-				continue
 			}
 
 			dependsOn = append(dependsOn, d)

--- a/pkg/server/singleprocess/service_pipeline_test.go
+++ b/pkg/server/singleprocess/service_pipeline_test.go
@@ -481,8 +481,8 @@ func TestServicePipeline_Run(t *testing.T) {
 		require.Equal(pb.Job_QUEUED, job.State)
 
 		// We should have all the job IDs
-		require.Len(resp.JobMap, 5)
-		require.Len(resp.AllJobIds, 5)
+		require.Len(resp.JobMap, 6)
+		require.Len(resp.AllJobIds, 6)
 	})
 
 	t.Run("runs a pipeline with embedded pipeline and workspace", func(t *testing.T) {
@@ -626,8 +626,8 @@ func TestServicePipeline_Run(t *testing.T) {
 		require.Equal(pb.Job_QUEUED, job.State)
 
 		// We should have all the job IDs
-		require.Len(resp.JobMap, 7)
-		require.Len(resp.AllJobIds, 7)
+		require.Len(resp.JobMap, 8)
+		require.Len(resp.AllJobIds, 8)
 
 		// find our embedded jobs and verify they used the correct workspace
 		for id, jobStep := range resp.JobMap {
@@ -879,7 +879,7 @@ func TestServicePipeline_Run(t *testing.T) {
 
 		require.NoError(err)
 		require.NotNil(resp)
-		require.Len(resp.AllJobIds, 5)
+		require.Len(resp.AllJobIds, 6)
 	})
 
 	// This is a nasty cycle graph


### PR DESCRIPTION
Prior to this commit we would ignore step refs of type pipeline and not
generate its own job. This caused an issue where if a embedded pipeline
steps parent step was also an embedded pipeline, we wouldn't have a job
id to wait on, which would make the step run out of order from its
parent.

This commit fixes that by tracking the step refs as a noop job, then
that job depends on all of its embedded jobs before it's complete. This
makes it easier for any consuming steps to wait on the noop job which is
essentially the last job of a pipeline.