### PR TITLE
maint: Send useful error message on bad token magic string

### DIFF
--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -342,7 +342,9 @@ func (s *Service) decodeToken(ctx context.Context, token string) (*pb.TokenTrans
 	}
 
 	if subtle.ConstantTimeCompare(data[:len(tokenMagic)], []byte(tokenMagic)) != 1 {
-		return nil, nil, errors.Errorf("bad magic")
+		return nil, nil, errors.Errorf("Failed to decode authentication token. " +
+			"The magic string embedded in the token does not match what was expected. " +
+			"This is likely due to the token string being an invalid auth token.")
 	}
 
 	var tt pb.TokenTransport


### PR DESCRIPTION
This commit sends some actual useful error messaging to the user in the case where they provided a bad auth token string that did not match the expected token magic during token decoding.