### PR TITLE
Docker server install - runner Docker socket binding fix

### DIFF
--- a/internal/runnerinstall/docker.go
+++ b/internal/runnerinstall/docker.go
@@ -157,7 +157,7 @@ func (i *DockerRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "docker-socket-path",
 		Target:  &i.Config.SocketPath,
-		Usage:   "The path of the docker socket that will be bound in runner",
+		Usage:   "The path of the Docker socket that will be bound in runner",
 		Default: "/var/run/docker.sock",
 	})
 }

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 
 	"github.com/hashicorp/waypoint/internal/clicontext"
@@ -29,8 +30,9 @@ type DockerInstaller struct {
 }
 
 type dockerConfig struct {
-	serverImage string `hcl:"server_image,optional"`
-	odrImage    string `hcl:"odr_image,optional"`
+	serverImage      string `hcl:"server_image,optional"`
+	odrImage         string `hcl:"odr_image,optional"`
+	runnerSocketPath string `hcl:"runner_socket_path,optional"`
 }
 
 var (
@@ -629,6 +631,7 @@ func (i *DockerInstaller) InstallRunner(
 	runnerInstaller := runnerinstall.DockerRunnerInstaller{Config: runnerinstall.DockerConfig{
 		RunnerImage: i.config.serverImage,
 		Network:     "waypoint",
+		SocketPath:  i.config.runnerSocketPath,
 	}}
 	err := runnerInstaller.Install(ctx, opts)
 	if err != nil {
@@ -703,6 +706,13 @@ func (i *DockerInstaller) InstallFlags(set *flag.Set) {
 		Usage: "Docker image for the Waypoint On-Demand Runners. This will " +
 			"default to the server image with the name (not label) suffixed with '-odr'.",
 	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "docker-runner-socket-path",
+		Target:  &i.config.runnerSocketPath,
+		Usage:   "The path of the docker socket that will be bound in runner",
+		Default: "/var/run/docker.sock",
+	})
 }
 
 func (i *DockerInstaller) UpgradeFlags(set *flag.Set) {
@@ -718,6 +728,13 @@ func (i *DockerInstaller) UpgradeFlags(set *flag.Set) {
 		Target: &i.config.odrImage,
 		Usage: "Docker image for the Waypoint On-Demand Runners. This will " +
 			"default to the server image with the name (not label) suffixed with '-odr'.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:    "docker-runner-socket-path",
+		Target:  &i.config.runnerSocketPath,
+		Usage:   "The path of the docker socket that will be bound in runner",
+		Default: "/var/run/docker.sock",
 	})
 }
 

--- a/internal/serverinstall/docker.go
+++ b/internal/serverinstall/docker.go
@@ -710,7 +710,7 @@ func (i *DockerInstaller) InstallFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "docker-runner-socket-path",
 		Target:  &i.config.runnerSocketPath,
-		Usage:   "The path of the docker socket that will be bound in runner",
+		Usage:   "The path of the Docker socket that will be bound in runner",
 		Default: "/var/run/docker.sock",
 	})
 }
@@ -733,7 +733,7 @@ func (i *DockerInstaller) UpgradeFlags(set *flag.Set) {
 	set.StringVar(&flag.StringVar{
 		Name:    "docker-runner-socket-path",
 		Target:  &i.config.runnerSocketPath,
-		Usage:   "The path of the docker socket that will be bound in runner",
+		Usage:   "The path of the Docker socket that will be bound in runner",
 		Default: "/var/run/docker.sock",
 	})
 }

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -62,6 +62,7 @@ and disable the UI, the command would be:
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
+- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -62,7 +62,7 @@ and disable the UI, the command would be:
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
+- `-docker-runner-socket-path=<string>` - The path of the Docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -55,7 +55,7 @@ the install, the command would be:
 
 - `-docker-runner-image=<string>` - The Docker image for the Waypoint runner. The default is hashicorp/waypoint.
 - `-docker-runner-network=<string>` - The Docker network in which to deploy the Waypoint runner.
-- `-docker-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
+- `-docker-socket-path=<string>` - The path of the Docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -62,6 +62,7 @@ and disable the UI, the command would be:
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
+- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -62,7 +62,7 @@ and disable the UI, the command would be:
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
+- `-docker-runner-socket-path=<string>` - The path of the Docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -45,6 +45,7 @@ manually installed runners will not be automatically upgraded.
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
+- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -45,7 +45,7 @@ manually installed runners will not be automatically upgraded.
 
 - `-docker-server-image=<string>` - Docker image for the Waypoint server. The default is hashicorp/waypoint:latest.
 - `-docker-odr-image=<string>` - Docker image for the Waypoint On-Demand Runners. This will default to the server image with the name (not label) suffixed with '-odr'.
-- `-docker-runner-socket-path=<string>` - The path of the docker socket that will be bound in runner. The default is /var/run/docker.sock.
+- `-docker-runner-socket-path=<string>` - The path of the Docker socket that will be bound in runner. The default is /var/run/docker.sock.
 
 #### ecs Options
 


### PR DESCRIPTION
PR #4246 added the configuration to set the Docker socket for a Waypoint runner installed to Docker to bind. This worked fine with `runner install`, but `server install` was not setting that new configuration when installing its companion runner, resulting in an overall failed server install to Docker, caught by our integration tests. This PR fixes that by making the runner's Docker socket customizable for the server install as well, with the appropriate default value set.