### PR TITLE
internal/core: Gracefully handle bad proto message from destroyments

### DIFF
--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -138,7 +138,7 @@ func (a *App) destroyDeploy(
 	if !ok {
 		a.UI.Output("Failed to convert operation to a Deployment proto message, "+
 			"cannot detail which resources were destroyed or left around. The deployment "+
-			"message is of type %T"+
+			"message is of type %T. "+
 			"Please report this issue if it persists. Waypoint will continue on...",
 			reflect.TypeOf(destroyment),
 			terminal.WithErrorStyle())

--- a/internal/core/app_deploy_destroy.go
+++ b/internal/core/app_deploy_destroy.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/hashicorp/go-argmapper"
 	"github.com/mitchellh/mapstructure"
@@ -127,10 +128,21 @@ func (a *App) destroyDeploy(
 	if err != nil {
 		return err
 	}
+	if destroyment == nil {
+		a.UI.Output("The destroy deployment operation returned nothing, cannot "+
+			"determine what old resources were destroyed or left behind", terminal.WithWarningStyle())
+		return nil
+	}
 
 	destroyProto, ok := destroyment.(*pb.Deployment)
 	if !ok {
-		return errors.New("error converting operation message into a Deployment proto message")
+		a.UI.Output("Failed to convert operation to a Deployment proto message, "+
+			"cannot detail which resources were destroyed or left around. The deployment "+
+			"message is of type %T"+
+			"Please report this issue if it persists. Waypoint will continue on...",
+			reflect.TypeOf(destroyment),
+			terminal.WithErrorStyle())
+		return nil
 	}
 
 	var message string


### PR DESCRIPTION
Prior to this commit, if a plugin returned a non-Deployment proto message, we would hard fail the entire operation. Considering that we are retreiving this message to print what resources were left around or destroyed, we should not hard fail on this and instead print the error to the user that we cannot tell them about these resources and move on. It also incldues the "type" that was returned.