### PR TITLE
Fix key for config sources in BoltDB

### DIFF
--- a/.changelog/4523.txt
+++ b/.changelog/4523.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli/snapshot: Fix server snapshot when a config source is set.
+```

--- a/internal/server/boltdbstate/config_source.go
+++ b/internal/server/boltdbstate/config_source.go
@@ -2,7 +2,7 @@ package boltdbstate
 
 import (
 	"context"
-	"encoding/binary"
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -335,9 +335,10 @@ func (s *State) configSourceIndexInit(dbTxn *bolt.Tx, memTxn *memdb.Txn) error {
 }
 
 func (s *State) configSourceId(idHash uint64) []byte {
-	configSourceId := make([]byte, 8)
-	binary.LittleEndian.PutUint64(configSourceId, idHash)
-	return configSourceId
+	// Convert uint64 to string before conversion to byte slice. BoltDB
+	// operations are OK with uint64, but server snapshots (a client of BoltDB)
+	// expect that all keys and values are UTF-8 encoded, which uint64 is not.
+	return []byte(fmt.Sprintf("%d", idHash))
 }
 
 func configSourceIndexSchema() *memdb.TableSchema {

--- a/internal/server/boltdbstate/config_source.go
+++ b/internal/server/boltdbstate/config_source.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure/v2"
@@ -316,7 +317,7 @@ func (s *State) configSourceIndexInit(dbTxn *bolt.Tx, memTxn *memdb.Txn) error {
 		// is the simplest way for users to upgrade since custom config sourcer
 		// plugins aren't yet supported, as of 1/10/2023.
 		key := string(k)
-		if re.MatchString(key) {
+		if re.MatchString(key) || !utf8.Valid(k) {
 			if err := bucket.Delete(k); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR updates how config source records are stored in BoltDB. Previously the key was a uint64 value converted to a byte slice - this is acceptable for BoltDB and reading from it; however, snapshots expect that the database values are UTF-8 encoded, which uint64 is not. This PR therefore converts the uint64 to a string BEFORE converting it to a byte slice, and that is the new "id" for a record in the config_source bucket.

Prior to this PR, `waypoint server snapshot` would fail, and the server would log an error indicating that an invalid UTF-8 character was written.