### PR TITLE
[website] Fix casing typo

### DIFF
--- a/website/content/docs/runner/index.mdx
+++ b/website/content/docs/runner/index.mdx
@@ -33,7 +33,7 @@ One issue with static runners is that they have fixed capacity: they can only ru
 many operations at a time. Additionally to run certain plugins like Docker, we need to have
 uniquely configured environments.
 
-For that reason, Waypoint makes heavy usage of On-demand runners:
+For that reason, Waypoint makes heavy usage of on-demand runners:
 
 ### On-Demand Runners
 


### PR DESCRIPTION
Saw in https://github.com/hashicorp/waypoint/pull/4163, but easier to do separately as should go to `main` and `stable-website`