### PR TITLE
Update bootstrap runner profile OCI URL during upgrade

### DIFF
--- a/.changelog/4175.txt
+++ b/.changelog/4175.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/upgrade: Update the OCI URL for the bootstrap runner profile during `server upgrade`
+```

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -377,7 +377,7 @@ func (c *InstallCommand) Run(args []string) int {
 			existingODRConfigSetup = true
 		}
 		// we pass nil for the ODR config because it's a fresh install
-		if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil, existingODRConfigSetup); code > 0 {
+		if code := installRunner(c.Ctx, log, client, c.ui, p, advertiseAddr, nil, existingODRConfigSetup, false); code > 0 {
 			return code
 		}
 	}
@@ -502,8 +502,7 @@ Alias: waypoint install
 //
 // This returns an exit code. If it is 0 it is success. Any other value is an
 // error. The function itself handles outputting error messages to the terminal.
-func installRunner(
-	ctx context.Context,
+func installRunner(ctx context.Context,
 	log hclog.Logger,
 	client pb.WaypointClient,
 	ui terminal.UI,
@@ -511,6 +510,7 @@ func installRunner(
 	advertiseAddr *pb.ServerConfig_AdvertiseAddr,
 	odrConfig *pb.OnDemandRunnerConfig,
 	existingODRConfigSetup bool,
+	isUpgrade bool,
 ) int {
 	sg := ui.StepGroup()
 	defer sg.Wait()
@@ -577,7 +577,7 @@ func installRunner(
 	// NOTE(briancain): Some installers like the Kubernetes Helm install already sets up a runner profile
 	// when the server is installed. For this reason, we shouldn't create another
 	// bootstrap runner profile.
-	if !existingODRConfigSetup {
+	if !existingODRConfigSetup || isUpgrade {
 		// If this installation platform supports an out-of-the-box ODR
 		// config then we set that up. This enables on-demand runners to
 		// work immediately.

--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -522,7 +522,7 @@ func (c *ServerUpgradeCommand) upgradeRunner(
 		// TODO(mitchellh): This creates a new auth token for the new runner.
 		// In the future, we need to invalidate the old token. We don't have
 		// the functionality to do this today.
-		return installRunner(ctx, installOpts.Log, client, c.ui, p, advertiseAddr, odr, true)
+		return installRunner(ctx, installOpts.Log, client, c.ui, p, advertiseAddr, odr, true, true)
 	}
 	return 0
 }


### PR DESCRIPTION
Prior to this PR, the various -odr-image flags for each platform on server upgrade were being ignored, so you'd end up with this:
```shell
% waypoint server upgrade -platform=docker -docker-server-image=waypoint:dev -docker-odr-image=waypoint-odr:dev
// successful upgrade

% waypoint runner profile list
Runner profiles
            NAME           | PLUGIN TYPE |            OCI URL            | TARGET RUNNER | DEFAULT  
---------------------------+-------------+-------------------------------+---------------+----------
  docker-bootstrap-profile | docker      | hashicorp/waypoint-odr:latest | *             | yes     
// the OCI URL did not change 
```

After this PR:
```shell
% waypoint server upgrade -platform=docker -docker-server-image=waypoint:dev -docker-odr-image=waypoint-odr:dev
// successful upgrade

% waypoint runner profile list
Runner profiles
            NAME           | PLUGIN TYPE |     OCI URL      | TARGET RUNNER | DEFAULT  
---------------------------+-------------+------------------+---------------+----------
  docker-bootstrap-profile | docker      | waypoint-odr:dev | *             | yes      
```