### PR TITLE
WAYP-404 Log context canceled errors in trace level

### DIFF
--- a/pkg/server/hcerr/hcerr.go
+++ b/pkg/server/hcerr/hcerr.go
@@ -1,6 +1,7 @@
 package hcerr
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
@@ -27,7 +28,12 @@ import (
 // These will be displayed as key/value pairs to the client. If there are an odd number of args,
 // this assumes it's a mistake and adds "EXTRA_VALUE_AT_END" as the label for the final arg.
 func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) error {
-	log.Error(msg, append(args, "error", err)...)
+
+	if errors.Is(err, context.Canceled) {
+		log.Trace(msg, append(args, "error", err)...)
+	} else {
+		log.Error(msg, append(args, "error", err)...)
+	}
 
 	// Preserve the proto status
 	// status.Status does not support errors.As (https://github.com/grpc/grpc-go/issues/2934)


### PR DESCRIPTION
Logs were being polluted by an error caused by context cancellation. 

The solution is a little more widespread. We basically catch any error that is a `context cancellation` error and log it at trace level. Any other errors will be logged through the normal flow.

This PR essentially assumes that most (if not all) context cancellation errors are expected errors and are mostly user produced when a user kills a build or cancels an action. 