### PR TITLE
Fixing job heartbeat test

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/waypoint/pkg/pagination"
 	"github.com/hashicorp/waypoint/pkg/serverstate"
@@ -2588,7 +2587,7 @@ func TestJobHeartbeat(t *testing.T, factory Factory, rf RestartFactory) {
 		// Should time out
 		require.Eventually(func() bool {
 			// Verify it is canceled
-			job, err = s.JobById(ctx, "A", nil)
+			job, err = s.JobById(context.Background(), "A", nil)
 			require.NoError(err)
 			return job.Job.State == pb.Job_ERROR
 		}, 4*time.Second, time.Second)


### PR DESCRIPTION
Prior to this change, we would cancel our context, but then use that context for a state lookup. This causes the lookup to fail with a context canceled error, which isn't our desired result.