### PR TITLE
`WatchTask` and `StopTask` for AWS ECS Task Launcher

### DIFF
--- a/.changelog/3918.txt
+++ b/.changelog/3918.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/ecs: Implement WatchTask plugin for AWS ECS task launcher. Store ECS on-demand runner logs in the job system.
+```

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -551,7 +551,7 @@ func (p *TaskLauncher) taskStatus(ctx context.Context, d time.Duration, taskStat
 			*taskStatusCh <- "DELETED"
 			return
 		} else {
-			log.Debug("ODR task status", "status", *odrTask.LastStatus)
+			log.Trace("ODR task status", "status", *odrTask.LastStatus)
 		}
 		*taskStatusCh <- *odrTask.LastStatus
 		time.Sleep(500 * time.Millisecond)

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -4,22 +4,23 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/oklog/ulid"
+	"google.golang.org/grpc/codes"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint-plugin-sdk/component"
 	"github.com/hashicorp/waypoint-plugin-sdk/docs"
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
-	"github.com/oklog/ulid"
 )
 
 // TaskLauncher implements the TaskLauncher plugin interface to support
@@ -309,7 +310,6 @@ func (p *TaskLauncher) WatchTask(
 
 				for _, logStream := range logStreamsResp.LogStreams {
 					if strings.Contains(*logStream.LogStreamName, ti.Id) {
-						// when the log stream is available, inform the main goroutine
 						logStreamName = *logStream.LogStreamName
 					}
 				}

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -282,7 +282,7 @@ func (p *TaskLauncher) WatchTask(
 
 	// this channel will receive the status of the ECS task
 	taskStatusCh := make(chan string)
-	go taskStatus(ctx, time.Duration(5*time.Minute), &taskStatusCh, log, sess, p.config.Cluster, ti.Id)
+	go p.taskStatus(ctx, 5*time.Minute, &taskStatusCh, log, sess, ti.Id)
 
 	var logStreamName string
 	// We wait 5 minutes for the log stream to be available
@@ -504,7 +504,7 @@ func roleArn(name string, sess *session.Session) (string, error) {
 
 // taskStatus gets the status of an ECS task and provides it to the caller via a channel
 // the caller is responsible for closing the channel
-func taskStatus(ctx context.Context, d time.Duration, taskStatusCh *chan string, log hclog.Logger, sess *session.Session, cluster string, taskId string) {
+func (p *TaskLauncher) taskStatus(ctx context.Context, d time.Duration, taskStatusCh *chan string, log hclog.Logger, sess *session.Session, taskId string) {
 	ecsSvc := ecs.New(sess)
 
 	taskContext, cancel := context.WithTimeout(ctx, d)

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -517,7 +517,7 @@ func (p *TaskLauncher) taskStatus(ctx context.Context, d time.Duration, taskStat
 		default:
 		}
 		tasks, err := ecsSvc.ListTasks(&ecs.ListTasksInput{
-			Cluster: aws.String(cluster),
+			Cluster: aws.String(p.config.Cluster),
 			Family:  aws.String("waypoint-runner"),
 		})
 		if err != nil {
@@ -527,7 +527,7 @@ func (p *TaskLauncher) taskStatus(ctx context.Context, d time.Duration, taskStat
 		var odrTask *ecs.Task
 		for _, taskArn := range tasks.TaskArns {
 			taskResp, err := ecsSvc.DescribeTasks(&ecs.DescribeTasksInput{
-				Cluster: aws.String(cluster),
+				Cluster: aws.String(p.config.Cluster),
 				Tasks:   aws.StringSlice([]string{*taskArn}),
 				Include: aws.StringSlice([]string{"TAGS"}),
 			})

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -322,41 +322,44 @@ func (p *TaskLauncher) WatchTask(
 	token := ""
 	var resp *cloudwatchlogs.GetLogEventsOutput
 	for {
-		// loop until log stream is ready
-		getLogsInput := &cloudwatchlogs.GetLogEventsInput{
-			LogGroupName:  aws.String(p.config.LogGroup),
-			LogStreamName: aws.String(logStreamName),
-			StartFromHead: aws.Bool(true),
-		}
-		if resp != nil {
-			token = *resp.NextForwardToken
-			getLogsInput.NextToken = aws.String(token)
-		}
-		resp, err = cwl.GetLogEvents(getLogsInput)
-		if err != nil {
-			return nil, err
-		}
-
-		if *resp.NextForwardToken == token {
-			// if the task is done, AND we're at the end of the log
-			// stream, we exit
-			taskStatus := <-taskStatusCh
-			if taskStatus == "DELETED" || taskStatus == "DEPROVISIONING" || taskStatus == "STOPPED" || taskStatus == "DEACTIVATING" {
-				close(taskStatusCh)
-				return &component.TaskResult{ExitCode: 0}, nil
+		select {
+		default:
+			// loop until log stream is ready
+			getLogsInput := &cloudwatchlogs.GetLogEventsInput{
+				LogGroupName:  aws.String(p.config.LogGroup),
+				LogStreamName: aws.String(logStreamName),
+				StartFromHead: aws.Bool(true),
 			}
+			if resp != nil {
+				token = *resp.NextForwardToken
+				getLogsInput.NextToken = aws.String(token)
+			}
+			resp, err = cwl.GetLogEvents(getLogsInput)
+			if err != nil {
+				return nil, err
+			}
+
+			if *resp.NextForwardToken == token {
+				// if the task is done, AND we're at the end of the log
+				// stream, we exit
+				taskStatus := <-taskStatusCh
+				if taskStatus == "DELETED" || taskStatus == "DEPROVISIONING" || taskStatus == "STOPPED" || taskStatus == "DEACTIVATING" {
+					close(taskStatusCh)
+					return &component.TaskResult{ExitCode: 0}, nil
+				}
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			for _, event := range resp.Events {
+				log.Info(*event.Message)
+				ui.Output(*event.Message, terminal.WithInfoStyle())
+			}
+
+			token = *resp.NextForwardToken
+			// Sleep for half a second to slam the CloudWatch API less
 			time.Sleep(500 * time.Millisecond)
-			continue
 		}
-
-		for _, event := range resp.Events {
-			log.Info(*event.Message)
-			ui.Output(*event.Message, terminal.WithInfoStyle())
-		}
-
-		token = *resp.NextForwardToken
-		// Sleep for half a second to slam the CloudWatch API less
-		time.Sleep(500 * time.Millisecond)
 	}
 }
 

--- a/builtin/aws/ecs/task.go
+++ b/builtin/aws/ecs/task.go
@@ -242,7 +242,7 @@ func (p *TaskLauncher) StopTask(
 		if err != nil {
 			return err
 		} else if len(taskResp.Tasks) != 1 {
-			return status.Errorf(codes.Internal, "there should be only 1 task", "num_tasks", len(taskResp.Tasks))
+			return status.Errorf(codes.Internal, "there should be only 1 task, but there are %d", len(taskResp.Tasks))
 		}
 		for _, tag := range taskResp.Tasks[0].Tags {
 			if *tag.Key == "waypoint-odr-task-name" && *tag.Value == ti.Id {

--- a/builtin/k8s/task.go
+++ b/builtin/k8s/task.go
@@ -186,14 +186,14 @@ func (p *TaskLauncher) Config() (interface{}, error) {
 	return &p.config, nil
 }
 
-// StopTask signals to docker to stop the container created previously
+// StopTask signals to Kubernetes to stop the container created previously
 func (p *TaskLauncher) StopTask(
 	ctx context.Context,
 	log hclog.Logger,
 	ti *TaskInfo,
 ) error {
-	// If a job completes and the coresponding pod exits with a "completed"
-	// status, we urposely do nothing here. We leverage the job TTL feature in
+	// If a job completes and the corresponding pod exits with a "completed"
+	// status, we purposely do nothing here. We leverage the job TTL feature in
 	// Kube 1.19+ so that Kubernetes automatically deletes old jobs and pods
 	// after they complete running.
 	//


### PR DESCRIPTION
Closes #3713.

The task launcher plugin for AWS ECS will use the ECS and CloudWatch AWS APIs to get the logs of the running on-demand runner task in ECS. 