### PR TITLE
Not using the ODR image for the k8s static runner

### DIFF
--- a/.changelog/3890.txt
+++ b/.changelog/3890.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+runner-install/kubernetes: Fix the static runner image used in the `waypoint runner install` command
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -8,6 +8,7 @@ import (
 	empty "google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -66,7 +67,7 @@ func (c *RunnerInstallCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "odr-image",
 			Usage:   "Docker image for the on-demand runners.",
-			Default: installutil.DefaultRunnerImage,
+			Default: installutil.DefaultODRImage,
 			Target:  &c.runnerProfileOdrImage,
 		})
 
@@ -288,6 +289,7 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 		if odc, ok := p.(installutil.OnDemandRunnerConfigProvider); ok {
 			odrConfig = odc.OnDemandRunnerConfig()
 			odrConfig.Name = odrConfig.Name + "-" + strings.ToUpper(id)
+			odrConfig.OciUrl = c.runnerProfileOdrImage // Use what we got from flags (or the default)
 		} else {
 			odrConfig = &pb.OnDemandRunnerConfig{
 				Name:       platform[0] + "-" + strings.ToUpper(id),

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -14,6 +14,7 @@ import (
 	hcljson "github.com/hashicorp/hcl/v2/json"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -257,7 +258,7 @@ func (c *RunnerProfileSetCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:    "oci-url",
 			Target:  &c.flagOCIUrl,
-			Default: installutil.DefaultRunnerImage,
+			Default: installutil.DefaultODRImage,
 			Usage:   "The url for the OCI image to launch for the on-demand runner.",
 		})
 

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/builtin/k8s"
 	clientpkg "github.com/hashicorp/waypoint/internal/client"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -431,7 +432,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 		} else {
 			ociUrl := odr.OciUrl
 			if ociUrl == "" {
-				ociUrl = installutil.DefaultRunnerImage
+				ociUrl = installutil.DefaultODRImage
 			}
 			odr = &pb.OnDemandRunnerConfig{
 				Id:                   oldRunnerConfig.Config.Id,

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -30,6 +30,8 @@ func DeriveDefaultODRImage(serverImage string) (string, error) {
 	return fmt.Sprintf("%s-odr:%s", imageName, tag), nil
 }
 
+// NOTE: the server image is also used for static (non-ODR) runners.
+// Static runners cannot use the ODR image.
 const DefaultServerImage = "hashicorp/waypoint:latest"
 
 // When we have a serverImage value to give to DeriveDefaultOdrImage,

--- a/internal/installutil/odr.go
+++ b/internal/installutil/odr.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/distribution/distribution/v3/reference"
+
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
-// DefaultODRImage returns the default Waypoint ODR image based on the
+// DeriveDefaultODRImage returns the default Waypoint ODR image based on the
 // supplied server image. We default the ODR image to the name of the server
 // image with the `-odr` suffix attached to it.
-func DefaultODRImage(serverImage string) (string, error) {
+func DeriveDefaultODRImage(serverImage string) (string, error) {
 	image, err := reference.Parse(serverImage)
 	if err != nil {
 		return "", fmt.Errorf("server image name %q is not a valid oci reference: %s", serverImage, err)
@@ -31,9 +32,9 @@ func DefaultODRImage(serverImage string) (string, error) {
 
 const DefaultServerImage = "hashicorp/waypoint:latest"
 
-// When we have a serverImage value to give to DefaultODRImage,
+// When we have a serverImage value to give to DeriveDefaultOdrImage,
 // we should use that. When we don't, we can use this value
-const DefaultRunnerImage = "hashicorp/waypoint-odr:latest"
+const DefaultODRImage = "hashicorp/waypoint-odr:latest"
 
 func DefaultRunnerName(id string) string {
 	return "waypoint-" + id + "-runner"

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -3,8 +3,6 @@ package runnerinstall
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/waypoint/internal/installutil"
-	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"os"
 	"time"
 
@@ -15,7 +13,10 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
 type DockerConfig struct {
@@ -217,7 +218,7 @@ func (i *DockerRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig 
 	// TODO: Add options for plugin config here
 	return &pb.OnDemandRunnerConfig{
 		Name:       "docker",
-		OciUrl:     i.Config.RunnerImage,
+		OciUrl:     installutil.DefaultODRImage,
 		PluginType: "docker",
 		Default:    false,
 	}

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"strconv"
 	"strings"
 	"time"
+
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"
@@ -20,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	awsinstallutil "github.com/hashicorp/waypoint/internal/installutil/aws"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -729,7 +731,7 @@ func (i *ECSRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 
 	return &pb.OnDemandRunnerConfig{
 		Name:         "ecs",
-		OciUrl:       i.Config.RunnerImage,
+		OciUrl:       installutil.DefaultODRImage,
 		PluginType:   "aws-ecs",
 		Default:      false,
 		PluginConfig: cfgJson,

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -236,9 +236,11 @@ func (i *K8sRunnerInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:    "k8s-runner-image",
-		Target:  &i.Config.RunnerImage,
-		Default: installutil.DefaultRunnerImage,
+		Name:   "k8s-runner-image",
+		Target: &i.Config.RunnerImage,
+		// This is the static (non-odr) runner, and therefore needs to use the non-ODR
+		// image. The server and the static runner use the same image.
+		Default: installutil.DefaultServerImage,
 		Usage:   "Docker image for the Waypoint runner.",
 	})
 

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -115,20 +115,6 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 		return err
 	}
 
-	odrImage := i.Config.OdrImage
-	if odrImage == "" {
-		odrImage, err = installutil.DefaultODRImage(i.Config.RunnerImage)
-		if err != nil {
-			opts.UI.Output("Error getting default ODR image: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
-			return err
-		}
-	}
-	odrImageRef, err := dockerparser.Parse(odrImage)
-	if err != nil {
-		opts.UI.Output("Error parsing ODR image name: %s", clierrors.Humanize(err), terminal.WithErrorStyle())
-		return err
-	}
-
 	clientSet, err := k8sinstallutil.NewClient(i.Config)
 	if err != nil {
 		opts.UI.Output("Error creating k8s clientset: %s", clierrors.Humanize(err), terminal.StatusError)
@@ -163,16 +149,10 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 				"repository": runnerImageRef.Repository(),
 				"tag":        runnerImageRef.Tag(),
 			},
-			"odr": map[string]interface{}{
-				"image": map[string]interface{}{
-					"repository": odrImageRef.Repository(),
-					"tag":        odrImageRef.Tag(),
-				},
-				"serviceAccount": map[string]interface{}{
-					"create": i.Config.CreateServiceAccount,
-					"name":   "waypoint-runner-odr",
-				},
-			},
+			// odr stanza not specified - this is used by the helm chart to
+			// give to the bootstrap job to populate the ODR profile, but only
+			// during a server install. For runner installs, we'll create the
+			// ODR profile ourselves later.
 			"resources": map[string]interface{}{
 				"requests": map[string]interface{}{
 					"memory": i.Config.MemRequest,
@@ -554,10 +534,14 @@ func (i *K8sRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 
 	return &pb.OnDemandRunnerConfig{
 		Name:         "kubernetes",
-		OciUrl:       i.Config.RunnerImage,
 		PluginType:   "kubernetes",
 		Default:      false,
 		PluginConfig: cfgJson,
 		ConfigFormat: pb.Hcl_JSON,
+		// Can't use i.Config.OdrImage here, because it hasn't been initalized.
+		// This doesn't matter in practice - this is used in the `runner install` command,
+		// which has its own -odr-image flag that it's going to use to overwrite
+		// this value.
+		OciUrl: installutil.DefaultODRImage,
 	}
 }

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/waypoint/internal/installutil"
-	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/hashicorp/waypoint/internal/clierrors"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	nomadutil "github.com/hashicorp/waypoint/internal/installutil/nomad"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
-	"k8s.io/apimachinery/pkg/util/wait"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
 type NomadRunnerInstaller struct {
@@ -29,7 +29,6 @@ type NomadConfig struct {
 	ServiceAnnotations map[string]string `hcl:"service_annotations,optional"`
 
 	RunnerImage string `hcl:"runner_image,optional"`
-	OdrImage    string `hcl:"odr_image,optional"`
 
 	Region         string   `hcl:"namespace,optional"`
 	Datacenters    []string `hcl:"datacenters,optional"`
@@ -435,7 +434,7 @@ func (i *NomadRunnerInstaller) OnDemandRunnerConfig() *pb.OnDemandRunnerConfig {
 
 	return &pb.OnDemandRunnerConfig{
 		Name:         "nomad",
-		OciUrl:       i.Config.RunnerImage,
+		OciUrl:       installutil.DefaultODRImage,
 		PluginType:   "nomad",
 		Default:      false,
 		PluginConfig: cfgJson,

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -6,10 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/hashicorp/waypoint/internal/installutil"
-
-	"github.com/hashicorp/waypoint/internal/runnerinstall"
-
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -18,11 +14,12 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
-
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
+	"github.com/hashicorp/waypoint/internal/installutil"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
+	"github.com/hashicorp/waypoint/internal/runnerinstall"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/serverconfig"
 )
@@ -53,7 +50,7 @@ func (i *DockerInstaller) Install(
 ) (*InstallResults, string, error) {
 	if i.config.odrImage == "" {
 		var err error
-		i.config.odrImage, err = installutil.DefaultODRImage(i.config.serverImage)
+		i.config.odrImage, err = installutil.DeriveDefaultODRImage(i.config.serverImage)
 		if err != nil {
 			return nil, "", err
 		}
@@ -295,7 +292,7 @@ func (i *DockerInstaller) Upgrade(
 ) {
 	if i.config.odrImage == "" {
 		var err error
-		i.config.odrImage, err = installutil.DefaultODRImage(i.config.serverImage)
+		i.config.odrImage, err = installutil.DeriveDefaultODRImage(i.config.serverImage)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -102,7 +103,7 @@ func (i *K8sInstaller) Install(
 ) (*InstallResults, string, error) {
 	if i.Config.OdrImage == "" {
 		var err error
-		i.Config.OdrImage, err = installutil.DefaultODRImage(i.Config.ServerImage)
+		i.Config.OdrImage, err = installutil.DeriveDefaultODRImage(i.Config.ServerImage)
 		if err != nil {
 			return nil, "", err
 		}
@@ -431,7 +432,7 @@ func (i *K8sInstaller) Upgrade(
 ) {
 	if i.Config.OdrImage == "" {
 		var err error
-		i.Config.OdrImage, err = installutil.DefaultODRImage(i.Config.ServerImage)
+		i.Config.OdrImage, err = installutil.DeriveDefaultODRImage(i.Config.ServerImage)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
+
 	"github.com/hashicorp/waypoint/internal/clicontext"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -149,7 +150,7 @@ func (i *NomadInstaller) Install(
 
 	if i.config.odrImage == "" {
 		var err error
-		i.config.odrImage, err = installutil.DefaultODRImage(i.config.serverImage)
+		i.config.odrImage, err = installutil.DeriveDefaultODRImage(i.config.serverImage)
 		if err != nil {
 			return nil, "", err
 		}
@@ -394,7 +395,7 @@ func (i *NomadInstaller) Upgrade(
 
 	if i.config.odrImage == "" {
 		var err error
-		i.config.odrImage, err = installutil.DefaultODRImage(i.config.serverImage)
+		i.config.odrImage, err = installutil.DeriveDefaultODRImage(i.config.serverImage)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +629,6 @@ func (i *NomadInstaller) InstallRunner(
 			RunnerImage:           i.config.serverImage,
 			Namespace:             i.config.namespace,
 			ServiceAnnotations:    i.config.serviceAnnotations,
-			OdrImage:              i.config.odrImage,
 			Region:                i.config.region,
 			Datacenters:           i.config.datacenters,
 			PolicyOverride:        i.config.policyOverride,

--- a/internal/serverinstall/serverinstall_test.go
+++ b/internal/serverinstall/serverinstall_test.go
@@ -1,11 +1,12 @@
 package serverinstall
 
 import (
-	"github.com/hashicorp/waypoint/internal/installutil"
 	"testing"
+
+	"github.com/hashicorp/waypoint/internal/installutil"
 )
 
-func TestDefaultODRImage(t *testing.T) {
+func TestDeriveDefaultODRImage(t *testing.T) {
 	tests := []struct {
 		name        string
 		serverImage string
@@ -45,13 +46,13 @@ func TestDefaultODRImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := installutil.DefaultODRImage(tt.serverImage)
+			got, err := installutil.DeriveDefaultODRImage(tt.serverImage)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("defaultODRImage() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("DeriveDefaultODRImage() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("defaultODRImage() got = %v, want %v", got, tt.want)
+				t.Errorf("DeriveDefaultODRImage() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -73,7 +73,7 @@ the install, the command would be:
 - `-k8s-context=<string>` - The Kubernetes context to install the Waypoint runner to. If left unset, Waypoint will use the current Kubernetes context.
 - `-k8s-helm-version=<string>` - The version of the Helm chart to use for the Waypoint runner install. The required version number format is: 'vX.Y.Z'.
 - `-k8s-namespace=<string>` - The namespace in the Kubernetes cluster into which the Waypoint runner will be installed. The default is default.
-- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint-odr:latest.
+- `-k8s-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint:latest.
 - `-k8s-cpu-request=<string>` - Requested amount of CPU for Waypoint runner. The default is 250m.
 - `-k8s-mem-request=<string>` - Requested amount of memory for Waypoint runner. The default is 256Mi.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.


### PR DESCRIPTION
## What does this fix?

Currently, if you run `waypoint runner install -platform=kubernetes ...` but you *don't* specify a specific `-k8s-runner-image`, you get the ODR image for the static runner, which appears to be incapable of launching ODRs.

Reverts this change: https://github.com/hashicorp/waypoint/pull/3800/files#diff-33ed847d2fd425bf13e47f27760372eccaa88ed101ae6f05d13780095f486ab1L263

Only the on-demand runner needs its own image, because it needs kaniko for builds. If you use the ODR image for the static runner, you get this error when attempting to launch tasks (in the static runner logs)

```
2022-09-15T22:23:54.331Z [INFO]  waypoint.runner.agent.runner: launching plugin: job_id=01GD1M0P0N0PP6K9Q4FSFZ58PC job_op=*gen.Job_StartTask type=TaskLauncher path=/kaniko/waypoint args=["/kaniko/waypoint", "plugin", "kubernetes"]
2022-09-15T22:23:54.413Z [ERROR] waypoint.runner.agent.runner.waypoint: plugin init error: job_id=01GD1M0P0N0PP6K9Q4FSFZ58PC job_op=*gen.Job_StartTask @module=plugin error="open /kaniko/tmp/plugin1917675357: permission denied" timestamp=2022-09-15T22:23:54.413Z
2022-09-15T22:23:54.418Z [ERROR] waypoint.runner.agent.runner: error creating plugin client: job_id=01GD1M0P0N0PP6K9Q4FSFZ58PC job_op=*gen.Job_StartTask
  err=
  | Unrecognized remote plugin message: 
  | 
  | This usually means that the plugin is either invalid or simply
  | needs to be recompiled to support the latest protocol.
```

This is what it looks like on the client side during a `waypoint build`:

```
$ waypoint build

» Building backend...
! Unrecognized remote plugin message: 
  
  This usually means that the plugin is either invalid or simply
  needs to be recompiled to support the latest protocol.
```

I haven't dug into _why_ the kaniko image can't launch tasks - it seems like it should be able to - but going back to using the server image for the static runner fixes the problem.

## Workaround

You can work around this by specifying a non-odr runner image during `waypoint runner install`.  I.e.:

```
waypoint runner install -platform=kubernetes -server-addr=api.hashicorp.cloud:443 -k8s-runner-image=hashicorp/waypoint:latest
```