### PR TITLE
Add operation flags to `config sync` command

### DIFF
--- a/.changelog/4143.txt
+++ b/.changelog/4143.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli/config-sync: Add operations flags to `config sync` command.
+```

--- a/internal/cli/config_sync.go
+++ b/internal/cli/config_sync.go
@@ -75,7 +75,7 @@ func (c *ConfigSyncCommand) Run(args []string) int {
 }
 
 func (c *ConfigSyncCommand) Flags() *flag.Sets {
-	return c.flagSet(0, nil)
+	return c.flagSet(flagSetOperation, nil)
 }
 
 func (c *ConfigSyncCommand) AutocompleteArgs() complete.Predictor {

--- a/website/content/commands/config-sync.mdx
+++ b/website/content/commands/config-sync.mdx
@@ -31,4 +31,14 @@ be deleted.
 - `-project=<string>` (`-p`) - Project to target.
 - `-workspace=<string>` (`-w`) - Workspace to operate in.
 
+#### Operation Options
+
+- `-label=<key=value>` - Labels to set for this operation. Can be specified multiple times.
+- `-local` - True to use a local runner to execute the operation, false to use a remote runner.
+  If unset, Waypoint will automatically determine where the operation will occur,
+  defaulting to remote if possible.
+- `-remote-source=<key=value>` - Override configurations for how remote runners source data. This is specified to the data source type being used in your configuration. This is used for example to set a specific Git ref to run against.
+- `-var=<key=value>` - Variable value to set for this operation. Can be specified multiple times.
+- `-var-file=<string>` - HCL or JSON file containing variable values to set for this operation. If any "_.auto.wpvars" or "_.auto.wpvars.json" files are present, they will be automatically loaded.
+
 @include "commands/config-sync_more.mdx"


### PR DESCRIPTION
This PR adds the set of operation flags (-local, for example) to the config sync command.

One benefit that is gained here is that in the (albeit unlikely) scenario that a user does not have Waypoint configured to launch on-demand runners, but they do have a static runner, `waypoint config sync -local=false` can be used to still sync dynamic configuration variables. Such behavior is not possible on a local runner.