### PR TITLE
maint: Show flags and help text for profile inspect CLI

### DIFF
--- a/internal/cli/runner_profile_inspect.go
+++ b/internal/cli/runner_profile_inspect.go
@@ -157,5 +157,5 @@ Usage: waypoint runner profile inspect <name>
 
   Show detailed information about a runner profile.
 
-`)
+` + c.Flags().Help())
 }

--- a/website/content/commands/runner-profile-inspect.mdx
+++ b/website/content/commands/runner-profile-inspect.mdx
@@ -17,6 +17,8 @@ Show detailed information about a runner profile.
 
 Usage: `waypoint runner profile inspect <name>`
 
+Show detailed information about a runner profile.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation. The default is false.


### PR DESCRIPTION
This commit updates the help text for `waypoint runner profile inspect` to include available flags like the other commands do.