### PR TITLE
test: Ensure a project and pipeline run is upserted for test

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -2191,6 +2191,12 @@ func TestJobCancel(t *testing.T, factory Factory, rf RestartFactory) {
 		s := factory(t)
 		defer s.Close()
 
+		// Write project
+		ref := &pb.Ref_Project{Project: "project"}
+		require.NoError(s.ProjectPut(ctx, serverptypes.TestProject(t, &pb.Project{
+			Name: ref.Project,
+		})))
+
 		// Create a new pipeline run
 		p := serverptypes.TestPipeline(t, nil)
 		err := s.PipelinePut(ctx, p)
@@ -2199,6 +2205,8 @@ func TestJobCancel(t *testing.T, factory Factory, rf RestartFactory) {
 			Pipeline: &pb.Ref_Pipeline{Ref: &pb.Ref_Pipeline_Id{Id: p.Id}},
 		}
 		r := serverptypes.TestPipelineRun(t, pr)
+		err = s.PipelineRunPut(ctx, r)
+		require.NoError(err)
 
 		// Create jobs
 		require.NoError(s.JobCreate(ctx, serverptypes.TestJobNew(t, &pb.Job{


### PR DESCRIPTION
SQLState is much stricter about what entries exist in the database, given the nature that it needs to query the database for IDs rather than being ok with references like boltdb. This commit updates these tests to upsert a project and a run.