### PR TITLE
ui: make `<ResourceTable>` resilient to resources without IDs

### DIFF
--- a/.changelog/3929.txt
+++ b/.changelog/3929.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: don’t crash when encountering resources without IDs
+```

--- a/ui/app/components/resources-table.hbs
+++ b/ui/app/components/resources-table.hbs
@@ -24,13 +24,18 @@
     {{#each @resources key="id" as |resource|}}
       <tr>
         <th scope="row">
-          <LinkTo
-            title={{resource.name}}
-            @route={{@route}}
-            @models={{append (or @models (array)) resource.id}}
-          >
-            {{resource.name}}
-          </LinkTo>
+          {{#if resource.id}}
+            <LinkTo
+              title={{resource.name}}
+              @route={{@route}}
+              @models={{append (or @models (array)) resource.id}}
+            >
+              {{resource.name}}
+            </LinkTo>
+          {{else}}
+            <FlightIcon @name="alert-triangle-fill" />
+            <span class="pds--visuallyHidden">{{resource.name}}</span>
+          {{/if}}
         </th>
         <td class="resource-icon"><FlightIcon @name={{icon-for-component resource.platform}} /> {{resource.type}}</td>
         <td>{{date-format-distance-to-now resource.createdTime.seconds}}</td>


### PR DESCRIPTION
## Why the change?

See #3928 for some background. In short, this stops the app from crashing hard when it encounters a resource without an ID.

## What does it look like?

### Before

<img width="1369" alt="CleanShot 2022-09-23 at 16 46 41@2x" src="https://user-images.githubusercontent.com/34030/191988547-06828f8b-144a-4fe1-a5ad-63e8ac75894c.png">

### After

<img width="1369" alt="CleanShot 2022-09-23 at 16 47 54@2x" src="https://user-images.githubusercontent.com/34030/191988579-41b53378-0b5c-4f03-a76e-f9439c8c4c2c.png">

## How do I test it?

1. Check out the branch
2. Run Waypoint Server locally
3. `cd ui && yarn start local`
4. Deploy an app to aws-ecs (without having remote runner or gitops configured)
5. Visit the deployment page in the UI
6. Verify it doesn’t crash
