### PR TITLE
test: Fixup test job tests when context was previously cancelled

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1475,7 +1475,7 @@ func TestJobComplete(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal(ctx.Err(), err)
 
 		// Should have both jobs
-		ctx, _ = context.WithCancel(context.Background())
+		ctx = context.Background()
 		jobs, _, err = s.JobList(ctx, &pb.ListJobsRequest{})
 		require.NoError(err)
 		require.Len(jobs, 2)
@@ -1538,7 +1538,7 @@ func TestJobComplete(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal(ctx.Err(), err)
 
 		// Dependent should be error
-		ctx, _ = context.WithCancel(context.Background())
+		ctx = context.Background()
 		job, err = s.JobById(ctx, "B", nil)
 		require.NoError(err)
 		require.Equal(pb.Job_ERROR, job.State)

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -963,7 +963,7 @@ func TestJobAssign(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal(ctx.Err(), err)
 
 		// Create a target
-		require.NoError(s.JobCreate(ctx, serverptypes.TestJobNew(t, &pb.Job{
+		require.NoError(s.JobCreate(context.Background(), serverptypes.TestJobNew(t, &pb.Job{
 			Id: "B",
 			TargetRunner: &pb.Ref_Runner{
 				Target: &pb.Ref_Runner_Id{
@@ -1022,11 +1022,11 @@ func TestJobAssign(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal("B", job.Id)
 
 		// Ack it
-		_, err = s.JobAck(ctx, "A", true)
+		_, err = s.JobAck(context.Background(), "A", true)
 		require.NoError(err)
 
 		// Complete it
-		require.NoError(s.JobComplete(ctx, "A", &pb.Job_Result{
+		require.NoError(s.JobComplete(context.Background(), "A", &pb.Job_Result{
 			Build: &pb.Job_BuildResult{},
 		}, nil))
 
@@ -1091,11 +1091,11 @@ func TestJobAssign(t *testing.T, factory Factory, rf RestartFactory) {
 			require.Equal(ctx.Err(), err)
 
 			// Ack it
-			_, err = s.JobAck(ctx, job.Id, true)
+			_, err = s.JobAck(context.Background(), job.Id, true)
 			require.NoError(err)
 
 			// Complete it
-			require.NoError(s.JobComplete(ctx, job.Id, &pb.Job_Result{
+			require.NoError(s.JobComplete(context.Background(), job.Id, &pb.Job_Result{
 				Build: &pb.Job_BuildResult{},
 			}, nil))
 		}

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -1475,7 +1475,7 @@ func TestJobComplete(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal(ctx.Err(), err)
 
 		// Should have both jobs
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, _ = context.WithCancel(context.Background())
 		jobs, _, err = s.JobList(ctx, &pb.ListJobsRequest{})
 		require.NoError(err)
 		require.Len(jobs, 2)
@@ -1538,7 +1538,7 @@ func TestJobComplete(t *testing.T, factory Factory, rf RestartFactory) {
 		require.Equal(ctx.Err(), err)
 
 		// Dependent should be error
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, _ = context.WithCancel(context.Background())
 		job, err = s.JobById(ctx, "B", nil)
 		require.NoError(err)
 		require.Equal(pb.Job_ERROR, job.State)


### PR DESCRIPTION
This commit creates a new context to do a simple check if a dependent job has been cancelled. Previously, we'd pass through an already cancelled context, which would fail as the context being cancelled when used again to get a job by id.