### PR TITLE
UI/hide sensitive variables

### DIFF
--- a/.changelog/4139.txt
+++ b/.changelog/4139.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui/input-variables: Adds the ability to set an input variable as sensitive and hides its value from the list and form
+```

--- a/ui/app/components/project-input-variables/list-item.hbs
+++ b/ui/app/components/project-input-variables/list-item.hbs
@@ -13,6 +13,7 @@
             <Pds::Input
               @type='text'
               data-test-input-variables-var-name
+              required
               id='input-variable-name'
               placeholder={{t 'form.project_variables_settings.variable_name_placeholder'}}
               value={{this.variable.name}}
@@ -28,6 +29,7 @@
                 <Pds::Input
                   @type='text'
                   data-test-input-variables-var-hcl
+                  required
                   id='input-variable-value'
                   placeholder={{if
                     this.writeOnly
@@ -42,6 +44,7 @@
                   @type='text'
                   id='input-variable-value'
                   data-test-input-variables-var-str
+                  required
                   placeholder={{if
                     this.writeOnly
                     (t 'form.project_variables_settings.variable_form_placeholder_sensitive')

--- a/ui/app/components/project-input-variables/list-item.hbs
+++ b/ui/app/components/project-input-variables/list-item.hbs
@@ -1,112 +1,112 @@
 <li data-test-input-variables-list-item>
   {{#if (or this.isEditing this.isCreating)}}
-    <form class='pds-form' data-test-input-variables-form {{on 'submit' this.saveVariable}}>
-      <div part='fields' class='card'>
-        <div class='card-header'>
-          <h4>{{t 'form.project_variables_settings.title'}}</h4>
+    <form class="pds-form" data-test-input-variables-form {{on "submit" this.saveVariable}}>
+      <div part="fields" class="card">
+        <div class="card-header">
+          <h4>{{t "form.project_variables_settings.title"}}</h4>
         </div>
-        <fieldset class='pds-formFieldSet'>
-          <div class='pds-formField'>
-            <label for='input-variable-name' class='pds-fieldName'>
-              {{t 'form.project_variables_settings.variable_name'}}
+        <fieldset class="pds-formFieldSet">
+          <div class="pds-formField">
+            <label for="input-variable-name" class="pds-fieldName">
+              {{t "form.project_variables_settings.variable_name"}}
             </label>
             <Pds::Input
-              @type='text'
+              @type="text"
               data-test-input-variables-var-name
               required
-              id='input-variable-name'
-              placeholder={{t 'form.project_variables_settings.variable_name_placeholder'}}
+              id="input-variable-name"
+              placeholder={{t "form.project_variables_settings.variable_name_placeholder"}}
               value={{this.variable.name}}
-              {{on 'input' (pick 'target.value' (set this 'variable.name'))}}
+              {{on "input" (pick "target.value" (set this "variable.name"))}}
             />
           </div>
-          <div class='pds-formField'>
-            <label for='input-variable-value' class='pds-fieldName'>
-              {{t 'form.project_variables_settings.variable_value'}}
+          <div class="pds-formField">
+            <label for="input-variable-value" class="pds-fieldName">
+              {{t "form.project_variables_settings.variable_value"}}
             </label>
-            <div class='pds-formField__input-inline-toggle'>
+            <div class="pds-formField__input-inline-toggle">
               {{#if this.isHcl}}
                 <Pds::Input
-                  @type='text'
+                  @type="text"
                   data-test-input-variables-var-hcl
                   required
-                  id='input-variable-value'
+                  id="input-variable-value"
                   placeholder={{if
                     this.writeOnly
-                    (t 'form.project_variables_settings.variable_value_placeholder_sensitive')
-                    (t 'form.project_variables_settings.variable_value_placeholder')
+                    (t "form.project_variables_settings.variable_value_placeholder_sensitive")
+                    (t "form.project_variables_settings.variable_value_placeholder")
                   }}
-                  value={{if this.writeOnly '' this.variable.hcl}}
-                  {{on 'input' (pick 'target.value' (set this 'variable.hcl'))}}
+                  value={{if this.writeOnly "" this.variable.hcl}}
+                  {{on "input" (pick "target.value" (set this "variable.hcl"))}}
                 />
               {{else}}
                 <Pds::Input
-                  @type='text'
-                  id='input-variable-value'
+                  @type="text"
+                  id="input-variable-value"
                   data-test-input-variables-var-str
                   required
                   placeholder={{if
                     this.writeOnly
-                    (t 'form.project_variables_settings.variable_form_placeholder_sensitive')
-                    (t 'form.project_variables_settings.variable_value_placeholder')
+                    (t "form.project_variables_settings.variable_form_placeholder_sensitive")
+                    (t "form.project_variables_settings.variable_value_placeholder")
                   }}
-                  value={{if this.writeOnly '' this.variable.str}}
-                  {{on 'input' (pick 'target.value' (set this 'variable.str'))}}
+                  value={{if this.writeOnly "" this.variable.str}}
+                  {{on "input" (pick "target.value" (set this "variable.str"))}}
                 />
               {{/if}}
-              <span class='pds-input-inline-toggle'>
+              <span class="pds-input-inline-toggle">
                 <input
-                  type='checkbox'
+                  type="checkbox"
                   data-test-input-variables-toggle-hcl
-                  id='input-variable-hcl'
+                  id="input-variable-hcl"
                   checked={{this.isHcl}}
-                  {{on 'change' (fn this.toggleHcl this.variable)}}
+                  {{on "change" (fn this.toggleHcl this.variable)}}
                 />
-                <label for='input-variable-hcl'>HCL</label>
+                <label for="input-variable-hcl">HCL</label>
               </span>
             </div>
-            <div class='pds-formField__input-inline-toggle'>
+            <div class="pds-formField__input-inline-toggle">
               <Hds::Form::Toggle::Field
                 data-test-input-variables-toggle-sensitive
                 checked={{this.isSensitive}}
-                {{on 'change' (fn this.toggleSensitive this.variable)}}
+                {{on "change" (fn this.toggleSensitive this.variable)}}
                 as |F|
               >
                 <F.Label>
-                  {{t 'form.project_variables_settings.variable_set_sensitive'}}
+                  {{t "form.project_variables_settings.variable_set_sensitive"}}
                 </F.Label>
               </Hds::Form::Toggle::Field>
             </div>
           </div>
         </fieldset>
-        <div class='card-footer'>
+        <div class="card-footer">
           <Pds::ButtonSet>
-            <Pds::Button data-test-input-variables-edit-save @variant='primary' @type='submit'>
-              {{t 'form.project_variables_settings.button_submit'}}
+            <Pds::Button data-test-input-variables-edit-save @variant="primary" @type="submit">
+              {{t "form.project_variables_settings.button_submit"}}
             </Pds::Button>
             <Pds::Button
               data-test-input-variables-edit-cancel
-              @variant='secondary'
-              {{on 'click' (if this.isCreating this.cancelCreate this.cancelEdit)}}
+              @variant="secondary"
+              {{on "click" (if this.isCreating this.cancelCreate this.cancelEdit)}}
             >
-              {{t 'form.project_variables_settings.button_cancel'}}
+              {{t "form.project_variables_settings.button_cancel"}}
             </Pds::Button>
           </Pds::ButtonSet>
         </div>
       </div>
     </form>
   {{else}}
-    <div class='variables--list-item'>
-      <span class='variables--list-item-name' data-test-input-variables-var-name>{{this.variable.name}}</span>
-      <span class='variables--list-item-value' data-test-input-variables-var-value>
+    <div class="variables--list-item">
+      <span class="variables--list-item-name" data-test-input-variables-var-name>{{this.variable.name}}</span>
+      <span class="variables--list-item-value" data-test-input-variables-var-value>
         {{#if this.isSensitive}}
           <Hds::Badge
             data-test-sensitive-var-badge
-            @icon='eye-off'
-            @text={{t 'form.project_variables_settings.variable_value_placeholder_sensitive'}}
+            @icon="eye-off"
+            @text={{t "form.project_variables_settings.variable_value_placeholder_sensitive"}}
           />
         {{else if this.isHcl}}
-          <b class='badge' data-test-input-variables-list-item-is-hcl>
+          <b class="badge" data-test-input-variables-list-item-is-hcl>
             HCL
           </b>
           {{this.variable.hcl}}
@@ -114,23 +114,23 @@
           {{this.variable.str}}
         {{/if}}
       </span>
-      <Pds::Dropdown @align='right' as |D|>
-        <D.Trigger data-test-input-variables-dropdown @variant='ghost'>
+      <Pds::Dropdown @align="right" as |D|>
+        <D.Trigger data-test-input-variables-dropdown @variant="ghost">
           Actions
         </D.Trigger>
         <D.Dialog>
           <section>
             <Pds::Button
               data-test-input-variables-dropdown-edit
-              @variant='secondary'
-              {{on 'click' (fn this.editVariable this.variable)}}
+              @variant="secondary"
+              {{on "click" (fn this.editVariable this.variable)}}
             >
               Edit
             </Pds::Button>
             <Pds::Button
               data-test-input-variables-dropdown-delete
-              @variant='warning'
-              {{on 'click' (fn this.deleteVariable this.variable)}}
+              @variant="warning"
+              {{on "click" (fn this.deleteVariable this.variable)}}
             >
               Delete
             </Pds::Button>

--- a/ui/app/components/project-input-variables/list-item.hbs
+++ b/ui/app/components/project-input-variables/list-item.hbs
@@ -1,86 +1,109 @@
 <li data-test-input-variables-list-item>
   {{#if (or this.isEditing this.isCreating)}}
-    <form class="pds-form" data-test-input-variables-form {{on "submit" this.saveVariable}}>
-      <div part="fields" class="card">
-        <div class="card-header">
-          <h4>{{t "form.project_variables_settings.title"}}</h4>
+    <form class='pds-form' data-test-input-variables-form {{on 'submit' this.saveVariable}}>
+      <div part='fields' class='card'>
+        <div class='card-header'>
+          <h4>{{t 'form.project_variables_settings.title'}}</h4>
         </div>
-        <fieldset class="pds-formFieldSet">
-          <div class="pds-formField">
-            <label for="input-variable-name" class="pds-fieldName">
-              {{t "form.project_variables_settings.variable_name"}}
+        <fieldset class='pds-formFieldSet'>
+          <div class='pds-formField'>
+            <label for='input-variable-name' class='pds-fieldName'>
+              {{t 'form.project_variables_settings.variable_name'}}
             </label>
             <Pds::Input
-              @type="text"
+              @type='text'
               data-test-input-variables-var-name
-              id="input-variable-name"
-              placeholder={{t "form.project_variables_settings.variable_name_placeholder"}}
+              id='input-variable-name'
+              placeholder={{t 'form.project_variables_settings.variable_name_placeholder'}}
               value={{this.variable.name}}
-              {{on "input" (pick "target.value" (set this "variable.name"))}}
+              {{on 'input' (pick 'target.value' (set this 'variable.name'))}}
             />
           </div>
-          <div class="pds-formField">
-            <label for="input-variable-value" class="pds-fieldName">
-              {{t "form.project_variables_settings.variable_value"}}
+          <div class='pds-formField'>
+            <label for='input-variable-value' class='pds-fieldName'>
+              {{t 'form.project_variables_settings.variable_value'}}
             </label>
-            <div class="pds-formField__input-inline-toggle">
+            <div class='pds-formField__input-inline-toggle'>
               {{#if this.isHcl}}
                 <Pds::Input
-                  @type="text"
+                  @type='text'
                   data-test-input-variables-var-hcl
-                  id="input-variable-value"
-                  placeholder={{t "form.project_variables_settings.variable_value_placeholder"}}
-                  value={{this.variable.hcl}}
-                  {{on "input" (pick "target.value" (set this "variable.hcl"))}}
+                  id='input-variable-value'
+                  placeholder={{if
+                    this.writeOnly
+                    (t 'form.project_variables_settings.variable_value_placeholder_sensitive')
+                    (t 'form.project_variables_settings.variable_value_placeholder')
+                  }}
+                  value={{if this.writeOnly '' this.variable.hcl}}
+                  {{on 'input' (pick 'target.value' (set this 'variable.hcl'))}}
                 />
               {{else}}
                 <Pds::Input
-                  @type="text"
-                  id="input-variable-value"
+                  @type='text'
+                  id='input-variable-value'
                   data-test-input-variables-var-str
-                  placeholder={{t "form.project_variables_settings.variable_value_placeholder"}}
-                  value={{this.variable.str}}
-                  {{on "input" (pick "target.value" (set this "variable.str"))}}
+                  placeholder={{if
+                    this.writeOnly
+                    (t 'form.project_variables_settings.variable_form_placeholder_sensitive')
+                    (t 'form.project_variables_settings.variable_value_placeholder')
+                  }}
+                  value={{if this.writeOnly '' this.variable.str}}
+                  {{on 'input' (pick 'target.value' (set this 'variable.str'))}}
                 />
               {{/if}}
-              <span class="pds-input-inline-toggle">
+              <span class='pds-input-inline-toggle'>
                 <input
-                  type="checkbox"
+                  type='checkbox'
                   data-test-input-variables-toggle-hcl
-                  id="input-variable-hcl"
+                  id='input-variable-hcl'
                   checked={{this.isHcl}}
-                  {{on "change" (fn this.toggleHcl this.variable)}}>
-                  <label for="input-variable-hcl">HCL</label>
+                  {{on 'change' (fn this.toggleHcl this.variable)}}
+                />
+                <label for='input-variable-hcl'>HCL</label>
               </span>
+            </div>
+            <div class='pds-formField__input-inline-toggle'>
+              <Hds::Form::Toggle::Field
+                data-test-input-variables-toggle-sensitive
+                checked={{this.isSensitive}}
+                {{on 'change' (fn this.toggleSensitive this.variable)}}
+                as |F|
+              >
+                <F.Label>
+                  {{t 'form.project_variables_settings.variable_set_sensitive'}}
+                </F.Label>
+              </Hds::Form::Toggle::Field>
             </div>
           </div>
         </fieldset>
-        <div class="card-footer">
+        <div class='card-footer'>
           <Pds::ButtonSet>
-            <Pds::Button
-              data-test-input-variables-edit-save
-              @variant="primary"
-              @type="submit">
-              {{t "form.project_variables_settings.button_submit"}}
+            <Pds::Button data-test-input-variables-edit-save @variant='primary' @type='submit'>
+              {{t 'form.project_variables_settings.button_submit'}}
             </Pds::Button>
             <Pds::Button
               data-test-input-variables-edit-cancel
-              @variant="secondary"
-              {{on "click"
-                (if this.isCreating this.cancelCreate this.cancelEdit)
-              }}>
-              {{t "form.project_variables_settings.button_cancel"}}
+              @variant='secondary'
+              {{on 'click' (if this.isCreating this.cancelCreate this.cancelEdit)}}
+            >
+              {{t 'form.project_variables_settings.button_cancel'}}
             </Pds::Button>
           </Pds::ButtonSet>
         </div>
       </div>
     </form>
   {{else}}
-    <div class="variables--list-item">
-      <span class="variables--list-item-name" data-test-input-variables-var-name>{{this.variable.name}}</span>
-      <span class="variables--list-item-value" data-test-input-variables-var-value>
-        {{#if this.isHcl}}
-          <b class="badge" data-test-input-variables-list-item-is-hcl>
+    <div class='variables--list-item'>
+      <span class='variables--list-item-name' data-test-input-variables-var-name>{{this.variable.name}}</span>
+      <span class='variables--list-item-value' data-test-input-variables-var-value>
+        {{#if this.isSensitive}}
+          <Hds::Badge
+            data-test-sensitive-var-badge
+            @icon='eye-off'
+            @text={{t 'form.project_variables_settings.variable_value_placeholder_sensitive'}}
+          />
+        {{else if this.isHcl}}
+          <b class='badge' data-test-input-variables-list-item-is-hcl>
             HCL
           </b>
           {{this.variable.hcl}}
@@ -88,24 +111,24 @@
           {{this.variable.str}}
         {{/if}}
       </span>
-      <Pds::Dropdown @align="right" as |D|>
-        <D.Trigger
-          data-test-input-variables-dropdown
-          @variant="ghost">
+      <Pds::Dropdown @align='right' as |D|>
+        <D.Trigger data-test-input-variables-dropdown @variant='ghost'>
           Actions
         </D.Trigger>
-        <D.Dialog >
+        <D.Dialog>
           <section>
             <Pds::Button
               data-test-input-variables-dropdown-edit
-              @variant="secondary"
-              {{on "click" (fn this.editVariable this.variable)}}>
+              @variant='secondary'
+              {{on 'click' (fn this.editVariable this.variable)}}
+            >
               Edit
             </Pds::Button>
             <Pds::Button
               data-test-input-variables-dropdown-delete
-              @variant="warning"
-              {{on "click" (fn this.deleteVariable this.variable)}}>
+              @variant='warning'
+              {{on 'click' (fn this.deleteVariable this.variable)}}
+            >
               Delete
             </Pds::Button>
           </section>

--- a/ui/app/components/project-input-variables/list-item.ts
+++ b/ui/app/components/project-input-variables/list-item.ts
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { Project, Variable } from 'waypoint-pb';
 import { inject as service } from '@ember/service';
-import ApiService from 'waypoint/services/api';
 
 interface VariableArgs {
   variable: Variable.AsObject;
@@ -17,13 +16,13 @@ interface VariableArgs {
 }
 
 export default class ProjectInputVariablesListItemComponent extends Component<VariableArgs> {
-  @service api!: ApiService;
   @service('pdsFlashMessages') flashMessages;
 
   initialVariable: Variable.AsObject;
   @tracked variable: Variable.AsObject;
   @tracked isCreating: boolean;
   @tracked isEditing: boolean;
+  @tracked writeOnly: boolean;
 
   constructor(owner: unknown, args: VariableArgs) {
     super(owner, args);
@@ -31,6 +30,7 @@ export default class ProjectInputVariablesListItemComponent extends Component<Va
     this.variable = variable;
     this.isEditing = isEditing;
     this.isCreating = isCreating;
+    this.writeOnly = false;
     this.initialVariable = JSON.parse(JSON.stringify(this.variable));
   }
 
@@ -38,8 +38,13 @@ export default class ProjectInputVariablesListItemComponent extends Component<Va
     return !!this.variable.hcl;
   }
 
+  get isSensitive(): boolean {
+    return !!this.variable.sensitive;
+  }
+
   storeInitialVariable(): void {
     this.initialVariable = JSON.parse(JSON.stringify(this.variable));
+    this.writeOnly = this.variable.sensitive ? true : false;
   }
 
   @action
@@ -98,5 +103,10 @@ export default class ProjectInputVariablesListItemComponent extends Component<Va
       this.variable.hcl = variable.str;
       this.variable.str = '';
     }
+  }
+
+  @action
+  toggleSensitive(variable: Variable.AsObject): void {
+    this.variable.sensitive = !variable.sensitive;
   }
 }

--- a/ui/app/services/api.ts
+++ b/ui/app/services/api.ts
@@ -230,6 +230,7 @@ export default class ApiService extends Service {
       } else {
         variable.setStr(v.str);
       }
+      variable.setSensitive(v.sensitive);
       return variable;
     });
     return varProtosList;

--- a/ui/mirage/factories/project.ts
+++ b/ui/mirage/factories/project.ts
@@ -20,6 +20,7 @@ export default Factory.extend({
     afterCreate(project, server) {
       server.createList('variable', 2, 'random-str', { project });
       server.create('variable', 'random-hcl', { project });
+      server.create('variable', 'is-sensitive', { project });
     },
   }),
 

--- a/ui/mirage/factories/variable.ts
+++ b/ui/mirage/factories/variable.ts
@@ -10,4 +10,9 @@ export default Factory.extend({
     name: () => faker.hacker.noun(),
     hcl: () => faker.hacker.adjective(),
   }),
+  'is-sensitive': trait({
+    name: () => faker.hacker.noun(),
+    str: () => faker.hacker.adjective(),
+    sensitive: true,
+  }),
 });

--- a/ui/mirage/models/variable.ts
+++ b/ui/mirage/models/variable.ts
@@ -9,6 +9,7 @@ export default Model.extend({
 
     result.setServer();
     result.setName(this.name);
+    result.setSensitive(this.sensitive);
     if (this.hcl) {
       result.setStr('');
       result.setHcl(this.hcl);

--- a/ui/tests/integration/components/project-input-variables-list-test.ts
+++ b/ui/tests/integration/components/project-input-variables-list-test.ts
@@ -103,4 +103,29 @@ module('Integration | Component | project-input-variables-list', function (hooks
       'the updated variable value is correct'
     );
   });
+
+  test('sensitive variables are hidden in list', async function (assert) {
+    let dbproj = await this.server.create('project', { name: 'Proj3' });
+    this.server.create('variable', 'is-sensitive', { project: dbproj });
+    let project = dbproj.toProtobuf();
+    this.set('project', project.toObject());
+
+    await render(hbs`<ProjectInputVariables::List @project={{this.project}}/>`);
+
+    assert.dom('[data-test-sensitive-var-badge]').exists();
+  });
+
+  test('sensitive variables are hidden in forms', async function (assert) {
+    let dbproj = await this.server.create('project', { name: 'Proj3' });
+    this.server.create('variable', 'is-sensitive', { project: dbproj });
+    let project = dbproj.toProtobuf();
+    this.set('project', project.toObject());
+
+    await render(hbs`<ProjectInputVariables::List @project={{this.project}}/>`);
+
+    await page.variablesList.objectAt(0).dropdown();
+    await page.variablesList.objectAt(0).dropdownEdit();
+
+    assert.dom('[data-test-input-variables-var-str]').hasAttribute('placeholder', 'sensitive - write only');
+  });
 });

--- a/ui/tests/integration/components/project-input-variables-list-test.ts
+++ b/ui/tests/integration/components/project-input-variables-list-test.ts
@@ -39,7 +39,7 @@ module('Integration | Component | project-input-variables-list', function (hooks
 
     await render(hbs`<ProjectInputVariables::List @project={{this.project}}/>`);
     assert.dom('.variables-list').exists('The list renders');
-    assert.equal(page.variablesList.length, 3, 'the list contains all variables');
+    assert.equal(page.variablesList.length, 4, 'the list contains all variables');
     assert.notOk(page.variablesList.objectAt(0).isHcl, 'the list contains a string variable');
     assert.ok(page.variablesList.objectAt(2).isHcl, 'the list contains a hcl variable');
   });
@@ -51,23 +51,23 @@ module('Integration | Component | project-input-variables-list', function (hooks
 
     await render(hbs`<ProjectInputVariables::List @project={{this.project}}/>`);
     assert.dom('.variables-list').exists('The list renders');
-    assert.equal(page.variablesList.length, 3, 'the list contains all variables');
+    assert.equal(page.variablesList.length, 4, 'the list contains all variables');
     await page.createButton();
     assert.ok(page.hasForm, 'Attempt to create: the form appears when the Add Variable button is clicked');
     await page.cancelButton();
     assert.equal(
       page.variablesList.length,
-      3,
+      4,
       'Attempt to create: the list still has the normal count of variables after cancelling'
     );
     await page.createButton();
     await page.varName('var_name');
     await page.varStr('foozbarz');
     await page.saveButton();
-    assert.equal(page.variablesList.length, 4, 'Create Variable: the list has the new variable');
+    assert.equal(page.variablesList.length, 5, 'Create Variable: the list has the new variable');
     await page.variablesList.objectAt(0).dropdown();
     await page.variablesList.objectAt(0).dropdownDelete();
-    assert.equal(page.variablesList.length, 3, 'Delete Variable: the variable has been removed');
+    assert.equal(page.variablesList.length, 4, 'Delete Variable: the variable has been removed');
   });
 
   test('editing variables works', async function (assert) {

--- a/ui/translations/en-us.yaml
+++ b/ui/translations/en-us.yaml
@@ -150,6 +150,9 @@ form:
     variable_name_placeholder: 'var_key'
     variable_value: 'Value'
     variable_value_placeholder: 'var_value'
+    variable_set_sensitive: Set as sensitive
+    variable_value_placeholder_sensitive: 'Sensitive - write only'
+    variable_form_placeholder_sensitive: 'sensitive - write only'
     button_submit: 'Save variable'
     button_cancel: 'Cancel'
   config_variables_settings:
@@ -315,7 +318,7 @@ image-ref:
 workspace-switcher:
   error: Failed to load workspaces
 
-runner-alert: 
+runner-alert:
   title: Remote runner required
   description: In order to connect to a repository, you must install a remote runner first.
   link: Waypoint Runners documentation


### PR DESCRIPTION
Closes [#2138](https://github.com/hashicorp/waypoint/issues/2138)

### Purpose of change

This PR adds a toggle switch on the input variables create/edit form for making an input "sensitive". If the input is set as such, in the list, there will be a badge in place of the displayed which says `Sensitive - write only`. If the user edits the variable, the value will be hidden and only the placeholder text `sensitive - write only` will be visible in the text input. The user will be unable to toggle off the sensitive switch and see the variable. If they toggle sensitive off, they will need to provide a new value in the input. This behavior matches HCP.  Please note this does not obscure the value from network requests.

Two component tests have been added.

### Demo

https://user-images.githubusercontent.com/17822084/199099172-c37d2fc6-0aed-435c-b41e-ca4e3ead4fef.mov

### To test the change

1. Navigate to a project
2. Click Manage
3. Click input variables
4. Create input variable and mark it "sensitive"
5. See that the variable value is hidden in the list
6. Edit the variable and see that the value is hidden in the form


