### PR TITLE
core/server: only queue init ops for active projects

### DIFF
--- a/pkg/server/singleprocess/service_project.go
+++ b/pkg/server/singleprocess/service_project.go
@@ -245,6 +245,10 @@ func queueInitOps(s *Service, ctx context.Context, project *pb.Project) error {
 }
 
 func projectNeedsRemoteInit(project *pb.Project) bool {
+	if project.State != pb.Project_ACTIVE {
+		return false
+	}
+
 	if project.DataSource == nil {
 		return false
 	}


### PR DESCRIPTION
## Why the change?

I noticed a few spurious init jobs while testing. This won’t have a massive impact, but should make things a little tidier.