### PR TITLE
UX: Combine git datasource ref information into single message

### DIFF
--- a/.changelog/4115.txt
+++ b/.changelog/4115.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Combine git clone messages from job stream into a single message
+```

--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -297,7 +297,7 @@ func (s *GitSource) Get(
 
 	// Output additinoal git info
 	ui.Output("Git Commit: %s", commit.Hash.String(), terminal.WithInfoStyle())
-	ui.Output(" Timestamp: %s", commitTs, terminal.WithInfoStyle())
+	ui.Output(" Timestamp: %s", commitTs.AsTime(), terminal.WithInfoStyle())
 	ui.Output("   Message: %s", commit.Message, terminal.WithInfoStyle())
 
 	return result, &pb.Job_DataSource_Ref{

--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -169,11 +169,14 @@ func (s *GitSource) Get(
 		return os.RemoveAll(td)
 	}
 
-	// Output
+	// Output git info
+	// NOTE(briancain): The leading whitespace here is to fit the formatting
+	// for when we display the commit, timestamp, and message later on so that the
+	// messages are all aligned.
 	ui.Output("Cloning data from Git", terminal.WithHeaderStyle())
-	ui.Output("URL: %s", source.Git.Url, terminal.WithInfoStyle())
+	ui.Output("       URL: %s", source.Git.Url, terminal.WithInfoStyle())
 	if source.Git.Ref != "" {
-		ui.Output("Ref: %s", source.Git.Ref, terminal.WithInfoStyle())
+		ui.Output("       Ref: %s", source.Git.Ref, terminal.WithInfoStyle())
 	}
 
 	// Setup auth information
@@ -291,6 +294,11 @@ func (s *GitSource) Get(
 	if p := source.Git.Path; p != "" {
 		result = filepath.Join(result, p)
 	}
+
+	// Output additinoal git info
+	ui.Output("Git Commit: %s", commit.Hash.String(), terminal.WithInfoStyle())
+	ui.Output(" Timestamp: %s", commitTs, terminal.WithInfoStyle())
+	ui.Output("   Message: %s", commit.Message, terminal.WithInfoStyle())
 
 	return result, &pb.Job_DataSource_Ref{
 		Ref: &pb.Job_DataSource_Ref_Git{

--- a/internal/jobstream/stream.go
+++ b/internal/jobstream/stream.go
@@ -140,16 +140,12 @@ func (s *stream) Run(ctx context.Context) (*pb.Job_Result, error) {
 			return nil, st.Err()
 
 		case *pb.GetJobStreamResponse_Download_:
-			if ui != nil {
-				ui.Output("Downloading from Git", terminal.WithHeaderStyle())
+			// Assume git type for now
+			git := event.Download.DataSourceRef.Ref.(*pb.Job_DataSource_Ref_Git)
 
-				// Assume git type for now
-				git := event.Download.DataSourceRef.Ref.(*pb.Job_DataSource_Ref_Git)
-
-				ui.Output("Git Commit: %s", git.Git.Commit, terminal.WithInfoStyle())
-				ui.Output(" Timestamp: %s", git.Git.Timestamp.AsTime(), terminal.WithInfoStyle())
-				ui.Output("   Message: %s", git.Git.CommitMessage, terminal.WithInfoStyle())
-			}
+			log.Debug("downloading from git",
+				"commit", git.Git.Commit, "timestamp", git.Git.Timestamp.AsTime(),
+				"message", git.Git.CommitMessage)
 
 		case *pb.GetJobStreamResponse_Terminal_:
 			if s.ignoreTerminal {


### PR DESCRIPTION
Prior to this commit, we were split outputting git data source information within a jobstream. With this fix, we now output the git information in a single place, and when we go to read the jobstream we simply log the information at DEBUG.

Fixes #4097