### PR TITLE
ui: bump `ember-source` to 3.28.10

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -94,7 +94,7 @@
     "ember-router-service-refresh-polyfill": "^0.1.0",
     "ember-set-helper": "^2.0.0",
     "ember-simple-auth": "^4.2.2",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.10",
     "ember-svg-jar": "^2.3.4",
     "ember-template-lint": "^3.15.0",
     "ember-test-selectors": "^6.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7349,10 +7349,10 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.28.8:
-  version "3.28.8"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.8.tgz#c58fd4a1538d6c4b9aebe76c764cabf5396c64d9"
-  integrity sha512-hA15oYzbRdi9983HIemeVzzX2iLcMmSPp6akUiMQhFZYWPrKksbPyLrO6YpZ4hNM8yBjQSDXEkZ1V3yxBRKjUA==
+ember-source@~3.28.10:
+  version "3.28.10"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.10.tgz#f4be7e2852d421a558f686505748f4c88f6d6ae6"
+  integrity sha512-TH8ug2rRUq6pLwqjciwvnuF8GDKBXNW2v5mvDkkf+k5S84XVHPjn3K0q2uGaR2W/mCDYg+mGmqu/PIGy0STx9Q==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"


### PR DESCRIPTION
Addresses just-announced prototype pollution CVE:
https://blog.emberjs.com/ember-4-8-1-released/