### PR TITLE
cli: Only show CompleteTime if set

### DIFF
--- a/.changelog/4113.txt
+++ b/.changelog/4113.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Only show "CompleteTime" on `waypoint pipeline list` if the job has a valid
+complete time.
+```

--- a/internal/cli/pipeline_list.go
+++ b/internal/cli/pipeline_list.go
@@ -131,7 +131,9 @@ func (c *PipelineListCommand) Run(args []string) int {
 				return 1
 			}
 
-			lastRunEnd = humanize.Time(j.CompleteTime.AsTime())
+			if j.CompleteTime != nil {
+				lastRunEnd = humanize.Time(j.CompleteTime.AsTime())
+			}
 			state = strings.ToLower(lastRun.State.String())
 		}
 


### PR DESCRIPTION
Prior to this commit, the `waypoint pipeline list` CLI would attempt to show an invalid complete time, even if not set on the job. This would mean if you started a pipeline, the list CLI would claim that the pipeline completed "a long time ago", which is really code for that timestamp being nil. This commit fixes that behavior by only setting the complete time string if set on the job.

Fixes #3748