### PR TITLE
`PlatformReleaser` plugin interface docs

### DIFF
--- a/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
@@ -10,7 +10,7 @@ description: |-
 https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#PlatformReleaser
 
 The `PlatformReleaser` interface is an optional interface that a Platform component
-can implement to provide default [`Release`](/docs/extending-waypoint/plugin-interfaces/release-manager) functionality. This only takes effect
+can implement to provide default [`Release`](/waypoint/docs/extending-waypoint/plugin-interfaces/release-manager) functionality. This only takes effect
 if no release is configured, therefore users cannot set custom configurations
 for default releasers. Releases will happen in a way that is wholly determined
 by the output of the deployment.

--- a/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
@@ -9,9 +9,9 @@ description: |-
 
 https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#PlatformReleaser
 
-The PlatformReleaser interface is an optional interface that a Platform component
-can implement to provide default Release functionality. This only takes effect
-if no release is configured. Therefore, users cannot set custom configurations
+The `PlatformReleaser` interface is an optional interface that a Platform component
+can implement to provide default [`Release`](/docs/extending-waypoint/plugin-interfaces/release-manager) functionality. This only takes effect
+if no release is configured, therefore users cannot set custom configurations
 for default releasers. Releases will happen in a way that is wholly determined
 by the output of the deployment.
 

--- a/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/platform-releaser.mdx
@@ -1,0 +1,58 @@
+---
+layout: docs
+page_title: 'PlatformReleaser'
+description: |-
+  How to implement the PlatformReleaser component for a Waypoint plugin
+---
+
+# PlatformReleaser
+
+https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#PlatformReleaser
+
+The PlatformReleaser interface is an optional interface that a Platform component
+can implement to provide default Release functionality. This only takes effect
+if no release is configured. Therefore, users cannot set custom configurations
+for default releasers. Releases will happen in a way that is wholly determined
+by the output of the deployment.
+
+For example, if a deployment creates a target group in AWS, a default releaser
+may manipulate that target group to route 100% of incoming traffic to the new
+target group. The user need not set an identifier for the target group, because
+the releaser will already have the necessary information from the deployment to
+"release" it.
+
+```go
+type PlatformReleaser interface {
+  // DefaultReleaserFunc() should return a function that returns
+  // a ReleaseManger implementation. This ReleaseManager will NOT have
+  // any config so it must work by default.
+  DefaultReleaserFunc() interface{}
+}
+```
+
+`PlatformReleaser` has a single function which must be implemented which
+returns a function called by Waypoint to release the deployment. The function
+returns the Releaser struct to Waypoint, which executes the Releaser's
+`Release` function, as a `ReleaseManager` would.
+
+```go
+type Platform struct {
+  // Other component fields
+}
+
+type Releaser struct {
+  p *Platform
+}
+
+func (p *Platform) DefaultReleaserFunc() interface{} {
+	return func() *Releaser { return &Releaser{p: p} }
+}
+
+func (r *Releaser) Release(
+	ctx context.Context,
+	log hclog.Logger,
+	src *component.Source,
+	ui terminal.UI,
+	target *Deployment,
+) (*Release, error)
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -636,6 +636,10 @@
             "path": "extending-waypoint/plugin-interfaces/platform"
           },
           {
+            "title": "PlatformReleaser",
+            "path": "extending-waypoint/plugin-interfaces/platform-releaser"
+          },
+          {
             "title": "ReleaseManager",
             "path": "extending-waypoint/plugin-interfaces/release-manager"
           },


### PR DESCRIPTION
This PR adds docs for the [`PlatformReleaser` interface of the plugin SDK](https://github.com/hashicorp/waypoint-plugin-sdk/blob/main/component/component.go#L119-L127)! 😄 