### PR TITLE
use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/failed-backport-check.yml
+++ b/.github/workflows/failed-backport-check.yml
@@ -1,6 +1,6 @@
 # This workflow notifies slack if a failed backport PR is opened (aka in draft mode)
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
This workflow didn't run on the most recent failed backport. Upon inspection of the GitHub docs:
>Note: Workflows will not run on pull_request activity if the pull request has a merge conflict.

Switching to `pull_request_target` should fix this.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target