### PR TITLE
Upgrading to go 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
           at: .
       - run:
           command: |
-            go get github.com/kevinburke/go-bindata/...
+            go install github.com/kevinburke/go-bindata/...
             PATH=/home/circleci/go/bin:$PATH make bin
             cp waypoint /home/circleci/go/bin
       # save dev build to pass to downstream jobs
@@ -259,7 +259,7 @@ jobs:
           at: .
       - run:
           command: |
-            go get github.com/kevinburke/go-bindata/...
+            go install github.com/kevinburke/go-bindata/...
             PATH=/home/circleci/go/bin:$PATH make bin/windows
       - notify_main_failure
 
@@ -434,7 +434,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: go get github.com/kevinburke/go-bindata/...
+      - run: go install github.com/kevinburke/go-bindata/...
       - run: make static-assets
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: *TEST_RESULTS_DIR
-    GOTESTSUM_RELEASE: 0.4.2
+    GOTESTSUM_RELEASE: 1.8.2
     EMAIL: noreply@hashicorp.com
     GIT_AUTHOR_NAME: circleci-waypoint
     GIT_COMMITTER_NAME: circleci-waypoint
@@ -35,7 +35,7 @@ jobs:
           name: Install golangci-lint
           command: |
             download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go v1.47.3
+            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go v1.50.1
       - run: go mod download
       - run:
           name: lint
@@ -315,7 +315,7 @@ jobs:
   image-release:
     docker:
       # Use a modern Circle image as we just need up-to-date Docker here
-      - image: docker.mirror.hashicorp.services/cimg/base:2021.12
+      - image: docker.mirror.hashicorp.services/cimg/base:2022.12
     resource_class: medium+
     environment:
       <<: *ENVIRONMENT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.17
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.19
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
     website: &WEBSITE_IMAGE docker.mirror.hashicorp.services/node:14
 
@@ -297,12 +297,12 @@ jobs:
       - attach_workspace:
           at: .
       # This is just to remind ourselves of what version of Go is default
-      # on this machine image; currently it's 1.18, but we should use 1.17
+      # on this machine image; currently it's 1.18, but we should use 1.19
       - run: go version
       - run:
-          name: Install go v1.17.6
+          name: Install go v1.19.6
           command: |
-            curl -SL --fail -o /tmp/golang.tar.gz https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz
+            curl -SL --fail -o /tmp/golang.tar.gz https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go
             sudo tar -C /usr/local/ -xzf /tmp/golang.tar.gz
             rm -rf /tmp/golang.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # builder builds the Waypoint binaries
 #--------------------------------------------------------------------
 
-FROM docker.mirror.hashicorp.services/golang:1.19.5-alpine3.17 AS builder
+FROM docker.mirror.hashicorp.services/golang:1.19-alpine3.17 AS builder
 
 RUN apk add --no-cache git gcc libc-dev make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # builder builds the Waypoint binaries
 #--------------------------------------------------------------------
 
-FROM docker.mirror.hashicorp.services/golang:1.17.5-alpine3.15 AS builder
+FROM docker.mirror.hashicorp.services/golang:1.19.5-alpine3.17 AS builder
 
 RUN apk add --no-cache git gcc libc-dev make
 
@@ -32,7 +32,7 @@ RUN touch /tmp/.keep
 #--------------------------------------------------------------------
 # This target is explicitly invoked from the command line, it's not used
 # by the non-odr stages.
-FROM gcr.io/kaniko-project/executor:v1.6.0 as odr
+FROM gcr.io/kaniko-project/executor:v1.9.1 as odr
 
 COPY --from=builder /tmp/wp-src/waypoint /kaniko/waypoint
 COPY --from=busybox /bin/busybox /kaniko/busybox
@@ -53,7 +53,7 @@ ENTRYPOINT ["/kaniko/waypoint"]
 # final image
 #--------------------------------------------------------------------
 
-FROM docker.mirror.hashicorp.services/alpine:3.15.0
+FROM docker.mirror.hashicorp.services/alpine:3.17.0
 
 # git is for gitrefpretty() and other calls for Waypoint
 RUN apk add --no-cache git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/waypoint
 
-go 1.17
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,7 @@ require (
 	github.com/evanphx/grpc-gateway v1.16.1-0.20220211183845-48e5be386c15
 	github.com/hashicorp/go-grpc-net-conn v0.0.0-20220321172933-7ab38178cb90
 	github.com/hashicorp/opaqueany v0.0.0-20220321170339-a5c6ff5bb0ec
-	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221012203316-0e4a0f6d94a2
+	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221209154611-9ceb8a691558
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/rs/cors v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1252,8 +1252,8 @@ github.com/hashicorp/vault/sdk v0.6.0 h1:6Z+In5DXHiUfZvIZdMx7e2loL1PPyDjA4bVh9ZT
 github.com/hashicorp/vault/sdk v0.6.0/go.mod h1:+DRpzoXIdMvKc88R4qxr+edwy/RvH5QK8itmxLiDHLc=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9 h1:i9hzlv2SpmaNcQ8ZLGn01fp2Gqyejj0juVs7rYDgecE=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221012203316-0e4a0f6d94a2 h1:N7+0EZJxh+cWvfZD24CUtMP7dCRC+HQ6xW+jlSjqmvs=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221012203316-0e4a0f6d94a2/go.mod h1:rogx91d8Lpgj/LC5yHtD7fea1OikuGKiut6QW75wNOA=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221209154611-9ceb8a691558 h1:61imENSEqhJdWpEq2H2ksVYH2DIYCBSd8pC2joaU5K0=
+github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20221209154611-9ceb8a691558/go.mod h1:rOgUMVr2mANMW8A0q5IijEpedGAtcX1/cMEemQtBo7k=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/go.sum
+++ b/go.sum
@@ -247,9 +247,7 @@ github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDw
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
-github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -258,7 +256,6 @@ github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
-github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -360,14 +357,12 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
-github.com/cheggaaa/pb v1.0.27 h1:wIkZHkNfC7R6GI5w7l/PdAdzXzlrbcI3p8OAlnkTsnc=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
 github.com/cheggaaa/pb/v3 v3.0.5/go.mod h1:X1L61/+36nz9bjIsrDU52qHKOQukUQe2Ge+YvGuquCw=
@@ -471,7 +466,6 @@ github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJ
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
-github.com/containerd/stargz-snapshotter v0.0.0-20201027054423-3a04e4c2c116 h1:cj2qTm4k9TlXzzwCROQK0puJc2oauyjUiegQiqpNkuk=
 github.com/containerd/stargz-snapshotter v0.0.0-20201027054423-3a04e4c2c116/go.mod h1:o59b3PCKVAf9jjiKtCc/9hLAd+5p/rfhBfm6aBcTEr4=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1 h1:5e7heayhB7CcgdTkqfZqrNaNv15gABwr3Q2jBTbLlt4=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
@@ -505,7 +499,6 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-oidc/v3 v3.0.0 h1:/mAA0XMgYJw2Uqm7WKGCsKnjitE/+A0FFbOmiRJm7LQ=
 github.com/coreos/go-oidc/v3 v3.0.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
@@ -639,7 +632,6 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exoscale/egoscale v0.18.1/go.mod h1:Z7OOdzzTOz1Q1PjQXumlz9Wn/CddH0zSYdCF3rnBKXE=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
@@ -663,10 +655,8 @@ github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.4.0/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
-github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
-github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -694,7 +684,6 @@ github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0
 github.com/go-acme/lego/v3 v3.4.0/go.mod h1:xYbLDuxq3Hy4bMUT1t9JIuz6GWIWb3m5X+TeTHYaT7M=
 github.com/go-acme/lego/v3 v3.5.0 h1:/0+NJQK+hNwRznhCi+19lbEa4xufhe7wJZOVd5j486s=
 github.com/go-acme/lego/v3 v3.5.0/go.mod h1:TXodhTGOiWEqXDdgrzBoCtJ5R4L9lfOE68CTM0KGkT0=
-github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=
 github.com/go-critic/go-critic v0.4.1/go.mod h1:7/14rZGnZbY6E38VEGk2kVhoq6itzc1E68facVDK23g=
 github.com/go-critic/go-critic v0.4.3/go.mod h1:j4O3D4RoIwRqlZw5jJpx0BNfXWWbpcJoKu5cYSe4YmQ=
@@ -717,7 +706,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
-github.com/go-ldap/ldap/v3 v3.1.10/go.mod h1:5Zun81jBTabRaI8lzN7E1JjyEl1g6zI6u9pd8luAK4Q=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -823,8 +811,6 @@ github.com/go-openapi/validate v0.19.15/go.mod h1:tbn/fdOwYHgrhPBzidZfJC2MIVvs9G
 github.com/go-openapi/validate v0.20.1/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE9E4k54HpKcJ0=
 github.com/go-openapi/validate v0.20.2 h1:AhqDegYV3J3iQkMPJSXkvzymHKMTw0BST3RK3hTT4ts=
 github.com/go-openapi/validate v0.20.2/go.mod h1:e7OJoKNgd0twXZwIn0A43tHbvIcr/rZIVCbJBpTUoY0=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-ozzo/ozzo-validation/v4 v4.2.1 h1:XALUNshPYumA7UShB7iM3ZVlqIBn0jfwjqAMIoyE1N0=
 github.com/go-ozzo/ozzo-validation/v4 v4.2.1/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -843,7 +829,6 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -1068,7 +1053,6 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/google/wire v0.4.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
-github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
@@ -1152,7 +1136,6 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-argmapper v0.2.3/go.mod h1:WA3PocIo+40wf4ko3dRdL3DEgxIQB4qaqp+jVccLV1I=
 github.com/hashicorp/go-argmapper v0.2.4 h1:HSnbvNcapx5PWtA6qvnlESc69LQXYrfDO/FRf1zroXg=
 github.com/hashicorp/go-argmapper v0.2.4/go.mod h1:WA3PocIo+40wf4ko3dRdL3DEgxIQB4qaqp+jVccLV1I=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
@@ -1182,7 +1165,6 @@ github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-kms-wrapping/entropy/v2 v2.0.0/go.mod h1:xvb32K2keAc+R8DSFG2IwDcydK9DBQE+fGA5fsw6hSk=
 github.com/hashicorp/go-memdb v1.3.2 h1:RBKHOsnSszpU6vxq80LzC2BaQjuuvoyaQbkLTf7V7g8=
 github.com/hashicorp/go-memdb v1.3.2/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -1194,7 +1176,6 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
-github.com/hashicorp/go-plugin v1.4.2/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
@@ -1210,17 +1191,13 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 h1:W9WN8p6moV1fjKLkeqEgkAMu5rauy9QeYDAmIaPuuiA=
 github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6/go.mod h1:MpCPSPGLDILGb4JMm94/mMi3YysIqsXzGCzkEZjcjXg=
-github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
-github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
@@ -1240,7 +1217,6 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcl/v2 v2.10.1-0.20210621220818-327f3ce2570e h1:ZloftGcVtVB6MnKQVI7kG4olKQUfUdi0284GOpkJHyc=
 github.com/hashicorp/hcl/v2 v2.10.1-0.20210621220818-327f3ce2570e/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcp-sdk-go v0.27.0 h1:L7fIiZMPD1QnN5iRYH5v/OnWTC05hi29nLoVD7ScZv0=
@@ -1289,7 +1265,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iancoleman/strcase v0.1.2/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.1.3 h1:dJBk1m2/qjL1twPLf68JND55vvivMupZ4wIzE8CTdBw=
 github.com/iancoleman/strcase v0.1.3/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -1555,7 +1530,6 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/hashstructure/v2 v2.0.1 h1:L60q1+q7cXE4JeEJJKMnh2brFIe3rZxCihYAB61ypAY=
 github.com/mitchellh/hashstructure/v2 v2.0.1/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
@@ -1569,7 +1543,6 @@ github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
@@ -2204,7 +2177,6 @@ golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2342,7 +2314,6 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
@@ -2714,7 +2685,6 @@ google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2760,7 +2730,6 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0 h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=
@@ -2930,7 +2899,6 @@ k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -2996,7 +2964,6 @@ sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcL
 sigs.k8s.io/kustomize/kyaml v0.11.0 h1:9KhiCPKaVyuPcgOLJXkvytOvjMJLoxpjodiycb4gHsA=
 sigs.k8s.io/kustomize/kyaml v0.11.0/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/internal/assets/dev_assets.go
+++ b/internal/assets/dev_assets.go
@@ -147,11 +147,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/internal/cli/base.go
+++ b/internal/cli/base.go
@@ -196,14 +196,14 @@ func (c *baseCommand) showValidations(validationResults config.ValidationResults
 // options will affect behavior of other functions that can be called later.
 //
 // In broad strokes, Init populates fields on the baseCommand by doing the following:
-// - Parse flags
-// - Parse input variables
-// - Creates a project client
-// - Triggers creation of the in-memory server (if necessary)
-// - Starts a local runner (if necessary)
-// - Attempts to find a waypoint.hcl config file, and parse it
-// - Determines which project/apps are being targeted, by looking at
-//   the -project and -app flags, the local config, the waypoint server.
+//   - Parse flags
+//   - Parse input variables
+//   - Creates a project client
+//   - Triggers creation of the in-memory server (if necessary)
+//   - Starts a local runner (if necessary)
+//   - Attempts to find a waypoint.hcl config file, and parse it
+//   - Determines which project/apps are being targeted, by looking at
+//     the -project and -app flags, the local config, the waypoint server.
 func (c *baseCommand) Init(opts ...Option) error {
 	baseCfg := baseConfig{}
 

--- a/internal/cli/datagen/datagen.go
+++ b/internal/cli/datagen/datagen.go
@@ -147,11 +147,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -57,10 +57,11 @@ func (c *Project) doJob(ctx context.Context, job *pb.Job, ui terminal.UI) (*pb.J
 
 // setupLocalJobSystem does the pre-work required to run jobs locally.
 // This includes:
-// - figure out if jobs should be executed locally or remotely.
-// - if job should be executed locally, start a local runner
-// - if jobs will be executed remotely, but local VCS is present and
-//   dirty, warn.
+//   - figure out if jobs should be executed locally or remotely.
+//   - if job should be executed locally, start a local runner
+//   - if jobs will be executed remotely, but local VCS is present and
+//     dirty, warn.
+//
 // This lives separately from DoJob because the logs and exec commands
 // need to conditionally warm up the local job infrastructure, but
 // don't actually create a job (the server does).

--- a/internal/client/server.go
+++ b/internal/client/server.go
@@ -27,12 +27,11 @@ import (
 //
 // This function will do one of two things:
 //
-//   1. If connection options were given, it'll attempt to connect to
-//      an existing Waypoint server.
+//  1. If connection options were given, it'll attempt to connect to
+//     an existing Waypoint server.
 //
-//   2. If WithLocal was specified and no connection addresses can be
-//      found, this will spin up an in-memory server.
-//
+//  2. If WithLocal was specified and no connection addresses can be
+//     found, this will spin up an in-memory server.
 func (c *Project) initServerClient(ctx context.Context, cfg *config) (*grpc.ClientConn, error) {
 	log := c.logger.Named("server")
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -350,10 +350,9 @@ func (c *Pipeline) Validate() error {
 // ValidateLabels validates a set of labels. This ensures that labels are
 // set according to our requirements:
 //
-//   * key and value length can't be greater than 255 characters each
-//   * keys must be in hostname format (RFC 952)
-//   * keys can't be prefixed with "waypoint/" which is reserved for system use
-//
+//   - key and value length can't be greater than 255 characters each
+//   - keys must be in hostname format (RFC 952)
+//   - keys can't be prefixed with "waypoint/" which is reserved for system use
 func ValidateLabels(labels map[string]string) ValidationResults {
 	var results ValidationResults
 

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -209,10 +209,9 @@ func (a *App) startPlugin(
 //
 // This always provides some common values for injection:
 //
-//   * *component.Source
-//   * *datadir.Project
-//   * history.Client
-//
+//   - *component.Source
+//   - *datadir.Project
+//   - history.Client
 func (a *App) callDynamicFunc(
 	ctx context.Context,
 	log hclog.Logger,

--- a/internal/pkg/ctystructure/object.go
+++ b/internal/pkg/ctystructure/object.go
@@ -97,10 +97,10 @@ func toValueObject(val reflect.Value, path cty.Path) (cty.Value, error) {
 // unwrapPointer is a helper for dealing with Go pointers. It has three
 // possible outcomes:
 //
-// - Given value isn't a pointer, so it's just returned as-is.
-// - Given value is a non-nil pointer, in which case it is dereferenced
-//   and the result returned.
-// - Given value is a nil pointer, in which case an invalid value is returned.
+//   - Given value isn't a pointer, so it's just returned as-is.
+//   - Given value is a non-nil pointer, in which case it is dereferenced
+//     and the result returned.
+//   - Given value is a nil pointer, in which case an invalid value is returned.
 //
 // For nested pointer types, like **int, they are all dereferenced in turn
 // until a non-pointer value is found, or until a nil pointer is encountered.

--- a/internal/pkg/gitdirty/gitdirty.go
+++ b/internal/pkg/gitdirty/gitdirty.go
@@ -194,8 +194,9 @@ func isHTTPSRemote(remote string) bool {
 
 // remoteConvertHTTPStoSSH converts an https-style remote into its corresponding ssh style remote.
 // Based on regex, and may not match every possible style of remote, but tested on github and gitlab.
-//    Example input: https://git.test/testorg/testrepo.git
-//           output: git@git.test:testorg/testrepo.git
+//
+//	Example input: https://git.test/testorg/testrepo.git
+//	       output: git@git.test:testorg/testrepo.git
 func remoteConvertHTTPStoSSH(httpsRemote string) (string, error) {
 	if !isHTTPSRemote(httpsRemote) {
 		return "", fmt.Errorf("%s is not an https remote", httpsRemote)
@@ -210,10 +211,11 @@ func remoteConvertHTTPStoSSH(httpsRemote string) (string, error) {
 
 // remoteConvertSSHtoHTTPS converts an ssh-style remote into its corresponding https style remote.
 // Based on regex, and may not match every possible style of remote, but tested on github and gitlab.
-//    Example input: git@git.test:testorg/testrepo.git
-//           output: https://git.test/testorg/testrepo.git
-//    Example input: git.test:testorg/testrepo.git
-//           output: https://git.test/testorg/testrepo.git
+//
+//	Example input: git@git.test:testorg/testrepo.git
+//	       output: https://git.test/testorg/testrepo.git
+//	Example input: git.test:testorg/testrepo.git
+//	       output: https://git.test/testorg/testrepo.git
 func remoteConvertSSHtoHTTPS(sshRemote string) (string, error) {
 	if !isSSHRemote(sshRemote) {
 		return "", fmt.Errorf("%s is not an ssh remote", sshRemote)

--- a/internal/pkg/httpfs/bindata_test.go
+++ b/internal/pkg/httpfs/bindata_test.go
@@ -265,11 +265,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/internal/pkg/jsonpb/decode.go
+++ b/internal/pkg/jsonpb/decode.go
@@ -67,6 +67,7 @@ type Unmarshaler struct {
 // implement JSONPBMarshaler so that the custom format can be produced.
 //
 // The JSON unmarshaling must follow the JSON to proto specification:
+//
 //	https://developers.google.com/protocol-buffers/docs/proto3#json
 //
 // Deprecated: Custom types should implement protobuf reflection instead.

--- a/internal/pkg/jsonpb/encode.go
+++ b/internal/pkg/jsonpb/encode.go
@@ -99,6 +99,7 @@ type Marshaler struct {
 // implement JSONPBUnmarshaler so that the custom format can be parsed.
 //
 // The JSON marshaling must follow the proto to JSON specification:
+//
 //	https://developers.google.com/protocol-buffers/docs/proto3#json
 //
 // Deprecated: Custom types should implement protobuf reflection instead.

--- a/internal/pkg/validationext/struct.go
+++ b/internal/pkg/validationext/struct.go
@@ -24,18 +24,18 @@ import (
 //
 // Full example:
 //
-//   s := &Person{
-//     Address: &Address{Number: 0},
-//   }
+//	s := &Person{
+//	  Address: &Address{Number: 0},
+//	}
 //
-//   validation.ValidateStruct(&s,
-//     validation.Field(&s.Address, validation.Required),
-//     StructField(&s.Address, func() []*validation.FieldRules {
-//       return []*validation.FieldRules{
-//         validation.Field(&s.Address.Number, validation.Required),
-//       }
-//     }),
-//   )
+//	validation.ValidateStruct(&s,
+//	  validation.Field(&s.Address, validation.Required),
+//	  StructField(&s.Address, func() []*validation.FieldRules {
+//	    return []*validation.FieldRules{
+//	      validation.Field(&s.Address.Number, validation.Required),
+//	    }
+//	  }),
+//	)
 //
 // In this example, the address number will be required, but will only
 // be checked if the address is non-nil. Without StructField, you either
@@ -69,33 +69,33 @@ func StructInterface(sv, t interface{}, f func() []*validation.FieldRules) *vali
 //
 // Given the protobuf of:
 //
-//   message Employee {
-//     oneof role {
-//       Eng eng = 1;
-//       Sales sales = 2;
-//     }
-//   }
+//	message Employee {
+//	  oneof role {
+//	    Eng eng = 1;
+//	    Sales sales = 2;
+//	  }
+//	}
 //
 // The generated types look something lke this:
 //
-//   type Employee { Role Role }
-//   type Role interface{}
-//   type Role_Eng struct { Eng *Eng }
-//   type Role_Sales struct { Sales *Sales }
-//   type Eng { Language string }
-//   ...
+//	type Employee { Role Role }
+//	type Role interface{}
+//	type Role_Eng struct { Eng *Eng }
+//	type Role_Sales struct { Sales *Sales }
+//	type Eng { Language string }
+//	...
 //
 // To validate this, you can do this:
 //
-//   var e *Employee
-//   validation.ValidateStruct(&e,
-//     StructOneof(&e.Role, (*Eng)(nil), func() []*validation.FieldRules {
-//       v := e.Role.(*Role_Eng)
-//       return []*validation.FieldRules{
-//         validation.Field(&v.Eng.Language, validation.Required),
-//       }
-//     }),
-//   )
+//	var e *Employee
+//	validation.ValidateStruct(&e,
+//	  StructOneof(&e.Role, (*Eng)(nil), func() []*validation.FieldRules {
+//	    v := e.Role.(*Role_Eng)
+//	    return []*validation.FieldRules{
+//	      validation.Field(&v.Eng.Language, validation.Required),
+//	    }
+//	  }),
+//	)
 //
 // Notice how the callback sets validation on the nested `e.Role.Eng` directly.
 // This helper saves a few lines of boilerplate and complicated pointer
@@ -108,12 +108,13 @@ func StructInterface(sv, t interface{}, f func() []*validation.FieldRules) *vali
 // intermediate wrapper struct is set. This results in the following cases:
 //
 // Valid:
-//   Employee{ Role: nil }
-//   Employee{ Role: &Role_Eng{ Eng: &Eng {} } }
+//
+//	Employee{ Role: nil }
+//	Employee{ Role: &Role_Eng{ Eng: &Eng {} } }
 //
 // Invalid (a validation error is produced):
-//   Employee{ Role: &Role_Eng{ Eng: nil } }
 //
+//	Employee{ Role: &Role_Eng{ Eng: nil } }
 func StructOneof(sv, t interface{}, f func() []*validation.FieldRules) *validation.FieldRules {
 	return validation.Field(sv, &structFieldRule{s: sv, rules: f, iface: t, oneof: true})
 }
@@ -131,20 +132,18 @@ func StructOneof(sv, t interface{}, f func() []*validation.FieldRules) *validati
 //
 // Example:
 //
+//	req := struct{
+//	  Employee []byte
+//	}
 //
-//   req := struct{
-//     Employee []byte
-//   }
-//
-//   var e pb.Employee
-//   validation.ValidateStruct(&req,
-//     StructJSONPB(&req.Employee, &e, func() []*validation.FieldRules {
-//       return []*validation.FieldRules{
-//         validation.Field(&e.Name, validation.Required),
-//       }
-//     }),
-//   )
-//
+//	var e pb.Employee
+//	validation.ValidateStruct(&req,
+//	  StructJSONPB(&req.Employee, &e, func() []*validation.FieldRules {
+//	    return []*validation.FieldRules{
+//	      validation.Field(&e.Name, validation.Required),
+//	    }
+//	  }),
+//	)
 func StructJSONPB(sv interface{}, v proto.Message, f func() []*validation.FieldRules) *validation.FieldRules {
 	return validation.Field(sv, &structJSONPBRule{s: sv, v: v, rules: f})
 }

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -35,7 +35,6 @@ type Config struct {
 //
 // This will search the paths given. You can use DefaultPaths() to get
 // the default set of paths.
-//
 func Discover(cfg *Config, paths []string) (*exec.Cmd, error) {
 	// Expected filename
 	expected := "waypoint-plugin-" + cfg.Name
@@ -79,10 +78,9 @@ func Discover(cfg *Config, paths []string) (*exec.Cmd, error) {
 
 // DefaultPaths returns the default search paths for plugins. These are:
 //
-//   * pwd given
-//   * "$pwd/.waypoint/plugins"
-//   * "$XDG_CONFIG_DIR/waypoint/plugins"
-//
+//   - pwd given
+//   - "$pwd/.waypoint/plugins"
+//   - "$XDG_CONFIG_DIR/waypoint/plugins"
 func DefaultPaths(pwd string) ([]string, error) {
 	xdgPath, err := xdg.ConfigFile("waypoint/plugins/.ignore")
 	if err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -39,20 +39,19 @@ const (
 //
 // To use a runner:
 //
-//   1. Initialize it with New. This will setup some initial state but
-//      will not register with the server or run jobs.
+//  1. Initialize it with New. This will setup some initial state but
+//     will not register with the server or run jobs.
 //
-//   2. Start the runner with "Start". This will register the runner and
-//      kick off some management goroutines. This will not execute any jobs.
+//  2. Start the runner with "Start". This will register the runner and
+//     kick off some management goroutines. This will not execute any jobs.
 //
-//   3. Run a single job with "Accept". This is named to be similar to a
-//      network listener "accepting" a connection. This will request a single
-//      job from the Waypoint server, block until one is available, and execute
-//      it. Repeat this call for however many jobs you want to execute.
+//  3. Run a single job with "Accept". This is named to be similar to a
+//     network listener "accepting" a connection. This will request a single
+//     job from the Waypoint server, block until one is available, and execute
+//     it. Repeat this call for however many jobs you want to execute.
 //
-//   4. Clean up with "Close". This will gracefully exit the runner, waiting
-//      for any running jobs to finish.
-//
+//  4. Clean up with "Close". This will gracefully exit the runner, waiting
+//     for any running jobs to finish.
 type Runner struct {
 	id          string
 	logger      hclog.Logger
@@ -509,8 +508,8 @@ func WithCookie(v string) Option {
 // state between restarts. This is optional, a runner can be stateless, but
 // has some limitations. The state dir enables:
 //
-//   * persisted runner ID across restarts
-//   * persisted adoption token across restarts
+//   - persisted runner ID across restarts
+//   - persisted adoption token across restarts
 //
 // The state directory will be created if it does not exist.
 func WithStateDir(v string) Option {

--- a/internal/server/boltdbstate/db.go
+++ b/internal/server/boltdbstate/db.go
@@ -19,14 +19,14 @@ var (
 	sysVersionKey = []byte("version")
 )
 
-//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //
-// DB Version
+// # DB Version
 //
 // THIS SHOULD BE CHANGED WITH EXTREME CAUTION. Changing this will force users
 // to perform a db upgrade when they upgrade their Waypoint version.
 //
-//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 const (
 	dbVersion int64 = 1
 )

--- a/internal/serverinstall/k8s.go
+++ b/internal/serverinstall/k8s.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/waypoint/pkg/serverconfig"
 )
 
-//
 type K8sInstaller struct {
 	Config k8sinstallutil.K8sConfig
 	// Config k8sConfig

--- a/pkg/auth/oidc/claims.go
+++ b/pkg/auth/oidc/claims.go
@@ -97,11 +97,11 @@ func extractMappings(
 // of claims and claims mappings.  The referenced claims must be strings and
 // the claims mappings must be of the structure:
 //
-//   {
-//       "/some/claim/pointer": "metadata_key1",
-//       "another_claim": "metadata_key2",
-//        ...
-//   }
+//	{
+//	    "/some/claim/pointer": "metadata_key1",
+//	    "another_claim": "metadata_key2",
+//	     ...
+//	}
 func extractListMappings(
 	all map[string]interface{}, mappings map[string]string,
 ) (map[string][]string, error) {

--- a/pkg/protocolversion/current.go
+++ b/pkg/protocolversion/current.go
@@ -5,15 +5,15 @@ import (
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
-//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //
-// Protocol Versions
+// # Protocol Versions
 //
 // These define the protocol versions supported by the server. You must be
 // VERY THOUGHTFUL when modifying these values. Please read and re-read our
 // upgrade policy to understand how these values work.
 //
-//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 const (
 	protocolVersionApiCurrent        uint32 = 1
 	protocolVersionApiMin                   = 1

--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -1388,9 +1388,9 @@ func (Hcl_Format) EnumDescriptor() ([]byte, []int) {
 	return file_pkg_server_proto_server_proto_rawDescGZIP(), []int{209, 0}
 }
 
-//*******************************************************************
+// *******************************************************************
 // UI
-//******************************************************************
+// ******************************************************************
 type UI struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -9151,9 +9151,9 @@ func (x *Artifact) GetArtifactJson() string {
 	return ""
 }
 
-//*******************************************************************
+// *******************************************************************
 // OnDemand Runners
-//******************************************************************
+// ******************************************************************
 type OnDemandRunnerConfig struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -13308,17 +13308,16 @@ func (x *LogBatch) GetLines() []*LogBatch_Entry {
 // both the project and app scope), the following rules are applied to determine
 // which variable value is used:
 //
-//   1. If a workspace is set one one but not the other, the variable
-//      with the workspace sorts higher than no workspace.
+//  1. If a workspace is set one one but not the other, the variable
+//     with the workspace sorts higher than no workspace.
 //
-//   2. The most specific "scope" is used: app over project over global.
+//  2. The most specific "scope" is used: app over project over global.
 //
-//   3. If scopes match, the variable with a label selector set is used.
+//  3. If scopes match, the variable with a label selector set is used.
 //
-//   4. If both have label selectors, the config variable with the longer
-//      label selector by string length is used. This is arbitrary but makes
-//      the process deterministic.
-//
+//  4. If both have label selectors, the config variable with the longer
+//     label selector by string length is used. This is arbitrary but makes
+//     the process deterministic.
 type ConfigVar struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/server/logbuffer/logbuffer.go
+++ b/pkg/server/logbuffer/logbuffer.go
@@ -27,21 +27,21 @@ var (
 // the next read may "jump" forward to catch up. There is no way to explicitly
 // detect a jump currently.
 //
-// Writer
+// # Writer
 //
 // The writer calls Write on the buffer as it gets log entries. Multiple
 // writers are safe to use. The buffer will always successfully write all
 // entries, though it may result in extra allocations.
 //
-//     buf.Write(entries...)
+//	buf.Write(entries...)
 //
-// Reader
+// # Reader
 //
 // A reader calls buf.Reader to get a Reader structure, and then calls Read
 // to read values from the buffer. The Reader structure is used to maintain
 // per-reader cursors so that multiple readers can exist at multiple points.
 //
-// Internal Details
+// # Internal Details
 //
 // A buffer is structured as a sliding window over a set of "chunks". A chunk
 // is a set of log entries. As you write into the buffer, the buffer will

--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6
+FROM golang:1.19
 
 ARG PROTOC_VERSION="3.17.3"
 


### PR DESCRIPTION
Most of these changes are the result of running the new go 1.19 formatter.