### PR TITLE
Bug: Fix pipeline run complete state machine

### DIFF
--- a/.changelog/4053.txt
+++ b/.changelog/4053.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pipelines: Properly mark a pipeline run as complete
+```

--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -14844,10 +14844,13 @@ type PipelineRun struct {
 
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// The sequence number for this pipeline run.
-	Sequence uint64            `protobuf:"varint,2,opt,name=sequence,proto3" json:"sequence,omitempty"`
-	Pipeline *Ref_Pipeline     `protobuf:"bytes,3,opt,name=pipeline,proto3" json:"pipeline,omitempty"`
-	Jobs     []*Ref_Job        `protobuf:"bytes,4,rep,name=jobs,proto3" json:"jobs,omitempty"`
-	State    PipelineRun_State `protobuf:"varint,5,opt,name=state,proto3,enum=hashicorp.waypoint.PipelineRun_State" json:"state,omitempty"`
+	Sequence uint64 `protobuf:"varint,2,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	// The pipeline this run is apart of.
+	Pipeline *Ref_Pipeline `protobuf:"bytes,3,opt,name=pipeline,proto3" json:"pipeline,omitempty"`
+	// The full list of jobs that are associated with this run.
+	Jobs []*Ref_Job `protobuf:"bytes,4,rep,name=jobs,proto3" json:"jobs,omitempty"`
+	// The current state of this pipeline run,
+	State PipelineRun_State `protobuf:"varint,5,opt,name=state,proto3,enum=hashicorp.waypoint.PipelineRun_State" json:"state,omitempty"`
 }
 
 func (x *PipelineRun) Reset() {

--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -14845,7 +14845,7 @@ type PipelineRun struct {
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// The sequence number for this pipeline run.
 	Sequence uint64 `protobuf:"varint,2,opt,name=sequence,proto3" json:"sequence,omitempty"`
-	// The pipeline this run is apart of.
+	// The pipeline associated with this run.
 	Pipeline *Ref_Pipeline `protobuf:"bytes,3,opt,name=pipeline,proto3" json:"pipeline,omitempty"`
 	// The full list of jobs that are associated with this run.
 	Jobs []*Ref_Job `protobuf:"bytes,4,rep,name=jobs,proto3" json:"jobs,omitempty"`

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -9477,16 +9477,19 @@
           "description": "The sequence number for this pipeline run."
         },
         "pipeline": {
-          "$ref": "#/definitions/hashicorp.waypoint.Ref.Pipeline"
+          "$ref": "#/definitions/hashicorp.waypoint.Ref.Pipeline",
+          "description": "The pipeline this run is apart of."
         },
         "jobs": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/hashicorp.waypoint.Ref.Job"
-          }
+          },
+          "description": "The full list of jobs that are associated with this run."
         },
         "state": {
-          "$ref": "#/definitions/hashicorp.waypoint.PipelineRun.State"
+          "$ref": "#/definitions/hashicorp.waypoint.PipelineRun.State",
+          "title": "The current state of this pipeline run,"
         }
       }
     },

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -9478,7 +9478,7 @@
         },
         "pipeline": {
           "$ref": "#/definitions/hashicorp.waypoint.Ref.Pipeline",
-          "description": "The pipeline this run is apart of."
+          "description": "The pipeline associated with this run."
         },
         "jobs": {
           "type": "array",

--- a/pkg/server/proto/server.proto
+++ b/pkg/server/proto/server.proto
@@ -4870,7 +4870,7 @@ message PipelineRun {
   // The sequence number for this pipeline run.
   uint64 sequence = 2;
 
-  // The pipeline this run is apart of.
+  // The pipeline associated with this run.
   Ref.Pipeline pipeline = 3;
 
   // The full list of jobs that are associated with this run.

--- a/pkg/server/proto/server.proto
+++ b/pkg/server/proto/server.proto
@@ -4870,10 +4870,13 @@ message PipelineRun {
   // The sequence number for this pipeline run.
   uint64 sequence = 2;
 
+  // The pipeline this run is apart of.
   Ref.Pipeline pipeline = 3;
 
+  // The full list of jobs that are associated with this run.
   repeated Ref.Job jobs = 4;
 
+  // The current state of this pipeline run,
   State state = 5;
 
   enum State {

--- a/pkg/server/singleprocess/service_pipeline.go
+++ b/pkg/server/singleprocess/service_pipeline.go
@@ -512,6 +512,7 @@ func (s *Service) buildStepJobs(
 			}
 		}
 
+		// Include a list of all associated jobs for this specific run
 		pipelineRun.Jobs = append(pipelineRun.Jobs, &pb.Ref_Job{Id: job.Id})
 		stepJobs = append(stepJobs, &pb.QueueJobRequest{
 			Job: job,


### PR DESCRIPTION
This pull request fixes a bug where the boltdb state for a pipeline run would never mark a finished pipeline as success and would be stuck in running forever. It fixes it by looking at all job references on a run and seeing if they are also complete before marking the pipeline as complete.

Fixes https://github.com/hashicorp/waypoint/issues/4032