### PR TITLE
cli: Add prune flags for a release for `waypoint deploy`

### DIFF
--- a/.changelog/4114.txt
+++ b/.changelog/4114.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add prune flags to `waypoint deploy` for configuring the automatic release.
+```

--- a/embedJson/gen/builder-consul.json
+++ b/embedJson/gen/builder-consul.json
@@ -1,0 +1,8 @@
+{
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": null,
+   "requiredFields": null,
+   "type": "builder",
+   "use": "the [`use` stanza](/docs/waypoint-hcl/use) for this plugin."
+}

--- a/embedJson/gen/configsourcer-consul.json
+++ b/embedJson/gen/configsourcer-consul.json
@@ -1,0 +1,66 @@
+{
+   "description": "Read configuration values from the Consul KV store.",
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": [
+      {
+         "Field": "allow_stale",
+         "Type": "bool",
+         "Synopsis": "whether to perform a stale query for retrieving the KV data",
+         "Summary": "If not set this will default to true. It must explicitly be set to false in order to use consistent queries.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      },
+      {
+         "Field": "datacenter",
+         "Type": "string",
+         "Synopsis": "the datacenter to load the KV value from.",
+         "Summary": "If not specified then it will default to the plugin's global datacenter configuration. If that is also not specified then Consul will default the datacenter like it would any other request.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      },
+      {
+         "Field": "namespace",
+         "Type": "string",
+         "Synopsis": "the namespace to load the KV value from.",
+         "Summary": "If not specified then it will default to the plugin's global namespace configuration. If that is also not specified then Consul will default the namespace like it would any other request.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      },
+      {
+         "Field": "partition",
+         "Type": "string",
+         "Synopsis": "the partition to load the KV value from.",
+         "Summary": "If not specified then it will default to the plugin's global partition configuration. If that is also not specified then Consul will default the partition like it would any other request.",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      }
+   ],
+   "requiredFields": [
+      {
+         "Field": "key",
+         "Type": "string",
+         "Synopsis": "the KV path to retrieve",
+         "Summary": "",
+         "Optional": false,
+         "Default": "",
+         "EnvVar": "",
+         "Category": false,
+         "SubFields": null
+      }
+   ],
+   "type": "configsourcer",
+   "use": "`dynamic` for sourcing [configuration values](/docs/app-config/dynamic) or [input variable values](/docs/waypoint-hcl/variables/dynamic)."
+}

--- a/embedJson/gen/platform-consul.json
+++ b/embedJson/gen/platform-consul.json
@@ -1,0 +1,8 @@
+{
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": null,
+   "requiredFields": null,
+   "type": "platform",
+   "use": "the [`use` stanza](/docs/waypoint-hcl/use) for this plugin."
+}

--- a/embedJson/gen/registry-consul.json
+++ b/embedJson/gen/registry-consul.json
@@ -1,0 +1,8 @@
+{
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": null,
+   "requiredFields": null,
+   "type": "registry",
+   "use": "the [`use` stanza](/docs/waypoint-hcl/use) for this plugin."
+}

--- a/embedJson/gen/releasemanager-consul.json
+++ b/embedJson/gen/releasemanager-consul.json
@@ -1,0 +1,8 @@
+{
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": null,
+   "requiredFields": null,
+   "type": "releasemanager",
+   "use": "the [`use` stanza](/docs/waypoint-hcl/use) for this plugin."
+}

--- a/embedJson/gen/task-consul.json
+++ b/embedJson/gen/task-consul.json
@@ -1,0 +1,8 @@
+{
+   "mappers": null,
+   "name": "consul",
+   "optionalFields": null,
+   "requiredFields": null,
+   "type": "task",
+   "use": "the [`use` stanza](/docs/waypoint-hcl/use) for this plugin."
+}

--- a/website/content/commands/deploy.mdx
+++ b/website/content/commands/deploy.mdx
@@ -46,5 +46,7 @@ can be disabled by using the "-release=false" flag.
 #### Command Options
 
 - `-release` - Release this deployment immediately. The default is true.
+- `-prune` - Prune old unreleased deployments. The default is true.
+- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0. The default is -1.
 
 @include "commands/deploy_more.mdx"

--- a/website/content/commands/deployment-deploy.mdx
+++ b/website/content/commands/deployment-deploy.mdx
@@ -46,5 +46,7 @@ can be disabled by using the "-release=false" flag.
 #### Command Options
 
 - `-release` - Release this deployment immediately. The default is true.
+- `-prune` - Prune old unreleased deployments. The default is true.
+- `-prune-retain=<int>` - The number of unreleased deployments to keep. If this isn't set or is set to any negative number, then this will default to 1 on the server. If you want to prune all unreleased deployments, set this to 0. The default is -1.
 
 @include "commands/deployment-deploy_more.mdx"


### PR DESCRIPTION
This commit includes the various `prune` flags for configuring an
automated release from the deploy CLI.

Fixes https://github.com/hashicorp/waypoint/issues/3592