### PR TITLE
feat(plugins/k8s): add `security_context` option for on-demand runners

### DIFF
--- a/.changelog/3903.txt
+++ b/.changelog/3903.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugins/k8s: Add `security_context` to the TaskLauncherConfig (on-demand runner configuration)
+```

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -1529,6 +1529,7 @@ type Container struct {
 // PodSecurityContext describes the security config for the Pod
 type PodSecurityContext struct {
 	RunAsUser    *int64 `hcl:"run_as_user"`
+	RunAsGroup   *int64 `hcl:"run_as_group"`
 	RunAsNonRoot *bool  `hcl:"run_as_non_root"`
 	FsGroup      *int64 `hcl:"fs_group"`
 }

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -89,8 +89,8 @@ type TaskLauncherConfig struct {
 	// its watching to start up before it attempts to stream its logs.
 	WatchTaskStartupTimeoutSeconds int `hcl:"watchtask_startup_timeout_seconds,optional"`
 
-	// The Pod Security Context to apply
-	SecurityContext *PodSecurityContext `hcl:"security_context,optional"`
+	// The PodSecurityContext to apply to the pod
+	SecurityContext *PodSecurityContext `hcl:"security_context,block"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -88,6 +88,9 @@ type TaskLauncherConfig struct {
 	// wordy because it's only for the WatchTask timing out waiting for the pod
 	// its watching to start up before it attempts to stream its logs.
 	WatchTaskStartupTimeoutSeconds int `hcl:"watchtask_startup_timeout_seconds,optional"`
+
+	// The Pod Security Context to apply
+	SecurityContext *PodSecurityContext `hcl:"security_context,optional"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {
@@ -379,6 +382,17 @@ func (p *TaskLauncher) StartTask(
 		}
 	}
 
+	var securityContext *corev1.PodSecurityContext = nil
+	podSc := p.config.SecurityContext
+	if podSc != nil {
+		securityContext = &corev1.PodSecurityContext{
+			RunAsUser:    podSc.RunAsUser,
+			RunAsGroup:   podSc.RunAsGroup,
+			RunAsNonRoot: podSc.RunAsNonRoot,
+			FSGroup:      podSc.FsGroup,
+		}
+	}
+
 	resourceRequirements := corev1.ResourceRequirements{
 		Limits:   resourceLimits,
 		Requests: resourceRequests,
@@ -428,6 +442,7 @@ func (p *TaskLauncher) StartTask(
 					Containers:         []corev1.Container{container},
 					ImagePullSecrets:   pullSecrets,
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					SecurityContext:    securityContext,
 				},
 			},
 		},


### PR DESCRIPTION
Certain locked down Kubernetes clusters require the users to run containers in an unprivileged mode, and enforce this by checking that the Pod SecurityContext settings do include stuff like `runAsNonRoot: true`.

This commit adds support for custom SecurityContexts, so that unprivileged runners can be dynamically spawned.