### PR TITLE
server: Ensure a job is not stuck in Running and is Completed on err processing job events

### DIFF
--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -610,11 +610,12 @@ func (s *Service) RunnerJobStream(
 		if err != nil {
 			return hcerr.Externalize(log, err, "failed to get job assignment for runner")
 		}
+		jobId = job.Id
 	}
 	if job == nil || job.Job == nil {
 		panic("job is nil, should never be nil at this point")
 	}
-	log = log.With("job_id", job.Id)
+	log = log.With("job_id", jobId)
 
 	// Load config sourcers to send along with the job assignment
 	cfgSrcs, err := s.state(ctx).ConfigSourceGetWatch(ctx, &pb.GetConfigSourceRequest{
@@ -685,7 +686,7 @@ func (s *Service) RunnerJobStream(
 	if !reattach {
 		// Send the ack OR nack, based on the value of +ack+.
 		var ackerr error
-		job, ackerr = s.state(ctx).JobAck(ctx, job.Id, ack)
+		job, ackerr = s.state(ctx).JobAck(ctx, jobId, ack)
 		if ackerr != nil {
 			// If this fails, we just log, there is nothing more we can do.
 			log.Warn("job ack failed", "outer_error", err, "error", ackerr)
@@ -708,14 +709,14 @@ func (s *Service) RunnerJobStream(
 		// we cancel the job.
 		if !ack {
 			log.Warn("reattach job was nacked, force cancelling")
-			err = s.state(ctx).JobCancel(ctx, job.Id, true)
+			err = s.state(ctx).JobCancel(ctx, jobId, true)
 		}
 	}
 
 	// If we have an error, return that. We also return if we didn't ack for
 	// any reason. This error can be set at any point since job assignment.
 	if err != nil {
-		return hcerr.Externalize(log, err, "failed to ack the job or the job was cancelled", "id")
+		return hcerr.Externalize(log, err, "failed to ack the job or the job was cancelled", "id", jobId)
 	}
 	if !ack {
 		// If runners don't ack the job, this means close the stream
@@ -742,7 +743,7 @@ func (s *Service) RunnerJobStream(
 	go func() {
 		for {
 			ws := memdb.NewWatchSet()
-			job, err = s.state(ctx).JobById(ctx, job.Id, ws)
+			job, err = s.state(ctx).JobById(ctx, jobId, ws)
 			if err != nil {
 				errCh <- errors.Wrapf(err, "failed getting job by id from state %q", jobId)
 				return

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -839,7 +839,22 @@ func (s *Service) RunnerJobStream(
 			if job == nil {
 				select {
 				case err := <-errCh:
+					// NOTE(briancain): In this case, it means we've received an event from
+					// the event channel, however `job` was nil, and `err` was not. This
+					// means we received an error trying to retrieve a job by Id and need
+					// to properly handle that.
 					log.Error("Job disappeared and there was an error while processing job event", "error", err, "event", req)
+
+					// Attempt to complete job with original jobId so that the original
+					// job Id isn't left hanging in a Running state. We also send through
+					// the error to give to the job details for why it's Errored.
+					if err := s.state(ctx).JobComplete(ctx, jobId, nil, err); err != nil {
+						return hcerr.Externalize(log, err,
+							"failed to complete job while failing to process job event",
+							"id", jobId,
+							"event_request", req)
+					}
+
 					return hcerr.Externalize(log, err, "failed to process job event", "event_request", req)
 				default:
 				}

--- a/pkg/server/singleprocess/service_runner.go
+++ b/pkg/server/singleprocess/service_runner.go
@@ -745,11 +745,11 @@ func (s *Service) RunnerJobStream(
 			ws := memdb.NewWatchSet()
 			job, err = s.state(ctx).JobById(ctx, jobId, ws)
 			if err != nil {
-				errCh <- errors.Wrapf(err, "failed getting job by id from state %q", jobId)
+				errCh <- errors.Wrapf(err, "error getting job by id from state %q", jobId)
 				return
 			}
 			if job == nil {
-				errCh <- status.Errorf(codes.Internal, "job disappeared")
+				errCh <- status.Errorf(codes.Internal, "failed to find job for id %q", jobId)
 				return
 			}
 


### PR DESCRIPTION
This pull request attempts to add more detailed logging in the bad event where Waypoint server fails to process a job event, and loses the job id that it was originally processing events for. Additionally, it will attempt to complete the original job we were processing with the original jobId so that Running jobs aren't stuck and don't lock out the users ability to run jobs.