### PR TITLE
Manual tweak to "Cleanup docs about runners."

### DIFF
--- a/website/content/docs/runner/index.mdx
+++ b/website/content/docs/runner/index.mdx
@@ -35,7 +35,7 @@ uniquely configured environments.
 
 For that reason, Waypoint makes heavy usage of On-demand runners:
 
-### On-demand runners
+### On-Demand Runners
 
 While the static runner is capable of performing operations on its own, it also
 supports the ability to spawn on-demand runners for a given platform. These
@@ -44,14 +44,6 @@ They can perform container builds without any privileged access, offer more isol
 between operations, and allow Waypoint to scale further.
 
 On-demand runners: see [on-demand runners](/docs/runner/on-demand-runner) for more information.
-
-This diagram shows a CLI runner, as well as remote static and on-demand runners:
-
-<ImageConfig width={400}>
-
-  ![CLI and remote runners](/img/oss_cli_and_remote_runners@2x.jpg)
-
-</ImageConfig>
 
 ### Runner Architecture
 
@@ -74,6 +66,36 @@ either specify `-local` or do not have any runners registered on the server, the
 itself acts as a runner capable of performing your operation. If your deployment needs
 AWS credentials, or a valid kubectl context, it can access the credentials from the
 environment that is performing the CLI command.
+
+### Remote Runner
+
+Not every operation in Waypoint needs to happen in response to a CLI invocation
+from a privileged workstation. Waypoint can trigger deployments from the UI or
+automatically based on git changes, or automatically poll the status of
+applications in the background. In these cases, Waypoint needs a "remote
+runner", a long-lived runner that is always available to run these operations.
+
+Waypoint automatically installs a single remote runner by default when the Waypoint
+server is installed with [`waypoint install`](/commands/install).
+
+### On-demand runners
+
+While the remote runner is capable of performing operations on its own, it also
+supports plugins to spawn on-demand runners for a given platform. These
+on-demand runners are ephemeral container instances that perform one operation
+before exiting. These on-demand runners can perform container builds without
+any privileged access, offer more isolation between operations, and allow
+Waypoint to scale further.
+
+On-demand runners: see [on-demand runners](/docs/runner/on-demand-runner) for more information.
+
+This diagram shows a CLI runner, as well as remote static and on-demand runners:
+
+<ImageConfig width={400}>
+
+![CLI and remote runners](/img/oss_cli_and_remote_runners@2x.jpg)
+
+</ImageConfig>
 
 ## Runner Targeting
 

--- a/website/content/docs/runner/index.mdx
+++ b/website/content/docs/runner/index.mdx
@@ -51,7 +51,7 @@ This diagram shows the relationship between Waypoint and remote static and on-de
 
 <ImageConfig width={400}>
 
-  ![Runner architecture](/img/oss_runner_no_control_plane@2x.jpg)
+![Runner architecture](/img/oss_runner_no_control_plane@2x.jpg)
 
 </ImageConfig>
 


### PR DESCRIPTION
For merge into https://github.com/hashicorp/waypoint/pull/4162

- Manually made changes to merge main with stable-website
  - Some content was deleted in https://github.com/hashicorp/waypoint/pull/3875, but that deleted content was later edited. If merged, this change would add the content from 3875 to what's live on https://developer.hashicorp.com/waypoint/docs/runner.
  - I think it makes sense as-is, but let me know if you have feedback! We could also make another pass of this page in a separate PR if @evanphx prefers the deletion for clarity (wasn't sure why at first glance), following this cleanup of `main` / `stable-website`.
- Ran `make gen/website-mdx`