### PR TITLE
cli: Only echo conf file on fmt change

### DIFF
--- a/.changelog/4111.txt
+++ b/.changelog/4111.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Only echo file name when config file is formatted with `waypoint fmt`.
+```

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -72,12 +72,17 @@ func (c *FmtCommand) Run(args []string) int {
 		return 1
 	}
 
+	fileChanged := false
+	if !bytes.Equal(src, out) {
+		fileChanged = true
+	}
+
 	if c.flagCheck {
 		// In the case where we're checking formatting, don't persist data
 		// ultimately this shouldn't even be used because we should return
 		// in this block
 		c.flagWrite = false
-		if bytes.Equal(src, out) {
+		if !fileChanged {
 			return 0
 		} else {
 			return 3
@@ -93,7 +98,9 @@ func (c *FmtCommand) Run(args []string) int {
 			)
 			return 1
 		}
-		fmt.Println(c.args[0])
+		if fileChanged {
+			fmt.Println(c.args[0])
+		}
 	} else {
 		// We must use fmt here and not c.ui since c.ui may wordwrap and trim.
 		fmt.Print(string(out))


### PR DESCRIPTION
Prior to this commit, the `waypoint fmt` command would echo the formatted file name even if the file was not formatted. This commit adjusts that to align the CLI to behave like `terraform fmt` where it only echos the file name in the case where the file was actually formatted.

Fixes #3816