### PR TITLE
core/install: Add configurable CSI mount flags to install

### DIFF
--- a/.changelog/4387.txt
+++ b/.changelog/4387.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+install/nomad: Allow mount options to be specified when provisioning a volume with CSI plugins
+```

--- a/internal/installutil/nomad/nomad.go
+++ b/internal/installutil/nomad/nomad.go
@@ -169,6 +169,7 @@ func CreatePersistentVolume(
 	id, name, csiPluginId, csiVolumeProvider, csiFS, csiExternalId string,
 	csiVolumeCapacityMin, csiVolumeCapacityMax int64,
 	csiTopologies, csiSecrets, csiParams map[string]string,
+	csiMountFlags []string,
 ) error {
 	vol := api.CSIVolume{
 		ID:         id,
@@ -182,7 +183,7 @@ func CreatePersistentVolume(
 		},
 		MountOptions: &api.CSIMountOptions{
 			FSType:     DefaultCSIVolumeMountFS,
-			MountFlags: []string{"noatime"},
+			MountFlags: csiMountFlags,
 		},
 		RequestedCapacityMin: DefaultCSIVolumeCapacityMin,
 		RequestedCapacityMax: DefaultCSIVolumeCapacityMax,

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -288,7 +288,7 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 	set.StringSliceVar(&flag.StringSliceVar{
 		Name:    "nomad-csi-mount-flags",
 		Target:  &i.Config.CsiMountFlags,
-		Usage:   "Nomad CSI volume mount option flags. The default is noatime.",
+		Usage:   "Nomad CSI volume mount option flags.",
 		Default: []string{"noatime"},
 	})
 

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -43,6 +43,7 @@ type NomadConfig struct {
 	CsiVolumeCapacityMin int64             `hcl:"csi_volume_capacity_min,optional"`
 	CsiVolumeCapacityMax int64             `hcl:"csi_volume_capacity_max,optional"`
 	CsiFS                string            `hcl:"csi_fs,optional"`
+	CsiMountFlags        []string          `hcl:"csi_mount_flags,optional"`
 	CsiTopologies        map[string]string `hcl:"nomad_csi_topologies,optional"`
 	CsiExternalId        string            `hcl:"nomad_csi_external_id,optional"`
 	CsiParams            map[string]string `hcl:"nomad_csi_params,optional"`
@@ -104,6 +105,7 @@ func (i *NomadRunnerInstaller) Install(ctx context.Context, opts *InstallOpts) e
 			i.Config.CsiTopologies,
 			i.Config.CsiSecrets,
 			i.Config.CsiParams,
+			i.Config.CsiMountFlags,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating Nomad persistent volume: %s", clierrors.Humanize(err))
@@ -281,6 +283,13 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.Config.CsiFS,
 		Usage:   "Nomad CSI volume mount option file system.",
 		Default: nomadutil.DefaultCSIVolumeMountFS,
+	})
+
+	set.StringSliceVar(&flag.StringSliceVar{
+		Name:    "nomad-csi-mount-flags",
+		Target:  &i.Config.CsiMountFlags,
+		Usage:   "Nomad CSI volume mount option flags. The default is noatime.",
+		Default: []string{"noatime"},
 	})
 
 	set.StringMapVar(&flag.StringMapVar{

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -1345,7 +1345,7 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 	set.StringSliceVar(&flag.StringSliceVar{
 		Name:    "nomad-csi-mount-flags",
 		Target:  &i.config.csiMountFlags,
-		Usage:   "Nomad CSI volume mount option flags. The default is noatime.",
+		Usage:   "Nomad CSI volume mount option flags.",
 		Default: []string{"noatime"},
 	})
 

--- a/internal/serverinstall/nomad.go
+++ b/internal/serverinstall/nomad.go
@@ -69,6 +69,7 @@ type nomadConfig struct {
 	csiVolumeCapacityMin int64             `hcl:"csi_volume_capacity_min,optional"`
 	csiVolumeCapacityMax int64             `hcl:"csi_volume_capacity_max,optional"`
 	csiFS                string            `hcl:"csi_fs,optional"`
+	csiMountFlags        []string          `hcl:"csi_mount_flags,optional"`
 	csiPluginId          string            `hcl:"csi_plugin_id,optional"`
 	csiExternalId        string            `hcl:"nomad_csi_external_id,optional"`
 	csiTopologies        map[string]string `hcl:"nomad_csi_topologies,optional"`
@@ -228,6 +229,7 @@ func (i *NomadInstaller) Install(
 			i.config.csiTopologies,
 			i.config.csiSecrets,
 			i.config.csiParams,
+			i.config.csiMountFlags,
 		)
 		if err != nil {
 			return nil, "", status.Errorf(codes.Internal, "Failed creating Nomad persistent volume: %s", err)
@@ -641,6 +643,7 @@ func (i *NomadInstaller) InstallRunner(
 			CsiVolumeCapacityMin:  i.config.runnerCsiVolumeCapacityMin,
 			CsiVolumeCapacityMax:  i.config.runnerCsiVolumeCapacityMax,
 			CsiFS:                 i.config.csiFS,
+			CsiMountFlags:         i.config.csiMountFlags,
 			CsiTopologies:         i.config.csiTopologies,
 			CsiExternalId:         i.config.csiExternalId,
 			CsiParams:             i.config.csiParams,
@@ -1337,6 +1340,13 @@ func (i *NomadInstaller) InstallFlags(set *flag.Set) {
 		Target:  &i.config.csiFS,
 		Usage:   "Nomad CSI volume mount option file system.",
 		Default: defaultCSIVolumeMountFS,
+	})
+
+	set.StringSliceVar(&flag.StringSliceVar{
+		Name:    "nomad-csi-mount-flags",
+		Target:  &i.config.csiMountFlags,
+		Usage:   "Nomad CSI volume mount option flags. The default is noatime.",
+		Default: []string{"noatime"},
 	})
 
 	set.StringMapVar(&flag.StringMapVar{

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -135,6 +135,7 @@ and disable the UI, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
+- `-nomad-csi-mount-flags=<string>` - Nomad CSI volume mount option flags. The default is noatime.
 - `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
 - `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -90,6 +90,7 @@ the install, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
+- `-nomad-csi-mount-flags=<string>` - Nomad CSI volume mount option flags. The default is noatime.
 - `-nomad-csi-params=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 - `-nomad-csi-topologies=<key=value>` - Locations from which the Nomad Volume will be accessible.
 - `-nomad-csi-external-id=<string>` - The ID of the physical volume from the Nomad storage provider.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -135,6 +135,7 @@ and disable the UI, the command would be:
 - `-nomad-csi-volume-capacity-min=<int>` - Nomad CSI volume capacity minimum, in bytes. The default is 1073741824.
 - `-nomad-csi-volume-capacity-max=<int>` - Nomad CSI volume capacity maximum, in bytes. The default is 2147483648.
 - `-nomad-csi-fs=<string>` - Nomad CSI volume mount option file system. The default is xfs.
+- `-nomad-csi-mount-flags=<string>` - Nomad CSI volume mount option flags. The default is noatime.
 - `-nomad-csi-secrets=<key=value>` - Secrets to provide for the CSI volume.
 - `-nomad-csi-parameters=<key=value>` - Parameters passed directly to the CSI plugin to configure the volume.
 - `-nomad-csi-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.


### PR DESCRIPTION
Before this commit the default mount settings for volumes created and attached were hardcoded to `noatime`. Some CSI driver setups, such as in NFS can produce incompatible setups in which the installation always fails.

This commit adds in the `-nomad-csi-mount-flags` flag which can be used to override the default mount flags.