### PR TITLE
Handle Remote datasources properly

### DIFF
--- a/internal/cli/project_inspect.go
+++ b/internal/cli/project_inspect.go
@@ -112,6 +112,7 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 			gitRef = ds.Git.Ref
 			gitPath = ds.Git.Path
 		case *pb.Job_DataSource_Remote:
+			dataSource = "Remote"
 			remoteDesc = ds.Remote.Description
 		}
 	}

--- a/internal/cli/project_inspect.go
+++ b/internal/cli/project_inspect.go
@@ -99,7 +99,7 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 		workspaceNames = append(workspaceNames, ws.Workspace.Workspace)
 	}
 
-	var gitUrl, gitRef, gitPath string
+	var gitUrl, gitRef, gitPath, remoteDesc string
 	dataSource := "Local" // if unset, assume local
 	if project.DataSource != nil {
 		switch ds := project.DataSource.Source.(type) {
@@ -111,6 +111,8 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 			gitUrl = ds.Git.Url
 			gitRef = ds.Git.Ref
 			gitPath = ds.Git.Path
+		case *pb.Job_DataSource_Remote:
+			remoteDesc = ds.Remote.Description
 		}
 	}
 
@@ -158,6 +160,9 @@ func (c *ProjectInspectCommand) FormatProject(projectTarget string) error {
 		},
 		{
 			Name: "Git Path", Value: gitPath,
+		},
+		{
+			Name: "Remote Info", Value: remoteDesc,
 		},
 		{
 			Name: "Data Source Poll Enabled", Value: strconv.FormatBool(datasourcePollEnabled),

--- a/internal/client/runner.go
+++ b/internal/client/runner.go
@@ -71,10 +71,10 @@ func remoteOpPreferred(ctx context.Context, client pb.WaypointClient, project *p
 
 	var hasRemoteDataSource bool
 	switch project.DataSource.GetSource().(type) {
-	case *pb.Job_DataSource_Git:
-		hasRemoteDataSource = true
-	default:
+	case *pb.Job_DataSource_Local:
 		hasRemoteDataSource = false
+	default:
+		hasRemoteDataSource = true
 	}
 
 	if !hasRemoteDataSource {


### PR DESCRIPTION
We introduced a Remote data source type, that goes along with Git and Local. The difference with Remote is that in indicates that only the Waypoint server knows how to perform the data source fetching.

The server already has the ability to translate a project with a Remote data source into job with a Git data source.

This updates the CLI to handle the presence of Remote properly (rather than assuming if it's not Git, it's local).