### PR TITLE
cli: Remove extra https in final output for app urls

### DIFF
--- a/.changelog/4208.txt
+++ b/.changelog/4208.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Remove extra `https` from deployment URL from pipeline run final output.
+```

--- a/.changelog/4208.txt
+++ b/.changelog/4208.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Remove extra `https` from deployment URL from pipeline run final output.
+cli: Ensure a deploy and release URL has a scheme included if not set.
 ```

--- a/internal/cli/deployment_create.go
+++ b/internal/cli/deployment_create.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/posener/complete"
@@ -132,6 +134,22 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 			result.Deployment.Generation.Id != "" &&
 			result.Deployment.Generation.InitialSequence != result.Deployment.Sequence
 
+		// Ensure deploy and release Urls have a scheme
+		du, err := url.Parse(deployUrl)
+		if err != nil && du.Scheme != "" {
+			return err
+		}
+		if du.Scheme == "" && deployUrl != "" {
+			deployUrl = fmt.Sprintf("https://%s", deployUrl)
+		}
+		ru, err := url.Parse(releaseUrl)
+		if err != nil && ru.Scheme != "" {
+			return err
+		}
+		if ru.Scheme == "" && releaseUrl != "" {
+			releaseUrl = fmt.Sprintf("https://%s", releaseUrl)
+		}
+
 		// Output
 		app.UI.Output("")
 		switch {
@@ -139,17 +157,17 @@ func (c *DeploymentCreateCommand) Run(args []string) int {
 			printInplaceInfo(inplace, app)
 			app.UI.Output("   Release URL: %s", releaseUrl, terminal.WithSuccessStyle())
 			if deployUrl != "" {
-				app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+				app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 			} else {
 				app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
 			}
 		case hostname != nil:
 			printInplaceInfo(inplace, app)
-			app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
-			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("           URL: %s", hostname.Fqdn, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 		case deployUrl != "":
 			printInplaceInfo(inplace, app)
-			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 		default:
 			app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
 		}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -303,17 +303,17 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			printInplaceInfo(inplaceDeploy, app)
 			app.UI.Output("   Release URL: %s", releaseUrl, terminal.WithSuccessStyle())
 			if deployUrl != "" {
-				app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+				app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 			} else {
 				app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
 			}
 		case hostname != nil:
 			printInplaceInfo(inplaceDeploy, app)
-			app.UI.Output("           URL: https://%s", hostname.Fqdn, terminal.WithSuccessStyle())
-			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("           URL: %s", hostname.Fqdn, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 		case deployUrl != "":
 			printInplaceInfo(inplaceDeploy, app)
-			app.UI.Output("Deployment URL: https://%s", deployUrl, terminal.WithSuccessStyle())
+			app.UI.Output("Deployment URL: %s", deployUrl, terminal.WithSuccessStyle())
 		default:
 			app.UI.Output(strings.TrimSpace(deployNoURL)+"\n", terminal.WithSuccessStyle())
 		}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/posener/complete"
@@ -294,6 +295,22 @@ func (c *PipelineRunCommand) Run(args []string) int {
 		})
 		if err == nil && len(hostnamesResp.Hostnames) > 0 {
 			hostname = hostnamesResp.Hostnames[0]
+		}
+
+		// Ensure deploy and release Urls have a scheme
+		du, err := url.Parse(deployUrl)
+		if err != nil && du.Scheme != "" {
+			return err
+		}
+		if du.Scheme == "" && deployUrl != "" {
+			deployUrl = fmt.Sprintf("https://%s", deployUrl)
+		}
+		ru, err := url.Parse(releaseUrl)
+		if err != nil && ru.Scheme != "" {
+			return err
+		}
+		if ru.Scheme == "" && releaseUrl != "" {
+			releaseUrl = fmt.Sprintf("https://%s", releaseUrl)
 		}
 
 		// Output app URL

--- a/internal/cli/release_create.go
+++ b/internal/cli/release_create.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -189,7 +190,16 @@ func (c *ReleaseCreateCommand) Run(args []string) int {
 			return nil
 		}
 
-		app.UI.Output("\nRelease URL: %s", result.Release.Url, terminal.WithSuccessStyle())
+		releaseUrl := result.Release.Url
+		ru, err := url.Parse(releaseUrl)
+		if err != nil && ru.Scheme != "" {
+			return err
+		}
+		if ru.Scheme == "" && releaseUrl != "" {
+			releaseUrl = fmt.Sprintf("https://%s", releaseUrl)
+		}
+
+		app.UI.Output("\nRelease URL: %s", releaseUrl, terminal.WithSuccessStyle())
 		return nil
 	})
 	if err != nil {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -77,6 +79,22 @@ func (c *UpCommand) Run(args []string) int {
 		inplace := result.Deploy.Deployment.Generation != nil &&
 			result.Deploy.Deployment.Generation.Id != "" &&
 			result.Deploy.Deployment.Generation.InitialSequence != result.Deploy.Deployment.Sequence
+
+		// Ensure deploy and release Urls have a scheme
+		du, err := url.Parse(deployUrl)
+		if err != nil && du.Scheme != "" {
+			return err
+		}
+		if du.Scheme == "" && deployUrl != "" {
+			deployUrl = fmt.Sprintf("https://%s", deployUrl)
+		}
+		ru, err := url.Parse(releaseUrl)
+		if err != nil && ru.Scheme != "" {
+			return err
+		}
+		if ru.Scheme == "" && releaseUrl != "" {
+			releaseUrl = fmt.Sprintf("https://%s", releaseUrl)
+		}
 
 		// Output
 		app.UI.Output("")


### PR DESCRIPTION
The deployUrl that comes in already will have https, so this removes the extra prepended https from the deployment url.

This matches how the Up CLI looks as well when it prints the deployment URL.