### PR TITLE
feat(plugins/k8s): Multiple Kubernetes task runner and kube-apply improvements

### DIFF
--- a/.changelog/3903.txt
+++ b/.changelog/3903.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugins/k8s: Add `security_context` to the TaskLauncherConfig (on-demand runner configuration)
+```

--- a/.changelog/3903.txt
+++ b/.changelog/3903.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-plugins/k8s: Add `security_context` to the TaskLauncherConfig (on-demand runner configuration)
-```

--- a/.changelog/3910.txt
+++ b/.changelog/3910.txt
@@ -1,4 +1,7 @@
 ```release-note:improvement
 plugins/k8s: Add `prune_whitelist` for `kubernetes-apply`
+```
+
+```release-note:improvement
 plugins/k8s: Add multiple customizations for on-demand runners
 ```

--- a/.changelog/3910.txt
+++ b/.changelog/3910.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+plugins/k8s: Add `prune_whitelist` for `kubernetes-apply`
+plugins/k8s: Add `security_context` customization for on-demand runners
+plugins/k8s: Add `scratch_path` customization for on-demand runners
+plugins/k8s: Add `env_from_secret` customization for on-demand runners
+plugins/k8s: Add `mount_secrets` customization for on-demand runners
+```

--- a/.changelog/3910.txt
+++ b/.changelog/3910.txt
@@ -1,7 +1,4 @@
 ```release-note:improvement
 plugins/k8s: Add `prune_whitelist` for `kubernetes-apply`
-plugins/k8s: Add `security_context` customization for on-demand runners
-plugins/k8s: Add `scratch_path` customization for on-demand runners
-plugins/k8s: Add `env_from_secret` customization for on-demand runners
-plugins/k8s: Add `mount_secrets` customization for on-demand runners
+plugins/k8s: Add multiple customizations for on-demand runners
 ```

--- a/builtin/k8s/commons.go
+++ b/builtin/k8s/commons.go
@@ -1,0 +1,37 @@
+package k8s
+
+import (
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func createScratchVolumes(scratchSpace []string) []corev1.Volume {
+	var volumes []corev1.Volume
+	for idx := range scratchSpace {
+		scratchName := fmt.Sprintf("scratch-%d", idx)
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: scratchName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		)
+	}
+	return volumes
+}
+
+func createVolumeMounts(scratchSpace []string, volumes []corev1.Volume) []corev1.VolumeMount {
+	var volumeMounts []corev1.VolumeMount
+	for idx, scratchSpaceLocation := range scratchSpace {
+		volumeMounts = append(
+			volumeMounts,
+			corev1.VolumeMount{
+				// We know all the volumes are identical
+				Name:      volumes[idx].Name,
+				MountPath: scratchSpaceLocation,
+			},
+		)
+	}
+	return volumeMounts
+}

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -1529,6 +1529,7 @@ type Container struct {
 // PodSecurityContext describes the security config for the Pod
 type PodSecurityContext struct {
 	RunAsUser    *int64 `hcl:"run_as_user"`
+	RunAsGroup   *int64 `hcl:"run_as_group"`
 	RunAsNonRoot *bool  `hcl:"run_as_non_root"`
 	FsGroup      *int64 `hcl:"fs_group"`
 }

--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -499,17 +499,7 @@ func configureContainer(
 		Requests: resourceRequests,
 	}
 
-	var volumeMounts []corev1.VolumeMount
-	for idx, scratchSpaceLocation := range scratchSpace {
-		volumeMounts = append(
-			volumeMounts,
-			corev1.VolumeMount{
-				// We know all the volumes are identical
-				Name:      volumes[idx].Name,
-				MountPath: scratchSpaceLocation,
-			},
-		)
-	}
+	volumeMounts := createVolumeMounts(scratchSpace, volumes)
 
 	container := corev1.Container{
 		Name:            c.Name,
@@ -628,7 +618,7 @@ func (p *Platform) resourceDeploymentCreate(
 
 	portStep := sg.Add("")
 	defer func() { portStep.Abort() }()
-	// we dont use %q to save us convering a uint Port to a string and handling the error
+	// we don't use %q to save us converting an uint Port to a string and handling the error
 	portStep.Update("Expected %q port \"%d\" for app %q",
 		appContainerSpec.Ports[0].Name,
 		appContainerSpec.Ports[0].Port,
@@ -650,18 +640,7 @@ func (p *Platform) resourceDeploymentCreate(
 	}
 
 	// Create scratch space volumes
-	var volumes []corev1.Volume
-	for idx := range p.config.ScratchSpace {
-		scratchName := fmt.Sprintf("scratch-%d", idx)
-		volumes = append(volumes,
-			corev1.Volume{
-				Name: scratchName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-		)
-	}
+	volumes := createScratchVolumes(p.config.ScratchSpace)
 
 	appImage := fmt.Sprintf("%s:%s", img.Image, img.Tag)
 	appContainerSpec.Name = src.App

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -89,8 +89,8 @@ type TaskLauncherConfig struct {
 	// its watching to start up before it attempts to stream its logs.
 	WatchTaskStartupTimeoutSeconds int `hcl:"watchtask_startup_timeout_seconds,optional"`
 
-	// The Pod Security Context to apply
-	SecurityContext *PodSecurityContext `hcl:"security_context,optional"`
+	// The PodSecurityContext to apply to the pod
+	SecurityContext *PodSecurityContext `hcl:"security_context,block"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -88,6 +88,9 @@ type TaskLauncherConfig struct {
 	// wordy because it's only for the WatchTask timing out waiting for the pod
 	// its watching to start up before it attempts to stream its logs.
 	WatchTaskStartupTimeoutSeconds int `hcl:"watchtask_startup_timeout_seconds,optional"`
+
+	// The Pod Security Context to apply
+	SecurityContext *PodSecurityContext `hcl:"security_context,optional"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {
@@ -379,6 +382,17 @@ func (p *TaskLauncher) StartTask(
 		}
 	}
 
+	var securityContext *corev1.PodSecurityContext = nil
+	podSc := p.config.SecurityContext
+	if podSc != nil {
+		securityContext = &corev1.PodSecurityContext{
+			RunAsUser:    podSc.RunAsUser,
+			RunAsGroup:   podSc.RunAsGroup,
+			RunAsNonRoot: podSc.RunAsNonRoot,
+			FSGroup:      podSc.FsGroup,
+		}
+	}
+
 	resourceRequirements := corev1.ResourceRequirements{
 		Limits:   resourceLimits,
 		Requests: resourceRequests,
@@ -428,6 +442,7 @@ func (p *TaskLauncher) StartTask(
 					Containers:         []corev1.Container{container},
 					ImagePullSecrets:   pullSecrets,
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					SecurityContext:    securityContext,
 				},
 			},
 		},

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -196,6 +196,21 @@ task {
 	)
 
 	doc.SetField(
+		"env_from_secret",
+		"env_from_secret defines a map of environment variables to be fetched from a Kubernetes Secret",
+	)
+
+	doc.SetField(
+		"scratch_path",
+		"scratch_path defines an array of directories that will be mounted as ephemeral storage in the Kubernetes pod",
+	)
+
+	doc.SetField(
+		"mount_secrets",
+		"mount_secrets defines the secrets to be mounted as files in the pod",
+	)
+
+	doc.SetField(
 		"image_pull_policy",
 		"pull policy to use for the task container image",
 	)
@@ -211,6 +226,11 @@ task {
 			"before attempting to stream its logs. If the pod does not start up within "+
 			"the given timeout, WatchTask will exit.",
 		docs.Default("30"),
+	)
+
+	doc.SetField(
+		"security_context",
+		"security_context defines the Pod Security Context to be applied to the pod",
 	)
 
 	return doc, nil

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -86,7 +86,7 @@ type TaskLauncherConfig struct {
 
 	// EnvFromSecret defines secrets to be load as environment variables from a Kubernetes Secret
 	// The syntax here is very similar to Kubernetes' SecretKeySelector
-	EnvFromSecret map[string]EnvFromSecret `hcl:"env_from_secret,optional"`
+	EnvFromSecret map[string]EnvFromSecret `hcl:"env_from_secret,attr"`
 
 	// ScratchSpace defines an array of paths to directories that will be mounted as EmptyDirVolumes in the pod
 	// to store temporary data.
@@ -102,8 +102,9 @@ type TaskLauncherConfig struct {
 }
 
 type EnvFromSecret struct {
-	Name string `hcl:"name"`
-	Key  string `hcl:"key"`
+	//https://github.com/hashicorp/hcl/issues/396
+	SecretName string `cty:"name"`
+	SecretKey  string `cty:"key"`
 }
 
 func (p *TaskLauncher) Documentation() (*docs.Documentation, error) {
@@ -319,8 +320,8 @@ func (p *TaskLauncher) StartTask(
 			Name: k,
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					Key:                  v.Key,
-					LocalObjectReference: corev1.LocalObjectReference{Name: v.Name},
+					Key:                  v.SecretKey,
+					LocalObjectReference: corev1.LocalObjectReference{Name: v.SecretName},
 				},
 			},
 		})

--- a/builtin/k8s/task_test.go
+++ b/builtin/k8s/task_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 )
 
+// TestStartTask makes sure that we can use this Task Launcher Configuration - useful
+// to test for example new fields and their parsing.
+
 func TestStartTask(t *testing.T) {
-	f, err := os.Open(os.Getenv("HCL_FILE"))
+	f, err := os.Open("./testdata/config.hcl")
 	if err != nil {
 		t.Fatalf("unable to open file: %v", err)
 	}

--- a/builtin/k8s/task_test.go
+++ b/builtin/k8s/task_test.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"fmt"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/waypoint-plugin-sdk/component"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestStartTask(t *testing.T) {
+	f, err := os.Open(os.Getenv("HCL_FILE"))
+	if err != nil {
+		t.Fatalf("unable to open file: %v", err)
+	}
+
+	fileContent, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("unable to read file: %v", err)
+	}
+
+	hclFile, diags := hclsyntax.ParseConfig(fileContent, "plugin.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("invalid HCL file: %v", diags.Error())
+	}
+
+	var hclCtx *hcl.EvalContext
+	var tlc TaskLauncherConfig
+	taskLauncher := TaskLauncher{
+		config: tlc,
+	}
+
+	diag := component.Configure(&taskLauncher, hclFile.Body, hclCtx.NewChild())
+	if diag.HasErrors() {
+		t.Fatalf("diag failed: %v", diag.Error())
+	}
+
+	fmt.Printf("task_launcher_config=%+v\n", taskLauncher.config)
+}

--- a/builtin/k8s/testdata/config.hcl
+++ b/builtin/k8s/testdata/config.hcl
@@ -1,0 +1,64 @@
+service_account = "service-account"
+namespace       = "default"
+image_secret    = "regcred"
+
+security_context {
+  run_as_non_root = true
+  run_as_user     = 1000
+  fs_group        = 1000
+}
+
+scratch_path = [
+  "/home/waypoint",
+  "/tmp",
+]
+
+mount_secrets {
+  mount_path  = "/opt/kubernetes/develop"
+  secret_name = "waypoint-kubeconfig-develop"
+  sub_path    = "kubeconfig"
+  default_mode = 420
+}
+
+mount_secrets {
+  mount_path  = "/opt/kubernetes/staging"
+  secret_name = "waypoint-kubeconfig-staging"
+  sub_path    = "kubeconfig"
+  default_mode = 420
+}
+
+mount_secrets {
+  mount_path  = "/opt/kubernetes/prod"
+  secret_name = "waypoint-kubeconfig-prod"
+  sub_path    = "kubeconfig"
+  default_mode = 420
+}
+
+mount_secrets {
+  mount_path  = "/home/waypoint/.docker/config.json"
+  secret_name = "regcred"
+  sub_path    = ".dockerconfigjson"
+  default_mode = 420
+}
+
+env_from_secret = {
+  "SSH_KEY_CONTENT" = {
+    name = "git"
+    key  = "ssh-key"
+  }
+
+  "SSH_KNOWN_HOSTS_CONTENT" = {
+    name = "git"
+    key  = "known-hosts"
+  }
+}
+
+cpu {
+  request = "20m"
+  limit   = "200m"
+}
+
+memory {
+  request = "128Mi"
+  limit   = "512Mi"
+}

--- a/embedJson/gen/platform-kubernetes.json
+++ b/embedJson/gen/platform-kubernetes.json
@@ -633,6 +633,17 @@
                      "SubFields": null
                   },
                   {
+                     "Field": "run_as_group",
+                     "Type": "int64",
+                     "Synopsis": "",
+                     "Summary": "",
+                     "Optional": false,
+                     "Default": "",
+                     "EnvVar": "",
+                     "Category": false,
+                     "SubFields": null
+                  },
+                  {
                      "Field": "run_as_non_root",
                      "Type": "bool",
                      "Synopsis": "indicates that the container must run as a non-root user",

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -204,6 +204,10 @@ A special supplemental group that applies to all containers in a pod.
 
 - Type: **int64**
 
+###### pod.security_context.run_as_group
+
+- Type: **int64**
+
 ###### pod.security_context.run_as_non_root
 
 Indicates that the container must run as a non-root user.


### PR DESCRIPTION
This PR contains multiple changes for the Task Runner implementation of Kubernetes.  
  
This PR contains the features already proposed as PRs in:
- #3903 (`prune_whitelist`, `kube-apply` related)
- #3868 (`security_context`)

and adds:

- `scratch_path`
- `env_from_secret`
- `mount_secrets`

Example usage of all the features together:

```hcl
security_context {
  run_as_non_root = true
  run_as_user     = 1000
  fs_group        = 1000
}

scratch_path = [
  "/home/waypoint",
  "/tmp",
]

env_from_secret = {
  "SSH_KEY_CONTENT" = {
    name = "git"
    key  = "ssh-key"
  },
  "SOME_OTHER_ENV" = {
    name = "git"
    key  = "ssh-key"
  }
}

mount_secrets {
  mount_path  = "/var/kube/develop"
  secret_name = "kubeconfig-develop"
  sub_path    = "kubeconfig"
  default_mode = 420
}

mount_secrets {
  mount_path  = "/var/kube/prod"
  secret_name = "kubeconfig-prod"
  sub_path    = "kubeconfig"
  default_mode = 420
}
```

Sadly I can't figure out how to use `mount_secrets` in a more clean way, namely:

```hcl
mount_secrets = [
  {
    mount_path  = "/var/kube/develop"
    secret_name = "kubeconfig-develop"
    sub_path    = "kubeconfig"
    default_mode = 420
  },
  {
    mount_path  = "/var/kube/staging"
    secret_name = "kubeconfig-staging"
    sub_path    = "kubeconfig"
    default_mode = 420
  }
]
```

see https://github.com/hashicorp/hcl/issues/396 for the reason (TL;DR: panic when parsing a structure)