### PR TITLE
boltdb/pipeline_run: Properly look up latest runs by sequence number, fix pipeline run tests

### DIFF
--- a/internal/server/boltdbstate/pipeline_run.go
+++ b/internal/server/boltdbstate/pipeline_run.go
@@ -3,7 +3,6 @@ package boltdbstate
 import (
 	"math"
 	"strings"
-	"sync/atomic"
 
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
@@ -58,7 +57,7 @@ func (s *State) PipelineRunPut(pr *pb.PipelineRun) error {
 			// increment sequence if this is not the first run
 			if raw != nil {
 				idx := raw.(*pipelineRunIndexRecord)
-				pr.Sequence = atomic.AddUint64(&idx.Sequence, 1)
+				pr.Sequence = idx.Sequence + 1
 			} else {
 				pr.Sequence = 1
 			}

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1711,7 +1711,7 @@ func TestJobPipeline_AckAndComplete(t *testing.T, factory Factory, rf RestartFac
 		r.Jobs = append(r.Jobs, jobRef)
 		err = s.PipelineRunPut(r)
 		require.NoError(err)
-		require.Equal(uint64(2), r.Sequence)
+		require.Equal(uint64(1), r.Sequence)
 		require.Equal(pb.PipelineRun_PENDING, r.State)
 
 		// Assign the job, we should get this build

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1696,6 +1696,8 @@ func TestJobPipeline_AckAndComplete(t *testing.T, factory Factory, rf RestartFac
 		// Create a new pipeline run
 		pr := &pb.PipelineRun{Pipeline: pipeline}
 		r := serverptypes.TestPipelineRun(t, pr)
+		err = s.PipelineRunPut(r)
+		require.NoError(err)
 
 		// Create a job
 		require.NoError(s.JobCreate(serverptypes.TestJobNew(t, &pb.Job{
@@ -1709,7 +1711,7 @@ func TestJobPipeline_AckAndComplete(t *testing.T, factory Factory, rf RestartFac
 		r.Jobs = append(r.Jobs, jobRef)
 		err = s.PipelineRunPut(r)
 		require.NoError(err)
-		require.Equal(uint64(1), r.Sequence)
+		require.Equal(uint64(2), r.Sequence)
 		require.Equal(pb.PipelineRun_PENDING, r.State)
 
 		// Assign the job, we should get this build

--- a/pkg/serverstate/statetest/test_pipeline_run.go
+++ b/pkg/serverstate/statetest/test_pipeline_run.go
@@ -173,17 +173,17 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 		pipeline := &pb.Ref_Pipeline{Ref: &pb.Ref_Pipeline_Id{Id: p.Id}}
 
 		// Set Pipeline Run
-		r := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "1", Pipeline: pipeline})
+		r := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "test1", Pipeline: pipeline})
 		err = s.PipelineRunPut(r)
 		require.NoError(err)
 
 		// Set Another Pipeline Run
-		r2 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "2", Pipeline: pipeline})
+		r2 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "test2", Pipeline: pipeline})
 		err = s.PipelineRunPut(r2)
 		require.NoError(err)
 
 		// Set Another Pipeline Run
-		r3 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "3", Pipeline: pipeline})
+		r3 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Id: "test3", Pipeline: pipeline})
 		err = s.PipelineRunPut(r3)
 		require.NoError(err)
 

--- a/pkg/serverstate/statetest/test_pipeline_run.go
+++ b/pkg/serverstate/statetest/test_pipeline_run.go
@@ -61,7 +61,7 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 
 		// Set another pipeline run
 		r2 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Pipeline: pipeline})
-		r2.Id = "pr2"
+		r2.Id = "ypr2"
 		err = s.PipelineRunPut(r2)
 		require.NoError(err)
 

--- a/pkg/serverstate/statetest/test_pipeline_run.go
+++ b/pkg/serverstate/statetest/test_pipeline_run.go
@@ -61,6 +61,7 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 
 		// Set another pipeline run
 		r2 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Pipeline: pipeline})
+		r2.Id = "pr2"
 		err = s.PipelineRunPut(r2)
 		require.NoError(err)
 
@@ -75,6 +76,7 @@ func TestPipelineRun(t *testing.T, factory Factory, restartF RestartFactory) {
 
 		// Set another pipeline run
 		r3 := ptypes.TestPipelineRun(t, &pb.PipelineRun{Pipeline: pipeline})
+		r3.Id = "pr3"
 		err = s.PipelineRunPut(r3)
 		require.NoError(err)
 


### PR DESCRIPTION
[Edit from @briancain] This pull request fixes a couple of things:

- The boltdb pipeline run state funcs were not properly looking up the latest pipeline run by sequence number. It happened to be correct outside of unit tests, because it was getting the latest by UUID. This ends up failing in the unit tests where we set Ids manually to something like "test" or "different_id". In that case, the lookup failed because these ids are not sequential.
  + We fixed this by properly querying for the latest sequence number rather than by uuid
- The pipeline ack and complete job tests needed to upsert a pipeline run prior to queueing any jobs, just like RunPipeline test.