### PR TITLE
docs: fix build_args summary (array vs map)

### DIFF
--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -158,8 +158,7 @@ build {
 		"build_args",
 		"build args to pass to docker for the build step",
 		docs.Summary(
-			"An array of strings of build-time variables passed as build-arg to docker",
-			" for the build step.",
+			"A map of key/value pairs passed as build-args to docker for the build step.",
 		),
 	)
 

--- a/embedJson/gen/builder-docker.json
+++ b/embedJson/gen/builder-docker.json
@@ -108,7 +108,7 @@
          "Field": "build_args",
          "Type": "map of string to string",
          "Synopsis": "build args to pass to docker for the build step",
-         "Summary": "An array of strings of build-time variables passed as build-arg to docker for the build step.",
+         "Summary": "A map of key/value pairs passed as build-args to docker for the build step.",
          "Optional": true,
          "Default": "",
          "EnvVar": "",

--- a/website/content/partials/components/builder-docker.mdx
+++ b/website/content/partials/components/builder-docker.mdx
@@ -102,7 +102,7 @@ Username of Docker registry account.
 
 Build args to pass to docker for the build step.
 
-An array of strings of build-time variables passed as build-arg to docker for the build step.
+A map of key/value pairs passed as build-args to docker for the build step.
 
 - Type: **map of string to string**
 - **Optional**


### PR DESCRIPTION
## Why the change?

The current summary says this property takes `string[]`, but the type information says it’s a `map[string]string`.

![CleanShot 2022-10-07 at 15 17 58@2x](https://user-images.githubusercontent.com/34030/194563401-3abb11b5-7ed4-48fb-89c3-541903dce303.png)