### PR TITLE
Adding new required policies to ecs odr

### DIFF
--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -79,6 +79,7 @@ const odrRolePolicy = `{
         "ecs:RegisterTaskDefinition",
         "ecs:DeregisterTaskDefinition",
         "ecs:RunTask",
+        "ecs:StopTask",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",
@@ -100,6 +101,7 @@ const odrRolePolicy = `{
         "logs:CreateLogGroup",
         "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets"
       ],


### PR DESCRIPTION
Without these, we can't do StopTask or WatchTask jobs with remote runners.

You get these errors:

```
 rpc error: code = Unknown desc = AccessDeniedException: User: arn:aws:sts::<account-id>:assumed-role/waypoint-runner/<id> is not authorized to perform: logs:GetLogEvents on resource: arn:aws:logs:us-east-1:<account-id>:log-group:waypoint-runner-logs:log-stream:waypoint-odr-task-<id>/waypoint-odr-task-<id>/<id> because no identity-based policy allows the logs:GetLogEvents action
```

```
2022-12-09T01:40:30.519Z [WARN]  waypoint.runner.agent.runner: error during job execution: job_id=01GKT8JC6X60X4ZFEET2C6AJEA job_op=*gen.Job_StopTask err="rpc error: code = Unknown desc = AccessDeniedException: User: arn:aws:sts::<account-id>:assumed-role/waypoint-runner/<id> is not authorized to perform: ecs:StopTask on resource: arn:aws:ecs:us-east-1:<account-id>:task/hcp-wp-integration/<id> because no identity-based policy allows the ecs:StopTask action"

```