### PR TITLE
Fix panic when setting odr env vars

### DIFF
--- a/.changelog/3995.txt
+++ b/.changelog/3995.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/runner-profile-set: Fix panic when setting runner profile environment variables
+```

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -215,6 +215,10 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 			"Flag '-env-vars' is deprecated, please use flag '-env-var=k=v'",
 			terminal.WithWarningStyle(),
 		)
+
+		if od.EnvironmentVariables == nil {
+			od.EnvironmentVariables = make(map[string]string)
+		}
 		for _, kv := range c.flagEnvVars {
 			idx := strings.IndexByte(kv, '=')
 			if idx != -1 {
@@ -224,6 +228,9 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 	}
 
 	if c.flagEnvVar != nil {
+		if od.EnvironmentVariables == nil {
+			od.EnvironmentVariables = make(map[string]string)
+		}
 		for k, v := range c.flagEnvVar {
 			if v == "" {
 				delete(od.EnvironmentVariables, k)


### PR DESCRIPTION
Prior to this, assignment to the nil map would panic. E.x:

```
$ waypoint runner profile set -name=k8s -plugin-type=kubernetes -env-var=container=docker
❌ Updating runner profile "k8s" ("01GEMHHFSA3K6XXQR4Q0FVCKGJ")...
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.(*RunnerProfileSetCommand).Run(0xc000246880, {0xc000311940, 0x6, 0xc})
	/Users/izaaklauer/dev/waypoint/internal/cli/runner_profile_set.go:231 +0x15e5
github.com/mitchellh/cli.(*CLI).Run(0xc00056a280)
	/Users/izaaklauer/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
github.com/hashicorp/waypoint/internal/cli.Main({0xc000198000?, 0x3813f60?, 0xc0000021a0?})
	/Users/izaaklauer/dev/waypoint/internal/cli/main.go:127 +0x545
main.main()
	/Users/izaaklauer/dev/waypoint/cmd/waypoint/main.go:14 +0x7f
```