### PR TITLE
website: add missing page descriptions

### DIFF
--- a/website/content/commands/index.mdx
+++ b/website/content/commands/index.mdx
@@ -1,6 +1,10 @@
 ---
 layout: commands
 page_title: 'Waypoint Commands (CLI)'
+description: >-
+  Waypoint is controlled via a very easy to use command-line interface (CLI). Waypoint
+  is only a single command-line application: `waypoint`. This application then takes a
+  subcommand such as `artifact` or `deployment`.
 ---
 
 # Waypoint Commands (CLI)

--- a/website/content/plugins/index.mdx
+++ b/website/content/plugins/index.mdx
@@ -1,6 +1,10 @@
 ---
 layout: plugins
 page_title: 'Plugins'
+description: >-
+  Waypoint uses a plugin architecture to provide its build, registry, deploy, and release
+  abilities. Waypoint plugins extend these functionalities without modifying the core
+  source code.
 ---
 
 # Plugins


### PR DESCRIPTION
Adds descriptions to the commands and plugins index pages, based on content from @tunzor