### PR TITLE
internal/runner: Run a status report on Deployments and Releases

### DIFF
--- a/.changelog/4099.txt
+++ b/.changelog/4099.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+core: Auto run a status report after a deployment or release operation rather
+than only if `waypoint deploy` or `waypoint release` CLI is run.
+```

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -70,18 +70,6 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 			hostname = hostnamesResp.Hostnames[0]
 		}
 
-		// Status Report
-		app.UI.Output("")
-		_, err = app.StatusReport(ctx, &pb.Job_StatusReportOp{
-			Target: &pb.Job_StatusReportOp_Deployment{
-				Deployment: deployment,
-			},
-		})
-		if err != nil {
-			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
-			return ErrSentinel
-		}
-
 		// Release if we're releasing
 		var releaseUrl string
 		if c.flagRelease {

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -182,18 +182,6 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 		tbl := fmtVariablesOutput(resp.VariableFinalValues)
 		c.ui.Table(tbl)
 
-		// Status Report
-		app.UI.Output("")
-		_, err = app.StatusReport(ctx, &pb.Job_StatusReportOp{
-			Target: &pb.Job_StatusReportOp_Release{
-				Release: result.Release,
-			},
-		})
-		if err != nil {
-			app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
-			return ErrSentinel
-		}
-
 		if result.Release.Url == "" {
 			app.UI.Output("\n"+strings.TrimSpace(releaseNoUrl),
 				deploy.Id,

--- a/internal/runner/operation_deploy.go
+++ b/internal/runner/operation_deploy.go
@@ -52,6 +52,12 @@ func (r *Runner) executeDeployOp(
 		return nil, err
 	}
 
+	// Run a status report on the recent deployment
+	_, err = app.DeploymentStatusReport(ctx, deployment)
+	if err != nil {
+		return nil, err
+	}
+
 	return &pb.Job_Result{
 		Deploy: &pb.Job_DeployResult{
 			Deployment: deployment,

--- a/internal/runner/operation_release.go
+++ b/internal/runner/operation_release.go
@@ -211,5 +211,11 @@ func (r *Runner) executeReleaseOp(
 		}
 	}
 
+	// Run a status report operation on the recent release
+	_, err = app.ReleaseStatusReport(ctx, release)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }


### PR DESCRIPTION
Prior to this commit, a status report operation was not auto-executed any time a deployment or release ran. This meant as Waypoint developers we had to be explicit when we wanted Waypoint to generate status reports. Given that our CLI runner auto-executes status reports on up, deploy, and release, it makes sense other systems that use these operations should also get status reports in an easy way. This commit updates the behavior of deploy and release to run a status report at the end of its execution so that we can get some simple checks after deploying or releasing.

Fixes #4072 