### PR TITLE
Initial set of externalized errors for artifact service

### DIFF
--- a/pkg/server/singleprocess/service_artifact.go
+++ b/pkg/server/singleprocess/service_artifact.go
@@ -33,7 +33,7 @@ func (s *Service) UpsertPushedArtifact(
 			return nil, hcerr.Externalize(
 				hclog.FromContext(ctx),
 				status.Errorf(codes.Internal, "uuid generation failed: %s", err),
-				"invalid pushed artifact request",
+				"failed to generate a uuid while upserting a pushed artifact",
 			)
 		}
 

--- a/pkg/server/singleprocess/service_artifact.go
+++ b/pkg/server/singleprocess/service_artifact.go
@@ -19,7 +19,7 @@ func (s *Service) UpsertPushedArtifact(
 	req *pb.UpsertPushedArtifactRequest,
 ) (*pb.UpsertPushedArtifactResponse, error) {
 	if err := serverptypes.ValidateUpsertPushedArtifactRequest(req); err != nil {
-		return nil, hcerr.Externalize(hclog.FromContext(ctx), err, "invalid pushed artifact request")
+		return nil, err
 	}
 
 	result := req.Artifact
@@ -53,7 +53,7 @@ func (s *Service) ListPushedArtifacts(
 	req *pb.ListPushedArtifactsRequest,
 ) (*pb.ListPushedArtifactsResponse, error) {
 	if err := serverptypes.ValidateListPushedArtifactsRequest(req); err != nil {
-		return nil, hcerr.Externalize(hclog.FromContext(ctx), err, "invalid list pushed artifact request")
+		return nil, err
 	}
 
 	result, err := s.state(ctx).ArtifactList(req.Application,
@@ -100,7 +100,7 @@ func (s *Service) GetLatestPushedArtifact(
 	req *pb.GetLatestPushedArtifactRequest,
 ) (*pb.PushedArtifact, error) {
 	if err := serverptypes.ValidateGetLatestPushedArtifactRequest(req); err != nil {
-		return nil, hcerr.Externalize(hclog.FromContext(ctx), err, "invalid get latest pushed artifact request")
+		return nil, err
 	}
 
 	a, err := s.state(ctx).ArtifactLatest(req.Application, req.Workspace)
@@ -122,7 +122,7 @@ func (s *Service) GetPushedArtifact(
 	req *pb.GetPushedArtifactRequest,
 ) (*pb.PushedArtifact, error) {
 	if err := serverptypes.ValidateGetPushedArtifactRequest(req); err != nil {
-		return nil, hcerr.Externalize(hclog.FromContext(ctx), err, "invalid get pushed artifact request")
+		return nil, err
 	}
 
 	a, err := s.state(ctx).ArtifactGet(req.Ref)

--- a/pkg/server/singleprocess/service_artifact.go
+++ b/pkg/server/singleprocess/service_artifact.go
@@ -30,7 +30,7 @@ func (s *Service) UpsertPushedArtifact(
 		if err != nil {
 			return nil, hcerr.Externalize(
 				hclog.FromContext(ctx),
-				fmt.Errorf("uuid generation failed: %s", err),
+				fmt.Errorf("uuid generation failed: %w", err),
 				"failed to generate a uuid while upserting a pushed artifact",
 			)
 		}

--- a/pkg/server/singleprocess/service_artifact.go
+++ b/pkg/server/singleprocess/service_artifact.go
@@ -2,9 +2,7 @@ package singleprocess
 
 import (
 	"context"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"fmt"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/waypoint/pkg/server"
@@ -32,7 +30,7 @@ func (s *Service) UpsertPushedArtifact(
 		if err != nil {
 			return nil, hcerr.Externalize(
 				hclog.FromContext(ctx),
-				status.Errorf(codes.Internal, "uuid generation failed: %s", err),
+				fmt.Errorf("uuid generation failed: %s", err),
 				"failed to generate a uuid while upserting a pushed artifact",
 			)
 		}


### PR DESCRIPTION
Wrap error returns in [hcerr.Externalize()](https://github.com/hashicorp/waypoint/blob/52e13de50ac6da2ffedb9c34f17f592c76de9fe1/pkg/server/hcerr/hcerr.go#L16-L29) to log more details correctly, and keep some details in logs as opposed to surfacing them to users. 