### PR TITLE
jira - remove `oss` as label

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -46,7 +46,6 @@ jobs:
         id: set-ticket-labels
         run: |
           LABELS="["
-          LABELS+="\"oss\", "
           if [[ "${{ contains(github.event.issue.labels.*.name, 'documentation') }}" == "true" ]]; then LABELS+="\"documentation\", "; fi
           if [[ "${{ contains(github.event.issue.labels.*.name, 'ui') }}" == "true" ]]; then LABELS+="\"ui\", "; else LABELS+="\"backend\", "; fi
           if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi


### PR DESCRIPTION
Per conversations on reorganizing our boards, we won't be using the `oss` label in Jira moving forward.