### PR TITLE
Adding mechanism for surfacing deep errors to users

### DIFF
--- a/pkg/server/hcerr/doc.go
+++ b/pkg/server/hcerr/doc.go
@@ -1,3 +1,14 @@
 // Package hcerr contains helpers to format and sanitize errors before returning
 // them to clients as grpc status errors.
+//
+// At the service layer, it's not safe to assume that errors produced from lower
+// layers can be returned directly to callers. Errors may contain sensitive
+// and irrelevant information, like the internal address of a database that
+// we've failed to connect to.
+//
+// Hcerr helps the service layer log context from these errors, and return
+// a known safe error to the caller.
+//
+// If an error producer deeper in the call stack wants to produce an error
+// that a caller will see, they can use hcerr.UserErrorf()
 package hcerr

--- a/pkg/server/hcerr/hcerr.go
+++ b/pkg/server/hcerr/hcerr.go
@@ -48,11 +48,23 @@ func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) e
 		code = codes.Internal
 	}
 
-	//var userError UserError
-	//if errors.As(err, &userError) {
-	//	// Otherwise use any code already in the error
-	//	msg = msg + " " + userError.Message
-	//}
+	var currentErr error
+	currentErr = err
+	var userErrs []UserError
+	for {
+		fmt.Println("starting loop")
+		if userErr, ok := currentErr.(UserError); ok {
+			userErrs = append(userErrs, userErr)
+		}
+		nextErr := errors.Unwrap(currentErr)
+		currentErr = nextErr
+		fmt.Println("hello0")
+		if currentErr == nil {
+			fmt.Println("hello1")
+			break
+		}
+		fmt.Println("hello2")
+	}
 
 	var details []*anypb.Any
 	if len(args) > 0 {

--- a/pkg/server/hcerr/hcerr.go
+++ b/pkg/server/hcerr/hcerr.go
@@ -87,9 +87,13 @@ func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) e
 		}
 	}
 
-	return status.FromProto(&spb.Status{
+	stat := status.FromProto(&spb.Status{
 		Code:    int32(code),
 		Message: msg,
 		Details: details,
-	}).Err()
+	})
+
+	ret := stat.Err()
+
+	return ret
 }

--- a/pkg/server/hcerr/hcerr.go
+++ b/pkg/server/hcerr/hcerr.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
@@ -47,6 +48,12 @@ func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) e
 		code = codes.Internal
 	}
 
+	//var userError UserError
+	//if errors.As(err, &userError) {
+	//	// Otherwise use any code already in the error
+	//	msg = msg + " " + userError.Message
+	//}
+
 	var details []*anypb.Any
 	if len(args) > 0 {
 
@@ -75,4 +82,18 @@ func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) e
 		Message: msg,
 		Details: details,
 	}).Err()
+}
+
+type UserError struct {
+	Message string
+}
+
+func (m UserError) Error() string {
+	return m.Message
+}
+
+// TODO: string interpolation arguments
+func UserErrorf(err error, message string) error {
+	return multierror.Append(err, UserError{Message: message})
+	//return multierror.Append(err, errors.New(message))
 }

--- a/pkg/server/hcerr/hcerr_test.go
+++ b/pkg/server/hcerr/hcerr_test.go
@@ -1,6 +1,7 @@
 package hcerr
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -54,4 +55,25 @@ func TestExternalize(t *testing.T) {
 		details := statusErr.Details()
 		require.Len(details, 2)
 	})
+}
+
+func TestUserError(t *testing.T) {
+	log := hclog.New(&hclog.LoggerOptions{Level: hclog.Debug})
+
+	baseError := errors.New("base")
+
+	userError := UserErrorf(baseError, "user facing message")
+
+	finalError := Externalize(log, userError, "top-level message")
+	fmt.Println(finalError)
+
+	t.Run("Multiple levels of user error", func(t *testing.T) {
+		baseError := errors.New("base")
+		userError1 := UserErrorf(baseError, "user facing message 1")
+		userError2 := UserErrorf(userError1, "user facing message 2")
+
+		finalError := Externalize(log, userError2, "top-level message")
+		fmt.Println(finalError)
+	})
+
 }

--- a/pkg/server/hcerr/hcerr_test.go
+++ b/pkg/server/hcerr/hcerr_test.go
@@ -1,7 +1,6 @@
 package hcerr
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -59,23 +58,39 @@ func TestExternalize(t *testing.T) {
 
 func TestUserError(t *testing.T) {
 	log := hclog.New(&hclog.LoggerOptions{Level: hclog.Debug})
+	require := require.New(t)
 
 	t.Run("One level of user errors", func(t *testing.T) {
-		baseError := errors.New("base")
+		baseError := errors.New("failed to connect to db at 10.0.0.sensitive")
+		userError := UserErrorf(baseError, "missing required field 'foo'. Try resubmitting after specifying 'foo'")
 
-		userError := UserErrorf(baseError, "user facing message")
+		finalError := Externalize(log, userError, "failed to perform action foobarbaz")
 
-		finalError := Externalize(log, userError, "top-level message")
-		fmt.Println(finalError)
+		require.NotContainsf(finalError.Error(), "failed to connect to db at 10.0.0.sensitive", "contains base error")
+		require.Contains(finalError.Error(), "missing required field 'foo'. Try resubmitting after specifying 'foo'")
+		require.Contains(finalError.Error(), "failed to perform action foobarbaz")
 	})
 
-	t.Run("Multiple levels of user error", func(t *testing.T) {
-		baseError := errors.New("base")
-		userError1 := UserErrorf(baseError, "user facing message 1")
-		userError2 := UserErrorf(userError1, "user facing message 2")
+	t.Run("Multiple levels of wrapping", func(t *testing.T) {
+		baseError := errors.New("failed to connect to db at 10.0.0.sensitive")
+		userError1 := UserErrorf(baseError, "missing required field 'foo'. Try resubmitting after specifying 'foo'")
+		middleError := errors.Wrapf(userError1, "failed to do specific internal thing")
+		userError2 := UserErrorf(middleError, "invalid value 'baz' for argument 'bar'")
 
-		finalError := Externalize(log, userError2, "top-level message")
-		fmt.Println(finalError)
+		finalError := Externalize(log, userError2, "failed to perform action foobarbaz")
+
+		require.NotContainsf(finalError.Error(), "failed to connect to db at 10.0.0.sensitive", "contains base error")
+		require.Contains(finalError.Error(), "missing required field 'foo'. Try resubmitting after specifying 'foo'")
+		require.NotContainsf(finalError.Error(), "failed to do specific internal thing", "contains middle internal error")
+		require.Contains(finalError.Error(), "invalid value 'baz' for argument 'bar'")
+		require.Contains(finalError.Error(), "failed to perform action foobarbaz")
 	})
 
+	t.Run("Supports status codes", func(t *testing.T) {
+		internalStatusErr := status.Errorf(codes.Internal, "unknown internal failure")
+		userErr := UserErrorWithCodef(codes.InvalidArgument, internalStatusErr, "it's not an internal error actually, you made a mistake o user")
+
+		finalErr := Externalize(log, userErr, "no new information for the user here")
+		require.Equal(status.Code(finalErr), codes.InvalidArgument)
+	})
 }

--- a/pkg/server/hcerr/hcerr_test.go
+++ b/pkg/server/hcerr/hcerr_test.go
@@ -60,12 +60,14 @@ func TestExternalize(t *testing.T) {
 func TestUserError(t *testing.T) {
 	log := hclog.New(&hclog.LoggerOptions{Level: hclog.Debug})
 
-	baseError := errors.New("base")
+	t.Run("One level of user errors", func(t *testing.T) {
+		baseError := errors.New("base")
 
-	userError := UserErrorf(baseError, "user facing message")
+		userError := UserErrorf(baseError, "user facing message")
 
-	finalError := Externalize(log, userError, "top-level message")
-	fmt.Println(finalError)
+		finalError := Externalize(log, userError, "top-level message")
+		fmt.Println(finalError)
+	})
 
 	t.Run("Multiple levels of user error", func(t *testing.T) {
 		baseError := errors.New("base")

--- a/pkg/server/hcerr/user_error.go
+++ b/pkg/server/hcerr/user_error.go
@@ -1,0 +1,70 @@
+package hcerr
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UserError is a custom error type designed to package
+// detail that will be displayed to a user, alongside
+// some internal error message that may be unsafe to surface.
+//
+// UserError also implements grpcError, allowing it to optionally
+// contain a custom grpc status code, which will be returned to the
+// user if set.
+type UserError struct {
+	UserMessage string
+	err         error
+	statusCode  codes.Code
+}
+
+func (m UserError) Error() string {
+	return fmt.Sprintf("%s: (user message: %q)", m.err.Error(), m.UserMessage)
+}
+
+func (m UserError) Unwrap() error {
+	return m.err
+}
+
+// GRPCStatus implements grpcError
+func (m UserError) GRPCStatus() *status.Status {
+	return status.New(m.statusCode, "")
+}
+
+// NewUserError returns a new error with a message intended to be seen by server callers.
+// The message should not contain anything sensitive or internal (i.e. database addresses,
+// details of our internal processing, etc), and should be helpful to users in diagnosing
+// why this error occurred and what they can do to avoid it in the future.
+func NewUserError(message string) error {
+	return UserError{
+		UserMessage: message,
+	}
+}
+
+// NewUserErrorf is the same as NewUserError, with string formatting for convenience
+func NewUserErrorf(format string, a ...interface{}) error {
+	return UserError{
+		UserMessage: fmt.Sprintf(format, a...),
+	}
+}
+
+// UserErrorf wraps an existing error with a UserError
+func UserErrorf(err error, format string, a ...interface{}) error {
+	return UserError{
+		UserMessage: fmt.Sprintf(format, a...),
+		err:         err,
+	}
+}
+
+// UserErrorWithCodef wraps an existing error with a UserError, and takes
+// a grpc status code, which will be used by the final hcerr.Externalize
+// call as the status code to present to the user.
+func UserErrorWithCodef(c codes.Code, err error, format string, a ...interface{}) error {
+	return UserError{
+		UserMessage: fmt.Sprintf(format, a...),
+		err:         err,
+		statusCode:  c,
+	}
+}

--- a/pkg/server/hcerr/user_error.go
+++ b/pkg/server/hcerr/user_error.go
@@ -9,7 +9,7 @@ import (
 )
 
 // UserError is a custom error type designed to package
-// detail that will be displayed to a user, alongside
+// details that will be displayed to a user, alongside
 // some internal error message that may be unsafe to surface.
 //
 // UserError also implements grpcError, allowing it to optionally

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -196,7 +196,7 @@ func (s *Service) queueJobReqToJob(
 		dur, err := time.ParseDuration(req.ExpiresIn)
 		if err != nil {
 			return nil, "", hcerr.UserErrorWithCodef(codes.FailedPrecondition, err,
-				"Invalid expiry duration: %s", err.Error())
+				"Invalid job expiry duration %q: %q", req.ExpiresIn, err.Error())
 		}
 		job.ExpireTime = timestamppb.New(time.Now().Add(dur))
 	}

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -135,21 +135,19 @@ func (s *Service) queueJobReqToJob(
 	log.Debug("checking job project", "project", job.Application.Project)
 	project, err := s.state(ctx).ProjectGet(ctx, &pb.Ref_Project{Project: job.Application.Project})
 	if status.Code(err) == codes.NotFound {
-		return nil, "", status.Errorf(codes.NotFound,
+		return nil, "", hcerr.UserErrorWithCodef(codes.NotFound, nil,
 			"Project %q was not found! Please ensure that 'waypoint init' was run with this project.",
-			job.Application.Project,
-		)
+			job.Application.Project)
 	}
 
 	if job.DataSource == nil {
 		if project.DataSource == nil {
-			return nil, "", status.Errorf(codes.FailedPrecondition,
+			return nil, "", hcerr.UserErrorWithCodef(codes.FailedPrecondition, nil,
 				"Project %s does not have a data source configured. Remote jobs "+
 					"require a data source such as Git to be configured with the project. "+
 					"Data sources can be configured via the CLI or UI. For help, see : "+
 					"https://www.waypointproject.io/docs/projects/git#configuring-the-project",
-				job.Application.Project,
-			)
+				job.Application.Project)
 		}
 
 		job.DataSource = project.DataSource
@@ -161,7 +159,7 @@ func (s *Service) queueJobReqToJob(
 			job, err = s.populateDataSource(ctx, job)
 			if err != nil {
 				log.Error("error populating data source for job", "error", err)
-				return nil, "", status.Errorf(codes.Internal,
+				return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
 					"An internal server issue was detected when calculating the data source")
 			}
 
@@ -169,14 +167,14 @@ func (s *Service) queueJobReqToJob(
 			// error out.
 			if job.DataSource.GetRemote() != nil {
 				log.Error("populateDataSource returned another remote DS job")
-				return nil, "", status.Errorf(codes.Internal,
+				return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
 					"An internal server issue was detected when calculating the data source")
 			}
 		} else {
 			log.Error("job has a remote DataSource but server provided no populateDataSource")
 			// This is a server misconfiguration.
 			if job.DataSource.GetRemote() != nil {
-				return nil, "", status.Errorf(codes.Internal,
+				return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
 					"An internal server issue was detected when calculating the data source")
 			}
 		}
@@ -186,7 +184,8 @@ func (s *Service) queueJobReqToJob(
 	if job.Id == "" {
 		id, err := server.Id()
 		if err != nil {
-			return nil, "", status.Errorf(codes.Internal, "uuid generation failed: %s", err)
+			return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
+				"uuid generation failed")
 		}
 		job.Id = id
 	}
@@ -196,7 +195,7 @@ func (s *Service) queueJobReqToJob(
 	if req.ExpiresIn != "" {
 		dur, err := time.ParseDuration(req.ExpiresIn)
 		if err != nil {
-			return nil, "", status.Errorf(codes.FailedPrecondition,
+			return nil, "", hcerr.UserErrorWithCodef(codes.FailedPrecondition, err,
 				"Invalid expiry duration: %s", err.Error())
 		}
 		job.ExpireTime = timestamppb.New(time.Now().Add(dur))


### PR DESCRIPTION
Closes https://github.com/hashicorp/waypoint/issues/3994 (and recommend reading that for context)

Big thanks to @cicoyle for pairing on this! 

Will squash before merging

## What does this do?

This adds a new error type in hcerr. If a function other than the top-level serivice handler (who calls hcerr.Externalize) wants to surface user-facing detail, they can use `hcerr.UserError*` functions to create a new error that contains user-safe detail. `hcerr.Externalize` will notice if the error stack has any UserErrors on it, and will gather those details and surface them to the user in the final error.

## Demonstration

Running `waypoint pipeline run` on a project without a remote ref before:

```
$ waypoint pipeline run up

» Running pipeline "up" for application "web"
❌ Requesting to queue run of pipeline "up"...

» Performing operation locally
! 1 error occurred:
  	* rpc error: code = FailedPrecondition desc = error queueing jobs for pipeline
  
```

and after

```
$ waypoint pipeline run hello

» Running pipeline "hello" for application "web"
❌ Requesting to queue run of pipeline "hello"...

» Performing operation locally
! 1 error occurred:
  	* rpc error: code = FailedPrecondition desc = error queueing jobs for pipeline
  Project nginx-project-metrictest does not have a data source configured. Remote
  jobs require a data source such as Git to be configured with the project. Data
  sources can be configured via the CLI or UI. For help, see :
  https://www.waypointproject.io/docs/projects/git#configuring-the-project

```

