### PR TITLE
docs: convert link to be relative to developer

### DIFF
--- a/website/content/docs/use-cases/waypoint-gh-actions.mdx
+++ b/website/content/docs/use-cases/waypoint-gh-actions.mdx
@@ -166,5 +166,5 @@ on:
   - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   - Actions can be configured to only run on certain branches, with certain `ref`s. This is considered an advanced use-case and is not covered for this tutorial.
 - GitHub Actions docs: https://docs.github.com/en/actions
-- Try HCP Waypoint: https://developer.hashicorp.com/hcp/docs/waypoint
+- Try [HCP Waypoint](/hcp/docs/waypoint)
 - Waypoint Tetris on GitHub: https://github.com/briancain/waypoint-tetris


### PR DESCRIPTION
Update a fully-qualified developer link to be relative. This ensures we can rely on client-side routing throughout the site.

Content checks before:
```
Status:  failure

content/docs/use-cases/waypoint-gh-actions.mdx
  169:21-169:70  error  Unexpected fully-qualified link to `developer.hashicorp.com`: `https://developer.hashicorp.com/hcp/docs/waypoint`. Replace with a relative path internal to Developer. Possibly: `/hcp/docs/waypoint`.  ensure-valid-link-format

✖ 1 error
```

Content checks after:
```
Running content conformance checks...

Status:  success
```