### PR TITLE
Bug fix: Filter out empty names from context list

### DIFF
--- a/.changelog/4257.txt
+++ b/.changelog/4257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/context: fix possible error when listing contexts if a non waypoint context file exists in the context directory
+```

--- a/internal/clicontext/storage.go
+++ b/internal/clicontext/storage.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Storage is the primary struct for interacting with stored CLI contexts.
@@ -50,7 +51,10 @@ func (m *Storage) List() ([]string, error) {
 			continue
 		}
 
-		result = append(result, m.nameFromPath(n))
+		// filter out possible non .hcl files
+		if strings.HasSuffix(n, ".hcl") {
+			result = append(result, m.nameFromPath(n))
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
On some operating systems (namely macOS), it's possible for something akin to a [`.DS_Store`](https://en.wikipedia.org/wiki/.DS_Store) file to exist in the directory where contexts are stored. If so, then when a user runs `waypoint context list` an internal method [`nameFromPath`](https://github.com/hashicorp/waypoint/blob/d4e1eddb95c8dad4300bad22ff5828258f9c77f8/internal/clicontext/storage.go#L242) returns an empty string for said file as it doesn't have a normal file extension. `context list` then tries to load a non-existing `/.hcl` file and errors like so:  

```
$ waypoint context list 
! Error loading context "": <nil>: Configuration file not found; The configuration file /Users/clint/Library/Preferences/waypoint/context/.hcl does not exist.
```

In this PR we simply filter out any non `.hcl` files before we call `nameFromPath`, which should save us from any other possible `.dotfiles` or other files that don't have a file extension at all. It would be odd to have any others in that folder but this should hopefully _Catch'em All_