### PR TITLE
CLI: Show Deployment and Release URLs, Input Variables at end of Pipeline Run

### DIFF
--- a/.changelog/4096.txt
+++ b/.changelog/4096.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli/pipeline_run: Show app deployment and release URLs if exist from running
+pipeline. Also show input variables used.
+```

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -265,8 +265,8 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		// push the deploy/release URLs off the top of the terminal.
 		// We also use the deploy result and not the release result,
 		// because the data will be the same and this is the deployment command.
+		app.UI.Output("Pipeline %q Run v%d Complete", pipelineIdent, runSeq, terminal.WithHeaderStyle())
 		app.UI.Output("")
-		app.UI.Output("Pipeline %q Run %q Complete", pipelineIdent, runSeq, terminal.WithHeaderStyle())
 		tbl := fmtVariablesOutput(finalVariableValues)
 		c.ui.Table(tbl)
 

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/posener/complete"
 
@@ -190,6 +191,12 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		step.Update("%d steps detected, run sequence %d", steps, runSeq)
 		step.Done()
 
+		var (
+			deployUrl     string
+			releaseUrl    string
+			inplaceDeploy bool
+		)
+
 		successful := steps
 		for _, jobId := range allRunJobs {
 			job, err := c.project.Client().GetJob(c.Ctx, &pb.GetJobRequest{
@@ -232,6 +239,22 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			if job.State != pb.Job_SUCCESS {
 				successful--
 			}
+
+			// Grab the deployment or release URL to display at the end of the pipeline run
+			if job.Result.Up != nil {
+				deployUrl := job.Result.Up.DeployUrl
+				relesaeUrl := job.Result.Up.ReleaseUrl
+			} else if job.Result.Deploy != nil && job.Result.Deploy.Deployment.Preload != nil {
+				deployUrl = job.Result.Deploy.Deployment.Preload.DeployUrl
+
+				// inplace is true if this was an in-place deploy. We detect this
+				// if we have a generation that uses a non-matching sequence number
+				inplaceDeploy = job.Result.Deploy.Deployment.Generation != nil &&
+					job.Result.Deploy.Deployment.Generation.Id != "" &&
+					job.Result.Deploy.Deployment.Generation.InitialSequence != job.Result.Deploy.Deployment.Sequence
+			} else if job.Result.Release != nil {
+				releaseUrl = job.Result.Release.Release.Url
+			}
 		}
 
 		output := fmt.Sprintf("Pipeline %q (%s) finished! %d/%d steps successfully completed.", pipelineIdent, app.Ref().Project, successful, steps)
@@ -241,6 +264,44 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			app.UI.Output("● %s", output, terminal.WithWarningStyle())
 		} else {
 			app.UI.Output("✔ %s", output, terminal.WithSuccessStyle())
+		}
+
+		// Try to get the hostname
+		var hostname *pb.Hostname
+		hostnamesResp, err := c.project.Client().ListHostnames(ctx, &pb.ListHostnamesRequest{
+			Target: &pb.Hostname_Target{
+				Target: &pb.Hostname_Target_Application{
+					Application: &pb.Hostname_TargetApp{
+						Application: app.Ref(),
+						Workspace:   c.project.WorkspaceRef(),
+					},
+				},
+			},
+		})
+		if err == nil && len(hostnamesResp.Hostnames) > 0 {
+			hostname = hostnamesResp.Hostnames[0]
+		}
+
+		// Output app URL
+		app.UI.Output("")
+		switch {
+		case releaseUrl != "":
+			printInplaceInfo(inplaceDeploy, app)
+			app.UI.Output("   Release URL: %s", releaseUrl, terminal.WithSuccessStyle())
+			if deployUrl != "" {
+				app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+			} else {
+				app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
+			}
+		case hostname != nil:
+			printInplaceInfo(inplaceDeploy, app)
+			app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+		case deployUrl != "":
+			printInplaceInfo(inplaceDeploy, app)
+			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+		default:
+			app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
 		}
 
 		return nil

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -192,9 +192,10 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		step.Done()
 
 		var (
-			deployUrl     string
-			releaseUrl    string
-			inplaceDeploy bool
+			deployUrl           string
+			releaseUrl          string
+			inplaceDeploy       bool
+			finalVariableValues map[string]*pb.Variable_FinalValue
 		)
 
 		successful := steps
@@ -242,8 +243,8 @@ func (c *PipelineRunCommand) Run(args []string) int {
 
 			// Grab the deployment or release URL to display at the end of the pipeline run
 			if job.Result.Up != nil {
-				deployUrl := job.Result.Up.DeployUrl
-				relesaeUrl := job.Result.Up.ReleaseUrl
+				deployUrl = job.Result.Up.DeployUrl
+				releaseUrl = job.Result.Up.ReleaseUrl
 			} else if job.Result.Deploy != nil && job.Result.Deploy.Deployment.Preload != nil {
 				deployUrl = job.Result.Deploy.Deployment.Preload.DeployUrl
 
@@ -255,7 +256,19 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			} else if job.Result.Release != nil {
 				releaseUrl = job.Result.Release.Release.Url
 			}
+
+			finalVariableValues = job.VariableFinalValues
 		}
+
+		// Show input variable values used in build
+		// We do this here so that if the list is long, it doesn't
+		// push the deploy/release URLs off the top of the terminal.
+		// We also use the deploy result and not the release result,
+		// because the data will be the same and this is the deployment command.
+		app.UI.Output("")
+		app.UI.Output("Pipeline %q Run %q Complete", pipelineIdent, runSeq, terminal.WithHeaderStyle())
+		tbl := fmtVariablesOutput(finalVariableValues)
+		c.ui.Table(tbl)
 
 		output := fmt.Sprintf("Pipeline %q (%s) finished! %d/%d steps successfully completed.", pipelineIdent, app.Ref().Project, successful, steps)
 		if successful == 0 {


### PR DESCRIPTION
This pull request includes the same UI messaging that our `deploy`, `release`, and `up` CLIs have. It will display the app URL for its deployment and or release if it exists. This pull request also updates the `pipeline run` command to show any job input variables used.
