### PR TITLE
Nomad Plugin bug fixes

### DIFF
--- a/.changelog/3883.txt
+++ b/.changelog/3883.txt
@@ -1,0 +1,8 @@
+```release-note:bug
+plugin/nomad: Update Nomad task launcher plugin to respect namespace and region
+configs in runner profile
+```
+```release-note:bug
+plugin/nomad-jobspec: Update Nomad jobspec status check to not report partial
+health for deployments with canaries
+```

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -257,6 +257,15 @@ func (p *Platform) resourceJobStatus(
 			}
 		}
 
+		// Need to subtract # of canaries in the update stanza from
+		// "completed". Canary allocs will end up in the "completed"
+		// state after the deployment, and thusly throw off the count
+		// of otherwise "completed" allocs, resulting in a partial
+		// state, when it's actually healthy
+		if complete > 0 {
+			complete = complete - *job.Update.Canary
+		}
+
 		if running == currentJobVersionAllocs && hasSquashedEvals == false {
 			jobResource.Health = sdk.StatusReport_READY
 			jobResource.HealthMessage = fmt.Sprintf("Job %q is reporting ready!", state.Name)

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -271,7 +271,11 @@ func (p *TaskLauncher) StartTask(
 	job.TaskGroups[0].Tasks[0].Config = config
 
 	log.Debug("registering on-demand task job", "task-name", taskName)
-	_, _, err = jobclient.Register(job, nil)
+	writeOptions := &api.WriteOptions{
+		Region:    p.config.Region,
+		Namespace: p.config.Namespace,
+	}
+	_, _, err = jobclient.Register(job, writeOptions)
 	if err != nil {
 		log.Debug("failed to register job to nomad")
 		return nil, err


### PR DESCRIPTION
1. Fixed a bug in the jobspec status check where a deployment that had canary allocs would always report as partially healthy, even if it was healthy
2. Fixed the Nomad task launcher plugin to deploy the Nomad ODRs to the region and namespace specified in the runner profile plugin config