### PR TITLE
CLI: Enhance Job CLI UX for `waypoint job list` and `waypoint job inspect`

### DIFF
--- a/.changelog/4531.txt
+++ b/.changelog/4531.txt
@@ -1,0 +1,8 @@
+```release-note:improvement
+cli: Include job `QueueTime` in output for `waypoint job list` and `waypoint job inspect`.
+```
+
+```release-note:improvement
+cli: Add a `-verbose` flag to `waypoint job list` to improve relevant columns shown to user
+at a glance.
+```

--- a/internal/cli/job_inspect.go
+++ b/internal/cli/job_inspect.go
@@ -145,6 +145,11 @@ func (c *JobInspectCommand) Run(args []string) int {
 		targetRunner = target.Id.Id
 	}
 
+	var queueTime string
+	if resp.QueueTime != nil {
+		queueTime = humanize.Time(resp.QueueTime.AsTime())
+	}
+
 	var completeTime string
 	if resp.CompleteTime != nil {
 		completeTime = humanize.Time(resp.CompleteTime.AsTime())
@@ -207,6 +212,9 @@ func (c *JobInspectCommand) Run(args []string) int {
 	c.ui.NamedValues([]terminal.NamedValue{
 		{
 			Name: "State", Value: jobState,
+		},
+		{
+			Name: "Queue Time", Value: queueTime,
 		},
 		{
 			Name: "Complete Time", Value: completeTime,

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -209,7 +209,7 @@ func (c *JobListCommand) Run(args []string) int {
 
 	c.ui.Output("Waypoint Jobs", terminal.WithHeaderStyle())
 
-	tblHeaders := []string{"ID", "Operation", "State", "Time Completed", "Target Runner", "Workspace", "Project", "Application", "Pipeline"}
+	tblHeaders := []string{"ID", "Operation", "State", "Time Queued", "Time Completed", "Target Runner", "Workspace", "Project", "Application", "Pipeline"}
 	tbl := terminal.NewTable(tblHeaders...)
 
 	for _, j := range jobs {
@@ -289,6 +289,11 @@ func (c *JobListCommand) Run(args []string) int {
 			targetRunner = target.Id.Id
 		}
 
+		var queueTime string
+		if j.QueueTime != nil {
+			queueTime = humanize.Time(j.QueueTime.AsTime())
+		}
+
 		var completeTime string
 		if j.CompleteTime != nil {
 			completeTime = humanize.Time(j.CompleteTime.AsTime())
@@ -303,6 +308,7 @@ func (c *JobListCommand) Run(args []string) int {
 			j.Id,
 			op,
 			jobState,
+			queueTime,
 			completeTime,
 			targetRunner,
 			j.Workspace.Workspace,

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -19,6 +19,7 @@ type JobListCommand struct {
 	*baseCommand
 
 	flagJson               bool
+	flagVerbose            bool
 	flagLimit              int
 	flagDesc               bool
 	flagState              []string
@@ -209,7 +210,10 @@ func (c *JobListCommand) Run(args []string) int {
 
 	c.ui.Output("Waypoint Jobs", terminal.WithHeaderStyle())
 
-	tblHeaders := []string{"ID", "Operation", "State", "Time Queued", "Time Completed", "Target Runner", "Workspace", "Project", "Application", "Pipeline"}
+	tblHeaders := []string{"ID", "Operation", "State", "Time Queued", "Time Completed", "Target Runner", "Project", "Workspace"}
+	if c.flagVerbose {
+		tblHeaders = append(tblHeaders, []string{"Application", "Pipeline"}...)
+	}
 	tbl := terminal.NewTable(tblHeaders...)
 
 	for _, j := range jobs {
@@ -311,10 +315,15 @@ func (c *JobListCommand) Run(args []string) int {
 			queueTime,
 			completeTime,
 			targetRunner,
-			j.Workspace.Workspace,
 			j.Application.Project,
-			j.Application.Application,
-			pipeline,
+			j.Workspace.Workspace,
+		}
+
+		if c.flagVerbose {
+			tblColumn = append(tblColumn, []string{
+				j.Application.Application,
+				pipeline,
+			}...)
 		}
 
 		tbl.Rich(tblColumn, nil)
@@ -380,7 +389,14 @@ func (c *JobListCommand) Flags() *flag.Sets {
 			Name:    "json",
 			Target:  &c.flagJson,
 			Default: false,
-			Usage:   "Output the list of jobs as json.",
+			Usage:   "Output the list of jobs as json. Includes all fields for jobs.",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "verbose",
+			Target:  &c.flagVerbose,
+			Default: false,
+			Usage:   "Output more details for a job.",
 		})
 
 		f.IntVar(&flag.IntVar{

--- a/website/content/commands/job-list.mdx
+++ b/website/content/commands/job-list.mdx
@@ -46,7 +46,8 @@ Options to filter job list by project, workspace, target runner, pipeline, and p
 - `-pipeline-name=<string>` - List jobs initiated by the specific pipeline, look up by pipeline owner.
 - `-run=<int>` - List jobs initiated by the specific pipeline run, only valid used together with -pipeline.
 - `-desc` - Output the list of jobs from newest to oldest. The default is false.
-- `-json` - Output the list of jobs as json. The default is false.
+- `-json` - Output the list of jobs as json. Includes all fields for jobs. The default is false.
+- `-verbose` - Output more details for a job. The default is false.
 - `-limit=<int>` - If set, will limit the number of jobs to list.
 
 @include "commands/job-list_more.mdx"


### PR DESCRIPTION
This pull request enhances the job CLIs in a couple of ways:

- Include the jobs `QueueTime` in the list and inspect outputs. This is an important field that will be useful for debugging stuck queued jobs.
- Shrink the default set of columns that `waypoint job list` shows by default. It hides `Application` and `Pipeline` from the default view, but the `-verbose` flag will reveal them fully.

Fixes https://github.com/hashicorp/waypoint/issues/4459