### PR TITLE
Modify `project destroy` to require `-p` flag and delete projects created in UI without data source

### DIFF
--- a/.changelog/4212.txt
+++ b/.changelog/4212.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+cli: `project destroy` requires the `-project` or `-p` flag regardless of where it's run.
+```
+
+```release-note:bug
+cli: `project destroy` now successfully destroys a project created in the UI without a remote source or local hcl file.
+```

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -39,7 +39,7 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Confirmation required
+	// Confirmation required without `-auto-approve` flag
 	if !c.confirm {
 		proceed, err := c.ui.Input(&terminal.Input{
 			Prompt: "Do you really want to destroy project \"" + project.Project.Name + "\" and its resources? Only 'yes' will be accepted to approve: ",

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -29,15 +29,30 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Get the project we're destroying
+	// Take project name from arguments if not in project directory.
+	var p *pb.Ref_Project
+	c.ui.Output("%q \n\n", c.args)
+	if c.flagProject == "" {
+		if len(c.args) > 0 {
+			p = &pb.Ref_Project{Project: c.args[0]}
+		} else {
+			c.ui.Output("Please explicitly specify project to delete.", terminal.WithWarningStyle())
+		}
+	} else {
+		p = c.project.Ref()
+		c.ui.Output("p: %q \n\n", p)
+	}
+
+	// Verify the project we're destroying exists
 	project, err := c.project.Client().GetProject(c.Ctx, &pb.GetProjectRequest{
-		Project: c.project.Ref(),
+		Project: p,
 	})
 	if err != nil {
+		c.ui.Output("Project %q not found.", p.Project, terminal.WithErrorStyle())
 		return 1
 	}
 
-	// Confirmation is required for destroying a project &/or its resources
+	// Confirmation required
 	if !c.confirm {
 		proceed, err := c.ui.Input(&terminal.Input{
 			Prompt: "Do you really want to destroy project \"" + project.Project.Name + "\" and its resources? Only 'yes' will be accepted to approve: ",

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -59,6 +59,8 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 		}
 	}
 
+	// If project has a remote data source, queue destroy operation.
+	// Otherwise, directly call server API to delete from the database.
 	if project.Project.DataSource == nil {
 		_, err = c.project.Client().DestroyProject(c.Ctx, &pb.DestroyProjectRequest{
 			Project: c.project.Ref(),

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -26,7 +26,7 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 	}
 
 	if c.flagProject == "" {
-		c.ui.Output("Must explicitly set -project (-p) flag to destroy project.", terminal.WithErrorStyle())
+		c.ui.Output("Must explicitly set -project (-p) flag to destroy project.\n %s", c.Flags().Help(), terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -104,12 +104,15 @@ func (c *ProjectDestroyCommand) Synopsis() string {
 
 func (c *ProjectDestroyCommand) Help() string {
 	return formatHelp(`
-Usage: waypoint project destroy [options]
+Usage: waypoint project destroy [options] -p <project>
 
   Delete the project and all resources created for all apps in the project, within
   the platform each app was deployed to.
 
-  You can optionally skip destroying the resources by setting
-  -skip-destroy-resources to true.
+  You must explicitly specify the project to destroy with the -project or -p flag.
+
+  You can skip destroying app resources with the -skip-destroy-resources flag.
+
+  You can skip the manual confirmation prompt with the -auto-approve flag.
 ` + c.Flags().Help())
 }

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -1,11 +1,12 @@
 package cli
 
 import (
+	"strings"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/internal/clierrors"
 	"github.com/hashicorp/waypoint/internal/pkg/flag"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
-	"strings"
 )
 
 type ProjectDestroyCommand struct {

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -24,32 +24,17 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.project == nil {
-		c.ui.Output("The -project flag must be set.", terminal.WithErrorStyle())
-		return 1
-	}
-
-	// Take project name from arguments if not in project directory.
-	var p *pb.Ref_Project
-	c.ui.Output("%q \n\n", c.args)
 	if c.flagProject == "" {
-		if len(c.args) > 0 {
-			p = &pb.Ref_Project{Project: c.args[0]}
-		} else {
-			c.ui.Output("Please explicitly specify project to delete.", terminal.WithWarningStyle())
-			return 1
-		}
-	} else {
-		p = c.project.Ref()
-		c.ui.Output("p: %q \n\n", p)
+		c.ui.Output("Must explicitly set -project flag to destroy project.", terminal.WithErrorStyle())
+		return 1
 	}
 
 	// Verify the project we're destroying exists
 	project, err := c.project.Client().GetProject(c.Ctx, &pb.GetProjectRequest{
-		Project: p,
+		Project: c.project.Ref(),
 	})
 	if err != nil {
-		c.ui.Output("Project %q not found.", p.Project, terminal.WithErrorStyle())
+		c.ui.Output("Project %q not found.", c.project.Ref().Project, terminal.WithErrorStyle())
 		return 1
 	}
 

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -37,6 +37,7 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 			p = &pb.Ref_Project{Project: c.args[0]}
 		} else {
 			c.ui.Output("Please explicitly specify project to delete.", terminal.WithWarningStyle())
+			return 1
 		}
 	} else {
 		p = c.project.Ref()

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -70,7 +70,7 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 		})
 	}
 	if err != nil {
-		c.ui.Output("Error destroying project: %s", err.Error(), terminal.WithErrorStyle())
+		c.ui.Output("Error destroying project %q: %s", project.Project.Name, err.Error(), terminal.WithErrorStyle())
 		return 1
 	}
 	c.ui.Output("Project %q destroyed!", project.Project.Name, terminal.WithSuccessStyle())

--- a/internal/cli/project_destroy.go
+++ b/internal/cli/project_destroy.go
@@ -25,7 +25,7 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 	}
 
 	if c.flagProject == "" {
-		c.ui.Output("Must explicitly set -project flag to destroy project.", terminal.WithErrorStyle())
+		c.ui.Output("Must explicitly set -project (-p) flag to destroy project.", terminal.WithErrorStyle())
 		return 1
 	}
 
@@ -57,10 +57,17 @@ func (c *ProjectDestroyCommand) Run(args []string) int {
 			return 1
 		}
 	}
-	_, err = c.project.DestroyProject(c.Ctx, &pb.Job_DestroyProjectOp{
-		Project:              &pb.Ref_Project{Project: project.Project.Name},
-		SkipDestroyResources: c.skipDestroyResources,
-	})
+
+	if project.Project.DataSource == nil {
+		_, err = c.project.Client().DestroyProject(c.Ctx, &pb.DestroyProjectRequest{
+			Project: c.project.Ref(),
+		})
+	} else {
+		_, err = c.project.DestroyProject(c.Ctx, &pb.Job_DestroyProjectOp{
+			Project:              &pb.Ref_Project{Project: project.Project.Name},
+			SkipDestroyResources: c.skipDestroyResources,
+		})
+	}
 	if err != nil {
 		c.ui.Output("Error destroying project: %s", err.Error(), terminal.WithErrorStyle())
 		return 1

--- a/internal/runner/accept.go
+++ b/internal/runner/accept.go
@@ -173,7 +173,7 @@ func (r *Runner) accept(ctx context.Context, id string) error {
 			// Grab this lock before updating canceled. You don't
 			// need to have this lock to touch canceled (we use atomic ops)
 			// but it is used when the streamCancel is being reset so that
-			// we don't set it up and race with cancelation.
+			// we don't set it up and race with cancellation.
 			streamCtxLock.Lock()
 			defer streamCtxLock.Unlock()
 

--- a/website/content/commands/project-destroy.mdx
+++ b/website/content/commands/project-destroy.mdx
@@ -15,13 +15,16 @@ Delete the specified project and optionally destroy its resources.
 
 ## Usage
 
-Usage: `waypoint project destroy [options]`
+Usage: `waypoint project destroy [options] -p <project>`
 
 Delete the project and all resources created for all apps in the project, within
 the platform each app was deployed to.
 
-You can optionally skip destroying the resources by setting
--skip-destroy-resources to true.
+You must explicitly specify the project to destroy with the -project or -p flag.
+
+You can skip destroying app resources with the -skip-destroy-resources flag.
+
+You can skip the manual confirmation prompt with the -auto-approve flag.
 
 #### Global Options
 


### PR DESCRIPTION
As the title suggests. :)

Previously, `waypoint project destroy` would ignore whatever arguments provided and attempt to destroy project in current directory. This enforces the use of the `-project` or `-p` flag regardless of where the command is called to resolve this bug, and for extra guardrails.

This PR also introduces the ability to delete projects created in the UI without a data source or `waypoint.hcl`.