### PR TITLE
Support approle auth method in Vault config sourcer plugin

### DIFF
--- a/.changelog/4057.txt
+++ b/.changelog/4057.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+plugin/vault: Update Vault plugin to support authenticating to Vault with the
+approle auth method.
+```

--- a/builtin/vault/auth.go
+++ b/builtin/vault/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/waypoint/builtin/vault/internal/auth"
+	"github.com/hashicorp/waypoint/builtin/vault/internal/auth/approle"
 	"github.com/hashicorp/waypoint/builtin/vault/internal/auth/aws"
 	"github.com/hashicorp/waypoint/builtin/vault/internal/auth/gcp"
 	"github.com/hashicorp/waypoint/builtin/vault/internal/auth/kubernetes"
@@ -59,6 +60,8 @@ func (cs *ConfigSourcer) initAuthMethod(
 		method, err = gcp.NewGCPAuthMethod(authConfig)
 	case "kubernetes":
 		method, err = kubernetes.NewKubernetesAuthMethod(authConfig)
+	case "approle":
+		method, err = approle.NewApproleAuthMethod(authConfig)
 	default:
 		return fmt.Errorf("unknown auth method: %s", cs.config.AuthMethod)
 	}

--- a/builtin/vault/config_sourcer.go
+++ b/builtin/vault/config_sourcer.go
@@ -491,7 +491,7 @@ config {
 		"auth_method",
 		"The authentication method to use for Vault.",
 		docs.Summary(
-			"This can be one of: `aws`, `kubernetes`.\n\n",
+			"This can be one of: `aws`, `approle`, `kubernetes`, `gcp`.\n\n",
 			"When this is set, configuration fields prefixed with the auth method",
 			"type should be set, if required. Configuration fields prefixed with",
 			"non-matching auth method types will be ignored (except for type validation).",
@@ -526,6 +526,22 @@ config {
 			"In standard Kubernetes environments, this doesn't have to be set.",
 		),
 		docs.Default("/var/run/secrets/kubernetes.io/serviceaccount/token"),
+	)
+
+	doc.SetField(
+		"approle_role_id",
+		"The role ID of the approle auth method to use for Vault.",
+		docs.Summary(
+			"This is required for the `approle` auth method.",
+		),
+	)
+
+	doc.SetField(
+		"approle_secret_id",
+		"The secret ID of the approle auth method to use for Vault.",
+		docs.Summary(
+			"This is required for the `approle` auth method.",
+		),
 	)
 
 	doc.SetField(
@@ -651,6 +667,9 @@ type sourceConfig struct {
 	AWSSecretKey        string `hcl:"aws_secret_key,optional"`
 	AWSRegion           string `hcl:"aws_region,optional"`
 	AWSHeaderValue      string `hcl:"aws_header_value,optional"`
+
+	ApproleRoleId   string `hcl:"approle_role_id,optional"`
+	ApproleSecretId string `hcl:"approle_secret_id,optional"`
 
 	GCPType           string `hcl:"gcp_type,optional"`
 	GCPRole           string `hcl:"gcp_role,optional"`

--- a/builtin/vault/internal/auth/approle/approle.go
+++ b/builtin/vault/internal/auth/approle/approle.go
@@ -1,0 +1,75 @@
+package approle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/waypoint/builtin/vault/internal/auth"
+)
+
+type approleMethod struct {
+	logger    hclog.Logger
+	mountPath string
+
+	roleId   string
+	secretId string
+}
+
+// NewApproleAuthMethod reads the user configuration and returns a configured
+// AuthMethod
+func NewApproleAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
+	if conf == nil {
+		return nil, errors.New("empty config")
+	}
+	if conf.Config == nil {
+		return nil, errors.New("empty config data")
+	}
+
+	a := &approleMethod{
+		logger:    conf.Logger,
+		mountPath: conf.MountPath,
+	}
+
+	roleIdRaw, ok := conf.Config["role_id"]
+	if !ok {
+		return nil, errors.New("missing 'role_id' value")
+	}
+	a.roleId, ok = roleIdRaw.(string)
+	if !ok {
+		return nil, errors.New("could not convert 'role_id' value into string")
+	}
+
+	secretIdRaw, ok := conf.Config["secret_id"]
+	if !ok {
+		return nil, errors.New("missing 'secret_id' value")
+	}
+	a.secretId, ok = secretIdRaw.(string)
+	if !ok {
+		return nil, errors.New("could not convert 'secret_id' value into string")
+	}
+
+	return a, nil
+}
+
+func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (retPath string, header http.Header, retData map[string]interface{}, retError error) {
+	a.logger.Trace("beginning authentication")
+	return fmt.Sprintf("auth/%s/login", a.mountPath), nil, map[string]interface{}{
+		"role_id":   a.roleId,
+		"secret_id": a.secretId,
+	}, nil
+}
+
+func (a *approleMethod) NewCreds() chan struct{} {
+	return nil
+}
+
+func (a *approleMethod) CredSuccess() {
+}
+
+func (a *approleMethod) Shutdown() {
+}

--- a/embedJson/gen/configsourcer-vault.json
+++ b/embedJson/gen/configsourcer-vault.json
@@ -28,10 +28,32 @@
          "SubFields": null
       },
       {
+         "Field": "approle_role_id",
+         "Type": "string",
+         "Synopsis": "The role ID of the approle auth method to use for Vault.",
+         "Summary": "This is required for the `approle` auth method.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      },
+      {
+         "Field": "approle_secret_id",
+         "Type": "string",
+         "Synopsis": "The secret ID of the approle auth method to use for Vault.",
+         "Summary": "This is required for the `approle` auth method.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      },
+      {
          "Field": "auth_method",
          "Type": "string",
          "Synopsis": "The authentication method to use for Vault.",
-         "Summary": "This can be one of: `aws`, `kubernetes`. When this is set, configuration fields prefixed with the auth method type should be set, if required. Configuration fields prefixed with non-matching auth method types will be ignored (except for type validation).  If no auth method is set, Vault assumes proper environment variables are set for Vault to find and connect to the Vault server. When this is set, `auth_method_mount_path` is required.",
+         "Summary": "This can be one of: `aws`, `approle`, `kubernetes`, `gcp`. When this is set, configuration fields prefixed with the auth method type should be set, if required. Configuration fields prefixed with non-matching auth method types will be ignored (except for type validation).  If no auth method is set, Vault assumes proper environment variables are set for Vault to find and connect to the Vault server. When this is set, `auth_method_mount_path` is required.",
          "Optional": true,
          "Default": "",
          "EnvVar": "",

--- a/website/content/partials/components/configsourcer-vault.mdx
+++ b/website/content/partials/components/configsourcer-vault.mdx
@@ -88,11 +88,29 @@ If this is not set, Vault agent will not be used. This should only be set if you
 - **Optional**
 - Environment Variable: **VAULT_AGENT_ADDR**
 
+##### approle_role_id
+
+The role ID of the approle auth method to use for Vault.
+
+This is required for the `approle` auth method.
+
+- Type: **string**
+- **Optional**
+
+##### approle_secret_id
+
+The secret ID of the approle auth method to use for Vault.
+
+This is required for the `approle` auth method.
+
+- Type: **string**
+- **Optional**
+
 ##### auth_method
 
 The authentication method to use for Vault.
 
-This can be one of: `aws`, `kubernetes`. When this is set, configuration fields prefixed with the auth method type should be set, if required. Configuration fields prefixed with non-matching auth method types will be ignored (except for type validation). If no auth method is set, Vault assumes proper environment variables are set for Vault to find and connect to the Vault server. When this is set, `auth_method_mount_path` is required.
+This can be one of: `aws`, `approle`, `kubernetes`, `gcp`. When this is set, configuration fields prefixed with the auth method type should be set, if required. Configuration fields prefixed with non-matching auth method types will be ignored (except for type validation). If no auth method is set, Vault assumes proper environment variables are set for Vault to find and connect to the Vault server. When this is set, `auth_method_mount_path` is required.
 
 - Type: **string**
 - **Optional**


### PR DESCRIPTION
This PR adds support for authenticating to Vault using the [approle auth method](https://developer.hashicorp.com/vault/docs/auth/approle) in the Vault config sourcer plugin. Below is an example of setting the source configuration in Waypoint to use the approle auth method for authenticating to Vault. Prior to this PR, Kubernetes, AWS, GCP, and token auth methods were supported. The approle auth method is typically used for machine authentication to Vault. Users who do not use the aforementioned platforms, and who don't want to directly supply a token to Vault, will benefit from the addition of this auth method.

`waypoint config source-set -type=vault -config=addr=$VAULT_ADDR -config=approle_role_id=$(vault read -format=json auth/approle/role/my-role/role-id | jq .data.role_id | tr -d '"') -config=approle_secret_id=$(vault write -f -format=json auth/approle/role/my-role/secret-id | jq .data.secret_id | tr -d '"') -config=auth_method=approle -config=auth_method_mount_path=approle/`