### PR TITLE
cli: Fix panic when no flag specified for `waypoint runner profile set`

### DIFF
--- a/.changelog/4013.txt
+++ b/.changelog/4013.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix panic in `waypoint runner profile set` when no flags are specified.
+```


### PR DESCRIPTION
Prior to this commit, if you ran the profile set command without any flags, the command would panic due to the flagPluginType being a string pointer. This commit fixes that by instead moving it back to a simple String flag with a emptry string default. It preserves the behavior where if not specified, the CLI will attempt to use the existing plugin type rather than setting it to empty string.

Fixes #4012