### PR TITLE
fix: Catch panic when null value defined in string variable

### DIFF
--- a/.changelog/4067.txt
+++ b/.changelog/4067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fix panic when null value is set on a string variable
+```

--- a/internal/config/variables/testdata/invalid_number.hcl
+++ b/internal/config/variables/testdata/invalid_number.hcl
@@ -1,0 +1,4 @@
+variable "even_more_important_information_below" {
+  default = null
+  type = number
+}

--- a/internal/config/variables/testdata/invalid_string.hcl
+++ b/internal/config/variables/testdata/invalid_string.hcl
@@ -1,0 +1,4 @@
+variable "important_information_below" {
+  default = null
+  type = string
+}

--- a/internal/config/variables/testdata/null_bool.hcl
+++ b/internal/config/variables/testdata/null_bool.hcl
@@ -1,0 +1,4 @@
+variable "is_important_information_below" {
+  default = null
+  type = bool
+}

--- a/internal/config/variables/variables.go
+++ b/internal/config/variables/variables.go
@@ -752,7 +752,17 @@ func getJobValues(vs map[string]*Variable, values Values, salt string) (map[stri
 		} else {
 			switch value.Value.Type() {
 			case cty.String:
-				varRefs[v].Value = &pb.Variable_FinalValue_Str{Str: value.Value.AsString()}
+				var str string
+				err := gocty.FromCtyValue(value.Value, &str)
+				if err != nil {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid string",
+						Detail:   err.Error(),
+					})
+					return nil, diags
+				}
+				varRefs[v].Value = &pb.Variable_FinalValue_Str{Str: str}
 			case cty.Bool:
 				varRefs[v].Value = &pb.Variable_FinalValue_Bool{Bool: value.Value.True()}
 			case cty.Number:

--- a/internal/config/variables/variables_test.go
+++ b/internal/config/variables/variables_test.go
@@ -455,6 +455,34 @@ func TestVariables_EvalInputValues(t *testing.T) {
 			expectedfvs: map[string]*pb.Variable_FinalValue{},
 			err:         "Unset variable",
 		},
+		{
+			name:        "null value for variable defined as string",
+			file:        "invalid_string.hcl",
+			inputValues: []*pb.Variable{},
+			expected:    Values{},
+			expectedfvs: map[string]*pb.Variable_FinalValue{},
+			err:         "Invalid string",
+		},
+		{
+			name:        "null value for variable defined as number",
+			file:        "invalid_number.hcl",
+			inputValues: []*pb.Variable{},
+			expected:    Values{},
+			expectedfvs: map[string]*pb.Variable_FinalValue{},
+			err:         "Invalid number",
+		},
+		{
+			name:        "null value for variable defined as boolean",
+			file:        "null_bool.hcl",
+			inputValues: []*pb.Variable{},
+			expected:    Values{},
+			expectedfvs: map[string]*pb.Variable_FinalValue{
+				"is_important_information_below": {
+					Value: &pb.Variable_FinalValue_Bool{Bool: false}, Source: pb.Variable_FinalValue_DEFAULT,
+				},
+			},
+			err: "",
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit allows for us to emit a more helpful error message when a null value is passed into a variable where we were expecting a string.

Fixes #4051