### PR TITLE
Update target group destroyer to wait for listener

### DIFF
--- a/.changelog/4497.txt
+++ b/.changelog/4497.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+plugin/ecs: Update ECS destroyer to wait for there to be zero listeners for the
+target group before destroying the target group.
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1378,7 +1378,7 @@ func (p *Platform) resourceTargetGroupDestroy(
 
 				listeners, err := elbsrv.DescribeListeners(describeListenersInput)
 				if err != nil {
-					return status.Errorf(codes.Internal, "failed to describe listeners for ALB (ARN: %q): %s", lb, err)
+					return status.Errorf(codes.Internal, "failed to describe listeners for ALB (ARN: %q): %s", *lb, err)
 				}
 				for _, listener := range listeners.Listeners {
 					for _, defaultAction := range listener.DefaultActions {


### PR DESCRIPTION
This PR updates the ECS platform destroyer to wait for there to be zero AWS ALB listeners targeting the target group to attempt to delete the target group, for a maximum of 5 minutes.

This does not fully address #4461, because my destroy attempts are still failing on deleting the security group, but it's a start! And deleting that will be fixed in a subsequent PR.