### PR TITLE
`TaskLauncher` plugin interface documentation

### DIFF
--- a/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
@@ -5,8 +5,8 @@ description: |-
   How to implement the TaskLauncher component for a Waypoint plugin
 ---
 
-The TaskLauncher component makes possible launching Waypoint [on-demand runners](https://developer.hashicorp.com/waypoint/docs/runner/on-demand-runner)
-in a given platform, to perform [remote operations](https://developer.hashicorp.com/waypoint/docs/projects/remote).
+The TaskLauncher component makes possible launching Waypoint [on-demand runners](/waypoint/docs/runner/on-demand-runner)
+in a given platform, to perform [remote operations](/waypoint/docs/projects/remote).
 
 https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#TaskLauncher
 
@@ -35,7 +35,7 @@ a function to be called by Waypoint. The function returned by `StartTaskFunc`
 `StopTaskFunc` stops & removes the on-demand runner in the platform. Finally,
 `WatchTaskFunc` returns a function that logs the stream of output from the
 on-demand runner. This is useful for investigating a job by viewing its logs
-with the [`waypoint job get-stream` command](https://developer.hashicorp.com/waypoint/commands/job-get-stream).
+with the [`waypoint job get-stream` command](/waypoint/commands/job-get-stream).
 
 ```go
 type TaskLauncher struct {

--- a/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
@@ -62,18 +62,24 @@ func (p *TaskLauncher) StartTask(
 	ctx context.Context,
 	log hclog.Logger,
 	tli *component.TaskLaunchInfo,
-) (*TaskInfo, error)
+) (*TaskInfo, error) {
+  return nil, nil
+}
 
 func (p *TaskLauncher) StopTask(
 	ctx context.Context,
 	log hclog.Logger,
 	ti *TaskInfo,
-) error
+) error {
+  return nil
+}
 
 func (p *TaskLauncher) WatchTask(
 	ctx context.Context,
 	log hclog.Logger,
 	ui terminal.UI,
 	ti *TaskInfo,
-) (*component.TaskResult, error)
+) (*component.TaskResult, error) {
+  return nil, nil
+}
 ```

--- a/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
@@ -1,0 +1,79 @@
+---
+layout: docs
+page_title: 'TaskLauncher'
+description: |-
+  How to implement the TaskLauncher component for a Waypoint plugin
+---
+
+The TaskLauncher component makes possible launching Waypoint [on-demand runners](https://developer.hashicorp.com/waypoint/docs/runner/on-demand-runner)
+in a given platform, to perform [remote operations](https://developer.hashicorp.com/waypoint/docs/projects/remote).
+
+https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#TaskLauncher
+
+```go
+type TaskLauncher interface {
+	// StartTaskFunc should return a method for the "start task" operation.
+	// This will have TaskLaunchInfo available to it to understand what the task
+	// should do.
+	StartTaskFunc() interface{}
+
+	// StopTaskFunc is called to force a previously started task to stop. It will
+	// be passed the state value returned by StartTaskFunc for identification.
+	StopTaskFunc() interface{}
+
+	// WatchTaskFunc is called after Start but before Stop to block and
+	// watch a single task. It should stream output to the given UI and
+	// return the exit status after it exits. It is given the state resulting
+	// from StartTaskFunc so that it can look up the resource.
+	WatchTaskFunc() interface{}
+}
+```
+
+`TaskLauncher` has three functions which must be implemented, that all return
+a function to be called by Waypoint. The function returned by `StartTaskFunc`
+"starts" the on-demand runner in the platform. The function returned by
+`StopTaskFunc` stops & removes the on-demand runner in the platform. Finally,
+`WatchTaskFunc` returns a function that logs the stream of output from the
+on-demand runner. This is useful for investigating a job by viewing its logs
+with the [`waypoint job get-stream` command](https://developer.hashicorp.com/waypoint/commands/job-get-stream).
+
+```go
+type TaskLauncher struct {
+	config TaskLauncherConfig
+}
+
+type TaskLauncherConfig struct {
+  // Other component fields
+}
+
+func (p *TaskLauncher) StartTaskFunc() interface{} {
+	return p.StartTask
+}
+
+func (p *TaskLauncher) StopTaskFunc() interface{} {
+	return p.StopTask
+}
+
+func (p *TaskLauncher) WatchTaskFunc() interface{} {
+	return p.WatchTask
+}
+
+func (p *TaskLauncher) StartTask(
+	ctx context.Context,
+	log hclog.Logger,
+	tli *component.TaskLaunchInfo,
+) (*TaskInfo, error)
+
+func (p *TaskLauncher) StopTask(
+	ctx context.Context,
+	log hclog.Logger,
+	ti *TaskInfo,
+) error
+
+func (p *TaskLauncher) WatchTask(
+	ctx context.Context,
+	log hclog.Logger,
+	ui terminal.UI,
+	ti *TaskInfo,
+) (*component.TaskResult, error)
+```

--- a/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
+++ b/website/content/docs/extending-waypoint/plugin-interfaces/task-launcher.mdx
@@ -5,7 +5,7 @@ description: |-
   How to implement the TaskLauncher component for a Waypoint plugin
 ---
 
-The TaskLauncher component makes possible launching Waypoint [on-demand runners](/waypoint/docs/runner/on-demand-runner)
+The `TaskLauncher` component makes possible launching Waypoint [On-Demand Runners](/waypoint/docs/runner/on-demand-runner)
 in a given platform, to perform [remote operations](/waypoint/docs/projects/remote).
 
 https://pkg.go.dev/github.com/hashicorp/waypoint-plugin-sdk/component#TaskLauncher

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -648,6 +648,10 @@
             "path": "extending-waypoint/plugin-interfaces/status"
           },
           {
+            "title": "TaskLauncher",
+            "path": "extending-waypoint/plugin-interfaces/task-launcher"
+          },
+          {
             "title": "Default Parameters",
             "path": "extending-waypoint/plugin-interfaces/default-parameters"
           }


### PR DESCRIPTION
This PR documents the [`TaskLauncher` interface of the plugin SDK](https://github.com/hashicorp/waypoint-plugin-sdk/blob/main/component/component.go#L54-L71)!