### PR TITLE
Fixing destroying non-ecs resources

### DIFF
--- a/.changelog/3896.txt
+++ b/.changelog/3896.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin: Fix panic in non-ECS plugins when destroying resources
+```

--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ require (
 	github.com/evanphx/grpc-gateway v1.16.1-0.20220211183845-48e5be386c15
 	github.com/hashicorp/go-grpc-net-conn v0.0.0-20220321172933-7ab38178cb90
 	github.com/hashicorp/opaqueany v0.0.0-20220321170339-a5c6ff5bb0ec
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220831214951-89c00954cebb
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220916144417-dbf0e8e09cc7
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/rs/cors v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef h1:YKouRHFf
 github.com/hashicorp/vault/sdk v0.1.14-0.20201202172114-ee5ebeb30fef/go.mod h1:cAGI4nVnEfAyMeqt9oB+Mase8DNn3qA/LDNHURiwssY=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220831214951-89c00954cebb h1:3fHZU0HzNxasyPXb5a+ilFLHbi7BZqqs0vjp74yYOHo=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220831214951-89c00954cebb/go.mod h1:rogx91d8Lpgj/LC5yHtD7fea1OikuGKiut6QW75wNOA=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220916144417-dbf0e8e09cc7 h1:3qylEnCEQa6YQv+r01knsPP19BvSiSj5Mdaw4letcgE=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20220916144417-dbf0e8e09cc7/go.mod h1:rogx91d8Lpgj/LC5yHtD7fea1OikuGKiut6QW75wNOA=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
Depends on https://github.com/hashicorp/waypoint-plugin-sdk/pull/74

This fixes and issue wherein if you attempt to create k8s resources and there's a problem, the ODR panics during the resource-manager rollback.