### PR TITLE
Feature: Update pipelines parser to evaluate input variables

### DIFF
--- a/.changelog/4132.txt
+++ b/.changelog/4132.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+pipelines: Add ability to evaluate input variables in pipelines stanzas.
+```

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -412,7 +412,7 @@ func (c *InitCommand) validateProject() bool {
 	for _, pn := range pipeNames {
 		sp.Update("Registering Pipeline %q with the server...", pn)
 
-		baseStep := map[string]*pb.Pipeline_Step{"root": &pb.Pipeline_Step{
+		baseStep := map[string]*pb.Pipeline_Step{"root": {
 			Name: "root",
 			Kind: &pb.Pipeline_Step_Pipeline_{},
 		}}

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -306,6 +306,7 @@ func TestPipelineProtos(t *testing.T) {
 				require.Len(pipelines[0].Steps, 1)
 
 				nestedStep := pipelines[0].Steps["test_nested"]
+				require.NotNil(nestedStep)
 				require.Equal(nestedStep.Name, "test_nested")
 			},
 		},

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/waypoint/internal/config/variables"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -38,6 +40,29 @@ func TestPipeline(t *testing.T) {
 
 		{
 			"pipeline_step.hcl",
+			"foo",
+			func(t *testing.T, c *Pipeline) {
+				require := require.New(t)
+
+				require.NotNil(t, c)
+				require.Equal("foo", c.Name)
+
+				steps := c.Steps
+				s := steps[0]
+
+				var p testStepPluginConfig
+				diag := s.Configure(&p, nil)
+				if diag.HasErrors() {
+					t.Fatal(diag.Error())
+				}
+
+				require.NotEmpty(t, p.config.Foo)
+				require.Equal("example.com/test", s.ImageURL)
+			},
+		},
+
+		{
+			"pipeline_input_var.hcl",
 			"foo",
 			func(t *testing.T, c *Pipeline) {
 				require := require.New(t)
@@ -222,7 +247,11 @@ func TestPipeline(t *testing.T) {
 			})
 			require.NoError(err)
 
-			pipeline, err := cfg.Pipeline(tt.Pipeline, nil)
+			evalCtx := EvalContext(nil, "").NewChild()
+			inputVars, _, _ := variables.EvaluateVariables(hclog.L(), nil, cfg.InputVariables, "")
+			AddVariables(evalCtx, inputVars)
+
+			pipeline, err := cfg.Pipeline(tt.Pipeline, evalCtx)
 			require.NoError(err)
 
 			tt.Func(t, pipeline)

--- a/internal/config/stages.go
+++ b/internal/config/stages.go
@@ -41,31 +41,6 @@ type scopedStage struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
-// Step are the step settings for pipelines
-type Step struct {
-	Labels map[string]string `hcl:"labels,optional"`
-	Use    *Use              `hcl:"use,block"`
-
-	// Give this step a name
-	Name string `hcl:",label"`
-
-	// If set, this step will depend on the defined step. The default step
-	// will be the previously defined step in order that it was defined
-	// in a waypoint.hcl
-	DependsOn []string `hcl:"depends_on,optional"`
-
-	// The OCI image to use for executing this step
-	ImageURL string `hcl:"image_url,optional"`
-
-	// An optional embedded pipeline stanza
-	Pipeline *Pipeline `hcl:"pipeline,block"`
-
-	ctx *hcl.EvalContext
-
-	// Optional workspace scoping
-	Workspace string `hcl:"workspace,optional"`
-}
-
 // Build are the build settings.
 type Build struct {
 	Labels map[string]string `hcl:"labels,optional"`

--- a/internal/config/testdata/pipelines/pipeline_input_var.hcl
+++ b/internal/config/testdata/pipelines/pipeline_input_var.hcl
@@ -1,0 +1,28 @@
+project = "foo"
+
+pipeline "foo" {
+  step "test" {
+    image_url = var.image_url
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+app "web" {
+    config {
+        env = {
+            static = "hello"
+        }
+    }
+
+    build {}
+
+    deploy {}
+}
+
+variable "image_url" {
+  default = "example.com/test"
+  type    = string
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -326,20 +326,20 @@ func (c *Config) validatePipeline(b *hcl.Block) []ValidationResult {
 func (c *Pipeline) Validate() error {
 	var result error
 
-	for _, stepRaw := range c.StepRaw {
-		if stepRaw == nil {
+	for _, step := range c.Steps {
+		if step == nil {
 			result = multierror.Append(result, fmt.Errorf(
 				"step stage in pipeline is nil, this is an internal error"))
-		} else if stepRaw != nil && (stepRaw.Use == nil && stepRaw.PipelineRaw == nil) {
+		} else if step != nil && (step.Use == nil && step.Pipeline == nil) {
 			result = multierror.Append(result, fmt.Errorf(
 				"step stage with a default 'use' stanza or a 'pipeline' stanza is required"))
-		} else if stepRaw.Use != nil && stepRaw.PipelineRaw != nil {
+		} else if step.Use != nil && step.Pipeline != nil {
 			result = multierror.Append(result, fmt.Errorf(
 				"step stage with both a 'use' stanza and pipeline stanza is not valid"))
-		} else if stepRaw.PipelineRaw == nil && (stepRaw.Use == nil || stepRaw.Use.Type == "") {
+		} else if step.Pipeline == nil && (step.Use == nil || step.Use.Type == "") {
 			result = multierror.Append(result, fmt.Errorf(
 				"step stage %q is required to define a 'use' stanza and label or a "+
-					"pipeline stanza but neither were found", stepRaw.Name))
+					"pipeline stanza but neither were found", step.Name))
 		}
 
 		// else, other step validations?

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -152,8 +152,9 @@ func NewProject(ctx context.Context, os ...Option) (*Project, error) {
 
 	// configure pipelines for project and its apps
 	for _, name := range opts.Config.Pipelines() {
+		// Set input variables for pipelines and steps in context
 		evalCtx := config.EvalContext(nil, p.dir.DataDir()).NewChild()
-		// TODO: Add variables
+		config.AddVariables(evalCtx, p.variables)
 
 		pipelineConfig, err := opts.Config.Pipeline(name, evalCtx)
 		if err != nil {


### PR DESCRIPTION
This pull request introduces input variables being evaluated inside `pipeline {}` stanzas. It ends up rearranging how we parse pipelines and steps to support the lazy-decoding that Waypoint does to evaluate and resolve variables later in the parsing process.

It also had to modify how `waypoint init` does its initial sync of pipeline definitions. Now instead we do a "shallow sync" of the pipeline name, owner, and a base step. This mirrors how we sync applications on `waypoint init` in that we don't sync the entire parsed hcl config, only the app name on init.

Fixes #4122