### PR TITLE
Make UserFromContext public.

### DIFF
--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -68,16 +68,16 @@ var (
 type userKey struct{}
 
 // UserWithContext inserts the user value u into the context. This can
-// be extracted with userFromContext.
+// be extracted with UserFromContext.
 func UserWithContext(ctx context.Context, u *pb.User) context.Context {
 	return context.WithValue(ctx, userKey{}, u)
 }
 
-// userFromContext returns the authenticated user in the request context.
+// UserFromContext returns the authenticated user in the request context.
 // This will return nil if the user is not authenticated. Note that a user
 // may not be authenticated but the request can still be authenticated
 // using a non-user token type. The safeste way to check is decodedTokenFromContext.
-func (s *Service) userFromContext(ctx context.Context) *pb.User {
+func (s *Service) UserFromContext(ctx context.Context) *pb.User {
 	value, ok := ctx.Value(userKey{}).(*pb.User)
 	if !ok && s.superuser {
 		value = &pb.User{Id: DefaultUserId, Username: DefaultUser}
@@ -446,7 +446,7 @@ func (s *Service) GenerateLoginToken(
 	log := hclog.FromContext(ctx)
 
 	// Get our user, that's what we log in as
-	currentUser := s.userFromContext(ctx)
+	currentUser := s.UserFromContext(ctx)
 
 	// If we have a duration set, set the expiry
 	var dur time.Duration
@@ -606,7 +606,7 @@ func (s *Service) GenerateInviteToken(
 ) (*pb.NewTokenResponse, error) {
 	log := hclog.FromContext(ctx)
 
-	currentUser := s.userFromContext(ctx)
+	currentUser := s.UserFromContext(ctx)
 	if currentUser == nil {
 		return nil, status.Errorf(codes.Unauthenticated, "current user is not authenticated")
 	}

--- a/pkg/server/singleprocess/auth_test.go
+++ b/pkg/server/singleprocess/auth_test.go
@@ -51,7 +51,7 @@ func TestServiceAuth(t *testing.T) {
 		ctx, err := s.Authenticate(context.Background(), bootstrapToken, "test", nil)
 		require.NoError(t, err)
 
-		user := s.userFromContext(ctx)
+		user := s.UserFromContext(ctx)
 		require.NotNil(t, user)
 		require.Equal(t, DefaultUserId, user.Id)
 	})
@@ -134,7 +134,7 @@ func TestServiceAuth(t *testing.T) {
 		// Auth
 		ctx, err := s.Authenticate(context.Background(), token, "UpsertDeployment", nil)
 		require.NoError(err)
-		user := s.userFromContext(ctx)
+		user := s.UserFromContext(ctx)
 		require.NotNil(user)
 		require.NotEqual(DefaultUserId, user.Id)
 		require.Equal("alice", user.Username)
@@ -156,7 +156,7 @@ func TestServiceAuth(t *testing.T) {
 			// Verify authing works
 			ctx, err := s.Authenticate(context.Background(), token, "test", nil)
 			require.NoError(err)
-			user := s.userFromContext(ctx)
+			user := s.UserFromContext(ctx)
 			require.NotNil(t, user)
 			require.NotEqual(t, DefaultUserId, user.Id)
 			require.Equal("alice", user.Username)
@@ -475,7 +475,7 @@ func TestServiceAuth_userSuperuserForced(t *testing.T) {
 	s := impl.(*Service)
 	ctx := context.Background()
 
-	user := s.userFromContext(ctx)
+	user := s.UserFromContext(ctx)
 	require.NotNil(t, user)
 	require.Equal(t, DefaultUserId, user.Id)
 }

--- a/pkg/server/singleprocess/service_user.go
+++ b/pkg/server/singleprocess/service_user.go
@@ -16,7 +16,7 @@ func (s *Service) GetUser(
 	req *pb.GetUserRequest,
 ) (*pb.GetUserResponse, error) {
 	// Currently logged in user by default
-	user := s.userFromContext(ctx)
+	user := s.UserFromContext(ctx)
 
 	// If we have a request, get that user
 	if req.User != nil {


### PR DESCRIPTION
Make UserFromContext a public function to be able to grab the user info from the context.