### PR TITLE
cli: Respect DataSourceOverrides CLI flag

### DIFF
--- a/.changelog/4319.txt
+++ b/.changelog/4319.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli: Respect `-remote-source` overrides for submitted job template when running
+`waypoint pipeline run`.
+```

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -103,6 +103,10 @@ func (c *PipelineRunCommand) Run(args []string) int {
 			Variables:    c.variables,
 		}
 
+		if c.flagRemoteSource != nil {
+			runJobTemplate.DataSourceOverrides = c.flagRemoteSource
+		}
+
 		// build the base api request
 		runPipelineReq := &pb.RunPipelineRequest{
 			JobTemplate: runJobTemplate,


### PR DESCRIPTION
Prior to this commit, the job template submitted by the pipeline run CLI would ignore any data source overrides defined by the base CLI flag. This commit updates that to respect those overrides, if set.