### PR TITLE
internal/runner: fix dropped error

### DIFF
--- a/internal/runner/operation_release.go
+++ b/internal/runner/operation_release.go
@@ -155,6 +155,9 @@ func (r *Runner) executeReleaseOp(
 			Application: app.Ref(),
 			Workspace:   project.WorkspaceRef(),
 		})
+		if err != nil {
+			return nil, err
+		}
 
 		var rs []*pb.Release
 		for _, release := range rl.Releases {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `internal/runner` package.