### PR TITLE
Add jq install to tools.Dockerfile

### DIFF
--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -14,6 +14,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC
 
 # Copy files required to update tooling
 RUN mkdir -p /tools/tools
+RUN apt-get install -y jq
 COPY ./tools/tools.go /tools/tools
 COPY ./Makefile /tools
 COPY go.mod /tools


### PR DESCRIPTION
Adds line to install jq in tools.Dockerfile. `make docker/gen/server` was failing without this.
