### PR TITLE
Add temporary link to current community plugin list

### DIFF
--- a/website/content/plugins/index.mdx
+++ b/website/content/plugins/index.mdx
@@ -13,3 +13,12 @@ Waypoint uses a plugin architecture to provide its build, registry, deploy, and 
 
 On the left are common plugin groups. You'll see multiple plugins listed on some pages, indicating
 that they're intended to be used together.
+
+## Community Plugin List
+
+Along with the builtin plugins seen here, you can view the list of plugins our community has created
+[here](https://github.com/hashicorp/waypoint-plugin-examples#community-built-plugins). If you create
+a plugin for Waypoint, add it to the list!
+
+-> Note: Our 0.11 release will include an improved experience for listing and finding Waypoint plugins,
+and filtering HashiCorp-maintained plugins, verified maintainers, and community.


### PR DESCRIPTION
This is a placeholder for the next few weeks to direct users to our current community plugins list