### PR TITLE
Fixup: `waypoint job list` Fixups

### DIFF
--- a/.changelog/4271.txt
+++ b/.changelog/4271.txt
@@ -1,4 +1,4 @@
-```release-note:feature
-server: Add pagination stubs in ListJobs
-cli: Add pagination in ListProjects
+```release-note:improvement
+core: `waypoint job list` will now retrieve paginated list of jobs to avoid
+grpc data limits per request
 ```

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -132,9 +132,10 @@ func (c *JobListCommand) Run(args []string) int {
 		sg := c.ui.StepGroup()
 		step := sg.Add("")
 		defer step.Abort()
+
 		page := 2
 		for resp.Pagination.NextPageToken != "" {
-			step.Update(fmt.Sprintf("Requesting page %d/x", page))
+			step.Update("Requesting page %d/x", page)
 
 			req.Pagination.NextPageToken = resp.Pagination.NextPageToken
 			resp, err = c.project.Client().ListJobs(ctx, req)
@@ -147,6 +148,8 @@ func (c *JobListCommand) Run(args []string) int {
 			jobs = append(jobs, resp.Jobs...)
 			page++
 		}
+
+		step.Update("")
 		step.Done()
 	}
 

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -130,12 +130,17 @@ func (c *JobListCommand) Run(args []string) int {
 	// Get additional pages if they exist
 	if resp.Pagination != nil && resp.Pagination.NextPageToken != "" {
 		sg := c.ui.StepGroup()
-		step := sg.Add("")
-		defer step.Abort()
+		var step terminal.Step
+		if !c.flagJson {
+			step = sg.Add("")
+			defer step.Abort()
+		}
 
 		page := 2
 		for resp.Pagination.NextPageToken != "" {
-			step.Update("Requesting page %d/x", page)
+			if !c.flagJson {
+				step.Update("Requesting page %d/x", page)
+			}
 
 			req.Pagination.NextPageToken = resp.Pagination.NextPageToken
 			resp, err = c.project.Client().ListJobs(ctx, req)
@@ -152,8 +157,10 @@ func (c *JobListCommand) Run(args []string) int {
 			page++
 		}
 
-		step.Update("")
-		step.Done()
+		if !c.flagJson {
+			step.Update("All pages retrieved!")
+			step.Done()
+		}
 	}
 
 	// sort by complete time

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -139,9 +139,12 @@ func (c *JobListCommand) Run(args []string) int {
 
 			req.Pagination.NextPageToken = resp.Pagination.NextPageToken
 			resp, err = c.project.Client().ListJobs(ctx, req)
-
 			if err != nil {
 				c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+				return 1
+			}
+			if resp.Pagination == nil {
+				c.ui.Output("No pagination in resposne to retrieving page %d, cannot continue", page, terminal.WithErrorStyle())
 				return 1
 			}
 

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -144,7 +144,7 @@ func (c *JobListCommand) Run(args []string) int {
 				return 1
 			}
 			if resp.Pagination == nil {
-				c.ui.Output("No pagination in resposne to retrieving page %d, cannot continue", page, terminal.WithErrorStyle())
+				c.ui.Output("No pagination in response to retrieving page %d, cannot continue", page, terminal.WithErrorStyle())
 				return 1
 			}
 


### PR DESCRIPTION
This pull request is my suggested feedback that came from the pull request https://github.com/hashicorp/waypoint/pull/4271

- I don't think we should print the page retrieval once complete. This is extra unrelated data that the user doesn't need to know and also breaks the `-json` flag
- Feedback on the changelog entry since it's user-facing, it's more targeted as to what this change is contributing.
- Extra check to prevent a panic in the case where the Waypoint API might return a malformed response that's missing the Pagination object