### PR TITLE
ui: removed fix for resolved safari bug with xterm/webgl

### DIFF
--- a/.changelog/4054.txt
+++ b/.changelog/4054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix safari bug with xterm/webgl rendering
+```

--- a/ui/app/utils/browser.ts
+++ b/ui/app/utils/browser.ts
@@ -1,7 +1,0 @@
-/* eslint-disable prettier/prettier */
-const userAgent = navigator.userAgent;
-
-export const isFirefox = (userAgent.indexOf('Firefox') >= 0);
-export const isWebKit = (userAgent.indexOf('AppleWebKit') >= 0);
-export const isChrome = (userAgent.indexOf('Chrome') >= 0);
-export const isSafari = (!isChrome && (userAgent.indexOf('Safari') >= 0));

--- a/ui/app/utils/create-terminal.ts
+++ b/ui/app/utils/create-terminal.ts
@@ -1,6 +1,5 @@
 import { ITerminalOptions, Terminal } from 'xterm';
 
-import { isSafari } from 'waypoint/utils/browser';
 import terminalTheme from 'waypoint/utils/terminal-theme';
 
 interface TerminalOptions {
@@ -17,12 +16,6 @@ export function createTerminal(options: TerminalOptions): Terminal {
     fontWeightBold: '700',
     theme: terminalTheme.light,
   };
-
-  // The optional boolean is used for DOM rendering in tests
-  // Because of a bug with Safari and webGL, we turn DOM rendering on in Safari only
-  if (options.domRendering === true || isSafari) {
-    terminalOptions.rendererType = 'dom';
-  }
 
   // Switch to dark theme if enabled
   if (window.matchMedia('(prefers-color-scheme: dark)').matches) {

--- a/ui/tests/integration/components/render-terminal-test.ts
+++ b/ui/tests/integration/components/render-terminal-test.ts
@@ -35,24 +35,4 @@ module('Integration | Component | render-terminal', function (hooks) {
     }, 10);
     await settled();
   });
-
-  test('non-canvas rendering renders the proper html output', async function (assert) {
-    // Setup terminal externally, as expected by the component
-    let terminal = createTerminal({ inputDisabled: true, domRendering: true });
-    this.set('terminal', terminal);
-    // pass terminal and render
-    await render(hbs`<RenderTerminal @terminal={{this.terminal}}/>`);
-    // write line and see if it renders
-    terminal.writeln('Welcome to Waypoint!');
-    // We have to use the runloop as writeln isn't async
-    // Note that even the xterm.js rendering tests use polling to evaluate rendering
-    later(() => {
-      assert.dom(terminal?.element).includesText('Welcome to Waypoint!');
-    }, 50);
-    assert.dom('[data-test-xterm-pane]').exists('the xterm pane renders');
-    assert.dom('.xterm').exists('the xterm terminal renders');
-    // Clean up terminal
-    await settled();
-    await clearRender();
-  });
 });


### PR DESCRIPTION
### Explanation for this change
- During HCP Waypoint beta testing, we were informed of a bug with viewing logs on Safari. The issue ended up being we had this if condition to handle a bug that previously existed with xterm rendering with Safari/WebGL which has since been fixed.
- Bug has been fixed in HCP Waypoint but not OSS yet until this PR