### PR TITLE
Use CSI params on Nomad server install

### DIFF
--- a/.changelog/4157.txt
+++ b/.changelog/4157.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+install/nomad: Update installation with Nomad to use CSI parameters.
+```

--- a/internal/installutil/nomad/nomad.go
+++ b/internal/installutil/nomad/nomad.go
@@ -168,7 +168,7 @@ func CreatePersistentVolume(
 	client *api.Client,
 	id, name, csiPluginId, csiVolumeProvider, csiFS, csiExternalId string,
 	csiVolumeCapacityMin, csiVolumeCapacityMax int64,
-	csiTopologies, csiSecrets map[string]string,
+	csiTopologies, csiSecrets, csiParams map[string]string,
 ) error {
 	vol := api.CSIVolume{
 		ID:         id,
@@ -187,6 +187,7 @@ func CreatePersistentVolume(
 		RequestedCapacityMin: DefaultCSIVolumeCapacityMin,
 		RequestedCapacityMax: DefaultCSIVolumeCapacityMax,
 		PluginID:             csiPluginId,
+		Parameters:           csiParams,
 		Provider:             csiVolumeProvider,
 		RequestedTopologies: &api.CSITopologyRequest{
 			Required:  nil,

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -101,6 +101,7 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 			i.Config.CsiVolumeCapacityMax,
 			i.Config.CsiTopologies,
 			i.Config.CsiSecrets,
+			map[string]string{},
 		)
 		if err != nil {
 			return fmt.Errorf("error creating Nomad persistent volume: %s", clierrors.Humanize(err))

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -44,6 +44,7 @@ type NomadConfig struct {
 	CsiFS                string            `hcl:"csi_fs,optional"`
 	CsiTopologies        map[string]string `hcl:"nomad_csi_topologies,optional"`
 	CsiExternalId        string            `hcl:"nomad_csi_external_id,optional"`
+	CsiParams            map[string]string `hcl:"nomad_csi_params,optional"`
 	CsiPluginId          string            `hcl:"nomad_csi_plugin_id"`
 	CsiSecrets           map[string]string `hcl:"nomad_csi_secrets,optional"`
 	CsiVolume            string            `hcl:"nomad_csi_volume,optional"`
@@ -101,7 +102,7 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 			i.Config.CsiVolumeCapacityMax,
 			i.Config.CsiTopologies,
 			i.Config.CsiSecrets,
-			map[string]string{},
+			i.Config.CsiParams,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating Nomad persistent volume: %s", clierrors.Humanize(err))
@@ -279,6 +280,12 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.Config.CsiFS,
 		Usage:   "Nomad CSI volume mount option file system.",
 		Default: nomadutil.DefaultCSIVolumeMountFS,
+	})
+
+	set.StringMapVar(&flag.StringMapVar{
+		Name:   "nomad-csi-params",
+		Target: &i.Config.CsiParams,
+		Usage:  "Parameters passed directly to the CSI plugin to configure the volume.",
 	})
 
 	set.StringMapVar(&flag.StringMapVar{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -642,6 +642,7 @@ func (i *NomadInstaller) InstallRunner(
 			CsiFS:                 i.config.csiFS,
 			CsiTopologies:         i.config.csiTopologies,
 			CsiExternalId:         i.config.csiExternalId,
+			CsiParams:             i.config.csiParams,
 			CsiPluginId:           i.config.csiPluginId,
 			CsiSecrets:            i.config.csiSecrets,
 			CsiVolume:             i.config.runnerCsiVolume,

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -226,6 +226,7 @@ func (i *NomadInstaller) Install(
 			i.config.csiVolumeCapacityMax,
 			i.config.csiTopologies,
 			i.config.csiSecrets,
+			i.config.csiParams,
 		)
 		if err != nil {
 			return nil, "", status.Errorf(codes.Internal, "Failed creating Nomad persistent volume: %s", err)

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -89,6 +89,7 @@ the install, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
+- `-nomad-csi-params=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.
 - `-nomad-csi-secrets=<key=value>` - Credentials for publishing volume for Waypoint runner.


### PR DESCRIPTION
Fixes #4152. CSI Parameters were not being passed to the creation of the CSI volume for the server before this PR.

This PR also adds a flag to the Nomad runner install to set CSI parameters.