### PR TITLE
add `-check` flag to fmt

### DIFF
--- a/.changelog/4020.txt
+++ b/.changelog/4020.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli/fmt: Add a `-check` flag that will determine if the `waypoint.hcl` is already
+properly formatted, similar to `terraform fmt -check`.
+```

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -20,6 +21,7 @@ type FmtCommand struct {
 	*baseCommand
 
 	flagWrite bool
+	flagCheck bool
 }
 
 func (c *FmtCommand) Run(args []string) int {
@@ -70,6 +72,18 @@ func (c *FmtCommand) Run(args []string) int {
 		return 1
 	}
 
+	if c.flagCheck {
+		// In the case where we're checking formatting, don't persist data
+		// ultimately this shouldn't even be used because we should return
+		// in this block
+		c.flagWrite = false
+		if bytes.Equal(src, out) {
+			return 0
+		} else {
+			return 3
+		}
+	}
+
 	// If we're writing then write it to the file. stdin never writes to a file
 	if c.flagWrite && !stdin {
 		if err := ioutil.WriteFile(c.args[0], out, 0644); err != nil {
@@ -108,7 +122,15 @@ func (c *FmtCommand) Flags() *flag.Sets {
 			Default: true,
 			Usage: "Overwrite the input file. If this is false, the formatted " +
 				"output will be written to STDOUT. This has no effect when formatting " +
-				"from STDIN.",
+				"from STDIN or when using the -check flag.",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "check",
+			Target:  &c.flagCheck,
+			Default: false,
+			Usage: "Check if the input is formatted. Exit status will be 0 if " +
+				"all input is properly formatted and non-zero otherwise.",
 		})
 	})
 }

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -130,7 +130,7 @@ func (c *FmtCommand) Flags() *flag.Sets {
 			Target:  &c.flagCheck,
 			Default: false,
 			Usage: "Check if the input is formatted. Exit status will be 0 if " +
-				"all input is properly formatted and non-zero otherwise.",
+				"all input is properly formatted and exit status 3 otherwise.",
 		})
 	})
 }

--- a/website/content/commands/fmt.mdx
+++ b/website/content/commands/fmt.mdx
@@ -38,6 +38,7 @@ work for older and newer configuration formats.
 
 #### Command Options
 
-- `-write` - Overwrite the input file. If this is false, the formatted output will be written to STDOUT. This has no effect when formatting from STDIN. The default is true.
+- `-write` - Overwrite the input file. If this is false, the formatted output will be written to STDOUT. This has no effect when formatting from STDIN or when using the -check flag. The default is true.
+- `-check` - Check if the input is formatted. Exit status will be 0 if all input is properly formatted and exit status 3 otherwise. The default is false.
 
 @include "commands/fmt_more.mdx"


### PR DESCRIPTION
This PR is meant to handle #3817 and add check support to the fmt command. There's not much to it but in local testing with waypoint.hcl files it seemed to perform as expected, though it's kinda funny that the default config is generated needing formatting.

```
matt$ ./waypoint fmt -h
Usage: waypoint fmt [options] [FILE]

  Rewrite a waypoint.hcl file to a canonical format.

  This only works for HCL-formatted Waypoint configuration files. JSON-formatted
  files do not work and will result in an error.

  If FILE is not specified, then the current directory will be searched
  for a "waypoint.hcl" file. If FILE is "-" then the content will be read
  from stdin.

  This command does not validate the waypoint.hcl configuration. This will
  work for older and newer configuration formats.

Global Options:

  -app=<string>
      App to target. Certain commands require a single app target for Waypoint
      configurations with multiple apps. If you have a single app, then this
      can be ignored. This is aliased as "-a".

  -plain
      Plain output: no colors, no animation. The default is false.

  -project=<string>
      Project to target. This is aliased as "-p".

  -workspace=<string>
      Workspace to operate in. This is aliased as "-w".

Command Options:

  -check
      Check if the input is formatted. Exit status will be 0 if all input is
      properly formatted and non-zero otherwise. The default is false.

  -write
      Overwrite the input file. If this is false, the formatted output will be
      written to STDOUT. This has no effect when formatting from STDIN or when
      using the -check flag. The default is true.

nick-cage:waypoint on 3817-fmt-check 
matt$ ./waypoint init
Do you want help generating a waypoint.hcl file? Type 'yes' to initialize the interactive generator or 'no' to generate a template waypoint.hcl file: no

Generating template file

Initial Waypoint configuration created!
No Waypoint configuration was found in this directory.

A sample configuration has been created in the file "waypoint.hcl". This
file is heavily commented to help you get started.

Once you've setup your initial configuration, run "waypoint init" again to
validate the configuration and initialize your project.


nick-cage:waypoint on 3817-fmt-check 
matt$ ./waypoint fmt -check waypoint.hcl 


nick-cage:waypoint on 3817-fmt-check 
matt$ echo $?
3

nick-cage:waypoint on 3817-fmt-check 
matt$ ./waypoint fmt
waypoint.hcl

nick-cage:waypoint on 3817-fmt-check 
matt$ ./waypoint fmt -check waypoint.hcl 

nick-cage:waypoint on 3817-fmt-check 
matt$ echo $?
0
```