### PR TITLE
chore: remove `null` from integrations release

### DIFF
--- a/.github/workflows/notify-integration-release-manual.yml
+++ b/.github/workflows/notify-integration-release-manual.yml
@@ -39,7 +39,6 @@ jobs:
           - "waypoint/hashicorp/nomad-jobspec-canary"
           - "waypoint/hashicorp/nomad-jobspec"
           - "waypoint/hashicorp/nomad"
-          - "waypoint/hashicorp/null"
           - "waypoint/hashicorp/pack"
           - "waypoint/hashicorp/packer"
           - "waypoint/hashicorp/terraform-cloud"


### PR DESCRIPTION
# Description

This removes the `null` plugin from the integration release process

This was not previously displayed on plugins (see https://tip.waypointproject.io/waypoint/plugins) so we will hide it for integrations as well