### PR TITLE
internal/cli: fix dropped errors

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -534,6 +534,15 @@ func installRunner(ctx context.Context,
 	}
 
 	config, err := client.GetServerConfig(ctx, &empty.Empty{})
+	if err != nil {
+		ui.Output(
+			"Error getting server config for runner: %s\n\n%s",
+			clierrors.Humanize(err),
+			errInstallRunner,
+			terminal.WithErrorStyle(),
+		)
+		return 1
+	}
 
 	// Build a serverconfig that uses the advertise addr and includes
 	// the token we just requested.

--- a/internal/cli/k8s_bootstrap.go
+++ b/internal/cli/k8s_bootstrap.go
@@ -254,6 +254,14 @@ func (c *K8SBootstrapCommand) Run(args []string) int {
 			Default:      true,
 		},
 	})
+	if err != nil {
+		c.ui.Output(
+			"Error storing runner config on server: %s",
+			clierrors.Humanize(err),
+			terminal.WithErrorStyle(),
+		)
+		return 1
+	}
 
 	log.Info("bootstrap complete")
 	return 0


### PR DESCRIPTION
This picks up two dropped `err` variables in the `internal/cli` package.