### PR TITLE
Runner uninstall enhancements

### DIFF
--- a/.changelog/3944.txt
+++ b/.changelog/3944.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli/runnerinstall: Delete EFS file system during ECS runner uninstall
+```
+```release-note:improvement
+cli/runnerinstall: Check if runner is registered to the server before
+attempting to forget it
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -268,6 +268,7 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 		c.ui.Output("Error installing runner: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
+		c.ui.Output(runnerInstallFailed, c.platform[0], id, terminal.WithWarningStyle())
 		return 1
 	}
 	s.Update("Runner %q installed successfully to %s", id, platform[0])
@@ -332,5 +333,12 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 var (
 	runnerInstalledButNotYetAdopted = strings.TrimSpace(`The installed runner must be adopted.
 Please run "waypoint runner adopt" before the runner can start accepting jobs.
+`)
+
+	runnerInstallFailed = strings.TrimSpace(`
+Please run the following to clean up the resources from the unsuccessful runner installation,
+specifying additional platform flags as needed:
+
+waypoint runner uninstall -platform=%[1]s -id=%[2]s <additional_platform_flags>
 `)
 )

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -4,12 +4,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/posener/complete"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	"github.com/hashicorp/waypoint/internal/runnerinstall"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-	"github.com/posener/complete"
 )
 
 type RunnerUninstallCommand struct {
@@ -164,11 +165,13 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 			if err != nil {
 				s.Update("Couldn't forget runner: %s", clierrors.Humanize(err))
 				s.Status(terminal.StatusWarn)
+				return 1
 			} else {
 				s.Update("Runner %q forgotten on server", c.id)
 				s.Status(terminal.StatusOK)
 			}
 			s.Done()
+			break
 		}
 	}
 

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -170,10 +170,10 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 				s.Update("Runner %q forgotten on server", c.id)
 				s.Status(terminal.StatusOK)
 			}
-			s.Done()
 			break
 		}
 	}
+	s.Done()
 
 	// TODO: Remove runner profiles associated solely with this runner
 

--- a/internal/cli/runner_uninstall.go
+++ b/internal/cli/runner_uninstall.go
@@ -137,8 +137,6 @@ func (c *RunnerUninstallCommand) Run(args []string) int {
 		Id:         c.id,
 	})
 	if err != nil {
-		s.Update("Unable to uninstall runner")
-		s.Abort()
 		c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
 		return 1
 	}

--- a/internal/installutil/aws/ecs.go
+++ b/internal/installutil/aws/ecs.go
@@ -124,6 +124,7 @@ func SetupEFS(
 	ui terminal.UI,
 	sess *session.Session,
 	netInfo *NetworkInformation,
+	efsTags []*efs.Tag,
 ) (*EfsInformation, error) {
 	sg := ui.StepGroup()
 	defer sg.Wait()
@@ -134,16 +135,10 @@ func SetupEFS(
 	efsSvc := efs.New(sess)
 	ulid, _ := component.Id()
 
-	// TODO: Use different tags for runner volume
 	fsd, err := efsSvc.CreateFileSystem(&efs.CreateFileSystemInput{
 		CreationToken: aws.String(ulid),
 		Encrypted:     aws.Bool(true),
-		Tags: []*efs.Tag{
-			{
-				Key:   aws.String(defaultServerTagName),
-				Value: aws.String(defaultServerTagValue),
-			},
-		},
+		Tags:          efsTags,
 	})
 	if err != nil {
 		return nil, err
@@ -198,6 +193,7 @@ EFSLOOP:
 	s.Update("Creating EFS Access Point...")
 	uid := aws.Int64(int64(100))
 	gid := aws.Int64(int64(1000))
+	// TODO: Change path to not always include "server"
 	accessPoint, err := efsSvc.CreateAccessPoint(&efs.CreateAccessPointInput{
 		FileSystemId: fsd.FileSystemId,
 		PosixUser: &efs.PosixUser{
@@ -292,6 +288,7 @@ func CreateService(serviceInput *ecs.CreateServiceInput, ecsSvc *ecs.ECS) (*ecs.
 }
 
 // TODO: Add runner ID as tag
+// SetupExecutionRole
 func SetupExecutionRole(
 	ctx context.Context,
 	ui terminal.UI,

--- a/internal/installutil/aws/ecs.go
+++ b/internal/installutil/aws/ecs.go
@@ -288,7 +288,7 @@ func CreateService(serviceInput *ecs.CreateServiceInput, ecsSvc *ecs.ECS) (*ecs.
 }
 
 // TODO: Add runner ID as tag
-// SetupExecutionRole
+// SetupExecutionRole creates the necessary IAM execution role for Waypoint, if it does not exist
 func SetupExecutionRole(
 	ctx context.Context,
 	ui terminal.UI,

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -170,7 +170,7 @@ func (d DockerRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 	s.Update("Finding runner container")
 	containerNames := []string{
 		installutil.DefaultRunnerName(opts.Id),
-		DefaultRunnerTagName,
+		defaultRunnerTagName,
 	}
 	var foundContainer types.Container
 	for _, containerName := range containerNames {

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -16,9 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/go-hclog"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -401,8 +398,8 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 					defer cancel()
 					select {
 					case <-ctx.Done():
-						return status.Errorf(codes.DeadlineExceeded, "After 5 minutes, the file system could"+
-							"not be deleted, because the mount targets weren't deleted.", terminal.WithErrorStyle())
+						return errors.New("after 5 minutes, the file system could" +
+							"not be deleted, because the mount targets weren't deleted")
 					default:
 						_, err = efsSvc.DeleteFileSystem(&efs.DeleteFileSystemInput{FileSystemId: fileSystem.FileSystemId})
 						if err != nil {

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -413,6 +413,8 @@ func (i *ECSRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 						_, err = efsSvc.DeleteFileSystem(&efs.DeleteFileSystemInput{FileSystemId: fileSystem.FileSystemId})
 						if err != nil {
 							if strings.Contains(err.Error(), "because it has mount targets") {
+								// sleep here for 5 seconds to avoid slamming the API
+								time.Sleep(5 * time.Second)
 								continue
 							}
 							return err

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/mitchellh/mapstructure"
 	dockerparser "github.com/novln/docker-parser"
 	"helm.sh/helm/v3/pkg/action"
@@ -17,6 +16,8 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 
 	"github.com/hashicorp/waypoint/builtin/k8s"
 	"github.com/hashicorp/waypoint/internal/clierrors"
@@ -124,7 +125,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 	// Determine if we need to make a service account
 	if i.Config.CreateServiceAccount {
 		saClient := clientSet.CoreV1().ServiceAccounts(i.Config.Namespace)
-		_, err = saClient.Get(ctx, DefaultRunnerTagName, metav1.GetOptions{})
+		_, err = saClient.Get(ctx, defaultRunnerTagName, metav1.GetOptions{})
 		if err != nil {
 			if k8sErrors.IsNotFound(err) {
 				err = nil
@@ -174,7 +175,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			},
 			"serviceAccount": map[string]interface{}{
 				"create": i.Config.CreateServiceAccount,
-				"name":   DefaultRunnerTagName,
+				"name":   defaultRunnerTagName,
 			},
 
 			"pullPolicy": "always",
@@ -277,7 +278,7 @@ func (i *K8sRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts) e
 	// Search for a runner with 0.8.x tag format, installed with k8s client
 	deploymentClient := clientset.AppsV1().Deployments(i.Config.Namespace)
 	k8sClientList, err := deploymentClient.List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", DefaultRunnerTagName),
+		LabelSelector: fmt.Sprintf("app=%s", defaultRunnerTagName),
 	})
 	if err != nil {
 		return fmt.Errorf("could not list deployments in namespace %q with current context: %s", i.Config.Namespace, err)
@@ -368,7 +369,7 @@ func (i *K8sRunnerInstaller) uninstallWithK8s(ctx context.Context, opts *Install
 	w, err := deploymentClient.Watch(
 		ctx,
 		metav1.ListOptions{
-			LabelSelector: "app=" + DefaultRunnerTagName,
+			LabelSelector: "app=" + defaultRunnerTagName,
 		},
 	)
 	if err != nil {
@@ -384,7 +385,7 @@ func (i *K8sRunnerInstaller) uninstallWithK8s(ctx context.Context, opts *Install
 		ctx,
 		metav1.DeleteOptions{},
 		metav1.ListOptions{
-			LabelSelector: "app=" + DefaultRunnerTagName,
+			LabelSelector: "app=" + defaultRunnerTagName,
 		},
 	); err != nil {
 		ui.Output(

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/installutil"
@@ -132,7 +133,7 @@ func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 	job.Namespace = &c.Namespace
 	job.Datacenters = c.Datacenters
 	job.Meta = c.ServiceAnnotations
-	tg := api.NewTaskGroup(DefaultRunnerTagName, 1)
+	tg := api.NewTaskGroup(defaultRunnerTagName, 1)
 	tg.Networks = []*api.NetworkResource{
 		{
 			Mode: "host",
@@ -152,13 +153,13 @@ func waypointRunnerNomadJob(c NomadConfig, opts *InstallOpts) *api.Job {
 	}
 
 	tg.Volumes = map[string]*api.VolumeRequest{
-		DefaultRunnerTagName: &volumeRequest,
+		defaultRunnerTagName: &volumeRequest,
 	}
 
 	job.AddTaskGroup(tg)
 
 	readOnly := false
-	volume := DefaultRunnerTagName
+	volume := defaultRunnerTagName
 	destination := "/data"
 	volumeMounts := []*api.VolumeMount{
 		{
@@ -325,7 +326,7 @@ func (i *NomadRunnerInstaller) Uninstall(ctx context.Context, opts *InstallOpts)
 	var waypointRunnerJobName string
 	possibleRunnerJobNames := []string{
 		installutil.DefaultRunnerName(opts.Id),
-		DefaultRunnerTagName,
+		defaultRunnerTagName,
 	}
 	for _, runnerJobName := range possibleRunnerJobNames {
 		jobs, _, err := client.Jobs().PrefixList(runnerJobName)

--- a/internal/runnerinstall/runnerinstall.go
+++ b/internal/runnerinstall/runnerinstall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
@@ -66,5 +67,5 @@ var Platforms = map[string]RunnerInstaller{
 }
 
 const (
-	DefaultRunnerTagName = "waypoint-runner"
+	defaultRunnerTagName = "waypoint-runner"
 )

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -174,7 +174,13 @@ func (i *ECSInstaller) Install(
 				return err
 			}
 
-			if efsInfo, err = awsinstallutil.SetupEFS(ctx, ui, sess, netInfo); err != nil {
+			efsTags := []*efs.Tag{
+				{
+					Key:   aws.String(defaultServerTagName),
+					Value: aws.String(defaultServerTagValue),
+				},
+			}
+			if efsInfo, err = awsinstallutil.SetupEFS(ctx, ui, sess, netInfo, efsTags); err != nil {
 				return err
 			}
 

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -158,7 +158,14 @@ func (i *ECSInstaller) Install(
 				return err
 			}
 
-			if netInfo, err = awsinstallutil.SetupNetworking(ctx, ui, sess, i.config.Subnets); err != nil {
+			grpcPort, _ := strconv.Atoi(serverconfig.DefaultGRPCPort)
+			httpPort, _ := strconv.Atoi(serverconfig.DefaultHTTPPort)
+			ports := []*int64{
+				aws.Int64(int64(grpcPort)),
+				aws.Int64(int64(httpPort)), // TODO: Not needed for runner install
+				aws.Int64(int64(2049)),     // EFS File system port
+			}
+			if netInfo, err = awsinstallutil.SetupNetworking(ctx, ui, sess, i.config.Subnets, ports); err != nil {
 				return err
 			}
 			i.netInfo = netInfo


### PR DESCRIPTION
This PR makes a few updates to `runner uninstall`, some general, and some specific to ECS. This addresses #3677. 

Regarding the general use of `runner uninstall`, if the install operation fails, a warning message is now output to let the user know that they can _attempt_ to uninstall the runner (which failed to be installed) with `runner uninstall`:

```terminal
$ waypoint runner install -platform=ecs -server-addr=<redacted>:9701 -server-tls-skip-verify -ecs-cluster=paladin-devops-cluster -ecs-region=ca-central-1
✓ Finished connecting to: <redacted>:9701
❌ Installing runner...
✓ Networking setup
✓ EFS ready
✓ Found existing IAM role to use: waypoint-runner-execution-role
✓ Found existing IAM role to use: waypoint-runner
✓ Using existing log group
❌ Using existing security group: waypoint-server-security-group
! Error installing runner: ClusterNotFoundException: Cluster not found.
Please run the following to clean up the resources from the unsuccessful runner installation,
specifying additional platform flags as needed:

waypoint runner uninstall -platform=ecs -id=01GE2MABHDJ7JPXGE5JDPTH86R <additional_platform_flags>
```

The other change being made for the general usage of `runner uninstall` is that we will check if a runner is registered to the server before attempting to forget it.

For ECS specifically, this PR adds a tag to the EFS volume which is created for the runner, and the tag contains the ID of the runner. When we uninstall the runner now, the EFS volume will also be deleted.

The log group, security group, IAM task role, and other resources are still **NOT** deleted, because they may be shared by other runners.

Tested scenarios:
- [x] runner install with existing server in ECS
- [x] runner uninstall with existing server in ECS
- [x] server install w/static runner to ECS
- [x] server uninstall w/static runner from ECS
- [ ] server upgrade w/static runner, from v0.10.1 in ECS