### PR TITLE
ui: clean-up `project.current` when leaving project route

### DIFF
--- a/ui/app/routes/workspace/projects/project.ts
+++ b/ui/app/routes/workspace/projects/project.ts
@@ -52,4 +52,12 @@ export default class ProjectDetail extends Route {
     this.pollModel.setup(this);
     this.project.current = model;
   }
+
+  deactivate() {
+    this.project.current = undefined;
+  }
+
+  willDestroy() {
+    this.project.current = undefined;
+  }
 }


### PR DESCRIPTION
A bit of very, very minor housekeeping. Unlikely to have had any real-world impact.