### PR TITLE
Correctly set image pull policy during k8s install

### DIFF
--- a/.changelog/3948.txt
+++ b/.changelog/3948.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli/install: Set image pull policy configuration on Helm installation
+of Waypoint server and runner
+```

--- a/internal/runnerinstall/k8s.go
+++ b/internal/runnerinstall/k8s.go
@@ -149,6 +149,7 @@ func (i *K8sRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) err
 			"image": map[string]interface{}{
 				"repository": runnerImageRef.Repository(),
 				"tag":        runnerImageRef.Tag(),
+				"pullPolicy": i.Config.ImagePullPolicy,
 			},
 			"odr": map[string]interface{}{
 				// odr image stanza not specified - this is used by the helm chart to
@@ -250,6 +251,13 @@ func (i *K8sRunnerInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.Config.CreateServiceAccount,
 		Default: true,
 		Usage:   "Create the service account if it does not exist.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "k8s-image-pull-policy",
+		Target:  &i.Config.ImagePullPolicy,
+		Default: "",
+		Usage:   "Set the pull policy for the Waypoint runner image",
 	})
 }
 

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -212,6 +212,7 @@ func (i *K8sInstaller) Install(
 			"image": map[string]interface{}{
 				"repository": imageRef.Repository(),
 				"tag":        imageRef.Tag(),
+				"pullPolicy": i.Config.ImagePullPolicy,
 			},
 			"resources": map[string]interface{}{
 				"requests": map[string]interface{}{
@@ -729,6 +730,7 @@ func (i *K8sInstaller) InstallRunner(
 			MemRequest:           i.Config.MemRequest,
 			CreateServiceAccount: true,
 			OdrImage:             i.Config.OdrImage,
+			ImagePullPolicy:      i.Config.ImagePullPolicy,
 		},
 	}
 	// parachute in case we remove the flag defaults one day

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -77,6 +77,7 @@ the install, the command would be:
 - `-k8s-cpu-request=<string>` - Requested amount of CPU for Waypoint runner. The default is 250m.
 - `-k8s-mem-request=<string>` - Requested amount of memory for Waypoint runner. The default is 256Mi.
 - `-k8s-runner-service-account-init` - Create the service account if it does not exist. The default is true.
+- `-k8s-image-pull-policy=<string>` - Set the pull policy for the Waypoint runner image.
 
 #### nomad Options
 


### PR DESCRIPTION
After converting to Helm for the server installation, as well as adding `runner install`, the configuration for k8s for the image pull policy was not updated to be set for a Helm install. This PR fixes that and closes #3866. 