### PR TITLE
plugin/ecs: Allow multiple port to be mapped in sidecars

### DIFF
--- a/.changelog/4530.txt
+++ b/.changelog/4530.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws: Allow multiple ports to be specified on ecs sidecar containers
+```

--- a/builtin/aws/ecs/components/platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/parameters.hcl
@@ -245,6 +245,13 @@ parameter {
 }
 
 parameter {
+  key         = "sidecar.container_ports"
+  description = "List of container port definitions for the container"
+  type        = "list of ecs.ContainerPort"
+  required    = false
+}
+
+parameter {
   key         = "sidecar.health_check"
   description = ""
   type        = "ecs.HealthCheckConfig"

--- a/builtin/aws/ecs/components/platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/parameters.hcl
@@ -247,8 +247,29 @@ parameter {
 parameter {
   key         = "sidecar.container_ports"
   description = "List of container port definitions for the container"
-  type        = "list of ecs.ContainerPort"
+  type        = "category"
   required    = false
+}
+
+parameter {
+  key         = "sidecar.container_ports.container_port"
+  description = "The port number for the container"
+  type        = ""
+  required    = true
+}
+
+parameter {
+  key         = "sidecar.container_ports.host_port"
+  description = "The port number for the container instance to reserve for your container"
+  type        = ""
+  required    = true
+}
+
+parameter {
+  key         = "sidecar.container_ports.protocol"
+  description = "The protocol used for the port mapping"
+  type        = ""
+  required    = true
 }
 
 parameter {

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -3072,6 +3072,22 @@ deploy {
 			doc.SetField(
 				"container_ports",
 				"List of container port definitions for the container",
+				docs.SubFields(func(doc *docs.SubFieldDoc) {
+					doc.SetField(
+						"container_port",
+						"The port number for the container",
+					)
+
+					doc.SetField(
+						"host_port",
+						"The port number for the container instance to reserve for your container",
+					)
+
+					doc.SetField(
+						"protocol",
+						"The protocol used for the port mapping",
+					)
+				}),
 			)
 
 			doc.SetField(

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -3070,6 +3070,11 @@ deploy {
 			)
 
 			doc.SetField(
+				"container_ports",
+				"List of container port definitions for the container",
+			)
+
+			doc.SetField(
 				"host_port",
 				"The port number on the host to reserve for the container",
 			)

--- a/embedJson/gen/platform-aws-ecs.json
+++ b/embedJson/gen/platform-aws-ecs.json
@@ -572,9 +572,46 @@
                "Optional": true,
                "Default": "",
                "EnvVar": "",
-               "Category": false,
+               "Category": true,
                "Example": "",
-               "SubFields": null
+               "SubFields": [
+                  {
+                     "Field": "container_port",
+                     "Type": "",
+                     "Synopsis": "The port number for the container",
+                     "Summary": "",
+                     "Optional": false,
+                     "Default": "",
+                     "EnvVar": "",
+                     "Category": false,
+                     "Example": "",
+                     "SubFields": null
+                  },
+                  {
+                     "Field": "host_port",
+                     "Type": "",
+                     "Synopsis": "The port number for the container instance to reserve for your container",
+                     "Summary": "",
+                     "Optional": false,
+                     "Default": "",
+                     "EnvVar": "",
+                     "Category": false,
+                     "Example": "",
+                     "SubFields": null
+                  },
+                  {
+                     "Field": "protocol",
+                     "Type": "",
+                     "Synopsis": "The protocol used for the port mapping",
+                     "Summary": "",
+                     "Optional": false,
+                     "Default": "",
+                     "EnvVar": "",
+                     "Category": false,
+                     "Example": "",
+                     "SubFields": null
+                  }
+               ]
             },
             {
                "Field": "health_check",

--- a/embedJson/gen/platform-aws-ecs.json
+++ b/embedJson/gen/platform-aws-ecs.json
@@ -565,6 +565,18 @@
                "SubFields": null
             },
             {
+               "Field": "container_ports",
+               "Type": "list of ecs.ContainerPort",
+               "Synopsis": "List of container port definitions for the container",
+               "Summary": "",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
                "Field": "health_check",
                "Type": "ecs.HealthCheckConfig",
                "Synopsis": "",

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -172,12 +172,23 @@ The port number for the container.
 - Type: **int**
 - **Optional**
 
-##### sidecar.container_ports
+##### sidecar.container_ports (category)
 
 List of container port definitions for the container.
 
-- Type: **list of ecs.ContainerPort**
 - **Optional**
+
+###### sidecar.container_ports.container_port
+
+The port number for the container.
+
+###### sidecar.container_ports.host_port
+
+The port number for the container instance to reserve for your container.
+
+###### sidecar.container_ports.protocol
+
+The protocol used for the port mapping.
 
 ##### sidecar.health_check
 

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -172,6 +172,13 @@ The port number for the container.
 - Type: **int**
 - **Optional**
 
+##### sidecar.container_ports
+
+List of container port definitions for the container.
+
+- Type: **list of ecs.ContainerPort**
+- **Optional**
+
 ##### sidecar.health_check
 
 - Type: **ecs.HealthCheckConfig**


### PR DESCRIPTION
This commit adds an additional field, `ContainerPorts`, which can be used multiple times to define multiple ports in a sidecar container within ecs