### PR TITLE
Pipeline run failures show run results

### DIFF
--- a/.changelog/4268.txt
+++ b/.changelog/4268.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: pipeline run now shows the number of steps successfully executed for a failed run
+```

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -144,7 +144,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 				return err
 			}
 
-			step.Update("Pipeline %q has started running. Attempting to read job stream sequentially in order", pipelineIdent)
+			step.Update("Pipeline %q has started running. Attempting to read job stream sequentially in order.", pipelineIdent)
 			step.Done()
 
 			steps = len(resp.JobMap)
@@ -185,8 +185,6 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			}
 			runSeq = respGet.PipelineRun.Sequence
 		}
-		// Receive job ids from running pipeline, use job client to attach to job stream
-		// and stream here. First pass can be linear job streaming
 		step = sg.Add("")
 		defer step.Abort()
 
@@ -200,6 +198,8 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			finalVariableValues map[string]*pb.Variable_FinalValue
 		)
 
+		// Receive job ids from running pipeline, use job client to attach to job stream
+		// and stream here. First pass can be linear job streaming
 		successful := 0
 		for _, jobId := range allRunJobs {
 			job, err := c.project.Client().GetJob(c.Ctx, &pb.GetJobRequest{
@@ -220,7 +220,6 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			if job.Workspace != nil {
 				ws = job.Workspace.Workspace
 			}
-			//app.UI.Output("Executing Step %q in workspace: %q", resp.JobMap[jobId].Step, ws, terminal.WithHeaderStyle())
 			stepName := job.Pipeline.Step
 			app.UI.Output("Executing Step %q in workspace: %q", stepName, ws, terminal.WithHeaderStyle())
 			app.UI.Output("Reading job stream (jobId: %s)...", jobId, terminal.WithInfoStyle())

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -135,8 +135,9 @@ func (c *PipelineRunCommand) Run(args []string) int {
 
 			err error
 		)
+
 		if !c.flagReattachRun {
-			step.Update("Requesting to queue run of pipeline %q...", pipelineIdent)
+			step.Update("Queuing run of pipeline %q...", pipelineIdent)
 
 			// take pipeline id and queue a RunPipeline with a Job Template.
 			resp, err = c.project.Client().RunPipeline(c.Ctx, runPipelineReq)
@@ -185,9 +186,9 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			}
 			runSeq = respGet.PipelineRun.Sequence
 		}
+
 		step = sg.Add("")
 		defer step.Abort()
-
 		step.Update("%d steps detected, run sequence %d", steps, runSeq)
 		step.Done()
 

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -200,7 +200,7 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			finalVariableValues map[string]*pb.Variable_FinalValue
 		)
 
-		successful := steps
+		successful := 0
 		for _, jobId := range allRunJobs {
 			job, err := c.project.Client().GetJob(c.Ctx, &pb.GetJobRequest{
 				JobId: jobId,
@@ -230,6 +230,8 @@ func (c *PipelineRunCommand) Run(args []string) int {
 				jobstream.WithClient(c.project.Client()),
 				jobstream.WithUI(app.UI))
 			if err != nil {
+				output := fmt.Sprintf("Pipeline %q (%s) failed to complete. %d/%d steps successfully executed.", pipelineIdent, app.Ref().Project, successful, steps)
+				app.UI.Output("✖ %s", output, terminal.WithErrorStyle())
 				return err
 			}
 
@@ -239,8 +241,8 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			if err != nil {
 				return err
 			}
-			if job.State != pb.Job_SUCCESS {
-				successful--
+			if job.State == pb.Job_SUCCESS {
+				successful++
 			}
 
 			// Grab the deployment or release URL to display at the end of the pipeline run


### PR DESCRIPTION
Fixes https://github.com/hashicorp/waypoint/issues/3850 
Pipeline runs now show progress even on failed runs.

(Abridged output)

```
❯ waypoint-dev pipeline run tester

» Running pipeline "tester" for application "example-java"
✓ Pipeline "tester" has started running. Attempting to read job stream sequentially in order
✓ 2 steps detected, run sequence 16

» Performing operation locally

» Executing Step "build" in workspace: "default"
  ......

» Executing Step "deploy" in workspace: "default"
  .....
  
! ✖ Pipeline "tester" (example-java) failed to complete. 1/2 steps successfully completed.
! 1 error occurred:
  	* rpc error: code = NotFound desc = failed to get latest artifact
 ```