### PR TITLE
[app_docs] add `hclFormat` func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ gen/doc: # generates the server proto docs
 		--doc_out=./doc --doc_opt=html,index.html \
 		./pkg/server/proto/server.proto
 
+.PHONY: gen/integrations-hcl
+gen/integrations-hcl: # Generates the HCL docs for integrations
+	go run ./cmd/waypoint docs -hcl
+
 .PHONY: gen/website-mdx
 gen/website-mdx: # Generates the website markdown files
 	go run ./cmd/waypoint docs -website-mdx

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -438,6 +438,8 @@ func removeEmptyStrings(s []string) []string {
 	return r
 }
 
+// generates README.md, parameters.hcl, and outputs.hcl for builtin plugins' components
+// TODO: consider treating config-sourcers differently
 func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 	// example target = builtin/aws/ami/components/builder/outputs.hcl
 
@@ -450,7 +452,9 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 		"releasemanager": "release-manager",
 		"task":           "task",
 	}
+
 	// mapping of plugin names to proper /builtin folder paths
+	// see internal/plugin/plugin.go > Builtins
 	nameToDirMapping := map[string]string{
 		"aws-alb":                  "aws/alb",
 		"aws-ami":                  "aws/ami",

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -503,6 +503,8 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 			panic(err)
 		}
 
+		fmt.Fprintln(readme, "<!-- This file was generated via `make gen/integrations-hcl -->")
+
 		fmt.Fprintf(readme, "## %s (%s)\n\n", name, ct)
 
 		if dets.Description != "" {
@@ -542,6 +544,7 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 		if err != nil {
 			panic(err)
 		}
+		fmt.Fprintln(parameters, "# This file was generated via `make gen/integrations-hcl")
 
 		// create new empty hcl file object
 		f := hclwrite.NewEmptyFile()
@@ -614,6 +617,8 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 		if err != nil {
 			panic(err)
 		}
+
+		fmt.Fprintln(outputs, "# This file was generated via `make gen/integrations-hcl")
 
 		// create new empty hcl file object
 		f := hclwrite.NewEmptyFile()

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -507,7 +507,7 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 			panic(err)
 		}
 
-		fmt.Fprintln(readme, "<!-- This file was generated via `make gen/integrations-hcl -->")
+		fmt.Fprintln(readme, "<!-- This file was generated via `make gen/integrations-hcl` -->")
 
 		fmt.Fprintf(readme, "## %s (%s)\n\n", name, ct)
 

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -548,7 +548,7 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Fprintln(parameters, "# This file was generated via `make gen/integrations-hcl")
+		fmt.Fprintln(parameters, "# This file was generated via `make gen/integrations-hcl`")
 
 		// create new empty hcl file object
 		f := hclwrite.NewEmptyFile()
@@ -622,7 +622,7 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 			panic(err)
 		}
 
-		fmt.Fprintln(outputs, "# This file was generated via `make gen/integrations-hcl")
+		fmt.Fprintln(outputs, "# This file was generated via `make gen/integrations-hcl`")
 
 		// create new empty hcl file object
 		f := hclwrite.NewEmptyFile()


### PR DESCRIPTION
### What

This is a poc/proposal to add a `hclFormat` func, along with a `gen/integrations-hcl` `Makefile` target.

https://user-images.githubusercontent.com/26389321/208122611-bb22ee72-9479-48d2-b416-37aacc3594dd.mp4


### Why

This automates the creation of a few files, that power the **Integrations** project. (See: [preview](https://dev-portal-git-product-integrations-hashicorp.vercel.app/waypoint/integrations/kubernetes?tab=platform))

```
./builtin
├── aws
│   ├── alb
│   │   ├── components 👈 (new folder)
│   │   │   ├── release-manager 👈
│   │   │   │   ├── parameters.hcl 👈
│   │   │   │   ├── outputs.hcl 👈
│   │   │   │   └── README.md 👈
```

These will eventually power the integrations frontend like so:

![CleanShot 2022-12-16 at 09 50 54@2x](https://user-images.githubusercontent.com/26389321/208124749-05c5379e-b1e0-4e27-9689-bf30380319af.png)


The alternative is manually writing ~100 files. Example:
- https://github.com/BrandonRomano/waypoint/pull/3

### How

This is largely modeled after the existing `mdxFormat` function but has a few changes to output up to 3 files alongside plugins within the `builtin/` directory. 

This leverages existing calls to [`waypoint-plugin-sdk/docs`](github.com/hashicorp/waypoint-plugin-sdk/docs).

###### Related

- https://github.com/hashicorp/waypoint/pull/151

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203295724413023