### PR TITLE
core/cli: Emit warning a week before used token expires

### DIFF
--- a/.changelog/3960.txt
+++ b/.changelog/3960.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Emit warning when token in the default context is near its expiration
+```

--- a/internal/cli/base_init.go
+++ b/internal/cli/base_init.go
@@ -136,7 +136,7 @@ func (c *baseCommand) initClient(
 	}
 
 	if err := c.checkTokenExpiry(time.Hour * 24 * 7); err != nil {
-		c.Log.Debug("Unable to decode token when checking token expiry.")
+		c.Log.Debug("Unable to decode token when checking token expiry.", err)
 	}
 
 	// Start building our client options


### PR DESCRIPTION
This commit adds a locally run check before creating a server client which commands use to talk to Waypoint server. This check emits a warning when a token is set to expire within 7 days so users can reauthenticate with Waypoint.