### PR TITLE
Scoped Config Sources Upgrade Fix

### DIFF
--- a/.changelog/4382.txt
+++ b/.changelog/4382.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+upgrade: Fixes a bug where pre-v0.10.4 config sources could not be updated or
+deleted.
+```

--- a/internal/server/boltdbstate/config_source.go
+++ b/internal/server/boltdbstate/config_source.go
@@ -3,6 +3,7 @@ package boltdbstate
 import (
 	"context"
 	"encoding/binary"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -304,10 +305,28 @@ func (s *State) configSourceIndexInit(dbTxn *bolt.Tx, memTxn *memdb.Txn) error {
 		if err := proto.Unmarshal(v, &value); err != nil {
 			return err
 		}
-		if err := s.configSourceIndexSet(memTxn, k, &value); err != nil {
-			return err
-		}
 
+		// If there are any records whose ID is the name of a plugin, pre-v0.10.4
+		// behavior, then we delete that record from the database, since it is
+		// about to be saved with a hashed ID. This is not very elegant, but
+		// is the simplest way for users to upgrade since custom config sourcer
+		// plugins aren't yet supported, as of 1/10/2023.
+		key := string(k)
+		re := regexp.MustCompile(`aws-ssm|consul|kubernetes|null|packer|terraform-cloud|vault`)
+		if re.MatchString(key) {
+			if err := bucket.Delete(k); err != nil {
+				return err
+			}
+			// configSourceSet will create a new record in Bolt DB, AND update
+			// Mem DB, with the ID value hashed as per the v0.10.4 hashing logic.
+			if err := s.configSourceSet(dbTxn, memTxn, &value); err != nil {
+				return err
+			}
+		} else {
+			if err := s.configSourceIndexSet(memTxn, k, &value); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
This PR updates the Bolt DB implementation of config sources to "upgrade" a pre-v0.10.4 database record from the config_source table. Prior to v0.10.4, the unique identifier for each record in the table was the name of the plugin. This was changed in v0.10.4 with the addition of [scoped config sources](https://github.com/hashicorp/waypoint/pull/4191), and now the ID is a hashed value, whose hash structure is defined by the plugin name, scope, and workspace name.

This PR therefore deletes any "old" records, those whose ID is the name of any known config sourcer plugin, from Bolt DB, and creates new records with the ID correctly hashed. With this fix, users who had config sources prior to v0.10.3 may continue to interact with those config sources, whereas before this commit, they could not, and the config sources were permanently "stuck" in the database as they were before upgrading.

Fixes #4360.