### PR TITLE
statetest: Ensure a project record exists prior to pipeline tests

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1682,6 +1682,12 @@ func TestJobPipeline_AckAndComplete(t *testing.T, factory Factory, rf RestartFac
 
 		jobRef := &pb.Ref_Job{Id: "root_job"}
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		p := serverptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(p)
 		require.NoError(err)

--- a/pkg/serverstate/statetest/test_pipeline.go
+++ b/pkg/serverstate/statetest/test_pipeline.go
@@ -9,6 +9,7 @@ import (
 
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/ptypes"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 )
 
 func init() {
@@ -23,6 +24,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set
 		p := ptypes.TestPipeline(t, nil)
@@ -58,6 +65,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set
 		p := ptypes.TestPipeline(t, nil)
 		p.Steps = nil
@@ -71,6 +84,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set
 		p := ptypes.TestPipeline(t, nil)
@@ -94,6 +113,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set
 		p := ptypes.TestPipeline(t, nil)
@@ -121,6 +146,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set
 		p := ptypes.TestPipeline(t, nil)
 		p.Steps = map[string]*pb.Pipeline_Step{
@@ -142,6 +173,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set a few pipelines
 		p := ptypes.TestPipeline(t, nil)
@@ -181,6 +218,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set a few pipelines
 		p := ptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(p)
@@ -219,6 +262,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set a few pipelines
 		p := ptypes.TestPipeline(t, nil)
@@ -283,6 +332,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set a few pipelines
 		p := ptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(p)
@@ -300,6 +355,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		})
 		err = s.PipelinePut(p2)
 		require.NoError(err)
+
+		// Write project
+		pref := &pb.Ref_Project{Project: "nintendo"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: pref.Project,
+		})))
 
 		// a third, same pipeline name but different project
 		p3 := ptypes.TestPipeline(t, &pb.Pipeline{
@@ -347,6 +408,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set
 		p := ptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(p)
@@ -370,6 +437,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set
 		p := ptypes.TestPipeline(t, nil)
@@ -422,6 +495,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 			require.Len(resp, 3)
 		}
 
+		// Write project
+		pref := &pb.Ref_Project{Project: "not-our-project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: pref.Project,
+		})))
+
 		// a fourth that is in a different project
 		p4 := ptypes.TestPipeline(t, &pb.Pipeline{
 			Id:   "wario",
@@ -451,6 +530,12 @@ func TestPipeline(t *testing.T, factory Factory, _ RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set
 		p := ptypes.TestPipeline(t, nil)

--- a/pkg/serverstate/statetest/test_pipeline_run.go
+++ b/pkg/serverstate/statetest/test_pipeline_run.go
@@ -7,6 +7,7 @@ import (
 
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/ptypes"
+	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
 )
 
 func init() {
@@ -21,6 +22,12 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set Pipeline
 		p := ptypes.TestPipeline(t, nil)
@@ -96,6 +103,12 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Set Pipeline
 		p := ptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(p)
@@ -143,6 +156,12 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 
 		s := factory(t)
 		defer s.Close()
+
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
 
 		// Set Pipeline
 		p := ptypes.TestPipeline(t, nil)


### PR DESCRIPTION
On the HCP side, Waypoint SQLState looks up a project by name to get its id. On the OSS boltdb side, we simply use project name since project has no id. This commit ensures the tests have an existing project record.