### PR TITLE
cli: Include full help flags for `runner inspect` command

### DIFF
--- a/.changelog/4435.txt
+++ b/.changelog/4435.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Show full command flags when displaying help text for `waypoint runner inspect`.
+```

--- a/internal/cli/runner_inspect.go
+++ b/internal/cli/runner_inspect.go
@@ -144,5 +144,5 @@ Usage: waypoint runner inspect <id>
 
   Show detailed information about a runner.
 
-`)
+` + c.Flags().Help())
 }

--- a/website/content/commands/runner-inspect.mdx
+++ b/website/content/commands/runner-inspect.mdx
@@ -17,6 +17,8 @@ Show detailed information about a runner.
 
 Usage: `waypoint runner inspect <id>`
 
+Show detailed information about a runner.
+
 #### Global Options
 
 - `-plain` - Plain output: no colors, no animation. The default is false.


### PR DESCRIPTION
The image below shows the before/after with this change! The flags were missing from the help output.

<img width="670" alt="Screen Shot 2023-01-23 at 12 05 18 PM" src="https://user-images.githubusercontent.com/810277/214138756-9c40c267-603f-40b0-ba72-a3ab95f97c15.png">