### PR TITLE
`nomad-jobspec` plugin periodic and system job fixes

### DIFF
--- a/.changelog/3963.txt
+++ b/.changelog/3963.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-plugin/nomad-jobspec: Fix deployment of periodic Nomad jobs.
+plugin/nomad-jobspec: Fix deployment of periodic and system Nomad jobs.
 ```

--- a/.changelog/3963.txt
+++ b/.changelog/3963.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/nomad-jobspec: Fix deployment of periodic Nomad jobs.
+```

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -137,11 +137,14 @@ func (p *Platform) resourceJobCreate(
 	state.Name = result.Name
 	st.Step(terminal.StatusOK, "Job registration successful")
 
-	// Wait on the allocation
+	// Wait on the allocation. Periodic Nomad jobs will not get an evaluation,
+	// so we don't monitor an evaluation if we don't have one.
 	evalID := regResult.EvalID
-	st.Update("Monitoring evaluation " + evalID)
-	if err := nomad.NewMonitor(st, client).Monitor(evalID); err != nil {
-		return err
+	if evalID != "" {
+		st.Update("Monitoring evaluation " + evalID)
+		if err := nomad.NewMonitor(st, client).Monitor(evalID); err != nil {
+			return err
+		}
 	}
 	st.Step(terminal.StatusOK, "Deployment successfully rolled out!")
 
@@ -410,11 +413,13 @@ func (p *Platform) Generation(
 		return nil, err
 	}
 
-	// If we have canaries, generate random ID, otherwise keep gen ID as job ID
 	canaryDeployment := false
-	for _, taskGroup := range job.TaskGroups {
-		if *taskGroup.Update.Canary > 0 {
-			canaryDeployment = true
+	// If we have canaries, generate random ID, otherwise keep gen ID as job ID
+	if !job.IsPeriodic() {
+		for _, taskGroup := range job.TaskGroups {
+			if *taskGroup.Update.Canary > 0 {
+				canaryDeployment = true
+			}
 		}
 	}
 

--- a/builtin/nomad/jobspec/platform.go
+++ b/builtin/nomad/jobspec/platform.go
@@ -414,8 +414,10 @@ func (p *Platform) Generation(
 	}
 
 	canaryDeployment := false
-	// If we have canaries, generate random ID, otherwise keep gen ID as job ID
-	if !job.IsPeriodic() {
+	// If we have canaries, generate random ID, otherwise keep gen ID as job ID.
+	// Periodic jobs and system jobs currently don't support canaries, so we don't
+	// do this check if our job fits either case.
+	if !job.IsPeriodic() && *job.Type != "system" {
 		for _, taskGroup := range job.TaskGroups {
 			if *taskGroup.Update.Canary > 0 {
 				canaryDeployment = true


### PR DESCRIPTION
Nomad periodic jobs don't have an "update" stanza, so we no longer check for canaries for such jobs. We also do not monitor a Nomad evaluation after the job is registered, because not all jobs (namely, periodic jobs) have an evaluation immediately after job registration. These changes allow periodic jobs to be registered using the jobspec plugin!

Additionally, we don't check for canaries if the job is of type `system`, because [`system` jobs don't support canaries ](https://www.nomadproject.io/docs/job-specification/update#update-stanza)at this time.

Closes #2982.
Closes #3920.