### PR TITLE
Fix pipeline `exec` steps run in Nomad

### DIFF
--- a/.changelog/4185.txt
+++ b/.changelog/4185.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+plugin/nomad: Update Nomad task launcher plugin to use `entrypoint` config - fixes
+pipeline exec steps run in Nomad.
+```

--- a/builtin/nomad/task.go
+++ b/builtin/nomad/task.go
@@ -263,9 +263,9 @@ func (p *TaskLauncher) StartTask(
 
 	// On-Demand runner specific configuration to start the task with
 	config := map[string]interface{}{
-		"image":   tli.OciUrl,
-		"args":    tli.Arguments,
-		"command": tli.Entrypoint,
+		"image":      tli.OciUrl,
+		"args":       tli.Arguments,
+		"entrypoint": tli.Entrypoint,
 	}
 
 	job.TaskGroups[0].Tasks[0].Config = config


### PR DESCRIPTION
Prior to this PR, the Nomad task launcher plugin previously set the[ "command" field](https://developer.hashicorp.com/nomad/docs/drivers/docker#command) for launching tasks. Before pipelines, this was fine for ODRs. However, pipelines pass a slice of string to the `TaskLaunchInfo` struct (from the Waypoint plugin SDK) for the Entrypoint field. The Nomad Docker driver's command field accepts only string, not slice of string. Therefore, any exec steps for pipelines run by Nomad ODRs would fail to start before this PR.

The entrypoint field of the Nomad Docker driver config does accept a slice of string, and that is the config now being set in the Nomad task launcher plugin.