### PR TITLE
internal/config: Fix panic if no scoped use stanza found

### DIFF
--- a/.changelog/4112.txt
+++ b/.changelog/4112.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: Fix panic if no Use stanza found for given workspace scope on a build,
+deploy, release, or registry stanza.
+```

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -280,7 +279,7 @@ func (c *App) BuildUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil {
 		return "", nil
 	} else if c.BuildRaw.Use == nil {
-		return "", fmt.Errorf("app %q has a build stanza, but no valid 'use' stanza!", c.Name)
+		return "", nil
 	}
 
 	useType := c.BuildRaw.Use.Type
@@ -300,7 +299,7 @@ func (c *App) RegistryUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil || c.BuildRaw.Registry == nil {
 		return "", nil
 	} else if c.BuildRaw.Registry.Use == nil {
-		return "", fmt.Errorf("app %q has a registry stanza, but no valid 'use' stanza!", c.Name)
+		return "", nil
 	}
 
 	useType := c.BuildRaw.Registry.Use.Type
@@ -320,7 +319,7 @@ func (c *App) DeployUse(ctx *hcl.EvalContext) (string, error) {
 	if c.DeployRaw == nil {
 		return "", nil
 	} else if c.DeployRaw.Use == nil {
-		return "", fmt.Errorf("app %q has a deploy stanza, but no valid 'use' stanza!", c.Name)
+		return "", nil
 	}
 
 	useType := c.DeployRaw.Use.Type
@@ -340,7 +339,7 @@ func (c *App) ReleaseUse(ctx *hcl.EvalContext) (string, error) {
 	if c.ReleaseRaw == nil {
 		return "", nil
 	} else if c.ReleaseRaw.Use == nil {
-		return "", fmt.Errorf("app %q has a release stanza, but no valid 'use' stanza!", c.Name)
+		return "", nil
 	}
 
 	useType := c.ReleaseRaw.Use.Type

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -278,6 +279,8 @@ func (c *App) Release(ctx *hcl.EvalContext) (*Release, error) {
 func (c *App) BuildUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil {
 		return "", nil
+	} else if c.BuildRaw.Use == nil {
+		return "", fmt.Errorf("app %q has a build stanza, but no valid 'use' stanza!", c.Name)
 	}
 
 	useType := c.BuildRaw.Use.Type
@@ -296,6 +299,8 @@ func (c *App) BuildUse(ctx *hcl.EvalContext) (string, error) {
 func (c *App) RegistryUse(ctx *hcl.EvalContext) (string, error) {
 	if c.BuildRaw == nil || c.BuildRaw.Registry == nil {
 		return "", nil
+	} else if c.BuildRaw.Registry.Use == nil {
+		return "", fmt.Errorf("app %q has a registry stanza, but no valid 'use' stanza!", c.Name)
 	}
 
 	useType := c.BuildRaw.Registry.Use.Type
@@ -314,6 +319,8 @@ func (c *App) RegistryUse(ctx *hcl.EvalContext) (string, error) {
 func (c *App) DeployUse(ctx *hcl.EvalContext) (string, error) {
 	if c.DeployRaw == nil {
 		return "", nil
+	} else if c.DeployRaw.Use == nil {
+		return "", fmt.Errorf("app %q has a deploy stanza, but no valid 'use' stanza!", c.Name)
 	}
 
 	useType := c.DeployRaw.Use.Type
@@ -332,6 +339,8 @@ func (c *App) DeployUse(ctx *hcl.EvalContext) (string, error) {
 func (c *App) ReleaseUse(ctx *hcl.EvalContext) (string, error) {
 	if c.ReleaseRaw == nil {
 		return "", nil
+	} else if c.ReleaseRaw.Use == nil {
+		return "", fmt.Errorf("app %q has a release stanza, but no valid 'use' stanza!", c.Name)
 	}
 
 	useType := c.ReleaseRaw.Use.Type


### PR DESCRIPTION
Prior to this commit, if you attempted to use a build, deploy, or release stanza that had a workspace scoped 'use' stanza but you were not using that workspace, Waypoint would panic attempting to evaluate the Use plugin type. This commit fixes that by first looking to see if a Use stanza is defined at all prior to obtaining the Use type.

Fixes #3759