### PR TITLE
Scoped config sources - CLI, runners, and entrypoint

### DIFF
--- a/.changelog/4196.txt
+++ b/.changelog/4196.txt
@@ -1,0 +1,3 @@
+```changelog:feature
+core: Enable configuration sources to be scoped globally, or by a project, app and workspace.
+```

--- a/internal/server/boltdbstate/config_source.go
+++ b/internal/server/boltdbstate/config_source.go
@@ -6,11 +6,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure/v2"
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/hashicorp/go-memdb"
 
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	serversort "github.com/hashicorp/waypoint/pkg/server/sort"

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -189,9 +189,10 @@ func (s *Service) EntrypointConfig(
 			// all down. In the future we may want to consider filtering this
 			// by only the types we actually need above.
 			sources, err := s.state(ctx).ConfigSourceGetWatch(ctx, &pb.GetConfigSourceRequest{
-				Scope: &pb.GetConfigSourceRequest_Global{
-					Global: &pb.Ref_Global{},
+				Scope: &pb.GetConfigSourceRequest_Application{
+					Application: deployment.Application,
 				},
+				Workspace: deployment.Workspace,
 			}, ws)
 			if err != nil {
 				return hcerr.Externalize(

--- a/website/content/commands/config-source-get.mdx
+++ b/website/content/commands/config-source-get.mdx
@@ -38,5 +38,6 @@ Configuration for this command is global. The "-app", "-project", and
 #### Command Options
 
 - `-type=<string>` - Dynamic source type to look up, such as 'vault'.
+- `-scope=<string>` - The scope for this configuration source. The configuration source will only appear within this scope. This can be one of 'global', 'project', or 'app'. The default is project.
 
 @include "commands/config-source-get_more.mdx"

--- a/website/content/commands/config-source-set.mdx
+++ b/website/content/commands/config-source-set.mdx
@@ -47,5 +47,6 @@ Configuration for this command is global. The "-app", "-project", and
 - `-type=<string>` - Dynamic source type to configure, such as 'vault'.
 - `-config=<key=value>` - Configuration for the dynamic source type. This may be repeated. The fields available are dependent on the dynamic source type, so please check the documentation for that specific type for more information.
 - `-delete` - Delete the configuration for this source type. If this is set then the -config flag is ignored. The default is false.
+- `-scope=<string>` - The scope for this configuration source. The configuration source will only appear within this scope. This can be one of 'global', 'project', or 'app'. The default is global.
 
 @include "commands/config-source-set_more.mdx"


### PR DESCRIPTION
This PR updates the CLI, runners, and the entrypoint to use the config source in the Waypoint database which most closely matches the input scope.