### PR TITLE
Job list filtered by pipelines displays latest run if none supplied

### DIFF
--- a/.changelog/4100.txt
+++ b/.changelog/4100.txt
@@ -1,0 +1,4 @@
+``release-note:improvement
+cli: Update `waypoint job list -pipeline-name` and `waypoint job list -pipeline-id` to display the latest run
+if no `-run` flag is supplied.
+```

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -255,7 +255,7 @@ func (c *JobListCommand) Run(args []string) int {
 		}
 
 		pipeline := ""
-		if j.Pipeline != nil {
+		if j.Pipeline != nil && j.Pipeline.RunSequence != 0 {
 			pipeline = "name: " + j.Pipeline.PipelineName + ", run: " + strconv.FormatUint(j.Pipeline.RunSequence, 10) + ", step: " + j.Pipeline.Step
 		}
 

--- a/internal/server/boltdbstate/job.go
+++ b/internal/server/boltdbstate/job.go
@@ -417,9 +417,6 @@ func (s *State) JobList(
 			if req.Pipeline.PipelineId != "" && (req.Pipeline.PipelineId != job.Pipeline.PipelineId) {
 				continue
 			}
-			if (req.Pipeline.PipelineId == job.Pipeline.PipelineId || req.Pipeline.PipelineName == job.Pipeline.PipelineName) && req.Pipeline.RunSequence != job.Pipeline.RunSequence {
-				continue
-			}
 		}
 
 		result = append(result, job)


### PR DESCRIPTION
Previously, `waypoint job list -pipeline-name/id=` would display no results if no `-run` flag is supplied. 

Now output defaults to latest run.