### PR TITLE
Fix crash created by passing a nil err

### DIFF
--- a/pkg/server/hcerr/hcerr.go
+++ b/pkg/server/hcerr/hcerr.go
@@ -53,7 +53,7 @@ func Externalize(log hclog.Logger, err error, msg string, args ...interface{}) e
 	// and add them to the final error message
 	currentError := err
 	for currentError != nil {
-		var userErr UserError
+		var userErr *UserError
 		if errors.As(currentError, &userErr) {
 			msg = fmt.Sprintf("%s\n%s", msg, userErr.UserMessage)
 			currentError = userErr.Unwrap()

--- a/pkg/server/hcerr/user_error.go
+++ b/pkg/server/hcerr/user_error.go
@@ -21,25 +21,29 @@ type UserError struct {
 	statusCode  *codes.Code // Optional - nil represents unset
 }
 
-func (m UserError) Error() string {
+func (m *UserError) Error() string {
+	if m.err == nil {
+		return m.UserMessage
+	}
+
 	return fmt.Sprintf("%s: (user message: %q)", m.err.Error(), m.UserMessage)
 }
 
-func (m UserError) Unwrap() error {
+func (m *UserError) Unwrap() error {
 	return m.err
 }
 
 // GRPCStatus implements grpcError. If no code has been set,
 // and no status error exists further up the error stack,
 // will default to Internal with no message.
-func (m UserError) GRPCStatus() *status.Status {
+func (m *UserError) GRPCStatus() *status.Status {
 
 	// status.Status does not support errors.As (https://github.com/grpc/grpc-go/issues/2934)
 	var grpcstatus interface{ GRPCStatus() *status.Status }
 
 	// If we don't have a status, return the status of errors further up the chain. Otherwise,
 	// anyone calling GRPCStatus() on us will get code zero.
-	if m.statusCode == nil && errors.As(m.err, &grpcstatus) {
+	if m.statusCode == nil && m.err != nil && errors.As(m.err, &grpcstatus) {
 		// This error has no code, and there's another grpc status
 		// further up the chain, so use that
 		return grpcstatus.GRPCStatus()
@@ -60,21 +64,21 @@ func (m UserError) GRPCStatus() *status.Status {
 // details of our internal processing, etc), and should be helpful to users in diagnosing
 // why this error occurred and what they can do to avoid it in the future.
 func NewUserError(message string) error {
-	return UserError{
+	return &UserError{
 		UserMessage: message,
 	}
 }
 
 // NewUserErrorf is the same as NewUserError, with string formatting for convenience
 func NewUserErrorf(format string, a ...interface{}) error {
-	return UserError{
+	return &UserError{
 		UserMessage: fmt.Sprintf(format, a...),
 	}
 }
 
 // UserErrorf wraps an existing error with a UserError
 func UserErrorf(err error, format string, a ...interface{}) error {
-	return UserError{
+	return &UserError{
 		UserMessage: fmt.Sprintf(format, a...),
 		err:         err,
 	}
@@ -84,9 +88,19 @@ func UserErrorf(err error, format string, a ...interface{}) error {
 // a grpc status code, which will be used by the final hcerr.Externalize
 // call as the status code to present to the user.
 func UserErrorWithCodef(c codes.Code, err error, format string, a ...interface{}) error {
-	return UserError{
+	return &UserError{
 		UserMessage: fmt.Sprintf(format, a...),
 		err:         err,
+		statusCode:  &c,
+	}
+}
+
+// UserConditionWithCodef generates a new error that takes
+// a grpc status code, which will be used by the final hcerr.Externalize
+// call as the status code to present to the user.
+func UserConditionWithCodef(c codes.Code, format string, a ...interface{}) error {
+	return &UserError{
+		UserMessage: fmt.Sprintf(format, a...),
 		statusCode:  &c,
 	}
 }

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -142,7 +142,7 @@ func (s *Service) queueJobReqToJob(
 
 	if job.DataSource == nil {
 		if project.DataSource == nil {
-			return nil, "", hcerr.UserErrorWithCodef(codes.FailedPrecondition, err,
+			return nil, "", hcerr.UserConditionWithCodef(codes.FailedPrecondition,
 				"Project %s does not have a data source configured. Remote jobs "+
 					"require a data source such as Git to be configured with the project. "+
 					"Data sources can be configured via the CLI or UI. For help, see : "+
@@ -167,14 +167,14 @@ func (s *Service) queueJobReqToJob(
 			// error out.
 			if job.DataSource.GetRemote() != nil {
 				log.Error("populateDataSource returned another remote DS job")
-				return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
+				return nil, "", hcerr.UserConditionWithCodef(codes.Internal,
 					"An internal server issue was detected when calculating the data source")
 			}
 		} else {
 			log.Error("job has a remote DataSource but server provided no populateDataSource")
 			// This is a server misconfiguration.
 			if job.DataSource.GetRemote() != nil {
-				return nil, "", hcerr.UserErrorWithCodef(codes.Internal, err,
+				return nil, "", hcerr.UserConditionWithCodef(codes.Internal,
 					"An internal server issue was detected when calculating the data source")
 			}
 		}


### PR DESCRIPTION
The code paths in service_job were passing a nil err in, which would cause an error to be generated on line 29.

This code fixes the issue in two ways:

1. The Error() function checks that err is nil before using it.
2. A new function is used to generate UserErrors without an underlaying error.

Lastly, we change UserError to be addressed as a pointer rather than a value because it's fairly large now.