### PR TITLE
Detected deleted projects in long-running EntrypointConfig

### DIFF
--- a/.changelog/3949.txt
+++ b/.changelog/3949.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Connected entrypoints for deleted projects now error out properly.
+```

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -111,13 +111,13 @@ func (s *Service) EntrypointConfig(
 		// Refresh the application record in case it's been deleted
 		_, err = s.state(ctx).AppGet(deployment.Application)
 		if err != nil {
-			log.Warn("detecting application has been removing in entrypoint",
+			log.Warn("detected removed application in entrypoint",
 				"project", deployment.Application.Project,
 				"application", deployment.Application.Application,
 				"lookup-error", err,
 			)
 
-			log.Warn("exitting EntrypointConfig because project was deleted")
+			log.Warn("exiting EntrypointConfig because project was deleted")
 			return status.Error(codes.Unavailable, "project has been deleted")
 		}
 

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -108,6 +108,19 @@ func (s *Service) EntrypointConfig(
 			}
 		}
 
+		// Refresh the application record in case it's been deleted
+		_, err = s.state(ctx).AppGet(deployment.Application)
+		if err != nil {
+			log.Warn("detecting application has been removing in entrypoint",
+				"project", deployment.Application.Project,
+				"application", deployment.Application.Application,
+				"lookup-error", err,
+			)
+
+			log.Warn("exitting EntrypointConfig because project was deleted")
+			return status.Error(codes.Unavailable, "project has been deleted")
+		}
+
 		// Build our config
 		config := &pb.EntrypointConfig{}
 		for _, exec := range execs {


### PR DESCRIPTION
When a project is deleted, the EntrypointConfig could still access that project. This makes it such that the EntrypointConfig won't refresh config when the project has been deleted.