### PR TITLE
Check target health before releasing ECS deployment

### DIFF
--- a/.changelog/4520.txt
+++ b/.changelog/4520.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/ecs: Update ECS releaser to verify deployment health before releasing.
+```


### PR DESCRIPTION
This PR updates the default releaser for AWS ECS to check that each target in the deployment target group is `healthy` before releasing the deployment (routing 100% of traffic to it). Closes #2187. 

If not all targets are healthy, the release fails with an error, informing the user that the release cannot happen until all targets are healthy.