### PR TITLE
add slack notification for failed backports

### DIFF
--- a/.github/workflows/failed-backport-check.yml
+++ b/.github/workflows/failed-backport-check.yml
@@ -1,0 +1,16 @@
+# This workflow notifies slack if a failed backport PR is opened (aka in draft mode)
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  # checks that a .changelog entry is present for a PR
+  failed-backport-check:
+    # We only run if it has "Backport" in the title and is a draft PR (as all failed backports will be)
+    if: "!contains(github.event.pull_request.title, 'Backport') && github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify Slack on failed Backport PRs
+      uses: slackapi/slack-github-action@v1.23.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/failed-backport-check.yml
+++ b/.github/workflows/failed-backport-check.yml
@@ -7,7 +7,7 @@ jobs:
   # checks that a .changelog entry is present for a PR
   failed-backport-check:
     # We only run if it has "Backport" in the title and is a draft PR (as all failed backports will be)
-    if: "!contains(github.event.pull_request.title, 'Backport') && github.event.pull_request.draft"
+    if: "contains(github.event.pull_request.title, 'Backport') && github.event.pull_request.draft"
     runs-on: ubuntu-latest
     steps:
     - name: Notify Slack on failed Backport PRs


### PR DESCRIPTION
This workflow will check if a newly opened PR is a draft, and if it has "Backport" in the title. If both of those are true (which will both be true for failed backport PRs), it sends a small message to our team's Slack channel.
<img width="325" alt="Screen Shot 2022-12-02 at 4 32 56 PM" src="https://user-images.githubusercontent.com/8461333/205391962-f4ddf6fe-80f8-4f75-9c45-be097f3fbbfe.png">

Just as a nudge, since this message will come within a minute or less of someone merging in a PR that had the `backport/*` label attached. I've updated the Slack workflow so it will now post to our team's channel, and added the necessary secrets to this repo.