### PR TITLE
Fix Job Stream test flakiness

### DIFF
--- a/pkg/serverhandler/handlertest/test_service_job.go
+++ b/pkg/serverhandler/handlertest/test_service_job.go
@@ -486,10 +486,11 @@ func TestServiceGetJobStream_complete(t *testing.T, factory Factory) {
 		require.NotNil(state.State.Job)
 	}
 
-	// We need to give the stream time to initialize the output readers
-	// so our output below doesn't become buffered. This isn't really that
-	// brittle and 100ms should be more than enough.
-	time.Sleep(100 * time.Millisecond)
+	// This sleep must be > than the time it takes to start a reader in
+	// getJobStreamOutputInit, from pkg/server/singleprocess; otherwise, the
+	// output will be buffered. If this test becomes flakey, this time should
+	// be increased.
+	time.Sleep(200 * time.Millisecond)
 
 	// Send some output
 	require.NoError(runnerStream.Send(&pb.RunnerJobStreamRequest{


### PR DESCRIPTION
In pkg/server/singleprocess, the function below starts the job output reader
```go
func (s *Service) getJobStreamOutputInit(
   ctx context.Context,
   log hclog.Logger,
   job *serverstate.Job,
   server pb.Waypoint_GetJobStreamServer,
) (<-chan []*pb.GetJobStreamResponse_Terminal_Event, error) {
   // Start a log stream reader for this job
   lsReader, err := s.logStreamProvider.StartReader(ctx, log, job)
```

I was able to reproduce the failing test locally by slipping in a long sleep, which leads to the output being buffered. This test can be run with the command `go test -test.v ./pkg/server/singleprocess -count=1 -run=TestHandlers/job/TestServiceGetJobStream_complete`.
```go
func (s *Service) getJobStreamOutputInit(
   ctx context.Context,
   log hclog.Logger,
   job *serverstate.Job,
   server pb.Waypoint_GetJobStreamServer,
) (<-chan []*pb.GetJobStreamResponse_Terminal_Event, error) {
   // Start a log stream reader for this job
   time.Sleep(time.Second * 5) // doing this causes the test to fail
   lsReader, err := s.logStreamProvider.StartReader(ctx, log, job)
```

This PR updates the amount of time to wait for the job output reader to start, to avoid the output becoming buffered, and thusly failing the test. If the test continues to be flakey, the time to sleep should be increased further.