### PR TITLE
Cleanup docs about runners

### DIFF
--- a/website/content/docs/internals/architecture.mdx
+++ b/website/content/docs/internals/architecture.mdx
@@ -38,10 +38,12 @@ The primary components of Waypoint are:
   enable this functionality.
 
 - **Runner** - A Waypoint runner executes operations such as build,
-  deploy, etc. Most commonly, the
-  [CLI acts as a runner](/docs/internals/execution#most-common-cli-and-a-remote-server),
-  but it is possible to run dedicated runners. This isn't shown in the diagram
-  above.
+  deploy, etc. There are two kinds of runners:
+
+  - **Static Runner** - A static runner is a long-lived runner that is very likely set up
+    when a team begins using Waypoint.
+  - **On-Demand Runner** - An on-demand runner is launched per operation within a
+    container platform.
 
 ## Failure Behavior
 
@@ -81,9 +83,10 @@ If a dedicated runner is down, then the capacity of the server to execute
 remote operations will be diminished. If no runners exist, jobs will queue.
 Operations include build, deploy, release, etc.
 
-This is only an issue if _remote runners_ are being used. In the most common
-case, the [CLI acts as a runner](/docs/internals/execution#most-common-cli-and-a-remote-server)
-and this is not a possible failure mode.
+If there are no static runners configured in the system or the user has specified
+`-local=true`, then the CLI will spawn a runner itself.
+
+See [CLI acts as a runner](/docs/internals/execution) for more details.
 
 ### CLI
 

--- a/website/content/docs/internals/execution.mdx
+++ b/website/content/docs/internals/execution.mdx
@@ -21,29 +21,12 @@ To improve the user experience, Waypoint simplifies what is required and
 automatically runs certain components as needed. We will cover all of these
 cases on this page.
 
-## Most Common: CLI and a Remote Server
+## Most Common: CLI, Remote Server, Static Runner, On-Demand Runner
 
-In most cases, you use a CLI directly with a Waypoint server. In this
-model, there are no standalone "runner" processes running. This is the
-usage style in the getting started guide that we introduce to new users of
-Waypoint.
-
-For this execution, the CLI transparently spins up a runner in-process.
-This runner registers with the server like any other runner process but
-advertises that it can only accept jobs that are directly assigned to it.
-The CLI queues a job with the server for the operation and directly assigns
-this to the runner it is running in-process. See the diagram below.
-The dotted
-boxes represent process boundaries (perhaps on different computers) and
-the white boxes are logical components within a single process.
-
-![CLI and a Remote Server](/img/execution-cli-server.png)
-
-## Most Advanced: CLI, Remote Server, Remote Runner
-
-The most advanced case is using a CLI to execute an operation that
-is executed on a remote runner. This scenario is most common to try to
-hide credentials, access internal systems the CLI may not be able to, etc.
+The common case is using a CLI to execute an operation that
+is executed remotely, which causes the static runner to spawn an on-demand
+runner to execute your operation. This provides the most stable and performant way to
+use Waypoint.
 
 For this style of execution, the CLI queues the job with the server, the server
 assigns the job to a runner, and the job executes it.
@@ -56,6 +39,22 @@ the white boxes are logical components within a single process.
 In this mode, the CLI does not need to remain attached to the server
 after queueing the job. The CLI may exit and the job will continue
 executing in the background.
+
+## Less Common: CLI Runner and a Remote Server
+
+In some cases, you use a CLI directly with a Waypoint server where there is no
+standalone "static runner" processes running.
+
+For this execution, the CLI transparently spins up a runner in-process.
+This runner registers with the server like any other runner process but
+advertises that it can only accept jobs that are directly assigned to it.
+The CLI queues a job with the server for the operation and directly assigns
+this to the runner it is running in-process. See the diagram below.
+The dotted
+boxes represent process boundaries (perhaps on different computers) and
+the white boxes are logical components within a single process.
+
+![CLI and a Remote Server](/img/execution-cli-server.png)
 
 ## Most Limited: CLI, No Server
 

--- a/website/content/docs/kubernetes/container-build.mdx
+++ b/website/content/docs/kubernetes/container-build.mdx
@@ -180,9 +180,10 @@ credentials directly in the `waypoint.hcl` file. Instead, you should use
 Input variables can be configured to read from environment variables so you
 can use well known environment variables (such as `AWS_ACCESS_KEY`), too.
 
-For remote runners, they can get access to input variables either by
-setting the variables in the web UI, or by setting
-[runner configuration](/docs/runner/config).
+Normally, runner configuration should be used to provide these details to a runner
+executing the operation that needs these details.
+
+See [runner configuration](/docs/runner/config) for details.
 
 ## Local vs. Remote Builds
 

--- a/website/content/docs/lifecycle/hooks.mdx
+++ b/website/content/docs/lifecycle/hooks.mdx
@@ -69,8 +69,9 @@ for details on all the fields a hook has and which are required.
 
 ## Execution Environment
 
-Hooks are executed alongside the Waypoint operation, most commonly [where the Waypoint CLI is running](/docs/internals/execution#most-common-cli-and-a-remote-server).
-Reference [Operation Execution](/docs/internals/execution) for more execution options including Remote Runners.
+Hooks are executed alongside the Waypoint operation, most commonly within an
+on-demand runner. For this reason, you may may need to add additional binaries and
+files to the OCI image used to launch the on-demand runner.
 
 Hooks are _not executed in the app deployment platform_. Therefore, operations
 such as database migrations or scripts that must be run within the context

--- a/website/content/docs/lifecycle/index.mdx
+++ b/website/content/docs/lifecycle/index.mdx
@@ -87,8 +87,8 @@ DNS, configuring a service mesh, etc.
 
 A **hook** is a customizable command that executes before or after the `build`,
 `registry`, `deploy`, or `release` operations.
-Hooks execute on the [Waypoint Runner](/docs/internals/execution#most-common-cli-and-a-remote-server),
-which is typically the Waypoint CLI.
+Hooks execute on the [Waypoint Runner](/docs/internals/execution),
+which is typically an on-demand runner.
 Hooks can be useful to do things such as perform a security scan on an image,
 run database migrations on a deploy, etc.
 

--- a/website/content/docs/runner/adoption.mdx
+++ b/website/content/docs/runner/adoption.mdx
@@ -7,51 +7,55 @@ description: |-
 
 # Adoption Workflow
 
-Waypoint Runners can exist in various states depending on how they are
-initially installed into a platform. Most runners will move from `Pending` to
+To introduce a static runner to the server, it goes through the Adoption Workflow.
+This allows the operator the ability to approve static runners before they're sent jobs to
+run.
+
+Waypoint static runners can exist in various states depending on how they are
+initially installed into a platform. Most will move from `Pending` to
 `Adopted` to `Rejected` states during their entire lifecycle.
 
-## Pending Runners
+## Preadopted Static Runners
 
-The `Pending` runner state is the default state which newly installed runners
-will be in as they have yet to receive a runner token from the server. Runners
-in this state may be configured to talk to a Waypoint Server but have not yet
-been adopted by the Server and therefore will not receive jobs to run. Runners
-will also show up in this state if they are forgotten about by the server with
+When creating a new static runner, it is possible to generate the runner token and install
+a static runner with the token on its initial installation. These runners are then
+able to immediately recieve jobs from the Waypoint server when they start.
+They also skip the `Pending` state to directly enter the `Preadopted` state.
+
+Preadopted static runners may be moved into the `Rejected` state like other runners by
+issuing the [`waypoint runner reject`](/commands/runner-reject) command. If a preadopted
+static runner is rejected, a new runner token must be created for the runner before it
+is allowed to receive jobs again.
+
+## Pending Static Runners
+
+The `Pending` runner state is the default state which newly installed static runners
+will be in, as they have yet to receive a runner token from the server. Static runners
+in this state can talk to a Waypoint server but will not receive jobs to run.
+Static runners will also show up in this state if they are forgotten about by the server with
 the [`waypoint runner forget`](/commands/runner-forget) command.
 
-When in the `Pending` state, runners may be moved into the `Adopted` state by
+When in the `Pending` state, static runners may be moved into the `Adopted` state by
 issuing the [`waypoint runner adopt`](/commands/runner-adopt) command with the
 desired Runner ID.
 
 Runners automatically skip this state if they are in the `Preadopted` state.
 
-## Preadopted Runners
+## Adopted Static Runners
 
-When creating a new runner it is possible to generate the runner token which
-seeded to the new runner before its initial installation. These runners which
-have an already valid runner token are able to immediately receive jobs from
-the Waypoint Server when they start. They also skip the `Pending` state to
-directly enter the `Preadopted` state.
-
-Preadopted runners may be moved into the `Rejected` state like other runners by
-issuing [`waypoint runner reject`](/commands/runner-reject). If a preadopted
-runner is rejected a new runner token must be created for the runner before it
-is allowed to receive jobs again.
-
-## Adopted Runners
-
-Runners adopted with [`waypoint runner adopt`](/commands/runner-adopt) will
-store the runner token received by the server in their configured state
-directory. Once a runner has been adopted it may start receiving job
-assignments from the Waypoint Server as usual.
+Static runners adopted with [`waypoint runner adopt`](/commands/runner-adopt) will
+store a runner token received by the server in their configured state
+directory, which is local to the static runner itself. Once a static runner has been
+adopted, it may start receiving job assignments from the Waypoint server as usual.
 
 ## Rejected Runners
 
-When a user rejects a Waypoint Runner with the [`waypoint runner reject`](/commands/runner-reject) command the rejected runner is no longer able
-to receive job assignments from the Waypoint Server. Rejected runners will
-continue to appear in the list of runners that the server knows about so that
-subsequent requests by this same runner are ignored.
+When a user rejects a Waypoint runner with the
+[`waypoint runner reject`](/commands/runner-reject) command, the rejected runner
+is no longer able to receive job assignments from the Waypoint server.
+
+Rejected runners will continue to appear in the list of runners that the server
+knows about so that subsequent requests by this same runner are ignored.
 
 Rejecting a runner does not invalidate its token. If a rejected runner is
 forgotten the previously rejected runner may reconnect to the server as long as
@@ -60,8 +64,8 @@ never rejected in the first place.
 
 # Runner Tokens
 
-Runner tokens are special tokens which can only be used by runners receiving
-job assignments from the Waypoint Server. These tokens cannot be revoked, only
+Runner tokens are special tokens which can only be used by runners to recieve
+job assignments from the Waypoint server. These tokens cannot be revoked, only
 rejected through the [`waypoint runner reject`](/commands/runner-reject)
 command. By default runner tokens are valid for 30 days and upon expiring they
 will need to be recreated with [`waypoint runner token`](/commands/runner-token).
@@ -69,9 +73,9 @@ Runners must then be restarted with the new token to receive job assignments
 again. Token expirations may be altered when generating a runner token with
 [`waypoint runner token`](/commands/runner-token).
 
-The Waypoint Runner will look for the token in two places before requesting a
-new token from the Waypoint Server. First the runner will look in its state
-directory for a `token` file containing a Waypoint Runner token. If a `token`
+The Waypoint runner will look for the token in two places before requesting a
+new token from the Waypoint server. First, the runner will look in its state
+directory for a `token` file containing a Waypoint runner token. If a `token`
 file doesn't exist then the Waypoint Runner will look in the
 `WAYPOINT_SERVER_TOKEN` environment variable. If both of these locations do not
 contain a token then the Waypoint Runner enters the `Pending` state and an

--- a/website/content/docs/runner/config.mdx
+++ b/website/content/docs/runner/config.mdx
@@ -24,7 +24,7 @@ $ waypoint config set -runner -scope=global AWS_ACCESS_KEY_ID=abcd AWS_SECRET_AC
 ```
 
 This will expose these environment variables on every runner (including
-the CLI when it runs operations locally). To unset any variables, assign it to
+a CLI runner when an operation runs locally). To unset any variables, assign it to
 an empty value. You may view the set of runner configuration values using
 `waypoint config get`:
 
@@ -36,15 +36,19 @@ $ waypoint config get -runner
   global  | AWS_SECRET_ACCESS_KEY | 1234  |           |
 ```
 
-~> **Security note:** These configuration values are stored as plaintext in the
-Waypoint server. If you do not want to store any secrets on the Waypoint server,
-you must set the environment variables manually when
+~> **Security note:** HCP Waypoint stores these values encrypted within its backend
+using HashiCorp Vault. If that's unsatisfactory, you can set the environment variables
+manually when [manually running the runner](/docs/runner/run-manual).
+
+~> **Security note:** On a self hosted Waypoint server, these configuration values are
+stored as plaintext in the Waypoint server data file. If you do not want to store any
+secrets on the Waypoint server, you must set the environment variables manually when
 [manually running the runner](/docs/runner/run-manual).
 
 You can use the `-scope` flag paired with flags such as `-project`,
 `-label-scope`, and `-workspace-scope` to set runner variables that are only
-available within certain scoped situations. Variables are otherwise server
-global by default.
+available within certain scoped situations. Unscoped variables are globally sent to
+all runners.
 
 Consider an example where you're using a `dev` and a `prod` workspace in Waypoint.
 These workspaces match up to your `dev` and `prod` environments.
@@ -97,9 +101,9 @@ the `waypoint.hcl` file.
 
 ## Files
 
-Using the `waypoint.hcl` file, you can configure files to be available
-within runners for that project or application. You cannot configure files
-to be available globally to the server. This behaves similarly to
+Using the `waypoint.hcl` file, you can configure data to be stored in files
+that are available to runners when running operations for that project or application.
+You cannot configure files to be available globally to the server. This behaves similarly to
 [application configuration files](/docs/app-config/files).
 
 ```hcl
@@ -116,7 +120,8 @@ config {
 
 -> **Note:** The user that is running the runner must have permission to
 write to the given file paths. File paths are not cleaned up after the
-runner operation completes since we assume single-use runners.
+runner operation completes as this feature presume On-demand runners are in use, as
+they are the most common production deployment setup.
 
 ## Dynamic Values
 

--- a/website/content/docs/runner/index.mdx
+++ b/website/content/docs/runner/index.mdx
@@ -7,79 +7,101 @@ description: |-
 
 # Waypoint Runners
 
-Waypoint utilizes "runners" to execute operations. Every build, deploy, or
-release operation happens on a Waypoint runner. Waypoint has three kinds of
-runners:
+Waypoint utilizes "runners" to execute operations. A runner is a program executing
+[`waypoint runner agent`](/command/runner-agent) that is configured with the details
+of the Waypoint server.
 
-### CLI Runner
+Every operation that Waypoint runs (build, deploy, release, etc) is executed by a Waypoint runner.
+The Waypoint server maintains a queue of jobs that the server hands out to connected
+runners. The server never connects directly to runners, runners always connect to the
+server. This is important because runners are designed to be run in the same
+environment that your application is deployed into because the plugins such as Deploy
+need to talk directly to your deployment platform APIs.
 
-When you trigger an action with the CLI, i.e. by running `waypoint deploy`, the CLI acts as a runner
-capable of performing your operation. If your deployment needs AWS credentials, or a valid kubectl context,
-it can access the credentials on the developer workstation that it's running on.
+In most deployments, there are two kinds of runners:
 
-If you only use Waypoint from the CLI, this is the only kind of runner that is used.
+### Static Runner
 
-### Remote Runner
+Static runners are long-lived runners that are installed into your deployment
+environment once, likely when you setup Waypoint for the first time.
 
-Not every operation in Waypoint needs to happen in response to a CLI invocation
-from a privileged workstation. Waypoint can trigger deployments from the UI or
-automatically based on git changes, or automatically poll the status of
-applications in the background. In these cases, Waypoint needs a "remote
-runner", a long-lived runner that is always available to run these operations.
+The [`waypoint install`](/commands/install) and [`waypoint runner install`](/commands/install)
+commands can install these runners for you, using details about your deployment
+environment.
 
-Waypoint automatically installs a single remote runner by default when the Waypoint
-server is installed with [`waypoint install`](/commands/install).
+One issue with static runners is that they have fixed capacity: they can only run so
+many operations at a time. Additionally to run certain plugins like Docker, we need to have
+uniquely configured environments.
+
+For that reason, Waypoint makes heavy usage of On-demand runners:
 
 ### On-demand runners
 
-While the remote runner is capable of performing operations on its own, it also
-supports plugins to spawn on-demand runners for a given platform. These
-on-demand runners are ephemeral container instances that perform one operation
-before exiting. These on-demand runners can perform container builds without
-any privileged access, offer more isolation between operations, and allow
-Waypoint to scale further.
+While the static runner is capable of performing operations on its own, it also
+supports the ability to spawn on-demand runners for a given platform. These
+on-demand runners are ephemeral container instances that perform one operation only.
+They can perform container builds without any privileged access, offer more isolation
+between operations, and allow Waypoint to scale further.
 
 On-demand runners: see [on-demand runners](/docs/runner/on-demand-runner) for more information.
 
+## Other Runners
+
+One runner behavior is used less often, the CLI runner:
+
+### CLI Runner
+
+When you trigger an action with the CLI, i.e. by running `waypoint deploy`, and
+either specify `-local` or do not have any runners registered on the server, the CLI
+itself acts as a runner capable of performing your operation. If your deployment needs
+AWS credentials, or a valid kubectl context, it can access the credentials from the
+environment that is performing the CLI command.
+
 ## Runner Targeting
 
-Runner targeting allows users to configure Waypoint to target specific runners
-to execute operations for an application. A runner `profile` can be specified
-in the `runner` stanza in the `waypoint.hcl` file. The `runner profile` can be
-configured to use a specific static runner, or multiple, based on labels.
+Runner targeting was designed with multi-environment and multi-region workflows in mind.
+Static runners can be installed with user-defined ID and labels.
+You can then set [runner profiles](docs/runner/profiles), which tell the server which static runner to target to handle operations,
+and the configurations of the short-lived on-demand runner that will execute jobs.
+Finally, specify which` runner profile` to use for an application via
+the `profile` option in the `runner` stanza of the `waypoint.hcl` file.
 
 ### Runner Targeting Example
 
-Runners can have labels applied to them with the `-label` flag provided
-alongside the `waypoint runner agent` command.
+If you install a runner with the `runner install` or `server install` commands,
+it comes with a preset `runner profile` and adopted static runner.
+
+The following example illustrates a custom local setup of a Waypoint runner and profile.
 
 ```terminal
-$ waypoint runner agent -label=org=hashicorp -label=env=dev
+$ waypoint runner agent -name=test -label=org=hashicorp -label=env=dev
 ```
 
-After the runner has started, it can be adopted by the server for use in remote
-operations. With `waypoint runner list`, you can see the full list of available
+Static runners need a valid runner token and server adoption in order to receive jobs.
+For more information on runner adoption, see [adoption workflow](/docs/runner/adoption).
+
+With `waypoint runner list`, you can see the full list of available
 runners and their labels.
 
 ```shell-session
 $ waypoint runner list
-              ID             |  STATE   |  KIND  |         LABELS         | LAST REGISTERED
------------------------------+----------+--------+------------------------+------------------
-  01G4N53X8DCJR3DJ9R56D6KZKH | pending  | remote | env:dev org:hashicorp  |
+    ID   |   STATE    |  KIND  |         LABELS         | LAST REGISTERED
+---------+------------+--------+------------------------+------------------
+  test   | preadopted | remote | org:hashicorp env:dev  | 6 seconds ago
 
-$ waypoint runner adopt 01G4N53X8DCJR3DJ9R56D6KZKH
-Runner "01G4N53X8DCJR3DJ9R56D6KZKH" adopted.
+$ waypoint runner adopt test
+Runner "test" adopted.
 
 $ waypoint runner list
-              ID             |  STATE   |  KIND  |         LABELS         | LAST REGISTERED
------------------------------+----------+--------+------------------------+------------------
-  01G4N53X8DCJR3DJ9R56D6KZKH | adopted  | remote | env:dev org:hashicorp  |
+    ID   |  STATE  |  KIND  |         LABELS         | LAST REGISTERED
+---------+---------+--------+------------------------+------------------
+  test   | adopted | remote | org:hashicorp env:dev  | 1 minute ago
 ```
 
-With a runner that has labels applied, you can then create a runner profile to
-target that runner (or runners). When this runner profile is used, Waypoint
-will only generate on-demand runners using a runner whose labels match those
-specified in the runner profile.
+You can now set a runner profile to target that specific static runner by ID,
+or any static runner that has matching labels. When there is a runner profile specified
+in the `waypoint.hcl` configurations, only a matching static runner can receive jobs
+for that application and generate on-demand runners to execute them.
 
 ```terminal
 $ waypoint runner profile set -name=docker-hashicorp-dev -plugin-type=docker -target-runner-label=org=hashicorp -target-runner-label=env=dev
@@ -92,11 +114,11 @@ $ waypoint runner profile set -name=docker-hashicorp-dev -plugin-type=docker -ta
   docker-hashicorp-dev                  | docker      | hashicorp/waypoint-odr:latest        | labels: {"env":"dev","org":"hashicorp"} |
 ```
 
-In the `waypoint.hcl` file, you can specify the runner profile to use with the
-`runner` stanza. In this example, a user variable "org" and the built-in
-`workspace` variable are interpolated into the runner profile name, so that at
-the time of execution of remote operations, Waypoint uses the desired runner
-profile.
+Specify the runner profile to use with the `runner` stanza in the `waypoint.hcl` file.
+In this example, a user variable "org" and the built-in
+`workspace` variable are interpolated into the runner profile name.
+At the time of execution of remote operations, Waypoint uses the desired runner
+profile based on the workspace and configuration variables.
 
 ```hcl
 project = "example-nodejs"
@@ -124,30 +146,36 @@ variable "org" {
 }
 ```
 
-An operation which would use the runner profile created in this example could
-be initiated with `waypoint build -w=dev -var=org=hashicorp -local=false`.
+Our runner targeting is all set up! An example operation that would use this runner profile:
+
+`waypoint build -w=dev -var=org=hashicorp -local=false`.
 
 ### Runner Targeting Advantages
 
-The example above demonstrates basic usage of runner targeting. However, in a
-production environment, runner targeting may be essential to achieving high
-availability. Multiple runners could be deployed with the same labels, and
-then a runner profile which targets runners with those labels would "round
-robin" between the available runners. If one goes down, as long as another with
-the same labels is still online, remote operations will continue to work.
+#### Multi-Cluster, Multi-Environment, Multi-Region
 
-Also shown in the above example is runner targeting for multi-environment
-operations. The workspace of the operation dev, is interpolated into the runner
-profile name dynamically at operation runtime. Additional runners and runner
-profiles could be created for a "test" or "prod" environment so that a runner
-can deploy to the right environment at runtime.
+As shown in the example above, enabling multi-environment operations is
+the most straightforward use-case for runner targeting. Waypoint dynamically interpolates
+the "dev" workspace into the runner profile name at operation runtime,
+which then targets the matching static runner for the "dev" environment.
+You could create additional runners and runner profiles for the "prod" and "test" environments,
+and Waypoint would target the correct runners automagically with a simple `-workspace` flag.
 
-Runner targeting is useful for workflows where you deploy to multiple clusters
-in a platform. For example, if you have a runner in one Kubernetes cluster,
-that runner could potentially only perform remote operations within that
-cluster. However, if there were a runner in multiple Kubernetes clusters, you
-would have the ability to deploy to any of the clusters with Waypoint remote
-operations by targeting the appropriate runners in each cluster.
+Runner targeting is also useful for workflows where you deploy to multiple clusters
+on a platform. A static runner pod in one Kubernetes cluster
+would only perform remote operations within that cluster.
+With runners in multiple Kubernetes clusters, you can easily target and deploy
+to any cluster with Waypoint remote operations.
+
+#### High Availability and Performance
+
+In a production environment, runner targeting may be essential to achieving high availability.
+Deploying multiple runners with the same labels and a runner profile that targets
+those same labels will cause Waypoint to "round-robin" between the available
+runners. This approach reduces bottleneck of one static runner handling a large job
+queue, and ensures continued availability if one of the runners goes down. As long as
+one of the static runners with matching labels remains online, remote operations on
+the application continue uninterrupted.
 
 ## Disabling Runners
 
@@ -161,10 +189,15 @@ With runners disabled, certain functionality becomes unavailable:
 
 - Remote operations
 - Git polling
+- Status Checks
 
 In addition to disabled functionality, consider that all clients must now
 have proper credentials for the target platforms (such as AWS, GCP, etc.)
 since without runners they must execute all operations locally.
+
+The reason this functionality is not available is the server creates jobs to
+perform these operations itself and without a long lived runner to execute them, the
+functionality is not available.
 
 ### Disabling Runner Installation
 
@@ -172,12 +205,20 @@ Prior to installation, runners can be disabled by specifying the
 `-runner=false` flag to the [`waypoint install`](/commands/install) command.
 This will not install a runner.
 
-To uninstall a runner that is already installed, the only option today is
-to uninstall and reinstall Waypoint with a
-[data snapshot and restore](/docs/server/run/maintenance#backup-restore). You
-may also manually go into your platform and delete the runner, but Waypoint
-can't automate this for you today.
+### Removing a Runner
 
 If there is a runner which you'd no longer like your server to use for remote
 operations, this runner can be "invalidated" for use by the server with the
-`waypoint runner forget` command, with the ID of the runner provided.
+`waypoint runner reject` command, with the ID of the runner provided.
+
+With the runner forgotten, the server will no longer send any jobs to it. To cleanup
+the resources being used by that runner though, there are two options:
+
+To uninstall a runner that is already installed, there are two options:
+
+1. You may also manually go into your platform and delete the runner. For instance
+   with kubernetes, you'd delete the StatefulSet that maintains the static runner.
+2. Uninstall and reinstall Waypoint with a
+   [data snapshot and restore](/docs/server/run/maintenance#backup-restore). This is
+   a fairly substantial action and should only be undertaken if there is no other
+   options.

--- a/website/content/docs/runner/on-demand-runner.mdx
+++ b/website/content/docs/runner/on-demand-runner.mdx
@@ -7,42 +7,44 @@ description: |-
 
 # On-Demand Runners
 
-On-demand runners allow a single Waypoint installation to scale very high by
-leveraging the defined platform to spawn resources to execute Waypoint jobs
-remotely. Through on-demand runner profiles and runner targeting, Waypoint can
-even utilize resources from other platforms that Waypoint has access to. For
-example, a local Kubernetes server install could be configured to use Amazon ECS
+On-demand runners allow a single Waypoint installation to scale by
+leveraging the defined platform to spawn resources to execute Waypoint jobs.
+Through on-demand runner profiles and static runner targeting, Waypoint can
+even utilize resources from multiple platforms.
+For example, you could configure a local Kubernetes server install could be configured to use Amazon ECS
 to execute jobs.
 
 ## Job Assignment
 
-When a job is submitted to the server, if on-demand runners are enabled, it
-will spawn an on-demand runner and the job is placed in a holding set. This is
-the same mechanism we use for automatic CLI runners. When the on-demand
+When the server receives a job, if on-demand runners are enabled, it
+will signal a static runner to spawn an on-demand runner and place the job in held.
+This is the same mechanism we use for automatic CLI runners. When the on-demand
 runner starts, it will execute the normal Waypoint runner code and connect back
-to the server. On connection, the server will see the job in the holding set
+to the server. Upon connection, the server sees the job being held
 and send it immediately to the new runner.
 
 The flow of information about the job uses the normal grpc runner APIs so all
-the input and output remain the same as if the work were performed by the
-CLI-runner.
+the input and output remain the same as if the work were performed by the any other
+runner type.
 
 Upon finishing the job, the on-demand runner will exit and the platform it runs
 on will reclaim its resources.
 
 ### Launching Tasks to Execute Jobs
 
-When Waypoint goes to launch an on-demand runner task, it will generate three
+When Waypoint goes to launch an on-demand runner task, it will generate four
 jobs:
 
 - `StartJob`
 - `TaskJob`
+- `WatchJob`
 - `StopJob`
 
-The start job is responsible for scheduling a resource in the platform to execute
-the assigned job. Once that resource exists, it will be a `TaskJob` that is
-responsible for actually running the assigned job. Once it's complete, the task
-plugin system will launch a stop job to clean up the launched platform resource.
+The start job schedules resources in the platform to execute
+the assigned job. Once that resources exists, the `TaskJob` runs the actual assigned job.
+While running, the `WatchJob` operation monitors output to provide debugging information about
+the on-demand runner. Finally, once the original operation completes, the task
+plugin system will launch a `StopJob` operation to clean up the launched platform resource.
 
 ## On-Demand Runner Profiles
 
@@ -52,28 +54,37 @@ See [runner profiles](/docs/runner/profiles) for more information.
 
 ## OCI/Docker Image
 
-By default, the server will launch on-demand runners using the same OCI image
-it was configured with. The on-demand configuration will also accept a specific
-OCI image url to use instead. This allows operators the ability to prepackage
-any Waypoint plugins into the image and use them in their configuration.
+By default, the server will launch on-demand runners using the same OCI image the
+server was configured with. For HCP Waypoint, there is no default. The on-demand
+configuration also accepts a specific OCI image URL to use instead. This allows
+operators the ability to prepackage any Waypoint plugins into the image and use
+them in their configuration.
 
-The official on-demand runner container image is built very similar to Waypoint
-server, with some additional packages such as `Kaniko` for doing in-container
+The official on-demand runner container image is built very similarly to the Waypoint
+server, with some additional packages such as `kaniko` for doing in-container
 builds for jobs like the `Build` operation.
 
 See the [runner profile docs on OCI URLs](/docs/runner/profiles#oci-url) for more information.
 
+## Profile Configuration
+
+To customize the environment and other launch configurations of an on-demand runner,
+please consult the [on-demand runner profile documentation](/docs/runner/profiles).
+
+Those docs detail how to configure and communicate the various aspects of an on-demand runner launch.
+
 ## Official Waypoint Supported Task Plugin Platforms
 
-When you use the `waypoint server install` command, we automatically set up a
-default On-Demand runner profile for you to use with Waypoint Server. Like our
-server install platform support, we also currently support these platforms
-for launching on-demand runner tasks:
+We currently support the following platforms for launching on-demand runner tasks:
 
 - [Kubernetes](/plugins/kubernetes#kubernetes-task)
 - [HashiCorp/Nomad](/plugins/nomad#nomad-task)
 - [AWS/ECS](/plugins/aws-ecs#aws-ecs-task)
 - [Docker](/plugins/docker#docker-task)
+
+-> **Self-managed Waypoint server:** When you use the `waypoint server install` command,
+we automatically set up a default on-demand runner profile for you that matches the
+platform of the server installation.
 
 ## Adding on-demand runner support for other platforms
 
@@ -83,82 +94,94 @@ using the [plugin SDK](/docs/extending-waypoint).
 Plugins expect to fulfill the SDK interface with the following functions:
 
 - `StartTask`
+- `WatchTask`
 - `StopTask`
 
-These functions are what will launch and stop the spawned resource with the
-task launcher.
+These functions are what launch, monitor, and stop the spawned resource used to
+execute the Waypoint runner code.
 
-Task plugins also can accept `TaskLauncherConfig` configuration which users can
-configure through an [on-demand runner profile](/docs/runner/profiles).
+## Task Inspection
 
-## Task Introspection
+The CLI command `waypoint task` gives users more insight into the task launcher system and
+what Waypoint does with remote-enabled projects. Tasks are the operations that
+on-demand runners are built off of within Waypoint.
 
-In Waypoint 0.9.0, we introduced the CLI command `waypoint task`. This command
-currently gives users more introspection into the task launcher system and
-what Waypoint is doing with remote-enabled projects. The simplest benefit
-to this command is listing all known tasks in the system:
+This command listing all known tasks in the system:
 
 ```shell
 $ waypoint task list
 
 » Waypoint On-Demand Runner Tasks
-              ID             | RUN JOB OPERATION | TASK STATE |   PROJECT   |  TIME CREATED  | TIME COMPLETED
------------------------------+-------------------+------------+-------------+----------------+-----------------
-  01G1RYP6JFSEAQVE2SQX38Q19D | Up                | RUNNING    | go-gitops-0 | 3 seconds ago  |
-  01G1RYP37X5FTD9TFZQE5J2BQM | QueueProject      | STOPPED    | go-gitops-0 | 7 seconds ago  | 3 seconds ago
-  01G1RYP08Z9V18HMBP5XDPP0KA | Poll              | STOPPED    | go-gitops-0 | 10 seconds ago | 6 seconds ago
-  01G1RYNTQJ5421K3QBYR6FPAZP | Init              | STOPPED    | go-gitops-0 | 15 seconds ago | 12 seconds ago
-  01G1RYNNEK141B23YDE26XPED7 | Init              | STOPPED    | go-gitops-0 | 21 seconds ago | 15 seconds ago
+              ID             | RUN JOB OPERATION | PIPELINE   | TASK STATE |   PROJECT   |  TIME CREATED  | TIME COMPLETED
+-----------------------------+-------------------+------------+------------+-------------+----------------+-----------------
+  01GBWYSZ02YEB3EHMVQCA5240G | ConfigSync        |            | STARTED    | k8s-tetris  | 1 week ago     |
+  01G1RYP6JFSEAQVE2SQX38Q19D | Up                |            | RUNNING    | go-gitops-0 | 3 seconds ago  |
+  01G1RYP37X5FTD9TFZQE5J2BQM | QueueProject      |            | STOPPED    | go-gitops-0 | 7 seconds ago  | 3 seconds ago
+  01G1RYP08Z9V18HMBP5XDPP0KA | Poll              |            | STOPPED    | go-gitops-0 | 10 seconds ago | 6 seconds ago
+  01G1RYNTQJ5421K3QBYR6FPAZP | Init              |            | STOPPED    | go-gitops-0 | 15 seconds ago | 12 seconds ago
+  01G1RYNNEK141B23YDE26XPED7 | Init              |            | STOPPED    | go-gitops-0 | 21 seconds ago | 15 seconds ago
 ```
 
 You can also take a closer look at an individual task using `waypoint task inspect`.
-This will provide information about the on-demand runner profile which ran the job,
-the job which executed the operation (the Run Job), as well as the job which was
-watching the Run Job (the Watch Job).
+This output includes information about the runners that handled the job,
+as well as the four jobs (TaskJob, StartJob, WatchJob, StopJob) in the operation task.
 
 ```shell
-$ waypoint task inspect 01G1RYP6JFSEAQVE2SQX38Q19D
+$ waypoint task inspect 01GBWYSZ02YEB3EHMVQCA5240G
 
 » On-Demand Runner Task Configuration
-      Task ID: 01G1RYP6JFSEAQVE2SQX38Q19D
-   Task State: RUNNING
+      Task ID: 01GBWYSZ02YEB3EHMVQCA5240G
+   Task State: STARTED
     Workspace: default
-      Project: go-gitops-0
-  Application: go
+      Project: k8s-tetris
+  Application: tetris
 
-» Run Job Configuration
+» Task Job Configuration
   Job Configuration:
-         Job ID: 01G1RYP6JDVM4FPXEZVHP2JPD9
-      Operation: Up
-  Target Runner: 01G1RYP6JD0AV2HEWF4B9CYY29
+         Job ID: 01GBWYSYYVEFK9JNYKNA73XZ0X
+      Operation: ConfigSync
+  Target Runner: 01GBWYSYYVAJWMS6RWFNQV9MGR
       Workspace: default
-        Project: go-gitops-0
-    Application: go
+        Project: k8s-tetris
+    Application: tetris
 
   Job Results:
-  State: Running
+  State: Queued
 
-» Start Job Configuration
+» Watch Job Configuration
   Job Configuration:
-         Job ID: 01G1RYP6JF57MV6MSGPHMCCQCR
-      Operation: StartTask
+         Job ID: 01GBWYSZ02YH9M2P5VPKPVG40G
+      Operation: WatchTask
   Target Runner: *
       Workspace: default
-        Project: go-gitops-0
-    Application: go
+        Project: k8s-tetris
+    Application: tetris
 
   Job Results:
           State: Success
-  Complete Time: 25 seconds ago
+  Complete Time: 1 week ago
+
+» Start Job Configuration
+  Job Configuration:
+         Job ID: 01GBWYSZ02W2N6SHF0A7BW6EXC
+      Operation: StartTask
+  Target Runner: *
+      Workspace: default
+        Project: k8s-tetris
+    Application: tetris
+
+  Job Results:
+          State: Success
+  Complete Time: 1 week ago
 
 » Stop Job Configuration
   Job Configuration:
-         Job ID: 01G1RYP6JFSS7SHZG2HETKVCBR
+         Job ID: 01GBWYSZ0237HREZ0FBJKMJ7HW
       Operation: StopTask
   Target Runner: *
       Workspace: default
-        Project: go-gitops-0
-    Application: go
+        Project: k8s-tetris
+    Application: tetris
 
   Job Results:
   State: Queued

--- a/website/content/docs/runner/profiles.mdx
+++ b/website/content/docs/runner/profiles.mdx
@@ -5,16 +5,20 @@ description: |-
   Each runner profile entry represents the ability to spawn runners (i.e. on-demand runners) when needed using the configured plugin.
 ---
 
-# Runner profiles
+# Runner Profiles
 
-With runner profiles, Waypoint's remote runners can be configured to spawn new ephemeral runner instances (i.e. on-demand runners)
-to perform operations like building and deploying apps. Runner profiles describe the configuration and settings
-necessary to create an on-demand runner. Profiles can be used globally, or by specific projects.
+Waypoint's static runners can be configured to spawn fresh ephemeral runner instances (i.e. on-demand runners)
+to perform app operations, such as building and deploying. Runner profiles describe the configuration and settings
+necessary to create an on-demand runner. Profiles can be used globally, by project, or by app.
 
-## Viewing runner profiles
+### Default Profiles
 
-Waypoint installations performed with the `waypoint install` command come with a default
-runner profile already configured. You can view runner profiles with the `waypoint runner profile list` command:
+Waypoint installations performed with the `waypoint install` command come with a
+default runner profile already configured.
+
+## Viewing Runner Profiles
+
+View runner profiles with the `waypoint runner profile list` command:
 
 ```shell-session
 $ waypoint runner profile list
@@ -24,11 +28,12 @@ $ waypoint runner profile list
   kubernetes-bootstrap-profile | kubernetes  | hashicorp/waypoint-odr:latest | yes
 ```
 
-If a default runner profile is configured for a given plugin, Waypoint will use that profile to create a new on-demand
-runner for each operation on the platform for that plugin. For the majority of users, this default runner profile should
-be sufficient.
+If there exists a default runner profile for a given plugin, Waypoint will use that
+profile to create on-demand runners for each operation on the platform with that
+plugin. For the majority of users, this default runner profile should be sufficient.
 
-You can also closely inspect a runner profile by name with the `waypoint runner profile inspect` command:
+You can also closely inspect a runner profile by name with the
+`waypoint runner profile inspect` command:
 
 ```shell-session
 # waypoint runner profile inspect kubernetes-bootstrap-profile
@@ -54,28 +59,34 @@ Runner profiles
   ecs                          | aws-ecs     | hashicorp/waypoint-odr:latest |
 ```
 
-## Modifying runner profiles
+## Runner Configuration
 
-It may be necessary to change the config (environment variables or files) delivered to on-demand runners.
-The best way is to add config to every runner and profile with the `waypoint config -runner`, detailed [here](/docs/runner/config).
+It may be necessary to add configuration (environment variables or files) to an
+on-demand runner. The best way is to use runner config via
+the `waypoint config -runner`, detailed [here](/docs/runner/config). These
+configuration variables will be available to any on-demand runner.
 
 ### Static environment variables
 
-If you need environment variables that are scoped to a specific runner profile, rather than every runner, you can use
-the `-env-vars` flag of `waypoint runner profile set`, i.e.:
+If you need to scope environment variables to a specific runner profile,
+rather than every runner, you can use the `-env-vars` flag of
+`waypoint runner profile set`, i.e.:
 
 ```shell-session
 $ waypoint runner profile set -name=kubernetes -env-vars="MODE=WAYPOINT_ODR" -env-vars="FOO=BAR" -plugin-type=kubernetes
 ```
 
-This can be useful to configure the behavior of a custom runner image with multiple modes of operation, for example.
+This can be useful to configure the behavior of a custom runner image with multiple
+modes of operation, for example.
 
-### OCI-URL
+### OCI URL
 
-It may be necessary to change the runner profile OCI Url. This can be used to upgrade or downgrade the version of the
-ODR image, or switch to a custom image built from hashicorp/waypoint-odr that contains custom tools or behavior.
+It may be necessary to change the runner profile OCI URL. This can be used to upgrade
+or downgrade the version of the ODR image, or switch to a custom image that contains
+custom tools or behavior.
 
-Below is an example of switching the odr image to a prerelease alpha version of Waypoint:
+Below is an example of switching the ODR image to a pre-release alpha version of
+Waypoint:
 
 ```shell-session
 $ waypoint runner profile set -name=kubernetes -oci-url=ghcr.io/hashicorp/waypoint/alpha-odr:latest -plugin-type=kubernetes
@@ -83,21 +94,27 @@ $ waypoint runner profile set -name=kubernetes -oci-url=ghcr.io/hashicorp/waypoi
 
 ### The Default Profile
 
-The default runner profile for any given plugin will be used to create on-demand runners for each operation on that plugin.
-The default profile can be changed with the `waypoint runner profile set` command by setting `-default=false` on the
-existing default profile, and `-default=true` on the new profile. If multiple profiles are set as the default,
-Waypoint will choose one at random for each operation.
+The default runner profile for any given plugin will be used to create on-demand
+runners for each operation on that plugin. The default profile can be changed to
+different profile with the `waypoint runner profile set` command by setting
+`-default=false` on the existing default profile, and `-default=true` on the new
+profile.
 
-### Using plugin-config
+If multiple profiles are set as the default, Waypoint will choose one at random for
+each operation.
 
-Waypoint on-demand runners are backed by the `Task` plugin type, which provides an interface for launching short-lived
-container-based instances and is implemented by the plugins for multiple platforms. To see the task config options for
-your platform of interest, see [plugin docs](/plugins). For example, the Kubernetes task plugin docs are located
-[here](/plugins/kubernetes#kubernetes-task).
+### Using Plugin-Config
 
-The `-plugin-config` flag lets you modify the way the plugin of interest launches tasks. For example, to modify the
-Kubernetes default runner profile to use a different Kubernetes service account for launching apps, create an hcl
-file with your new plugin config, for example the following at `./k8s-runner-profile-plugin-config.hcl`:
+Waypoint on-demand runners are backed by the `Task` plugin type, which provides an
+interface for launching short-lived container-based instances and is implemented by
+the plugins for multiple platforms. To see the task config options for your platform
+of interest, see [plugin docs](/plugins). For example, the Kubernetes task plugin
+docs are located [here](/plugins/kubernetes#kubernetes-task).
+
+The `-plugin-config` flag lets you modify the way that tasks are launched.
+For example, to modify the Kubernetes default runner profile to use a
+different Kubernetes service account, create an hcl file with your
+new plugin config, following at location `./k8s-runner-profile-plugin-config.hcl`:
 
 ```hcl
 service_account=my-custom-service-account
@@ -109,12 +126,13 @@ And then apply it to your plugin with `waypoint runner profile set`:
 $ waypoint runner profile set -name=kubernetes -plugin-type=kubernetes -plugin-config=./k8s-runner-profile-plugin-config.hcl
 ```
 
-### Adding a new runner profile
+### Adding a New Runner Profile
 
-New runner profiles can be added with the `waypoint profile set` command, using a `-name` that doesn't already exist.
+Add new runner profiles with the `waypoint profile set` command. Customize the identifier with the `-name` flag.
+
 Here's an example of creating a runner profile for aws-ecs:
 
-Sample task plugin (at `./aws-ecs-plugin-config.hcl`)
+First, write sample task plugin data to `./aws-ecs-plugin-config.hcl`:
 
 ```hcl
 cluster = waypoint
@@ -128,17 +146,18 @@ subnets = "subnet-01exmplc,subnet-fbexmpl3,subnet-acexmpl7,subnet-9aexmpl0"
 task_role_name = waypoint-runner
 ```
 
+Set the runner profile, referencing the above data.
+
 ```shell-session
 waypoint runner profile set -name=ecs -plugin-type=aws-ecs -plugin-config=./aws-ecs-plugin-config.hcl
 ```
 
-This can either be set as the default plugin, or be used for specific projects. Note that to use this profile,
-the Waypoint remote runner will need permission and credentials to create ECS tasks in the desired cluster.
+Note that to use this profile, the Waypoint static runner will need permission and
+credentials to create ECS tasks in the desired cluster.
 
-### Deleting a runner profile
+### Deleting a Runner Profile
 
-Runner profiles can be deleted with the `waypoint runner profile delete` command including the ID as the argument.
-
+Delete runner profiles with the `waypoint runner profile delete` command with the ID as the argument.
 To get the runner ID, run `waypoint runner profile inspect` for a named runner.
 
 ```shell-session
@@ -148,6 +167,7 @@ Runner profiles
 ---------+-------------+-------------------------------+---------------+----------
   docker | docker      | waypoint-odr:dev              | *             | yes
   dev    | kubernetes  | hashicorp/waypoint-odr:latest | dev           |
+
 
 $ waypoint runner profile inspect dev
 » Runner profile:
@@ -159,7 +179,7 @@ $ waypoint runner profile inspect dev
           Target Runner: dev
   Environment Variables: map[]
 
-$ waypoint runner profile delete 01G65VD1SSB3HYJ3FS9K629A3B
 
+$ waypoint runner profile delete 01G65VD1SSB3HYJ3FS9K629A3B
 » Runner profile deleted
 ```

--- a/website/content/docs/runner/run-manual.mdx
+++ b/website/content/docs/runner/run-manual.mdx
@@ -1,27 +1,34 @@
 ---
 layout: docs
-page_title: Additional Runners
+page_title: Additional Static Runners
 description: |-
-  The `waypoint install` command installs and manages a single Waypoint runner. Waypoint supports any number of additional runners. Additional runners must be run manually today.
+  The `waypoint install` command installs and manages a single Waypoint static
+  runner. Additional static runners can be installed using `waypoint runner install` or
+  mannualy.
 ---
 
 # Additional Runners
 
-The `waypoint install` command installs and manages a single Waypoint runner.
-Waypoint supports any number of additional runners. Additional runners must
-be run manually today. A future version of Waypoint will introduce more
-automated management for additional runners.
+With self managed Waypoint servers, the `waypoint install` command installs and
+manages a single Waypoint static runner.
 
-## Installing a Runner
+Additional static runners can be added using [`waypoint runner install`](/commands/runner-install), which automates the process of creating
+resources in Kubernetes, Nomad, ECS, or Docker to execute a static runner.
 
-Waypoint supports deploying a runner to multiple platforms with one command.
-Depending on the platform, different configurations may be provided to control
-various aspects of the runner deployed in the given platform. By default, the
-server will adopt the runner and create a new runner profile for it after it
+In the case that none of these work for you, you can configure a static runner manually as
+well.
+
+## Installing a Static Runner Automatically
+
+Waypoint supports deploying a static runner to multiple platforms with one command.
+Depending on the platform, different configurations can be provided to control
+how the runner is deployed in a platform. By default, the
+server will adopt the static runner and create a new runner profile for it after it
 reports to the server.
 
-To install a runner, use the `waypoint runner install` command. Below is an
-example of using that command to install a Waypoint runner to Docker:
+To install a static runner, use the [`waypoint runner install`](/commands/runner-install)
+command. Below is an example of using that command to install a Waypoint static runner to
+Docker:
 
 ```shell-session
 $ waypoint runner install -platform=docker -docker-runner-network=waypoint -server-addr=waypoint-server:9701 -server-tls-skip-verify=true
@@ -70,14 +77,21 @@ Currently, Waypoint supports installing runners on the following platforms:
 - Amazon ECS
 - Docker
 
-## Manually Running a Runner
+## Manually Running a Static Runner
 
-The instructions below are only if you're installing additional runners
-manually. `waypoint install` automatically installs a single runner and
-you don't need to manually add any additional runners until the load
-requires it.
+The instructions below are only if you're installing additional static runners
+manually. It's recommended that you utilize the the automated static runner installation if
+possible.
 
-To run a runner, use the `waypoint runner agent` command:
+The primary reason you'd need to install a new static runner manually is because the
+environment it will run in can't be captured by the above automation.
+
+Under normal circumstances, on-demand runners should be the mechanism used to provide
+additional capacity within an installation, not additional static runners.
+
+### Waypoint Runner Agent
+
+To run a static runner, use the `waypoint runner agent` command:
 
 ```shell-session
 $ WAYPOINT_SERVER_ADDR=<server addr> \

--- a/website/content/docs/troubleshooting.mdx
+++ b/website/content/docs/troubleshooting.mdx
@@ -90,7 +90,7 @@ Locate the volumes named starting with `pack-cache-` and remove them with `docke
 
 ## Remote Operations Failure
 
-If your Waypoint operation with remote runners fails, task introspection can help
+If your Waypoint operation fails, task introspection can help
 troubleshoot the issue. Logs from the on-demand runner may not be readily available
 from the platform in which the runners are launched, and task introspection can
 get the information needed to troubleshoot.

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -130,7 +130,7 @@ waypoint server upgrade -platform=kubernetes -auto-approve
 This will automatically save a snapshot of the server in your current directory
 prior to upgrading.
 
-If the server was installed with a remote runner, Waypoint will uninstall the existing runner and install a new one with the new version.
+If the server was installed with a static runner, Waypoint will uninstall the existing runner and install a new one with the new version.
 
 ### Client Upgrade
 

--- a/website/content/docs/waypoint-hcl/registry.mdx
+++ b/website/content/docs/waypoint-hcl/registry.mdx
@@ -13,14 +13,14 @@ The `registry` stanza configures the result of a build to be pushed
 to a registry such as a Docker Registry, Amazon ECR, Artifactory, etc. A registry
 is used to make the result of a build available to the deployment platform.
 
-A `registry` is required when using a [remote runner](/docs/runner#remote-runner)
-with GitOps. The remote runner will build your image and push the artifact to
-this registery.
+A `registry` is required unless using the Docker build plugin via a [CLI
+runner](/docs/runner#cli-runner). This is not the common case, and thusly almost
+always a `registry` stanza should be used.
 
-For local Waypoint runs, registries are **optional.** Please see the documentation on the
+Please see the documentation on the
 [registry phase of the Waypoint lifecycle](/docs/lifecycle/build#registry)
-for examples of when a registry is necessary and the behavior of Waypoint
-without a registry specified.
+for examples of when a registry is necessary and the behavior of Waypoint without a
+registry specified.
 
 ```hcl
 app "frontend" {

--- a/website/content/docs/waypoint-hcl/variables/dynamic.mdx
+++ b/website/content/docs/waypoint-hcl/variables/dynamic.mdx
@@ -14,8 +14,8 @@ sourced using the
 set as a default value for an
 [input variable](/docs/waypoint-hcl/variables/input).
 
--> **Requirements:** External data fetching only works for jobs that run
-on [remote runners](/docs/extending-waypoint). You can still operate locally
+-> **Requirements:** External data fetching does not works in jobs that run
+on [CLI runners](/docs/extending-waypoint). You can still operate locally
 on waypoint.hcl files that fetch external data, but all the variables that fetch
 external values must be manually overridden.
 


### PR DESCRIPTION
* Many various clarifications
* Clarify `remote runner` => `static runner`
* Remove many mentions of CLI runners being the most common setup