### PR TITLE
Include Packer in integration release notification

### DIFF
--- a/.github/workflows/notify-integration-release-manual.yml
+++ b/.github/workflows/notify-integration-release-manual.yml
@@ -41,6 +41,7 @@ jobs:
           - "waypoint/hashicorp/nomad"
           - "waypoint/hashicorp/null"
           - "waypoint/hashicorp/pack"
+          - "waypoint/hashicorp/packer"
           - "waypoint/hashicorp/terraform-cloud"
           - "waypoint/hashicorp/vault"
     steps:


### PR DESCRIPTION
🎟️ [Register forgotten waypoint/packer Integration](https://app.asana.com/0/1203792701577283/1203879536690954/f)

Something @zchsh caught on some related work; we forgot to include the Packer plugin as part of our integration migration efforts. We will need to include this line to ensure that when we trigger an integration release that our Packer plugin is included & it is consumed.