### PR TITLE
Jira - fix duplication bug

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           LABELS="["
           if [[ "${{ contains(github.event.issue.labels.*.name, 'documentation') }}" == "true" ]]; then LABELS+="\"documentation\", "; fi
-          if [[ "${{ contains(github.event.issue.labels.*.name, 'ui') }}" == "true" ]]; then LABELS+="\"ui\", "; else LABELS+="\"backend\", "; fi
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'ui') }}" == "true" ]]; then LABELS+="\"experiences\", "; else LABELS+="\"foundations\", "; fi
           if [[ ${#LABELS} != 1 ]]; then LABELS=${LABELS::-2}"]"; else LABELS+="]"; fi
           echo "::set-output name=labels::${LABELS}"
       

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -73,7 +73,7 @@ jobs:
         uses: tomhjp/gh-action-jira-search@v0.2.1
         with:
           # cf[10089] is Issue Link (use JIRA API to retrieve)
-          jql: 'issuetype = "${{ steps.set-ticket-type.outputs.type }}" and cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
+          jql: 'cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
 
       - name: Create ticket
         if: ( github.event.action == 'labeled' && steps.is-team-member.outputs.message == 'true' && !steps.search.outputs.issue )


### PR DESCRIPTION
Because the workflow runs each time any label is added, if someone adds multiple labels at once -- one of which is the `jira` label -- it creates a race condition.
For example, this could happen:
1. jira label added - workflow runs -> create new jira ticket with Task type
2. core label added - workflow runs -> check for duplicates with type `task`; finds the Task ticket; does not create new
3. bug label added - workflow runs -> check for duplicates with type `bug`; doesn't find a matching Bug ticket; create new jira ticket with Bug type

This PR fixes:
- removed the `issuetype` search filter to solve for the race condition that was ending up with duplicate issues.

Also bonus update:
- updated names of labels to match what we'll be using in Jira