### PR TITLE
Runner install default profile

### DIFF
--- a/.changelog/3922.txt
+++ b/.changelog/3922.txt
@@ -1,0 +1,4 @@
+```release-note: improvement
+cli/runnerinstall: Update `runner install` to set the new profile as the default
+if none exist
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -315,6 +315,15 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 			}
 		}
 
+		// if we have no runner profiles, make this one the default
+		profiles, err := client.ListOnDemandRunnerConfigs(ctx, &empty.Empty{})
+		if err != nil {
+			c.ui.Output("Error getting runner profiles: %s", clierrors.Humanize(err))
+		}
+		if len(profiles.Configs) == 0 {
+			odrConfig.Default = true
+		}
+
 		runnerProfile, err := client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{Config: odrConfig})
 		if err != nil {
 			c.ui.Output("Error creating runner profile: %s", clierrors.Humanize(err),

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -319,6 +319,7 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 		profiles, err := client.ListOnDemandRunnerConfigs(ctx, &empty.Empty{})
 		if err != nil {
 			c.ui.Output("Error getting runner profiles: %s", clierrors.Humanize(err))
+			return 1
 		}
 		if len(profiles.Configs) == 0 {
 			odrConfig.Default = true


### PR DESCRIPTION
During `runner install`, if no existing runner profiles are detected, then we set the new runner profile as the default.