### PR TITLE
Initial addition of GH->Jira workflow

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           project: WAYP
           issuetype: "${{ steps.set-ticket-type.outputs.type }}" # Does this need to be `issuetype: "GH Issue"`? Waiting on clarification from TPM team
-          summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
+          summary: "${{ github.event.repository.name }} [Issue #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,112 @@
+on:
+  issues:
+    # `labeled` is for copying GH Issue -> Jira; other states are for updating the created Jira issue when the GH Issue has a change
+    types: [labeled, closed, deleted, reopened]
+  # On Waypoint, we don't put PRs into Jira at this time
+  # pull_request_target:
+  #   types: [opened, closed, reopened]
+  issue_comment:
+    # Allows the copying of GitHub Issue comments to the corresponding Jira ticket (1-way only, GH->Jira)
+    types: [created]
+  
+  workflow_dispatch:
+
+name: Jira Sync
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Jira sync
+    if: contains(github.event.issue.labels.*.name, 'jira')
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Set ticket type
+        id: set-ticket-type
+        run: |
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'bug') }}" == "true" ]]; then
+            echo "::set-output name=type::Bug"
+          elif [[ "${{ contains(github.event.issue.labels.*.name, 'enhancement') }}" == "true" ]]; then
+            echo "::set-output name=type::Story"
+          else
+            echo "::set-output name=type::Task"
+          fi
+
+      # Use this to add Jira labels to a ticket based on what labels are present in GitHub
+      # bash note: '${#VAR}' returns the length of the variable's value
+      # label assignment is simple; currently assigns 'ui', 'documentation', or 'backend'
+      # with 'backend' being a catchall for things not 'ui'
+      - name: Set ticket labels
+        if: github.event.action == 'labeled' # the parent if-statement checks for a label with a value of "Jira", so here we just need to know if that label is new or not
+        id: set-ticket-labels
+        run: |
+          LABELS="["
+          LABELS+="\"oss\", "
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'documentation') }}" == "true" ]]; then LABELS+="\"documentation\", "; fi
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'ui') }}" == "true" ]]; then LABELS+="\"ui\", "; else LABELS+="\"backend\", "; fi
+          if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
+          echo "::set-output name=labels::${LABELS}"
+      
+      # Only Waypoint team members may add GitHub issues to Jira
+      - name: Check if team member
+        if: github.event.action == 'labeled'
+        id: is-team-member
+        run: |
+          TEAM=waypoint
+          ROLE="$(hub api orgs/hashicorp/teams/${TEAM}/memberships/${{ github.actor }} | jq -r '.role | select(.!=null)')"
+          if [[ -n ${ROLE} ]]; then
+            echo "Actor ${{ github.actor }} is a ${TEAM} team member"
+            echo "::set-output name=message::true"
+          else
+            echo "Actor ${{ github.actor }} is NOT a ${TEAM} team member"
+            echo "::set-output name=message::false"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.JIRA_SYNC_GITHUB_TOKEN }}
+
+      - name: Search
+        id: search
+        uses: tomhjp/gh-action-jira-search@v0.2.1
+        with:
+          # cf[10089] is Issue Link (use JIRA API to retrieve)
+          jql: 'issuetype = "${{ steps.set-ticket-type.outputs.type }}" and cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+
+      - name: Create ticket
+        if: ( github.event.action == 'labeled' && steps.is-team-member.outputs.message == 'true' && !steps.search.outputs.issue )
+        uses: tomhjp/gh-action-jira-create@v0.1.3
+        with:
+          project: WAYP
+          issuetype: "${{ steps.set-ticket-type.outputs.type }}" # Does this need to be `issuetype: "GH Issue"`? Waiting on clarification from TPM team
+          summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
+          description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
+          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
+          extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
+                          "customfield_10371": { "value": "GitHub" },            
+                          "components": [{ "name": "${{ github.event.repository.name }}" }],
+                          "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
+
+      - name: Sync comment
+        if: github.event.action == 'created' && steps.search.outputs.issue
+        uses: tomhjp/gh-action-jira-comment@v0.1.0
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
+
+      - name: Close ticket
+        if: ( github.event.action == 'closed' || github.event.action == 'deleted' ) && steps.search.outputs.issue
+        uses: atlassian/gajira-transition@v2.0.1
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          transition: "Closed"
+
+      - name: Reopen ticket
+        if: github.event.action == 'reopened' && steps.search.outputs.issue
+        uses: atlassian/gajira-transition@v2.0.1
+        with:
+          issue: ${{ steps.search.outputs.issue }}
+          transition: "Pending Triage"


### PR DESCRIPTION
Things this does:
- checks for a `jira` label before doing anything
- checks for a ticket in Jira that matches the format this workflow will create new ticket titles with
- if the `jira` label was just added **and** a ticket does not already exist **and** the user who added the label is a `waypoint` team member, create a new ticket in the Waypoint project
- if the issue already had a `jira` label and was updated with a comment, was closed, or was reopened, update the activity/status of the corresponding Jira ticket