### PR TITLE
Upgrade backport-assistant to 0.3.1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.2.3
+    container: hashicorpdev/backport-assistant:0.3.1
     steps:
       - name: Run Backport Assistant for stable-website
         run: |


### PR DESCRIPTION
This is mostly to pull in the changes from https://github.com/hashicorp/backport-assistant/pull/47 that will make the backport warnings more obvious, both via the improved text alert formatting and also because it will now @-mention the person who merged in the original PR.

A change that we'll get automatically, but should be beneficial:
- [Make opened PR a draft on error](https://github.com/hashicorp/backport-assistant/pull/34)

Other changes we will have access to, but should not impact our usage of backport-assistant at this time unless we change other parts of our setup:
- the ability to auto-merge only if all tests pass ([README section](https://github.com/hashicorp/backport-assistant#commands))
- specify `merge`, `squash`, or `rebase` for auto-merges ([README section](https://github.com/hashicorp/backport-assistant#commands))
- When BACKPORT_MERGE_COMMIT is set, make backport PRs use the merge commit instead of the PR commits. Only for use with the squash merge commit strategy. ([README section](https://github.com/hashicorp/backport-assistant#commands))