### PR TITLE
doc: Update scratch_path to emptydir

### DIFF
--- a/builtin/k8s/platform.go
+++ b/builtin/k8s/platform.go
@@ -1911,7 +1911,7 @@ use "kubernetes" {
 		"scratch_path",
 		"a path for the service to store temporary data",
 		docs.Summary(
-			"a path to a directory that will be created for the service to store temporary data using tmpfs",
+			"a path to a directory that will be created for the service to store temporary data using EmptyDir.",
 		),
 	)
 

--- a/embedJson/gen/platform-kubernetes.json
+++ b/embedJson/gen/platform-kubernetes.json
@@ -265,7 +265,7 @@
          "Field": "scratch_path",
          "Type": "list of string",
          "Synopsis": "a path for the service to store temporary data",
-         "Summary": "a path to a directory that will be created for the service to store temporary data using tmpfs",
+         "Summary": "a path to a directory that will be created for the service to store temporary data using EmptyDir.",
          "Optional": true,
          "Default": "",
          "EnvVar": "",

--- a/website/content/partials/components/platform-kubernetes.mdx
+++ b/website/content/partials/components/platform-kubernetes.mdx
@@ -583,7 +583,7 @@ Resource limits and requests for a container. This exists to allow any possible 
 
 A path for the service to store temporary data.
 
-A path to a directory that will be created for the service to store temporary data using tmpfs.
+A path to a directory that will be created for the service to store temporary data using EmptyDir.
 
 - Type: **list of string**
 - **Optional**


### PR DESCRIPTION
This PR updates the documentation for the kubernetes platform to reflect that we use emptydir instead of one of emptydir's specific implementations, tmpdir.

Addresses #3687