### PR TITLE
aws/lambda: Inject deployment configs to Lambda functions

### DIFF
--- a/.changelog/4328.txt
+++ b/.changelog/4328.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+aws/lambda: fix issue where deployment configuration was not injected in to
+Lambda function environments, preventing waypoint-entrypoint from authenticating
+with the Waypoint server
+```

--- a/builtin/aws/lambda/platform.go
+++ b/builtin/aws/lambda/platform.go
@@ -303,6 +303,10 @@ func (p *Platform) Deploy(
 		envVars[k] = aws.String(v)
 	}
 
+	for k, v := range deployConfig.Env() {
+		envVars[k] = aws.String(v)
+	}
+
 	step.Done()
 
 	step = sg.Add("Reading Lambda function: %s", src.App)


### PR DESCRIPTION
This PR injects the Waypoint deployment env vars into the Lambda function environment, so that the bundled entrypoint has the information it needs to connect to the Waypoint server. This should enable things like config vars to work in lambda functions. 

This does expose the values in the functions configuration for all to see, but I don't know if that is a concern or not: 

![lambda_configs](https://user-images.githubusercontent.com/61721/207470198-7d9555e2-6543-4aec-abc6-0b181ad6a448.png)