### PR TITLE
Add CORS options to lambda-function-url releaser

### DIFF
--- a/.changelog/4418.txt
+++ b/.changelog/4418.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws: Add CORS configuration to lambda-function-url releaser
+```

--- a/embedJson/gen/releasemanager-lambda-function-url.json
+++ b/embedJson/gen/releasemanager-lambda-function-url.json
@@ -1,6 +1,6 @@
 {
    "description": "Create an AWS Lambda function URL",
-   "example": "release {\n\tuse \"lambda-function-url\" {\n\t\tauth_type = \"NONE\"\n\t}\n}",
+   "example": "release {\n\tuse \"lambda-function-url\" {\n\t\tauth_type = \"NONE\"\n\t\tcors {\n\t\t\tallow_methods = [\"*\"]\n\t\t}\n\t}\n}",
    "input": "lambda.Deployment",
    "mappers": null,
    "name": "lambda-function-url",
@@ -16,6 +16,91 @@
          "Category": false,
          "Example": "",
          "SubFields": null
+      },
+      {
+         "Field": "cors",
+         "Type": "function_url.ReleaserConfigCors",
+         "Synopsis": "CORS configuration for the function URL",
+         "Summary": "",
+         "Optional": false,
+         "Default": "NONE",
+         "EnvVar": "",
+         "Category": true,
+         "Example": "",
+         "SubFields": [
+            {
+               "Field": "allow_credentials",
+               "Type": "bool",
+               "Synopsis": "Whether to allow cookies or other credentials in requests to your function URL.",
+               "Summary": "",
+               "Optional": true,
+               "Default": "false",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "allow_headers",
+               "Type": "list of string",
+               "Synopsis": "The HTTP headers that origins can include in requests to your function URL. For example: Date, Keep-Alive, X-Custom-Header.",
+               "Summary": "",
+               "Optional": true,
+               "Default": "[]",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "allow_methods",
+               "Type": "list of string",
+               "Synopsis": "The HTTP methods that are allowed when calling your function URL. For example: GET, POST, DELETE, or the wildcard character (*).",
+               "Summary": "",
+               "Optional": true,
+               "Default": "[]",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "allow_origins",
+               "Type": "list of string",
+               "Synopsis": "The origins that can access your function URL. You can list any number of specific origins, separated by a comma. You can grant access to all origins using the wildcard character (*).",
+               "Summary": "",
+               "Optional": true,
+               "Default": "[]",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "expose_headers",
+               "Type": "list of string",
+               "Synopsis": "The HTTP headers in your function response that you want to expose to origins that call your function URL. For example: Date, Keep-Alive, X-Custom-Header.",
+               "Summary": "",
+               "Optional": true,
+               "Default": "[]",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "max_age",
+               "Type": "int64",
+               "Synopsis": "The maximum amount of time, in seconds, that web browsers can cache results of a preflight request.",
+               "Summary": "",
+               "Optional": true,
+               "Default": "0",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            }
+         ]
       },
       {
          "Field": "principal",

--- a/website/content/partials/components/releasemanager-lambda-function-url.mdx
+++ b/website/content/partials/components/releasemanager-lambda-function-url.mdx
@@ -13,6 +13,9 @@ Create an AWS Lambda function URL.
 release {
 	use "lambda-function-url" {
 		auth_type = "NONE"
+		cors {
+			allow_methods = ["*"]
+		}
 	}
 }
 ```
@@ -34,6 +37,58 @@ The AuthType parameter determines how Lambda authenticates or authorizes request
 - Type: **string**
 - **Optional**
 - Default: NONE
+
+#### cors (category)
+
+CORS configuration for the function URL.
+
+##### cors.allow_credentials
+
+Whether to allow cookies or other credentials in requests to your function URL.
+
+- Type: **bool**
+- **Optional**
+- Default: false
+
+##### cors.allow_headers
+
+The HTTP headers that origins can include in requests to your function URL. For example: Date, Keep-Alive, X-Custom-Header.
+
+- Type: **list of string**
+- **Optional**
+- Default: []
+
+##### cors.allow_methods
+
+The HTTP methods that are allowed when calling your function URL. For example: GET, POST, DELETE, or the wildcard character (\*).
+
+- Type: **list of string**
+- **Optional**
+- Default: []
+
+##### cors.allow_origins
+
+The origins that can access your function URL. You can list any number of specific origins, separated by a comma. You can grant access to all origins using the wildcard character (\*).
+
+- Type: **list of string**
+- **Optional**
+- Default: []
+
+##### cors.expose_headers
+
+The HTTP headers in your function response that you want to expose to origins that call your function URL. For example: Date, Keep-Alive, X-Custom-Header.
+
+- Type: **list of string**
+- **Optional**
+- Default: []
+
+##### cors.max_age
+
+The maximum amount of time, in seconds, that web browsers can cache results of a preflight request.
+
+- Type: **int64**
+- **Optional**
+- Default: 0
 
 #### principal
 


### PR DESCRIPTION
## Why the change?

Addresses #4233

## What’s the plan?

- [x] Get it working
- [x] Changelog
- [x] Make sure docs are decent

## What does it look like?

https://user-images.githubusercontent.com/34030/214331215-f7ab0256-44ec-47a6-bef6-a2fd4e7ed32e.mov

<img width="1360" alt="CleanShot 2023-01-24 at 19 33 11@2x" src="https://user-images.githubusercontent.com/34030/214378646-2a151f9b-35a4-482c-bd66-023c6daf2dd8.png">

## How do I test it?

Try adding CORS config to one of the [Lambda examples](https://github.com/hashicorp/waypoint-examples/tree/main/aws/lambda).

Visit the [website preview](https://waypoint-o4b1g2i7b-hashicorp.vercel.app/waypoint/plugins/aws-lambda#lambda-function-url-releasemanager) and verify the docs make sense.