### PR TITLE
Fix issue with docker-pull and authentication 

### DIFF
--- a/.changelog/4121.txt
+++ b/.changelog/4121.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+plugin/docker: fix issue with authenticating with registries when using
+docker-pull
+```

--- a/builtin/docker/pull/kaniko.go
+++ b/builtin/docker/pull/kaniko.go
@@ -160,7 +160,7 @@ func (b *Builder) pullWithKaniko(
 			}
 			sourceProxy.AuthConfig.Username = user
 			sourceProxy.AuthConfig.Password = pass
-		} else if *b.config.Auth != (wpdocker.Auth{}) {
+		} else if b.config.Auth != nil && *b.config.Auth != (wpdocker.Auth{}) {
 			//If EncodedAuth is not set, and Auth is, use Auth
 			sourceProxy.AuthConfig.Username = b.config.Auth.Username
 			sourceProxy.AuthConfig.Password = b.config.Auth.Password

--- a/builtin/docker/pull/kaniko.go
+++ b/builtin/docker/pull/kaniko.go
@@ -41,101 +41,116 @@ func (b *Builder) pullWithKaniko(
 		Location: &wpdocker.Image_Registry{Registry: &wpdocker.Image_RegistryLocation{}},
 	}
 
-	var oci ociregistry.Server
-	oci.DisableEntrypoint = b.config.DisableCEB
-	oci.Logger = log
-
-	if ai.Auth != nil {
-		switch sv := ai.Auth.(type) {
-		case *wpdocker.AccessInfo_Encoded:
-			user, pass, err := wpdocker.CredentialsFromConfig(sv.Encoded)
-			if err != nil {
-				return nil, err
+	// destinationProxy is the OCI Proxy server that the Kaniko process will push the
+	// resulting docker container to. It authenticates and proxies the image to
+	// the location specified in the build->registry block of a waypoint.hcl file.
+	var destinationProxy ociregistry.Server
+	// localRef represents the destination of the resulting image for use with
+	// Kaniko
+	var localRef string
+	destinationProxy.DisableEntrypoint = b.config.DisableCEB
+	destinationProxy.Logger = log
+	{
+		// Setup the proxy authentication for the destination registry. This
+		// information comes from the "registry" block via the docker AccessInfo
+		if ai.Auth != nil {
+			switch sv := ai.Auth.(type) {
+			case *wpdocker.AccessInfo_Encoded:
+				user, pass, err := wpdocker.CredentialsFromConfig(sv.Encoded)
+				if err != nil {
+					return nil, err
+				}
+				destinationProxy.AuthConfig.Username = user
+				destinationProxy.AuthConfig.Password = pass
+			case *wpdocker.AccessInfo_Header:
+				destinationProxy.AuthConfig.Auth = sv.Header
+			case *wpdocker.AccessInfo_UserPass_:
+				destinationProxy.AuthConfig.Username = sv.UserPass.Username
+				destinationProxy.AuthConfig.Password = sv.UserPass.Password
+			default:
+				return nil, status.Error(codes.Unauthenticated, "Unexpected auth type.")
 			}
-			oci.AuthConfig.Username = user
-			oci.AuthConfig.Password = pass
-		case *wpdocker.AccessInfo_Header:
-			oci.AuthConfig.Auth = sv.Header
-		case *wpdocker.AccessInfo_UserPass_:
-			oci.AuthConfig.Username = sv.UserPass.Username
-			oci.AuthConfig.Password = sv.UserPass.Password
-		default:
-			return nil, status.Error(codes.Unauthenticated, "Unexpected auth type.")
-		}
-	}
-
-	// Determine the host that we're setting auth for. We have to parse the
-	// image for this cause it may not contain a host. Luckily Docker has
-	// libs to normalize this all for us.
-	log.Trace("determining host for auth configuration", "image", target.Name())
-	ref, err := reference.ParseNormalizedNamed(target.Image)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to parse image name: %s", err)
-	}
-
-	host := reference.Domain(ref)
-	if host == "docker.io" {
-		// The normalized name parse above will turn short names like "foo/bar"
-		// into "docker.io/foo/bar" but the actual registry host for these
-		// is "index.docker.io".
-		host = "index.docker.io"
-	}
-
-	if ai.Insecure {
-		oci.Upstream = "http://" + host
-	} else {
-		oci.Upstream = "https://" + host
-	}
-
-	refPath := reference.Path(ref)
-
-	err = oci.Negotiate(ref.Name())
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to negotiate with upstream")
-	}
-
-	if !b.config.DisableCEB {
-		step.Update("Injecting entrypoint...")
-		// For Kaniko we can use our runtime arch because the image we build
-		// always matches the architecture of our Kaniko environment.
-		assetName, ok := assets.CEBArch[runtime.GOARCH]
-		if !ok {
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"automatic entrypoint injection not supported for architecture: %s", runtime.GOARCH)
 		}
 
-		data, err := assets.Asset(assetName)
+		// Determine the host that we're setting auth for. We have to parse the
+		// image for this cause it may not contain a host. Luckily Docker has
+		// libs to normalize this all for us.
+		log.Trace("determining host for auth configuration", "image", target.Name())
+		ref, err := reference.ParseNormalizedNamed(target.Image)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to restore custom entrypoint binary: %s", err)
+			return nil, status.Errorf(codes.Internal, "unable to parse image name: %s", err)
 		}
-		step.Done()
 
-		step = sg.Add("Testing registry and uploading entrypoint layer")
-		err = oci.SetupEntrypointLayer(refPath, data)
+		host := reference.Domain(ref)
+		if host == "docker.io" {
+			// The normalized name parse above will turn short names like "foo/bar"
+			// into "docker.io/foo/bar" but the actual registry host for these
+			// is "index.docker.io".
+			host = "index.docker.io"
+		}
+
+		if ai.Insecure {
+			destinationProxy.Upstream = "http://" + host
+		} else {
+			destinationProxy.Upstream = "https://" + host
+		}
+
+		refPath := reference.Path(ref)
+
+		err = destinationProxy.Negotiate(ref.Name())
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer to host: %q, err: %s", oci.Upstream, err)
+			return nil, errors.Wrapf(err, "unable to negotiate with upstream")
 		}
-		step.Done()
+
+		if !b.config.DisableCEB {
+			step.Update("Injecting entrypoint...")
+			// For Kaniko we can use our runtime arch because the image we build
+			// always matches the architecture of our Kaniko environment.
+			assetName, ok := assets.CEBArch[runtime.GOARCH]
+			if !ok {
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"automatic entrypoint injection not supported for architecture: %s", runtime.GOARCH)
+			}
+
+			data, err := assets.Asset(assetName)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "unable to restore custom entrypoint binary: %s", err)
+			}
+			step.Done()
+
+			step = sg.Add("Testing registry and uploading entrypoint layer")
+			err = destinationProxy.SetupEntrypointLayer(refPath, data)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "error setting up entrypoint layer to host: %q, err: %s", destinationProxy.Upstream, err)
+			}
+			step.Done()
+		}
+
+		// Setting up local registry to which Kaniko will push
+		li, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			return nil, err
+		}
+
+		defer li.Close()
+		go http.Serve(li, &destinationProxy)
+
+		port := li.Addr().(*net.TCPAddr).Port
+
+		localRef = fmt.Sprintf("localhost:%d/%s:%s", port, refPath, ai.Tag)
 	}
 
-	// Setting up local registry to which Kaniko will push
-	li, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return nil, err
-	}
-
-	defer li.Close()
-	go http.Serve(li, &oci)
-
-	port := li.Addr().(*net.TCPAddr).Port
-
-	localRef := fmt.Sprintf("localhost:%d/%s:%s", port, refPath, ai.Tag)
-
-	////// setup pull ref
+	// sourceProxy is the OCI Proxy server that the Kaniko process will pull the
+	// base docker container from. It authenticates and proxies the image from
+	// the location specified in the build->docker-pull block.
+	var sourceProxy ociregistry.Server
+	// remoteRef represents the address of the pullProxy that will be inserted
+	// into an on-demand Docker file: ex "FROM localhost:1234/image:tag"
 	var remoteRef string
-	var rci ociregistry.Server
-	rci.DisableEntrypoint = b.config.DisableCEB
-	rci.Logger = log
+	// DisableEntrypoint shouldn't matter on the source, but we set it to be
+	// consistent with the destination proxy
+	sourceProxy.DisableEntrypoint = b.config.DisableCEB
+	sourceProxy.Logger = log
 	{
 		if b.config.EncodedAuth != "" {
 			//If EncodedAuth is set, use that
@@ -143,15 +158,15 @@ func (b *Builder) pullWithKaniko(
 			if err != nil {
 				return nil, err
 			}
-			rci.AuthConfig.Username = user
-			rci.AuthConfig.Password = pass
+			sourceProxy.AuthConfig.Username = user
+			sourceProxy.AuthConfig.Password = pass
 		} else if *b.config.Auth != (wpdocker.Auth{}) {
 			//If EncodedAuth is not set, and Auth is, use Auth
-			rci.AuthConfig.Username = b.config.Auth.Username
-			rci.AuthConfig.Password = b.config.Auth.Password
-			rci.AuthConfig.Auth = b.config.Auth.Auth
-			rci.AuthConfig.IdentityToken = b.config.Auth.IdentityToken
-			rci.AuthConfig.RegistryToken = b.config.Auth.RegistryToken
+			sourceProxy.AuthConfig.Username = b.config.Auth.Username
+			sourceProxy.AuthConfig.Password = b.config.Auth.Password
+			sourceProxy.AuthConfig.Auth = b.config.Auth.Auth
+			sourceProxy.AuthConfig.IdentityToken = b.config.Auth.IdentityToken
+			sourceProxy.AuthConfig.RegistryToken = b.config.Auth.RegistryToken
 		}
 
 		// Determine the host that we're setting auth for. We have to parse the
@@ -171,16 +186,12 @@ func (b *Builder) pullWithKaniko(
 			host = "index.docker.io"
 		}
 
-		// we dont support insecure docker-pull it seems
-		// if b.config.Insecure {
-		// 	oci.Upstream = "http://" + host
-		// } else {
-		rci.Upstream = "https://" + host
-		// }
+		// we dont support insecure docker-pull
+		sourceProxy.Upstream = "https://" + host
 
 		refPath := reference.Path(ref)
 
-		err = rci.Negotiate(ref.Name())
+		err = sourceProxy.Negotiate(ref.Name())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to negotiate with upstream")
 		}
@@ -192,7 +203,7 @@ func (b *Builder) pullWithKaniko(
 		}
 
 		defer li.Close()
-		go http.Serve(li, &rci)
+		go http.Serve(li, &sourceProxy)
 
 		port := li.Addr().(*net.TCPAddr).Port
 
@@ -200,11 +211,10 @@ func (b *Builder) pullWithKaniko(
 	}
 
 	dockerfileBS := []byte(fmt.Sprintf("FROM %s\n", remoteRef))
-	err = os.WriteFile("Dockerfile", dockerfileBS, 0644)
+	err := os.WriteFile("Dockerfile", dockerfileBS, 0644)
 	if err != nil {
 		return nil, err
 	}
-	/////
 
 	contextDir, relDockerfile, err := build.GetContextFromLocalDir(".", "Dockerfile")
 	if err != nil {

--- a/internal/pkg/epinject/ociregistry/server.go
+++ b/internal/pkg/epinject/ociregistry/server.go
@@ -265,6 +265,15 @@ func (s *Server) FetchBlob(name string, id string) ([]byte, error) {
 }
 
 func (s *Server) uploadEntrypoint() error {
+	found, err := s.probeBlob(s.entrypointRepo, s.entrypointId)
+	if err != nil {
+		return err
+	}
+
+	if found {
+		s.Logger.Debug("entrypoint layer already exists, not reuploading")
+		return nil
+	}
 	s.Logger.Debug("uploading entrypoint layer")
 	if _, err := s.writeBlob(s.entrypointRepo, s.entrypointData); err != nil {
 		return err


### PR DESCRIPTION
Fix an issue where both `docker-pull` and subsequent `registry` blocks needed separate authentication. 

Example:

```hcl
app "some-app" {
  build {
    use "docker" {
      // Use the included Dockerfile
    }
    workspace "production" {
      use "docker-pull" {
        image = "some-private-registry/image"
        tag   = "stable"
        encoded_auth = base64encode(
          jsonencode({
            username = "some-username",
            password = "some-password"
          })
        )
      }
    }

    registry {
      use "docker" {
        image    = "somerepo/image"
        tag      = "latest"
        username = "some-username"
        password = "some-password"
      }
    }
  }
  
  [...]
}
```

Prior to these changes, Waypoint could only authenticate with the registry in the `registry` block, and did not properly authenticate with the registry that the `docker-pull` block would eventually be talking to. 

In this PR we create a 2nd [OCI Proxy Server](https://github.com/hashicorp/waypoint/blob/b0017806980a11f93d9c2411815818a123ae6ccd/internal/pkg/epinject/ociregistry/server.go#L39) to handle authentication with the registry we pull from, and modify the resulting generate `Dockerfile` to then pull from the proxy and not directly from the source. 

Along the way we ran into some issues with manifests so we had to make some changes to the proxy server itself as well. 

Fixes https://github.com/hashicorp/waypoint/issues/4055