### PR TITLE
cli/pipeline_run: Include variables in job template for pipeline run

### DIFF
--- a/.changelog/4137.txt
+++ b/.changelog/4137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix bug where input variables were not included on pipeline run jobs.
+```

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -99,6 +99,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			Application:  app.Ref(),
 			Workspace:    c.project.WorkspaceRef(),
 			TargetRunner: &pb.Ref_Runner{Target: &pb.Ref_Runner_Any{}},
+			Variables:    c.variables,
 		}
 
 		// build the base api request


### PR DESCRIPTION
Prior to this commit, when a pipeline was run, the CLI variables from the job client were not included in the submitted job template that the CLI would send to the server to run pipeline jobs. This means any CLI variables would not be properly resolved when the job went to execute. This commit fixes that by including those variables in the job template.

Fixes #4134