### PR TITLE
datasource/git: Align git fields for UX

### DIFF
--- a/internal/datasource/git.go
+++ b/internal/datasource/git.go
@@ -599,7 +599,7 @@ func (s *GitSource) auth(
 	switch authcfg := source.Git.Auth.(type) {
 	case *pb.Job_Git_Basic_:
 		if ui != nil {
-			ui.Output("Auth: username/password", terminal.WithInfoStyle())
+			ui.Output("      Auth: username/password", terminal.WithInfoStyle())
 		}
 		return &http.BasicAuth{
 			Username: authcfg.Basic.Username,
@@ -614,7 +614,7 @@ func (s *GitSource) auth(
 		}
 
 		if ui != nil {
-			ui.Output("Auth: ssh", terminal.WithInfoStyle())
+			ui.Output("      Auth: ssh", terminal.WithInfoStyle())
 		}
 		auth, err := ssh.NewPublicKeys(
 			user,


### PR DESCRIPTION
This commit aligns the auth fields if used when displaying the git datasource information