### PR TITLE
feat(cli): add socket-path flag to runner install

### DIFF
--- a/.changelog/4246.txt
+++ b/.changelog/4246.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: add socket-path flag to runner install
+```

--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -22,6 +22,7 @@ import (
 type DockerConfig struct {
 	RunnerImage string `hcl:"runner_image,optional"`
 	Network     string `hcl:"network,optional"`
+	SocketPath  string `hcl:"socket_path,optional"`
 }
 
 type DockerRunnerInstaller struct {
@@ -116,7 +117,7 @@ func (i *DockerRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) 
 	}, &container.HostConfig{
 		Privileged: true,
 		CapAdd:     []string{"CAP_DAC_OVERRIDE"},
-		Binds:      []string{"/var/run/docker.sock:/var/run/docker.sock"},
+		Binds:      []string{i.Config.SocketPath + ":/var/run/docker.sock"},
 		// These security options are required for the runner so that
 		// Docker daemonless image building works properly.
 		SecurityOpt: []string{
@@ -151,6 +152,13 @@ func (i *DockerRunnerInstaller) InstallFlags(set *flag.Set) {
 		Name:   "docker-runner-network",
 		Target: &i.Config.Network,
 		Usage:  "The Docker network in which to deploy the Waypoint runner.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "docker-socket-path",
+		Target:  &i.Config.SocketPath,
+		Usage:   "The path of the docker socket that will be bound in runner",
+		Default: "/var/run/docker.sock",
 	})
 }
 

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -55,6 +55,7 @@ the install, the command would be:
 
 - `-docker-runner-image=<string>` - The Docker image for the Waypoint runner. The default is hashicorp/waypoint.
 - `-docker-runner-network=<string>` - The Docker network in which to deploy the Waypoint runner.
+- `-docker-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 


### PR DESCRIPTION
Add a socket-path flag to `waypoint runner install`, this allows to override the socket that will be bound using volume when creating the runner.
The issue is that docker socket may not be `/var/run/docker.sock` on the server that will host the runner, this would be in another place when running rootless docker for example.
This also helps greatly to start runners when using podman (ref: #3781).