### PR TITLE
Update all error returns in RunnerJobStream to use hcerr.Externalize()

### DIFF
--- a/.changelog/3872.txt
+++ b/.changelog/3872.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: improve runner job stream error logging
+```

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/emptypb"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -53,7 +52,7 @@ func (s *Service) RunnerGetDeploymentConfig(
 	req *pb.RunnerGetDeploymentConfigRequest,
 ) (*pb.RunnerGetDeploymentConfigResponse, error) {
 	// Get our server config
-	serverConfig, err := s.GetServerConfig(ctx, &emptypb.Empty{})
+	serverConfig, err := s.GetServerConfig(ctx, &empty.Empty{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get server config to populate runner start job server addr")
 	}

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -676,7 +676,7 @@ func (s *Service) RunnerJobStream(
 	// If we have an error, return that. We also return if we didn't ack for
 	// any reason. This error can be set at any point since job assignment.
 	if err != nil {
-		return hcerr.Externalize(log, err, "failed to ack the job or the job was cancelled", "id", runnerId, "job", job.Id)
+		return hcerr.Externalize(log, err, "failed to ack the job or the job was cancelled", "id")
 	}
 	if !ack {
 		// If runners don't ack the job, this means close the stream
@@ -687,7 +687,7 @@ func (s *Service) RunnerJobStream(
 	if s.logStreamProvider != nil {
 		logStreamWriter, err = s.logStreamProvider.StartWriter(ctx, log, s.state(ctx), job)
 		if err != nil {
-			return hcerr.Externalize(log, err, "failed to start a log writer to handle jog logs", "id", runnerId, "job", job.Id)
+			return hcerr.Externalize(log, err, "failed to start a log writer to handle jog logs")
 		}
 	}
 


### PR DESCRIPTION
Wrap error returns in [`hcerr.Externalize()`](https://github.com/hashicorp/waypoint/blob/52e13de50ac6da2ffedb9c34f17f592c76de9fe1/pkg/server/hcerr/hcerr.go#L16-L29) to log more details correctly