### PR TITLE
bolt: Cancel WatchJob for TaskCancel

### DIFF
--- a/.changelog/3893.txt
+++ b/.changelog/3893.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Update TaskCancel to also cancel WatchTask job, if it was launched.
+```

--- a/internal/server/boltdbstate/task.go
+++ b/internal/server/boltdbstate/task.go
@@ -98,10 +98,18 @@ func (s *State) TaskCancel(ref *pb.Ref_Task) error {
 		return err
 	}
 
-	s.log.Trace("canceling task job for task", "task id", task.Id, "start job id", task.TaskJob.Id)
+	s.log.Trace("canceling task job for task", "task id", task.Id, "task job id", task.TaskJob.Id)
 	err = s.JobCancel(task.TaskJob.Id, false)
 	if err != nil {
 		return err
+	}
+
+	if task.WatchJob != nil {
+		s.log.Trace("canceling watch job for task", "task id", task.Id, "watch job id", task.WatchJob.Id)
+		err = s.JobCancel(task.WatchJob.Id, false)
+		if err != nil {
+			return err
+		}
 	}
 
 	s.log.Trace("canceling stop job for task", "task id", task.Id, "stop job id", task.StopJob.Id)

--- a/pkg/serverstate/statetest/test_task.go
+++ b/pkg/serverstate/statetest/test_task.go
@@ -274,6 +274,9 @@ func TestTaskCancel(t *testing.T, factory Factory, restartF RestartFactory) {
 			Id: "j_test",
 		})))
 		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
+			Id: "watch_job",
+		})))
+		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
 			Id: "stop_job",
 		})))
 
@@ -281,6 +284,7 @@ func TestTaskCancel(t *testing.T, factory Factory, restartF RestartFactory) {
 			Id:       "t_test",
 			TaskJob:  &pb.Ref_Job{Id: "j_test"},
 			StartJob: &pb.Ref_Job{Id: "start_job"},
+			WatchJob: &pb.Ref_Job{Id: "watch_job"},
 			StopJob:  &pb.Ref_Job{Id: "stop_job"},
 		})
 		require.NoError(err)
@@ -307,6 +311,12 @@ func TestTaskCancel(t *testing.T, factory Factory, restartF RestartFactory) {
 		require.NotEmpty(job.CancelTime)
 
 		job, err = s.JobById("j_test", nil)
+		require.NoError(err)
+		require.Equal(pb.Job_ERROR, job.Job.State)
+		require.NotNil(job.Job.Error)
+		require.NotEmpty(job.CancelTime)
+
+		job, err = s.JobById("watch_job", nil)
 		require.NoError(err)
 		require.Equal(pb.Job_ERROR, job.Job.State)
 		require.NotNil(job.Job.Error)


### PR DESCRIPTION
This commit updates TaskCancel to also cancel the WatchTask job if it exists. Not all task launcher plugins implement WatchTask so there's an extra check that the job ref was set prior to cancellation.