### PR TITLE
logstream: Respect workspace if requested on logs

### DIFF
--- a/.changelog/4009.txt
+++ b/.changelog/4009.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Respect the -workspace flag when requesting a logstream for a deployment
+by workspace
+```

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -104,8 +104,10 @@ func (c *LogsCommand) Flags() *flag.Sets {
 	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
 		f := set.NewSet("Command Options")
 		f.StringVar(&flag.StringVar{
-			Name:   "deployment-seq",
-			Usage:  "Get logs for a specific deployment of the app using the deployment sequence number.",
+			Name: "deployment-seq",
+			Usage: "Get logs for a specific deployment of the app using the deployment " +
+				"sequence number. Not valid with the -workspace param as deployment sequence " +
+				"numbers span across workspaces.",
 			Target: &c.flagDeploySeq,
 		})
 	})

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -17,7 +17,7 @@ import (
 type LogsCommand struct {
 	*baseCommand
 
-	deployment string
+	flagDeploySeq string
 }
 
 var logColors = map[pb.LogBatch_Entry_Source]*color.Color{
@@ -36,7 +36,7 @@ func (c *LogsCommand) Run(args []string) int {
 	}
 
 	err := c.DoApp(c.Ctx, func(ctx context.Context, app *clientpkg.App) error {
-		stream, err := app.Logs(ctx, c.deployment)
+		stream, err := app.Logs(ctx, c.flagDeploySeq)
 		if err != nil {
 			if !clierrors.IsCanceled(err) {
 				app.UI.Output("Error reading logs: %s", err, terminal.WithErrorStyle())
@@ -106,7 +106,7 @@ func (c *LogsCommand) Flags() *flag.Sets {
 		f.StringVar(&flag.StringVar{
 			Name:   "deployment-seq",
 			Usage:  "Get logs for a specific deployment of the app using the deployment sequence number.",
-			Target: &c.deployment,
+			Target: &c.flagDeploySeq,
 		})
 	})
 }

--- a/internal/client/operation.go
+++ b/internal/client/operation.go
@@ -213,7 +213,7 @@ func (c *App) Release(ctx context.Context, op *pb.Job_ReleaseOp) (*pb.Job_Releas
 	return result.Release, nil
 }
 
-func (a *App) Logs(ctx context.Context, deployment string) (pb.Waypoint_GetLogStreamClient, error) {
+func (a *App) Logs(ctx context.Context, deploySeq string) (pb.Waypoint_GetLogStreamClient, error) {
 	log := a.project.logger.Named("logs")
 
 	// Depending on which deployments are at play, and which plugins those deployments
@@ -226,8 +226,8 @@ func (a *App) Logs(ctx context.Context, deployment string) (pb.Waypoint_GetLogSt
 	}
 	var logStreamRequest *pb.GetLogStreamRequest
 
-	if deployment != "" {
-		i, err := strconv.ParseUint(deployment, 10, 64)
+	if deploySeq != "" {
+		i, err := strconv.ParseUint(deploySeq, 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/singleprocess/service_logs.go
+++ b/pkg/server/singleprocess/service_logs.go
@@ -288,6 +288,7 @@ func (s *Service) GetLogStream(
 
 			deployments, err := s.state(ctx).DeploymentList(scope.Application.Application,
 				serverstate.ListWithPhysicalState(pb.Operation_CREATED),
+				serverstate.ListWithWorkspace(scope.Application.Workspace),
 				serverstate.ListWithStatusFilter(&pb.StatusFilter{
 					Filters: []*pb.StatusFilter_Filter{
 						{

--- a/website/content/commands/logs.mdx
+++ b/website/content/commands/logs.mdx
@@ -45,6 +45,6 @@ to a specific deployment or filter out certain log messages.
 
 #### Command Options
 
-- `-deployment-seq=<string>` - Get logs for a specific deployment of the app using the deployment sequence number.
+- `-deployment-seq=<string>` - Get logs for a specific deployment of the app using the deployment sequence number. Not valid with the -workspace param as deployment sequence numbers span across workspaces.
 
 @include "commands/logs_more.mdx"


### PR DESCRIPTION
Prior to this commit, the logstream API endpoint would not properly respect a requested workspace when listing deployments to stream for logs. This commit fixes that by including the list with workspace filter on deployment lists.

Fixes #3395