### PR TITLE
Use Case: Dynamic config w/Vault Dynamic secrets

### DIFF
--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -114,8 +114,7 @@ $ waypoint config source-set -type=vault -config=addr=http://127.0.0.1:8200 -con
 Configuration set for dynamic source "vault"!
 ```
 
-To double-check that the token and address are what is expected, `waypoint config
-source-get` can be run:
+To double-check that the token and address are what is expected, `waypoint config source-get` can be run:
 
 ```shell
 $ waypoint config source-get -type=vault
@@ -268,8 +267,8 @@ If a user deployed to Docker on their laptop for some local development testing,
 or an EKS cluster in AWS, as long as the application container can access the Vault
 cluster, the secrets necessary to run the application will be provided by Waypoint.
 
-
 ## Further Reading
+
 [Waypoint dynamic app configuration](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
 [Waypoint dynamic variables](https://developer.hashicorp.com/waypoint/docs/waypoint-hcl/variables/dynamic)
 [Vault config sourcer plugin docs](https://developer.hashicorp.com/waypoint/plugins/vault)

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -29,7 +29,7 @@ but in instances where Waypoint is used to deploy an app, it can be abstracted a
 by using Waypoint’s dynamic configuration integration with Vault, even when not
 deploying to my Nomad cluster. Let’s look into how this can be configured in Waypoint.
 
-My application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/dynamic-config-example/learn/dynamic-application-configuration)
+My application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/d83e0831c2751163dc88503249c6559e88a6d912/learn/dynamic-application-configuration)
 in the waypoint-examples GitHub repository, will eventually need read-only access
 from my Postgres database, and I want to provide dynamic credentials to access the
 data. To make this happen, I’ll create a role in a Postgres database with read-only

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -7,11 +7,9 @@ description: |-
 
 # Dynamic Secrets for Waypoint with Vault
 
-Hashicorp Waypoint is an application deployment platform that simplifies how users
-test and release apps onto platforms and utilize infrastructure managed by Terraform.
-After deploying your app, Waypoint can also be used to configure it! This can be
-done with static application configuration, where static environment variables
-or files can be applied to your running deployment. Alternatively, configuration
+When an app is deployed with Waypoint, its deployment can also be configured using Waypoint!
+This can be done with static application configuration, where static environment
+variables or files can be applied to your running deployment. Alternatively, configuration
 can be sourced dynamically from external sources, using a config sourcer plugin.
 
 The [HashiCorp Vault plugin for Waypoint](https://developer.hashicorp.com/waypoint/plugins/vault)
@@ -24,13 +22,12 @@ the security of your application, as any possibly leaked secrets would automatic
 expire after a pre-configured amount of time, among other things including that
 developers and operators don’t need to know secrets for their deployed applications.
 
-Prior to using Waypoint to deploy my Nomad jobs, I’ve relied on [Nomad’s integration
-with Vault](https://developer.hashicorp.com/nomad/docs/integrations/vault-integration)
-to template secrets to my applications. I still do make use of this integration,
-but in instances where I use Waypoint to deploy my app, I can abstract away that
-integration by using Waypoint’s dynamic configuration integration with Vault, even
-when I’m not deploying to my Nomad cluster. Let’s look into how I configured this
-in Waypoint.
+Prior to using Waypoint to deploy my Nomad jobs, Nomad users have relied on
+[Nomad’s integration with Vault](https://developer.hashicorp.com/nomad/docs/integrations/vault-integration)
+to template secrets to their applications. Users may still make use of this integration,
+but in instances where Waypoint is used to deploy an app, it can be abstracted away
+by using Waypoint’s dynamic configuration integration with Vault, even when not
+deploying to my Nomad cluster. Let’s look into how this can be configured in Waypoint.
 
 My application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/dynamic-config-example/learn/dynamic-application-configuration)
 in the waypoint-examples GitHub repository, will eventually need read-only access
@@ -46,8 +43,8 @@ $ psql -h <POSTGRES_IP> -p <POSTGRES_PORT> -U <POSTGRES_USER> -c "CREATE ROLE \"
 $ psql -h <POSTGRESIP> -p <POSTGRES_PORT> -U postgres -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"ro\";"
 ```
 
-I already have a Vault cluster up and running, and I’m going to enable and configure
-the database secrets engine, so that Vault can connect to my database and generate
+There is already a Vault cluster up and running, and a database secrets engine
+will be configured and enabled, so that Vault can connect to a database and generate
 credentials dynamically.
 
 ```shell
@@ -64,9 +61,9 @@ $ vault write database/config/postgresql \
 Success! Data written to: database/config/postgresql
 ```
 
-In my database secrets engine, I’ve configured a connection as well as a role in
-the secrets engine. With this, authorized entities in Vault will be able to generate
-dynamic credentials in the secrets engine.
+In the database secrets engine, a connection and role have been configured. With
+this, authorized entities in Vault will be able to generate dynamic credentials
+in the secrets engine.
 
 ```shell
 $ tee readonly.sql <<EOF
@@ -83,7 +80,7 @@ Success! Data written to: database/roles/readonly
 ```
 
 The final steps in Vault are to create a Vault policy, which will allow an entity
-to access the database secrets engine and generate a dynamic credential for our
+to access the database secrets engine and generate a dynamic credential for the
 database, and to create a token with this policy attached to it:
 
 ```shell
@@ -108,15 +105,17 @@ identity_policies    []
 policies             ["default" "waypoint"]
 ```
 
-Now that we have things configured in Vault, Waypoint needs to be configured to
-connect to Vault. A configuration source for the Vault plugin will be added like so:
+Now that Vault is configured to produce dynamic database credentials, Waypoint
+needs to be configured to connect to Vault. A configuration source for the Vault
+plugin will be added like so:
 
 ```shell
 $ waypoint config source-set -type=vault -config=addr=http://127.0.0.1:8200 -config=token=<VAULT_TOKEN>
 Configuration set for dynamic source "vault"!
 ```
 
-We can double-check that the token and address are what we expect as well:
+To double-check that the token and address are what is expected, `waypoint config
+source-get` can be run:
 
 ```shell
 $ waypoint config source-get -type=vault
@@ -126,9 +125,9 @@ $ waypoint config source-get -type=vault
   token | <VAULT_TOKEN>
 ```
 
-At this point, we aren’t actually using the config source yet, but we can get that
-ready by adding it to our waypoint.hcl file, and committing it to the git repository
-for the project.
+At this point, the config source isn't actually being used yet, but that can be
+made ready by adding it to our waypoint.hcl file, and committing it to the git
+repository for the project.
 
 ```hcl
 project = “waypoint-dynamic-config-vault”
@@ -218,17 +217,18 @@ variable "registry_password" {
 }
 ```
 
-In the configuration above, we’ve informed Waypoint that we want the Waypoint Entrypoint,
-which will wrap the entrypoint to the Docker container that the Pack plugin is
-building, to get a secret from Vault at the path `database/creds/my-role`. The
-values for the keys `username` and `password` at that secret path will be configured
+In the configuration above, Waypoint has been informed that it must get a secret
+from Vault at the path `database/creds/my-role`. To learn more about how Waypoint
+does this, see the [Waypoint Entrypoint docs](https://developer.hashicorp.com/waypoint/docs/entrypoint).
+
+The values for the keys `username` and `password` at the secret path will be configured
 as environment variables, `USERNAME` and `PASSWORD`, in the deployment of the app. We
 can confirm that the secret was successfully templated after running `waypoint up`,
 by checking the environment variables using `waypoint exec`, and checking the application
 logs using `waypoint logs`:
 
 ```shell
-// To run this operation, I exported my input variables to my environment, prefixed with “WP_VAR_”
+// To run this operation, input variables were exported to the environment, prefixed with “WP_VAR_”
 // The output below is abbreviated for brevity
 $ waypoint up
 ✓ Running build v2
@@ -261,9 +261,16 @@ $ waypoint logs
 ```
 
 With the application successfully deployed and configured with dynamic credentials,
-it can securely connect to the database, and we never needed to provide the app
+it can securely connect to the database, and no user ever needed to provide the app
 with an actual secret value. The Waypoint Entrypoint, built-in to the application image,
 can now dynamically source this Vault configuration wherever the app is deployed.
-If I deploy to Docker on my laptop for some local development testing, or my EKS
-cluster in AWS, as long as the application container can access the Vault cluster,
-the secrets necessary to run the application will be provided by Waypoint.
+If a user deployed to Docker on their laptop for some local development testing,
+or an EKS cluster in AWS, as long as the application container can access the Vault
+cluster, the secrets necessary to run the application will be provided by Waypoint.
+
+
+## Further Reading
+[Waypoint dynamic app configuration](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
+[Waypoint dynamic variables](https://developer.hashicorp.com/waypoint/docs/waypoint-hcl/variables/dynamic)
+[Vault config sourcer plugin docs](https://developer.hashicorp.com/waypoint/plugins/vault)
+[Vault dynamic database credentials tutorial](https://developer.hashicorp.com/vault/tutorials/db-credentials/database-secrets)

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -269,7 +269,7 @@ cluster, the secrets necessary to run the application will be provided by Waypoi
 
 ## Further Reading
 
-[Waypoint dynamic app configuration](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
-[Waypoint dynamic variables](https://developer.hashicorp.com/waypoint/docs/waypoint-hcl/variables/dynamic)
-[Vault config sourcer plugin docs](https://developer.hashicorp.com/waypoint/plugins/vault)
-[Vault dynamic database credentials tutorial](https://developer.hashicorp.com/vault/tutorials/db-credentials/database-secrets)
+- [Waypoint dynamic app configuration](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
+- [Waypoint dynamic variables](https://developer.hashicorp.com/waypoint/docs/waypoint-hcl/variables/dynamic)
+- [Vault config sourcer plugin docs](https://developer.hashicorp.com/waypoint/plugins/vault)
+- [Vault dynamic database credentials tutorial](https://developer.hashicorp.com/vault/tutorials/db-credentials/database-secrets)

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -1,0 +1,269 @@
+---
+layout: docs
+page_title: Dynamic App Config using Vault Dynamic Secrets
+description: |-
+  Waypoint enables you to source config dynamically from various external data sources using config sourcer plugins - this use case depicts doing just that with Vault dynamic database secrets.
+---
+
+# Dynamic Secrets for Waypoint with Vault
+
+Hashicorp Waypoint is an application deployment platform that simplifies how users
+test and release apps onto platforms and utilize infrastructure managed by Terraform.
+After deploying your app, Waypoint can also be used to configure it! This can be
+done with static application configuration, where static environment variables
+or files can be applied to your running deployment. Alternatively, configuration
+can be sourced dynamically from external sources, using a config sourcer plugin.
+
+The [Hashicorp Vault plugin for Waypoint](https://developer.hashicorp.com/waypoint/plugins/vault)
+is one of the [config sourcer plugins](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
+that is built-in to the Waypoint binary. This plugin can be used to source static
+values from the Vault KV secrets engine, but also for dynamic secrets! A [dynamic secret](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-dynamic-secrets)
+is one that is managed by Vault and has a lease associated with it, where
+the secret will expire after a set time to live (TTL). This is a huge benefit to
+the security of your application, as any possibly leaked secrets would automatically
+expire after a pre-configured amount of time, among other things including that
+developers and operators don’t need to know secrets for their deployed applications.
+
+Prior to using Waypoint to deploy my Nomad jobs, I’ve relied on [Nomad’s integration
+with Vault](https://developer.hashicorp.com/nomad/docs/integrations/vault-integration)
+to template secrets to my applications. I still do make use of this integration,
+but in instances where I use Waypoint to deploy my app, I can abstract away that
+integration by using Waypoint’s dynamic configuration integration with Vault, even
+when I’m not deploying to my Nomad cluster. Let’s look into how I configured this
+in Waypoint.
+
+My application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/dynamic-config-example/learn/dynamic-application-configuration)
+in the waypoint-examples GitHub repository, will eventually need read-only access
+from my Postgres database, and I want to provide dynamic credentials to access the
+data. To make this happen, I’ll create a role in a Postgres database with read-only
+access, using the psql command line tool. The IP, port, and user below should be
+filled in based on the configuration and environment in which your Postgres instance
+is running.
+
+```shell
+$ psql -h <POSTGRES_IP> -p <POSTGRES_PORT> -U <POSTGRES_USER> -c "CREATE ROLE \"ro\" NOINHERIT;"
+
+$ psql -h <POSTGRESIP> -p <POSTGRES_PORT> -U postgres -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"ro\";"
+```
+
+I already have a Vault cluster up and running, and I’m going to enable and configure
+the database secrets engine, so that Vault can connect to my database and generate
+credentials dynamically.
+
+```shell
+$ vault secrets enable database
+Success! Enabled the database secrets engine at: database/
+
+$ vault write database/config/postgresql \
+  plugin_name=postgresql-database-plugin \
+  connection_url="postgresql://{{username}}:{{password}}@<POSTGRES_ADDR>/postgres?sslmode=disable" \
+  allowed_roles=readonly \
+  username="<POSTGRES_USER>" \
+  password="<POSTGRES_PASSWORD>"
+
+Success! Data written to: database/config/postgresql
+```
+
+In my database secrets engine, I’ve configured a connection as well as a role in
+the secrets engine. With this, authorized entities in Vault will be able to generate
+dynamic credentials in the secrets engine.
+
+```shell
+$ tee readonly.sql <<EOF
+CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' INHERIT;
+GRANT ro TO "{{name}}";
+EOF
+
+$ vault write database/roles/readonly \
+  db_name=postgresql \
+  creation_statements=@readonly.sql \
+  default_ttl=1h \
+  max_ttl=24h
+Success! Data written to: database/roles/readonly
+```
+
+The final steps in Vault are to create a Vault policy, which will allow an entity
+to access the database secrets engine and generate a dynamic credential for our
+database, and to create a token with this policy attached to it:
+
+```shell
+$ tee waypoint-policy.vault.hcl <<EOF
+path "database/creds/readonly" {
+  capabilities = [ "read" ]
+}
+EOF
+
+$ vault policy write waypoint waypoint-policy.vault.hcl
+Success! Uploaded policy: waypoint-policy
+
+$ vault token create -policy=waypoint -ttl=24h
+Key                  Value
+---                  -----
+token                <VAULT_TOKEN>
+token_accessor       <VAULT_TOKEN_ACCESSOR>
+token_duration       24h
+token_renewable      true
+token_policies       ["default" "waypoint"]
+identity_policies    []
+policies             ["default" "waypoint"]
+```
+
+Now that we have things configured in Vault, Waypoint needs to be configured to
+connect to Vault. A configuration source for the Vault plugin will be added like so:
+
+```shell
+$ waypoint config source-set -type=vault -config=addr=https://vault.service.consul:8200 -config=token=<VAULT_TOKEN>
+Configuration set for dynamic source "vault"!
+```
+
+We can double-check that the token and address are what we expect as well:
+
+```shell
+$ waypoint config source-get -type=vault
+  KEY  |           VALUE
+--------+----------------------------
+  addr  | https://vault.service.consul:8200
+  token | <VAULT_TOKEN>
+```
+
+At this point, we aren’t actually using the config source yet, but we can get that
+ready by adding it to our waypoint.hcl file, and committing it to the git repository
+for the project.
+
+```hcl
+project = “waypoint-dynamic-config-vault”
+
+app “my-app” {
+  build {
+    use “pack” {}
+
+    registry {
+      use “docker” {
+        image = var.image_name
+        tag   = var.image_tag
+        auth {
+          username = var.username
+          password = var.password
+        }
+      }
+    }
+  }
+
+  deploy {
+    use “nomad” {
+      // The application code is written such that the app will listen on port 80,
+      // so Nomad should configure the job to listen on this port.
+      service_port = 80
+    }
+  }
+
+  config {
+    env = {
+      // These environment variables use dynamic configuration from Vault's dynamic
+      // database secrets engine
+      USERNAME = dynamic(“vault”, {
+        path = “database/creds/my-role”
+        key = “username”
+      })
+
+      PASSWORD = dynamic(“vault”, {
+        path = “database/creds/my-role”
+        key = “password”
+      })
+
+      HOST   = var.postgres_ip
+      PORT   = var.postgres_port
+      DBNAME = var.postgres_dbname
+    }
+  }
+}
+
+variable "postgres_ip" {
+  description = "IP address at which the Postgres DB server is listening."
+  type        = string
+}
+
+variable "postgres_port" {
+  description = "Port on which the Postgres DB server is listening."
+  type        = number
+  default     = 5432
+}
+
+variable "postgres_dbname" {
+  description = "Name of the Postgres DB to access."
+  type        = string
+  default     = “postgres”
+}
+
+variable "image_name" {
+  decription = "Name of the Docker image for the app built by Waypoint. This will be used with the tag to push an image to a Docker repository."
+  type = string
+}
+
+variable "image_tag" {
+  decription = "Tag of the Docker image for the app built by Waypoint. This will be used with the name to push an image to a Docker repository."
+  type = string
+}
+
+variable "registry_username" {
+  description = "Username of user with push access to your Docker registry."
+  type      = string
+  sensitive = true
+}
+
+variable "registry_password" {
+  description = "Password for the configured user with push access to your Docker registry."
+  type      = string
+  sensitive = true
+}
+```
+
+In the configuration above, we’ve informed Waypoint that we want the Waypoint Entrypoint,
+which will wrap the entrypoint to the Docker container that the Pack plugin is
+building, to get a secret from Vault at the path `database/creds/my-role`. The
+values for the keys `username` and `password` at that secret path will be configured
+as environment variables, `USERNAME` and `PASSWORD`, in the deployment of the app. We
+can confirm that the secret was successfully templated after running `waypoint up`,
+by checking the environment variables using `waypoint exec`, and checking the application
+logs using `waypoint logs`:
+
+```shell
+// To run this operation, I exported my input variables to my environment, prefixed with “WP_VAR_”
+// The output below is abbreviated for brevity
+$ waypoint up
+✓ Running build v2
+✓ Building Buildpack with kaniko...
+✓ Repository is available and ready: devopspaladin/hello-database:latest
+✓ Executing kaniko...
+…
+✓ Image pushed to 'devopspaladin/hello-database:latest'
+✓ Running push build v1
+✓ Running deploy v2
+✓ Job registration successful
+✓ Allocation "4a0788ae-a6c0-bf55-4a84-46a4f0ff4a81" created: node "b9a637ea-6098-4b22-6f52-9d5b94581a75", group
+"dynamic-go-01gj1s1sqj31r72qn38t09xj7p"
+✓ Evaluation status changed: "pending" -> "complete"
+✓ Evaluation "d1c03461-fddd-2e68-bb7b-d6e7e718f121" finished with status "complete"
+✓ Deployment successfully rolled out!
+✓ Job "dynamic-go-01gj1s1sqj31r72qn38t09xj7p" is reporting ready!
+✓ Finished building report for Nomad platform
+
+// The values for USERNAME and PASSWORD below are dynamic credentials generated by Vault!
+$ waypoint exec env
+…
+USERNAME=v-token-readonly-wOdEtyXQ5MktQ5SwTnXo-1668702202
+PASSWORD=e-4QVqEpUhGfmpTncKTy
+…
+
+$ waypoint logs
+...
+2022-11-17T16:41:36.491Z D60TJX: 2022/11/17 16:41:36 Successfully connected to the database! :)
+```
+
+With the application successfully deployed and configured with dynamic credentials,
+it can securely connect to the database, and we never needed to provide the app
+with an actual secret value. The Waypoint Entrypoint, built-in to the application image,
+can now dynamically source this Vault configuration wherever the app is deployed.
+If I deploy to Docker on my laptop for some local development testing, or my EKS
+cluster in AWS, as long as the application container can access the Vault cluster,
+the secrets necessary to run the application will be provided by Waypoint.

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -14,12 +14,12 @@ done with static application configuration, where static environment variables
 or files can be applied to your running deployment. Alternatively, configuration
 can be sourced dynamically from external sources, using a config sourcer plugin.
 
-The [Hashicorp Vault plugin for Waypoint](https://developer.hashicorp.com/waypoint/plugins/vault)
+The [HashiCorp Vault plugin for Waypoint](https://developer.hashicorp.com/waypoint/plugins/vault)
 is one of the [config sourcer plugins](https://developer.hashicorp.com/waypoint/docs/app-config/dynamic)
 that is built-in to the Waypoint binary. This plugin can be used to source static
 values from the Vault KV secrets engine, but also for dynamic secrets! A [dynamic secret](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-dynamic-secrets)
 is one that is managed by Vault and has a lease associated with it, where
-the secret will expire after a set time to live (TTL). This is a huge benefit to
+the secret will expire after a set time to live (TTL). This is a huge benefit for
 the security of your application, as any possibly leaked secrets would automatically
 expire after a pre-configured amount of time, among other things including that
 developers and operators don’t need to know secrets for their deployed applications.
@@ -112,7 +112,7 @@ Now that we have things configured in Vault, Waypoint needs to be configured to
 connect to Vault. A configuration source for the Vault plugin will be added like so:
 
 ```shell
-$ waypoint config source-set -type=vault -config=addr=https://vault.service.consul:8200 -config=token=<VAULT_TOKEN>
+$ waypoint config source-set -type=vault -config=addr=http://127.0.0.1:8200 -config=token=<VAULT_TOKEN>
 Configuration set for dynamic source "vault"!
 ```
 

--- a/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/intro/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -22,18 +22,18 @@ the security of your application, as any possibly leaked secrets would automatic
 expire after a pre-configured amount of time, among other things including that
 developers and operators don’t need to know secrets for their deployed applications.
 
-Prior to using Waypoint to deploy my Nomad jobs, Nomad users have relied on
+Prior to using Waypoint to deploy Nomad jobs, Nomad users have relied on
 [Nomad’s integration with Vault](https://developer.hashicorp.com/nomad/docs/integrations/vault-integration)
 to template secrets to their applications. Users may still make use of this integration,
 but in instances where Waypoint is used to deploy an app, it can be abstracted away
 by using Waypoint’s dynamic configuration integration with Vault, even when not
-deploying to my Nomad cluster. Let’s look into how this can be configured in Waypoint.
+deploying to a Nomad cluster. This use goes over how this can be done in Waypoint.
 
-My application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/d83e0831c2751163dc88503249c6559e88a6d912/learn/dynamic-application-configuration)
+An example application, located at [this path](https://github.com/hashicorp/waypoint-examples/tree/d83e0831c2751163dc88503249c6559e88a6d912/learn/dynamic-application-configuration)
 in the waypoint-examples GitHub repository, will eventually need read-only access
-from my Postgres database, and I want to provide dynamic credentials to access the
-data. To make this happen, I’ll create a role in a Postgres database with read-only
-access, using the psql command line tool. The IP, port, and user below should be
+from a Postgres database, and should provide dynamic credentials to access it.
+To make this happen, a role will be created in the Postgres database with read-only
+access, using the `psql` command line tool. The IP, port, and user below should be
 filled in based on the configuration and environment in which your Postgres instance
 is running.
 
@@ -63,7 +63,7 @@ Success! Data written to: database/config/postgresql
 
 In the database secrets engine, a connection and role have been configured. With
 this, authorized entities in Vault will be able to generate dynamic credentials
-in the secrets engine.
+using the secrets engine.
 
 ```shell
 $ tee readonly.sql <<EOF
@@ -120,12 +120,12 @@ To double-check that the token and address are what is expected, `waypoint confi
 $ waypoint config source-get -type=vault
   KEY  |           VALUE
 --------+----------------------------
-  addr  | https://vault.service.consul:8200
+  addr  | http://127.0.0.1:8200
   token | <VAULT_TOKEN>
 ```
 
 At this point, the config source isn't actually being used yet, but that can be
-made ready by adding it to our waypoint.hcl file, and committing it to the git
+made ready by adding it to the waypoint.hcl file, and committing it to the git
 repository for the project.
 
 ```hcl

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -26,6 +26,15 @@
             "path": "intro/vs/kubernetes"
           }
         ]
+      },
+      {
+        "title": "Use Cases",
+        "routes": [
+          {
+            "title": "Dynamic App Config with Vault Dynamic Secrets",
+            "path": "intro/use-cases/dynamic-config-vault-dynamic-secrets"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
The Use Case in this PR goes over how one can configure Vault and Waypoint to use dynamic secrets in their dynamic application configuration, with the help of config sourcers and the Waypoint Entrypoint.

Note: the capability of using dynamic secrets from Vault depends on a fix to the Vault plugin that is yet to be released in v0.10.4.