### PR TITLE
Docs Recontextualization & URL Adjustments for Plugins -> Integrations Library

### DIFF
--- a/website/content/docs/app-config/dynamic.mdx
+++ b/website/content/docs/app-config/dynamic.mdx
@@ -28,15 +28,15 @@ not thoroughly explain the config setting CLI or `waypoint.hcl` stanzas.
 The following is a list of currently available configuration sources
 and their associated documentation:
 
-- [Terraform Cloud](/waypoint/plugins/terraform-cloud#terraform-cloud-configsourcer) -
+- [Terraform Cloud](/waypoint/integrations/hashicorp/terraform-cloud/latest/components/config-sourcer) -
   Read Terraform state outputs from Terraform Cloud.
-- [Kubernetes](/waypoint/plugins/kubernetes#kubernetes-configsourcer) - Read values from
+- [Kubernetes](/waypoint/integrations/hashicorp/kubernetes/latest/components/config-sourcer) - Read values from
   ConfigMaps and Secrets.
-- [Vault](/waypoint/plugins/vault#vault-configsourcer) - Read values from Vault secrets,
+- [Vault](/waypoint/integrations/hashicorp/vault/latest/components/config-sourcer) - Read values from Vault secrets,
   including dynamic secrets such as database credentials.
-- [AWS SSM](/waypoint/plugins/aws-ssm#aws-ssm-configsourcer) - Read configuration values
+- [AWS SSM](/waypoint/integrations/hashicorp/aws-ssm/latest/components/config-sourcer) - Read configuration values
   from AWS SSM Parameter Store.
-- [Consul](/waypoint/plugins/consul#consul-configsourcer) - Read values from Consul key
+- [Consul](/waypoint/integrations/hashicorp/consul/latest/components/config-sourcer) - Read values from Consul key
   value storage.
 
 -> **Custom configuration source plugins are coming soon.** Currently it's overly
@@ -92,7 +92,7 @@ $ waypoint config set PORT=
 
 Configuration sources sometimes support global settings for their behavior or
 require global settings to be set for them to function at all.
-For example, [Vault](/waypoint/plugins/vault#vault-configsourcer) has some global
+For example, [Vault](/waypoint/integrations/hashicorp/vault/latest/components/config-sourcer) has some global
 settings around how to authenticate. Without setting these, Vault configurations
 in applications will not work. These _source settings_ are set at the server
 level and used by all `dynamic` calls.

--- a/website/content/docs/entrypoint/disable.mdx
+++ b/website/content/docs/entrypoint/disable.mdx
@@ -70,7 +70,7 @@ Therefore, it cannot be set with [application configuration](/waypoint/docs/app-
 It must be set at build time or by using functionality of your deployment
 plugin.
 
-The example below shows how to set this using the [Kubernetes plugin](/waypoint/plugins/kubernetes):
+The example below shows how to set this using the [Kubernetes plugin](/waypoint/integrations/hashicorp/kubernetes):
 
 ```hcl
 deploy {

--- a/website/content/docs/extending-waypoint/plugin-interfaces/configsourcer.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/configsourcer.mdx
@@ -10,7 +10,7 @@ description: |-
 https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#ConfigSourcer
 
 `ConfigSourcer` can be implemented to dynamically load configs from external
-sources such as [Vault](/waypoint/plugins/vault#vault-configsourcer) and [Terraform Cloud](/waypoint/plugins/terraform-cloud#terraform-cloud-configsourcer).
+sources such as [Vault](/waypoint/integrations/hashicorp/vault/latest/components/config-sourcer) and [Terraform Cloud](/waypoint/integrations/hashicorp/terraform-cloud/latest/components/config-sourcer).
 Waypoint uses dynamic config sourcers to run alongside the application. The
 plugin interface expects a `ReadFunc()` for reading configuration and a
 `StopFunc()` for stopping configuration sourcing.

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -42,7 +42,7 @@ enhancement request issue on GitHub, or contribute your own!
 
 ## Extending
 
-The [plugin documentation](/waypoint/plugins) describes more resources available to use
+The [integration library](/waypoint/integrations) describes more resources available to use
 in your Waypoint configuration. Contribute by writing your own plugin with this
 [plugin tutorial](/waypoint/docs/extending-waypoint/creating-plugins).
 

--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -38,7 +38,7 @@ Waypoint includes these builtin plugins to build a Docker image for your app.
 - [Docker Pull Build](/waypoint/integrations/hashicorp/docker-pull/latest/components/builder)
 - [Cloud Native Buildpacks](/waypoint/integrations/hashicorp/pack)
 
-You can also create a [plugin](/waypoint/integrations) to extend Waypoint with your own builder.
+You can also create a [plugin](/waypoint/docs/plugins) to extend Waypoint with your own builder.
 
 ### Choosing How to Build Your App
 

--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -34,11 +34,11 @@ app "my-app" {
 
 Waypoint includes these builtin plugins to build a Docker image for your app.
 
-- [Docker Build](/waypoint/plugins/docker#docker-builder)
-- [Docker Pull Build](/waypoint/plugins/docker#docker-pull-builder)
-- [Cloud Native Buildpacks](/waypoint/plugins/pack)
+- [Docker Build](/waypoint/integrations/hashicorp/docker/latest/components/builder)
+- [Docker Pull Build](/waypoint/integrations/hashicorp/docker-pull/latest/components/builder)
+- [Cloud Native Buildpacks](/waypoint/integrations/hashicorp/pack)
 
-You can also create a [plugin](/waypoint/plugins) to extend Waypoint with your own builder.
+You can also create a [plugin](/waypoint/integrations) to extend Waypoint with your own builder.
 
 ### Choosing How to Build Your App
 
@@ -59,7 +59,7 @@ image. If you application works with the `docker build`
 [Docker command](https://docs.docker.com/engine/reference/commandline/build/)
 it should work well the Waypoint Docker plugin.
 
-Reference the [Docker plugin](/waypoint/plugins/docker) for all configuration options.
+Reference the [Docker plugin](/waypoint/integrations/hashicorp/docker) for all configuration options.
 
 #### Docker Pull Build
 
@@ -215,7 +215,7 @@ Example Docker Registry Configuration
 ...
 ```
 
-Reference `aws-ecs` plugin documentation for an [AWS Elastic Container Registry example](/waypoint/plugins/aws-ecs#examples).
+Reference the [AWS ECS plugin](/waypoint/integrations/hashicorp/aws-ecs) documentation for an AWS Elastic Container Registry example.
 
 ### Scenarios for a Registry
 

--- a/website/content/docs/lifecycle/deploy.mdx
+++ b/website/content/docs/lifecycle/deploy.mdx
@@ -55,7 +55,7 @@ You can currently use Waypoint to deploy your app to any of these platforms.
 
 #### How to Add a Deployment Platform to Waypoint
 
-You can also create a [plugin](/waypoint/integrations) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
+You can also create a [plugin](/waypoint/docs/plugins) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
 
 ## Automatic Release
 

--- a/website/content/docs/lifecycle/deploy.mdx
+++ b/website/content/docs/lifecycle/deploy.mdx
@@ -43,19 +43,19 @@ The deployment platform must be compatible with the app artifact output format f
 
 You can currently use Waypoint to deploy your app to any of these platforms.
 
-- [Kubernetes](/waypoint/plugins/kubernetes)
-- [HashiCorp Nomad](/waypoint/plugins/nomad)
-- [AWS EC2](/waypoint/plugins/aws-ec2)
-- [AWS ECS](/waypoint/plugins/aws-ecs)
-- [AWS Lambda](/waypoint/plugins/aws-lambda)
-- [Google Cloud Run](/waypoint/plugins/google-cloud-run)
-- [Azure Container Instances](/waypoint/plugins/azure-container-instance)
+- [Kubernetes](/waypoint/integrations/hashicorp/kubernetes)
+- [HashiCorp Nomad](/waypoint/integrations/hashicorp/nomad)
+- [AWS EC2](/waypoint/integrations/hashicorp/aws-ec2)
+- [AWS ECS](/waypoint/integrations/hashicorp/aws-ecs)
+- [AWS Lambda](/waypoint/integrations/hashicorp/aws-lambda)
+- [Google Cloud Run](/waypoint/integrations/hashicorp/google-cloud-run)
+- [Azure Container Instances](/waypoint/integrations/hashicorp/azure-container-instance)
 
 ~> You may use the Kubernetes plugin to target any Kubernetes instance. For example, AWS EKS, Azure AKS, Google GKE, and Kubernetes for Docker Desktop.
 
 #### How to Add a Deployment Platform to Waypoint
 
-You can also create a [plugin](/waypoint/plugins) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
+You can also create a [plugin](/waypoint/integrations) to extend Waypoint with your own deployment platform. If you would like to add a plugin for a platform currently not in Waypoint, please file a [GitHub Issue for the project](https://github.com/hashicorp/waypoint/issues).
 
 ## Automatic Release
 
@@ -90,8 +90,7 @@ For Kubernetes, reference [authenticate to private container registries
 with a kubernetes
 secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 If you named the secret `example-registry-secret`, then you can [reference the
-secret in
-Waypoint](/waypoint/plugins/kubernetes#image_secret) like:
+secret in Waypoint](/waypoint/integrations/hashicorp/kubernetes/latest/components/platform#parameters.image_secret) like:
 
 ```hcl
 ...

--- a/website/content/docs/platforms/kubernetes/container-build.mdx
+++ b/website/content/docs/platforms/kubernetes/container-build.mdx
@@ -34,7 +34,7 @@ found on the [build lifecycle page](/waypoint/docs/lifecycle/build).
 
 The most popular way to build container images today is using a manually
 written `Dockerfile`. Waypoint can also build images from Dockerfiles
-using the [`docker` builder](/waypoint/plugins/docker#docker-builder). This also is
+using the [`docker` builder](/waypoint/integrations/hashicorp/docker/latest/components/builder). This also is
 the easiest way to get started with Waypoint with existing applications, since
 most existing applications for Kubernetes have Dockerfiles.
 

--- a/website/content/docs/platforms/kubernetes/deploy.mdx
+++ b/website/content/docs/platforms/kubernetes/deploy.mdx
@@ -201,6 +201,6 @@ for more information.
 ## Reference Documentation
 
 To view a full list of the available options for the Kubernetes plugin,
-please see the [plugin reference documentation](/waypoint/plugins/kubernetes).
+please see the [plugin reference documentation](/waypoint/integrations/hashicorp/kubernetes).
 This documentation is more dense and has less examples, but is an
 exhaustive list of the available options.

--- a/website/content/docs/platforms/kubernetes/external-build.mdx
+++ b/website/content/docs/platforms/kubernetes/external-build.mdx
@@ -15,7 +15,7 @@ net new use cases).
 
 ## Configuring Waypoint to Use an Existing Image
 
-The [docker-pull builder](/waypoint/plugins/docker#docker-pull-builder) was designed
+The [docker-pull builder](/waypoint/integrations/hashicorp/docker-pull/latest/components/builder) was designed
 so that Waypoint can use pre-built Docker images. These images can be built
 anyway you want: manually, CI pipelines, 3rd party sources, etc.
 

--- a/website/content/docs/platforms/kubernetes/helm-deploy.mdx
+++ b/website/content/docs/platforms/kubernetes/helm-deploy.mdx
@@ -29,7 +29,7 @@ The Helm deployment plugin for Waypoint is aimed primarily at people
 who either already use Helm or need to use a tool that lets them specify
 any custom Kubernetes resources. If you don't know Helm and are just trying
 to deploy a typical web service, you can use the YAML-less
-[`kubernetes`](/waypoint/plugins/helm#values) plugin. And you can always switch
+[`kubernetes`](/waypoint/integrations/hashicorp/helm/latest/components/platform) plugin. And you can always switch
 deployment plugins later, so you don't need to be worried about making a
 "wrong" decision.
 
@@ -99,7 +99,7 @@ built already) and Waypoint will use Helm to deploy your application.
 
 -> **Note:** The `set` syntax is the same as the `--set` flag used
 with the `helm` CLI. This is documented on the Helm website [here](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set). You can also specify
-[values YAML files](/waypoint/plugins/helm#values).
+[values YAML files](/waypoint/integrations/hashicorp/helm/latest/components/platform).
 
 ### Chart Repositories
 
@@ -198,6 +198,6 @@ to specify a values YAML file.
 ## Reference Documentation
 
 To view a full list of the available options for the Helm plugin,
-please see the [plugin reference documentation](/waypoint/plugins/helm).
+please see the [plugin reference documentation](/waypoint/integrations/hashicorp/helm).
 This documentation is more dense and has less examples, but is an
 exhaustive list of the available options.

--- a/website/content/docs/plugins.mdx
+++ b/website/content/docs/plugins.mdx
@@ -22,7 +22,7 @@ as external plugins. To see a list of supported plugins, see the
 
 You can see a list of all built-in plugins in our [integrations library](/waypoint/integrations).
 
-We do not maintain a list of external plugins currently, but plan to incorporate them into our integrations library in the future.
+We maintain a list of external plugins [here](https://github.com/hashicorp/waypoint-plugin-examples#community-built-plugins), and we plan to incorporate them into our integrations library in the future.
 
 ## Using an External Plugin
 

--- a/website/content/docs/plugins.mdx
+++ b/website/content/docs/plugins.mdx
@@ -16,13 +16,13 @@ how to write plugins, see the [Extending Waypoint guide](/waypoint/docs/extendin
 Waypoint ships with dozens of built-in plugins. These plugins are available
 out-of-the-box with Waypoint and are built directly on the same plugin system
 as external plugins. To see a list of supported plugins, see the
-[plugin documentation](/waypoint/plugins).
+[integrations library](/waypoint/integrations).
 
 ## Available Plugins
 
-You can see a list of [all built-in plugins here](/waypoint/plugins).
+You can see a list of all built-in plugins in our [integrations library](/waypoint/integrations).
 
-We do not maintain a list of external plugins currently.
+We do not maintain a list of external plugins currently, but plan to incorporate them into our integrations library in the future.
 
 ## Using an External Plugin
 

--- a/website/content/docs/runner/on-demand-runner.mdx
+++ b/website/content/docs/runner/on-demand-runner.mdx
@@ -77,10 +77,10 @@ Those docs detail how to configure and communicate the various aspects of an on-
 
 We currently support the following platforms for launching on-demand runner tasks:
 
-- [Kubernetes](/waypoint/plugins/kubernetes#kubernetes-task)
-- [HashiCorp/Nomad](/waypoint/plugins/nomad#nomad-task)
-- [AWS/ECS](/waypoint/plugins/aws-ecs#aws-ecs-task)
-- [Docker](/waypoint/plugins/docker#docker-task)
+- [Kubernetes](/waypoint/integrations/hashicorp/kubernetes/latest/components/task)
+- [HashiCorp/Nomad](/waypoint/integrations/hashicorp/nomad/latest/components/task)
+- [AWS/ECS](/waypoint/integrations/hashicorp/aws-ecs/latest/components/task)
+- [Docker](/waypoint/integrations/hashicorp/docker/latest/components/task)
 
 -> **Self-managed Waypoint server:** When you use the `waypoint server install` command,
 we automatically set up a default on-demand runner profile for you that matches the

--- a/website/content/docs/runner/profiles.mdx
+++ b/website/content/docs/runner/profiles.mdx
@@ -108,8 +108,8 @@ each operation.
 Waypoint on-demand runners are backed by the `Task` plugin type, which provides an
 interface for launching short-lived container-based instances and is implemented by
 the plugins for multiple platforms. To see the task config options for your platform
-of interest, see [plugin docs](/waypoint/plugins). For example, the Kubernetes task plugin
-docs are located [here](/waypoint/plugins/kubernetes#kubernetes-task).
+of interest, see [plugin docs](/waypoint/integrations). For example, the Kubernetes task plugin
+docs are located [here](/waypoint/integrations/hashicorp/kubernetes/latest/components/task).
 
 The `-plugin-config` flag lets you modify the way that tasks are launched.
 For example, to edit the Kubernetes default runner profile's plugin config to use a

--- a/website/content/docs/use-cases/blue-green-deployment.mdx
+++ b/website/content/docs/use-cases/blue-green-deployment.mdx
@@ -460,7 +460,7 @@ minimizing downtime and user impact.
 ## Further Reading
 
 - [Waypoint Pipelines](/waypoint/docs/pipelines)
-- [Waypoint Integrations Library](/waypoint/integrations)
+- [Waypoint Plugins](/waypoint/docs/plugins)
 - [Nomad Blue-Green Deployment](/nomad/tutorials/job-updates/job-blue-green-and-canary-deployments)
 - [Terraform Provider for Waypoint](https://registry.terraform.io/providers/hashicorp-dev-advocates/waypoint)
 - [Consul Service Splitter Config Entries](/consul/docs/connect/config-entries/service-splitter)

--- a/website/content/docs/use-cases/blue-green-deployment.mdx
+++ b/website/content/docs/use-cases/blue-green-deployment.mdx
@@ -460,7 +460,7 @@ minimizing downtime and user impact.
 ## Further Reading
 
 - [Waypoint Pipelines](/waypoint/docs/pipelines)
-- [Waypoint Plugins](/waypoint/plugins)
+- [Waypoint Integrations Library](/waypoint/integrations)
 - [Nomad Blue-Green Deployment](/nomad/tutorials/job-updates/job-blue-green-and-canary-deployments)
 - [Terraform Provider for Waypoint](https://registry.terraform.io/providers/hashicorp-dev-advocates/waypoint)
 - [Consul Service Splitter Config Entries](/consul/docs/connect/config-entries/service-splitter)

--- a/website/content/docs/use-cases/dynamic-config-vault-dynamic-secrets.mdx
+++ b/website/content/docs/use-cases/dynamic-config-vault-dynamic-secrets.mdx
@@ -12,7 +12,7 @@ This can be done with static application configuration, where static environment
 variables or files can be applied to your running deployment. Alternatively, configuration
 can be sourced dynamically from external sources, using a config sourcer plugin.
 
-The [HashiCorp Vault plugin for Waypoint](/waypoint/plugins/vault)
+The [HashiCorp Vault plugin for Waypoint](/waypoint/integrations/hashicorp/vault)
 is one of the [config sourcer plugins](/waypoint/docs/app-config/dynamic)
 that is built-in to the Waypoint binary. This plugin can be used to source static
 values from the Vault KV secrets engine, but also for dynamic secrets! A [dynamic secret](/vault/tutorials/getting-started/getting-started-dynamic-secrets)
@@ -271,5 +271,5 @@ cluster, the secrets necessary to run the application will be provided by Waypoi
 
 - [Waypoint dynamic app configuration](/waypoint/docs/app-config/dynamic)
 - [Waypoint dynamic variables](/waypoint/docs/waypoint-hcl/variables/dynamic)
-- [Vault config sourcer plugin docs](/waypoint/plugins/vault)
+- [Vault config sourcer plugin docs](/waypoint/integrations/hashicorp/vault/latest/components/config-sourcer)
 - [Vault dynamic database credentials tutorial](/vault/tutorials/db-credentials/database-secrets)

--- a/website/content/docs/waypoint-hcl/use.mdx
+++ b/website/content/docs/waypoint-hcl/use.mdx
@@ -40,7 +40,7 @@ app "frontend" {
 The `use` stanza takes a label. The label of the stanza is the name
 of the plugin to use.
 
-The plugin name must match the name of a [built-in plugin](/waypoint/plugins)
+The plugin name must match the name of a [built-in plugin](/waypoint/integrations?flags=builtin)
 or an [external plugin](/waypoint/docs/plugins). The plugin will be validated as part of
 the `waypoint init` process.
 
@@ -51,4 +51,4 @@ You must look at the documentation of the plugin you're using to determine
 the available configuration options.
 
 As an example, if you were using the Docker builder you could find
-the available parameters [documented here](/waypoint/plugins/docker#docker-builder).
+the available parameters [documented here](/waypoint/integrations/hashicorp/docker/latest/components/builder#parameters).

--- a/website/content/docs/waypoint-hcl/variables/artifact.mdx
+++ b/website/content/docs/waypoint-hcl/variables/artifact.mdx
@@ -21,7 +21,7 @@ the name and tag of a built Docker image, or the AMI of a built
 EC2 machine image.
 
 The exact fields within an `artifact` variable are dependent on the
-[plugin used for the build](/waypoint/plugins) and the available fields are
+[plugin used for the build](/waypoint/integrations) and the available fields are
 documented alongside plugins.
 
 ## Example: Docker

--- a/website/content/docs/waypoint-hcl/variables/deploy.mdx
+++ b/website/content/docs/waypoint-hcl/variables/deploy.mdx
@@ -14,7 +14,7 @@ the deployment within a release. This can be used to access information
 such as the resulting instance ID, IP address, etc.
 
 The exact fields within a `deploy` variable are dependent on the
-[plugin used for the build](/waypoint/plugins) and the available fields are
+[plugin used for the build](/waypoint/integrations) and the available fields are
 documented alongside plugins.
 
 ## Example: AWS ECS


### PR DESCRIPTION
- Adjust URLs to point to the new plugin locations after our integration library is live
- Include some minor language tweaks to reference the integration library

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203895768051438