### PR TITLE
Fix panic when omitting odr profile plugin type

### DIFF
--- a/.changelog/3996.txt
+++ b/.changelog/3996.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/runner-profile-set: Fix panic when omitting the -plugin-type flag
+```

--- a/internal/cli/runner_profile_set.go
+++ b/internal/cli/runner_profile_set.go
@@ -233,8 +233,12 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 		}
 	}
 
-	if c.flagPluginType != nil || od.PluginType == "" {
-		if *c.flagPluginType == "" {
+	if c.flagPluginType != nil && *c.flagPluginType != "" {
+		// If the user specified a plugin type, we use that.
+		od.PluginType = *c.flagPluginType
+	} else {
+		if od.PluginType == "" {
+			// The user didn't specify a plugin type, and we don't have one already
 			c.ui.Output(
 				"Flag '-plugin-type' must be set to a valid plugin type like 'docker' or 'kubernetes'.\n\n%s",
 				c.Help(),
@@ -242,7 +246,6 @@ func (c *RunnerProfileSetCommand) Run(args []string) int {
 			)
 			return 1
 		}
-		od.PluginType = *c.flagPluginType
 	}
 
 	// Upsert


### PR DESCRIPTION
Omitting the -plugin-type flag currently panics if there is no existing profile:

```
$ waypoint runner profile set -name=panic
❌ No existing runner profile found for id "panic"...command will create a new profile
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x35fdf26]

goroutine 1 [running]:
github.com/hashicorp/waypoint/internal/cli.(*RunnerProfileSetCommand).Run(0xc0011bc480, {0xc000892240, 0x1, 0x4})
	/private/tmp/waypoint-20221004-4456-137m6f6/waypoint-0.10.2/internal/cli/runner_profile_set.go:237 +0x1246
github.com/mitchellh/cli.(*CLI).Run(0xc00088a000)
	/Users/brew/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
github.com/hashicorp/waypoint/internal/cli.Main({0xc0000720a0?, 0x3853280?, 0xc0000061a0?})
	/private/tmp/waypoint-20221004-4456-137m6f6/waypoint-0.10.2/internal/cli/main.go:127 +0x56d
main.main()

```

With this change, it outputs a warning if there is no plugin type is set

Also tested updating an existing plugin type, and it works as expected.