### PR TITLE
Add `UI_GetPipelineRun`

### DIFF
--- a/internal/pkg/graph/transitive.go
+++ b/internal/pkg/graph/transitive.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package graph
+
+// TransitiveReduction performs a transitive reduction on the graph, effectively
+// removing any “shortcuts” from the graph. It performs the reduction *in-place*
+// so please call Copy to avoid mutating the original.
+func (g *Graph) TransitiveReduction() *Graph {
+	// Recursive walk function for use later on
+	var walk func(i Vertex, k Vertex, d int) (int, bool)
+	walk = func(i Vertex, k Vertex, d int) (int, bool) {
+		result := d
+		found := false
+
+		for _, j := range g.OutEdges(i) {
+			if hashcode(j) == hashcode(k) && d >= result {
+				result = d + 1
+				found = true
+				continue
+			}
+			if dd, ok := walk(j, k, d+1); ok && dd > result {
+				result = dd
+				found = true
+				continue
+			}
+		}
+		return result, found
+	}
+
+	// Build longest-path matrix
+	depths := make(map[Vertex]map[Vertex]int)
+	for _, i := range g.Vertices() {
+		depths[i] = make(map[Vertex]int)
+
+		for _, j := range g.Vertices() {
+			if i == j {
+				continue
+			}
+
+			if d, ok := walk(i, j, 0); ok {
+				depths[i][j] = d
+			}
+		}
+	}
+
+	// Remove shortcuts
+	for _, i := range g.Vertices() {
+		for _, j := range g.OutEdges(i) {
+			if depths[i][j] > 1 {
+				g.RemoveEdge(i, j)
+			}
+		}
+	}
+
+	return g
+}

--- a/internal/pkg/graph/transitive_test.go
+++ b/internal/pkg/graph/transitive_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransitiveReduction(t *testing.T) {
+	require := require.New(t)
+
+	var g Graph
+
+	g.Add("A")
+	g.Add("B")
+	g.Add("C")
+	g.Add("D")
+	g.AddEdge("A", "B")
+	g.AddEdge("B", "C")
+	g.AddEdge("C", "D")
+	g.AddEdge("A", "D") // we expect this edge to be removed
+
+	g.TransitiveReduction()
+
+	require.Equal([]Vertex{"B"}, g.OutEdges("A"))
+	require.Equal([]Vertex{"C"}, g.OutEdges("B"))
+	require.Equal([]Vertex{"D"}, g.OutEdges("C"))
+}

--- a/pkg/server/ptypes/pipeline.go
+++ b/pkg/server/ptypes/pipeline.go
@@ -266,6 +266,14 @@ func ValidateUIListPipelineRunsRequest(v *pb.UI_ListPipelineRunsRequest) error {
 	))
 }
 
+// ValidateUIGetPipelineRunRequest
+func ValidateUIGetPipelineRunRequest(v *pb.UI_GetPipelineRunRequest) error {
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Pipeline, validation.Required),
+		validation.Field(&v.Sequence, validation.Required)),
+	)
+}
+
 // ValidateListPipelineRunsRequest
 func ValidateListPipelineRunsRequest(v *pb.ListPipelineRunsRequest) error {
 	return validationext.Error(validation.ValidateStruct(v,

--- a/pkg/server/ptypes/pipeline_ui.go
+++ b/pkg/server/ptypes/pipeline_ui.go
@@ -1,0 +1,482 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ptypes
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/waypoint/internal/pkg/graph"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// UI_PipelineRunTreeFromJobs takes a graph of Jobs and StatusReports and
+// returns a specialized tree representation that drives the pipeline-run
+// timeline UI.
+func UI_PipelineRunTreeFromJobs(jobs []*pb.Job, statusReports []*pb.StatusReport) (*pb.UI_PipelineRunTreeNode, error) {
+	processor := newUIPipelineProcessor(jobs, statusReports)
+
+	return processor.run()
+}
+
+// newUIPipelineProcessor creates a new uiPipelineProcessor for the given jobs and status reports
+func newUIPipelineProcessor(jobs []*pb.Job, statusReports []*pb.StatusReport) uiPipelineProcessor {
+	p := uiPipelineProcessor{
+		jobIdx:  make(map[string]*pb.Job),
+		nodeIdx: make(map[string]*pb.UI_PipelineRunTreeNode),
+	}
+
+	// Populate job index
+	for _, job := range jobs {
+		p.jobIdx[job.Id] = job
+	}
+
+	// Populate status report index
+	statusReportIdx := make(map[string]*pb.StatusReport)
+	for _, statusReport := range statusReports {
+		if d := statusReport.GetDeploymentId(); d != "" {
+			statusReportIdx[d] = statusReport
+		} else if r := statusReport.GetReleaseId(); r != "" {
+			statusReportIdx[r] = statusReport
+		}
+	}
+
+	// Populate node index
+	for _, job := range jobs {
+		var step *pb.Pipeline_Step
+		var statusReport *pb.StatusReport
+
+		if stepOp := job.GetPipelineStep(); stepOp != nil {
+			step = stepOp.Step
+		} else {
+			// This job represents a nested or referenced pipeline
+			// invocation. It doesn’t encode all the necessary
+			// information to infer the step details, so we’ll
+			// create a placeholder step and fill in the details as
+			// we learn more from other jobs in the set.
+			step = &pb.Pipeline_Step{
+				Name:      job.Pipeline.Step,
+				DependsOn: []string{},
+				Kind:      &pb.Pipeline_Step_Pipeline_{},
+			}
+		}
+
+		// Look up the latest status report for this node
+		if d := job.Result.GetDeploy().GetDeployment(); d != nil {
+			statusReport = statusReportIdx[d.Id]
+		}
+		if r := job.Result.GetRelease().GetRelease(); r != nil {
+			statusReport = statusReportIdx[r.Id]
+		}
+
+		// Build the node (children will be populated later)
+		node := &pb.UI_PipelineRunTreeNode{
+			Step:               step,
+			Job:                &pb.Ref_Job{Id: job.Id},
+			State:              p.nodeStateFromJob(job),
+			StartTime:          job.AckTime,
+			CompleteTime:       job.CompleteTime,
+			Application:        job.Application,
+			Workspace:          job.Workspace,
+			Result:             job.Result,
+			LatestStatusReport: statusReport,
+			Children: &pb.UI_PipelineRunTreeNode_Children{
+				Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+				Nodes: []*pb.UI_PipelineRunTreeNode{},
+			},
+		}
+
+		// Register the node the index
+		p.nodeIdx[job.Id] = node
+	}
+
+	// Build graph from job `DependsOn` fields
+	for i, job := range p.jobIdx {
+		p.graph.Add(i)
+
+		for _, j := range job.DependsOn {
+			if _, exists := p.jobIdx[j]; !exists {
+				// If the referenced job isn’t in the set then
+				// we can safely ignore it. It’s likely a
+				// task-releated ancillary job.
+				continue
+			}
+
+			p.graph.Add(j)
+			p.graph.AddEdge(j, i)
+		}
+	}
+
+	return p
+}
+
+// uiPipelineProcessor encapsulates all the state required to transform a set of
+// jobs and status reports into our desired output
+type uiPipelineProcessor struct {
+	jobIdx  map[string]*pb.Job
+	nodeIdx map[string]*pb.UI_PipelineRunTreeNode
+	graph   graph.Graph
+}
+
+// run performs our battery of transformations and returns the root of the
+// output tree, or an error if something went wrong.
+func (p uiPipelineProcessor) run() (*pb.UI_PipelineRunTreeNode, error) {
+	var rootId string
+	var rootNode *pb.UI_PipelineRunTreeNode
+
+	// Remove shortcuts from the graph. We do this because sometimes jobs
+	// contain redundant entries in their DependsOn list.
+	p.graph.TransitiveReduction()
+
+	// Find the root id/node
+	rootId, rootNode, err := p.root()
+	if err != nil {
+		return nil, err
+	}
+
+	// Process the tree starting at the root ID in the context of the root node
+	if err := p.processSubGraph(rootId, rootNode); err != nil {
+		return nil, err
+	}
+
+	return rootNode, nil
+}
+
+// root returns the root ID and node.
+func (p uiPipelineProcessor) root() (string, *pb.UI_PipelineRunTreeNode, error) {
+	sorted := p.graph.KahnSort()
+
+	id, ok := sorted[0].(string)
+	if !ok {
+		return "", nil, fmt.Errorf("could not find root node")
+	}
+
+	node, ok := p.nodeIdx[id]
+	if !ok {
+		return "", nil, fmt.Errorf("could not find root node")
+	}
+
+	return id, node, nil
+}
+
+// processSubGraph performs transformations starting at the given inputId, and
+// collecting the results into the given outputNode.
+func (p uiPipelineProcessor) processSubGraph(inputId string, outputNode *pb.UI_PipelineRunTreeNode) error {
+	var nextIds []string
+	for _, v := range p.graph.OutEdges(inputId) {
+		nextIds = append(nextIds, v.(string))
+	}
+	sort.Strings(nextIds)
+	degree := len(nextIds)
+
+	if degree == 1 {
+		nextId := nextIds[0]
+		nextNode := p.nodeIdx[nextId]
+		inputPipelineId := p.jobIdx[inputId].Pipeline.GetPipelineId()
+		nextPipelineId := p.jobIdx[nextId].Pipeline.GetPipelineId()
+
+		if inputPipelineId != nextPipelineId {
+			invokeId, err := p.foldSubPipeline(nextId, inputPipelineId)
+			if err != nil {
+				return err
+			}
+			nextId = invokeId
+			nextNode = p.nodeIdx[nextId]
+		}
+
+		outputNode.Children.Nodes = append(outputNode.Children.Nodes, nextNode)
+
+		return p.processSubGraph(nextId, outputNode)
+	}
+
+	if degree > 1 {
+		virtualId, virtualNode, err := p.foldBranches(inputId, outputNode)
+		if err != nil {
+			return err
+		}
+
+		// Continue processing the parent graph from the new
+		// virtual node, but accumulating into the output node.
+		if err := p.processSubGraph(virtualId, outputNode); err != nil {
+			return err
+		}
+
+		// Process all the input children as sub-graphs,
+		// accumulating into the virtual node.
+		for _, nextId := range nextIds {
+			nextNode := p.nodeIdx[nextId]
+			inputJob := p.jobIdx[inputId]
+			nextJob := p.jobIdx[nextId]
+			inputPipelineId := inputJob.Pipeline.GetPipelineId()
+			nextPipelineId := nextJob.Pipeline.GetPipelineId()
+
+			if inputPipelineId != nextPipelineId {
+				invokeId, err := p.foldSubPipeline(nextId, inputPipelineId)
+				if err != nil {
+					return err
+				}
+				nextId = invokeId
+				nextNode = p.nodeIdx[nextId]
+			}
+
+			virtualNode.Children.Nodes = append(virtualNode.Children.Nodes, nextNode)
+
+			if err := p.processSubGraph(nextId, nextNode); err != nil {
+				return err
+			}
+		}
+
+		p.inferNodeAttrsFromChildren(virtualNode)
+	}
+
+	return nil
+}
+
+// foldBranches replaces parallel branches of a graph with a single node.
+//
+// Before:
+//
+//	  A
+//	┌─┴─┐
+//	B   D
+//	C   E
+//	└─┬─┘
+//	  F
+//
+// After:
+//
+//	A
+//	V
+//	F
+//
+// It returns the new node and assumes the parent function will perform further
+// processing to embed the original children within the new node.
+func (p uiPipelineProcessor) foldBranches(
+	inputId string,
+	outputNode *pb.UI_PipelineRunTreeNode,
+) (string, *pb.UI_PipelineRunTreeNode, error) {
+	nextIds := p.graph.OutEdges(inputId)
+	degree := len(nextIds)
+
+	// Create a “virtual node” to encapsulate concurrent work.
+	virtualId := outputNode.Job.Id + "-virtual"
+	virtualNode := &pb.UI_PipelineRunTreeNode{
+		Job: &pb.Ref_Job{
+			Id: virtualId,
+		},
+		Children: &pb.UI_PipelineRunTreeNode_Children{
+			Mode:  pb.UI_PipelineRunTreeNode_Children_PARALLEL,
+			Nodes: []*pb.UI_PipelineRunTreeNode{},
+		},
+	}
+	virtualJob := &pb.Job{
+		Pipeline: p.jobIdx[inputId].Pipeline,
+	}
+	p.nodeIdx[virtualId] = virtualNode
+	p.jobIdx[virtualId] = virtualJob
+
+	// Add the virtual node into the graph as a child of the
+	// input node.
+	p.graph.Add(virtualId)
+	p.graph.AddEdge(inputId, virtualId)
+	// And add the virtual node to the output node’s children.
+	outputNode.Children.Nodes = append(outputNode.Children.Nodes, virtualNode)
+
+	// Disconnect all children from the input node.
+	for _, nextId := range nextIds {
+		p.graph.RemoveEdge(inputId, nextId)
+	}
+
+	// Find common descendent (if any)
+	var commonDescendent string
+	seen := make(map[graph.Vertex]int)
+	for _, i := range nextIds {
+		err := p.graph.DFS(i, func(j graph.Vertex, c func() error) error {
+			seen[j] += 1
+			if seen[j] == degree {
+				commonDescendent = j.(string)
+				return nil
+			} else {
+				return c()
+			}
+		})
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	if commonDescendent != "" {
+		// If there is a common ancestor, disconnect
+		// anything that’s pointing to it.
+		for _, a := range p.graph.InEdges(commonDescendent) {
+			p.graph.RemoveEdge(a, commonDescendent)
+		}
+		// And connect the virtual node instead.
+		p.graph.AddEdge(virtualId, commonDescendent)
+	}
+
+	return virtualId, virtualNode, nil
+}
+
+// foldSubPipeline replaces nested pipeline invocations with a single node.
+func (p uiPipelineProcessor) foldSubPipeline(inputId string, parentPipelineId string) (string, error) {
+	var invokeId string
+	inputNode := p.nodeIdx[inputId]
+
+	// Find the node in which we return to the parent pipeline. This is the
+	// `use "pipeline"` step from the pipeline.
+	err := p.graph.DFS(inputId, func(v graph.Vertex, c func() error) error {
+		id := v.(string)
+		job := p.jobIdx[id]
+
+		if job.Pipeline.GetPipelineId() == parentPipelineId {
+			invokeId = id
+			return nil
+		}
+
+		return c()
+	})
+	if err != nil {
+		return "", err
+	}
+	if invokeId == "" {
+		subPipelineId := p.jobIdx[inputId].Pipeline.GetPipelineId()
+		return "", fmt.Errorf("Invocation node not found for sub-pipeline %q", subPipelineId)
+	}
+
+	// Disconnect the invoke node from it’s current inbound edges
+	for _, i := range p.graph.InEdges(invokeId) {
+		p.graph.RemoveEdge(i, invokeId)
+	}
+
+	// Moves inbound edges from the input node to the invoke node
+	for _, i := range p.graph.InEdges(inputId) {
+		p.graph.RemoveEdge(i, inputId)
+		p.graph.AddEdge(i, invokeId)
+	}
+
+	invokeNode := p.nodeIdx[invokeId]
+
+	// Embed the original input node in the invoke node
+	invokeNode.Children.Nodes = append(invokeNode.Children.Nodes, inputNode)
+
+	// Process the sub-graph starting at the input node
+	if err := p.processSubGraph(inputId, invokeNode); err != nil {
+		return "", err
+	}
+
+	// Extract sub-pipeline information from children
+	invokeNode.Step.Kind = p.stepRefFromJob(p.jobIdx[inputId])
+	p.inferNodeAttrsFromChildren(invokeNode)
+
+	return invokeId, nil
+}
+
+// nodeStateFromJob return the “tree node state” for a given job. The tree node
+// state is somewhat abstracted/inferred from job state, thus the need for this
+// mapping.
+func (p uiPipelineProcessor) nodeStateFromJob(j *pb.Job) pb.UI_PipelineRunTreeNode_State {
+	switch j.State {
+	case pb.Job_QUEUED, pb.Job_WAITING:
+		return pb.UI_PipelineRunTreeNode_QUEUED
+	case pb.Job_RUNNING:
+		return pb.UI_PipelineRunTreeNode_RUNNING
+	case pb.Job_ERROR:
+		if j.CancelTime != nil {
+			return pb.UI_PipelineRunTreeNode_CANCELLED
+		} else {
+			return pb.UI_PipelineRunTreeNode_ERROR
+		}
+	case pb.Job_SUCCESS:
+		return pb.UI_PipelineRunTreeNode_SUCCESS
+	}
+
+	return pb.UI_PipelineRunTreeNode_UNKNOWN
+}
+
+// stepRefFromJob returns a pipeline step definition from a given job. This
+// function doesn’t do anything terribly complex, really it just encapsulates a
+// lot of protobuf boilerplate.
+func (p uiPipelineProcessor) stepRefFromJob(job *pb.Job) *pb.Pipeline_Step_Pipeline_ {
+	return &pb.Pipeline_Step_Pipeline_{
+		Pipeline: &pb.Pipeline_Step_Pipeline{
+			Ref: &pb.Ref_Pipeline{
+				Ref: &pb.Ref_Pipeline_Owner{
+					Owner: &pb.Ref_PipelineOwner{
+						Project:      &pb.Ref_Project{Project: job.Application.Project},
+						PipelineName: job.Pipeline.PipelineName,
+					},
+				},
+			},
+		},
+	}
+}
+
+// inferNodeAttrsFromChildren takes a node and sets the following attributes
+// based on the attributes of its children:
+//
+// * Application
+// * StartTime
+// * CompleteTime
+// * State
+func (p uiPipelineProcessor) inferNodeAttrsFromChildren(node *pb.UI_PipelineRunTreeNode) {
+	children := node.Children.Nodes
+
+	if len(children) == 0 {
+		return
+	}
+
+	// Extract application
+	node.Application = children[0].Application
+
+	// Extract start time
+	for _, n := range children {
+		t1 := node.StartTime
+		t2 := n.StartTime
+
+		if t1 == nil {
+			node.StartTime = t2
+			continue
+		}
+
+		if t2 == nil {
+			continue
+		}
+
+		if t2.AsTime().Before(t1.AsTime()) {
+			node.StartTime = t2
+		}
+	}
+
+	// Extract complete time
+	for _, n := range node.Children.Nodes {
+		t1 := node.CompleteTime
+		t2 := n.CompleteTime
+
+		if t1 == nil {
+			node.CompleteTime = t2
+			continue
+		}
+
+		if t2 == nil {
+			// We’ve found an incomplete step, so the parent is also incomplete
+			node.CompleteTime = nil
+			break
+		}
+
+		if t2.AsTime().After(t1.AsTime()) {
+			node.CompleteTime = t2
+		}
+	}
+
+	// Extract state
+	for _, n := range node.Children.Nodes {
+		s := n.State
+		node.State = s
+
+		if s != pb.UI_PipelineRunTreeNode_SUCCESS {
+			break
+		}
+	}
+}

--- a/pkg/server/ptypes/pipeline_ui_test.go
+++ b/pkg/server/ptypes/pipeline_ui_test.go
@@ -1,0 +1,1284 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ptypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+func TestUI_PipelineRunTreeFromJobs(t *testing.T) {
+	appRef := &pb.Ref_Application{
+		Project:     "test-project",
+		Application: "test-app",
+	}
+
+	cases := map[string]struct {
+		Jobs          []*pb.Job
+		StatusReports []*pb.StatusReport
+		Tree          *pb.UI_PipelineRunTreeNode
+	}{
+		"one queued exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State: pb.Job_QUEUED,
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State: pb.UI_PipelineRunTreeNode_QUEUED,
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one running exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State:   pb.Job_RUNNING,
+					AckTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State:     pb.UI_PipelineRunTreeNode_RUNNING,
+				StartTime: quickTimestamp("2023-01-01T13:00:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one successful exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_SUCCESS,
+					AckTime:      quickTimestamp("2023-01-01T13:00:00Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+				StartTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one errored exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_ERROR,
+					AckTime:      quickTimestamp("2023-01-01T13:00:00Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State:        pb.UI_PipelineRunTreeNode_ERROR,
+				StartTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one cancelled exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_ERROR,
+					AckTime:      quickTimestamp("2023-01-01T13:00:00Z"),
+					CancelTime:   quickTimestamp("2023-01-01T13:08:00Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State:        pb.UI_PipelineRunTreeNode_CANCELLED,
+				StartTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one queued exec step with application": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State:       pb.Job_QUEUED,
+					Application: appRef,
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State: pb.UI_PipelineRunTreeNode_QUEUED,
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Application: appRef,
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one queued exec step with workspace": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					State: pb.Job_QUEUED,
+					Workspace: &pb.Ref_Workspace{
+						Workspace: "test",
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State: pb.UI_PipelineRunTreeNode_QUEUED,
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Workspace: &pb.Ref_Workspace{
+					Workspace: "test",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one successful build step with result": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-build-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "build",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Build_{
+									Build: &pb.Pipeline_Step_Build{
+										DisablePush: true,
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_SUCCESS,
+					AckTime:      quickTimestamp("2023-01-01T13:00:00Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+					Result: &pb.Job_Result{
+						Build: &pb.Job_BuildResult{
+							Build: &pb.Build{
+								Id: "build-from-build-step",
+							},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "build",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "build",
+					Kind: &pb.Pipeline_Step_Build_{
+						Build: &pb.Pipeline_Step_Build{
+							DisablePush: true,
+						},
+					},
+				},
+				State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+				StartTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-build-step",
+				},
+				Result: &pb.Job_Result{
+					Build: &pb.Job_BuildResult{
+						Build: &pb.Build{
+							Id: "build-from-build-step",
+						},
+					},
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one successful deploy step with result": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-deploy-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "deploy",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Deploy_{
+									Deploy: &pb.Pipeline_Step_Deploy{
+										Release: false,
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_SUCCESS,
+					AckTime:      quickTimestamp("2023-01-01T13:00:00Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+					Result: &pb.Job_Result{
+						Deploy: &pb.Job_DeployResult{
+							Deployment: &pb.Deployment{
+								Id: "deployment-from-deploy-step",
+							},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "deploy",
+						RunSequence:  1,
+					},
+				},
+			},
+			StatusReports: []*pb.StatusReport{
+				{
+					TargetId: &pb.StatusReport_DeploymentId{DeploymentId: "deployment-from-deploy-step"},
+					Id:       "status-report-for-deployment",
+					Health:   &pb.StatusReport_Health{HealthStatus: "READY"},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "deploy",
+					Kind: &pb.Pipeline_Step_Deploy_{
+						Deploy: &pb.Pipeline_Step_Deploy{
+							Release: false,
+						},
+					},
+				},
+				State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+				StartTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:10:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-deploy-step",
+				},
+				Result: &pb.Job_Result{
+					Deploy: &pb.Job_DeployResult{
+						Deployment: &pb.Deployment{
+							Id: "deployment-from-deploy-step",
+						},
+					},
+				},
+				LatestStatusReport: &pb.StatusReport{
+					TargetId: &pb.StatusReport_DeploymentId{DeploymentId: "deployment-from-deploy-step"},
+					Id:       "status-report-for-deployment",
+					Health:   &pb.StatusReport_Health{HealthStatus: "READY"},
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{},
+				},
+			},
+		},
+		"one running exec step and one queued exec step": {
+			Jobs: []*pb.Job{
+				{
+					Id: "job-for-hello-step",
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "hello",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hello"},
+									},
+								},
+							},
+						},
+					},
+					AckTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					State:   pb.Job_RUNNING,
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "hello",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id:        "job-for-bye-step",
+					DependsOn: []string{"job-for-hello-step"},
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "bye",
+								DependsOn: []string{"hello"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"bye"},
+									},
+								},
+							},
+						},
+					},
+					State: pb.Job_QUEUED,
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "pipeline-id",
+						PipelineName: "pipeline-name",
+						Step:         "bye",
+						RunSequence:  1,
+					}},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name: "hello",
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"hello"},
+						},
+					},
+				},
+				State:     pb.UI_PipelineRunTreeNode_RUNNING,
+				StartTime: quickTimestamp("2023-01-01T13:00:00Z"),
+				Job: &pb.Ref_Job{
+					Id: "job-for-hello-step",
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode: pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{
+						{
+							Step: &pb.Pipeline_Step{
+								Name: "bye",
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"bye"},
+									},
+								},
+								DependsOn: []string{"hello"},
+							},
+							State: pb.UI_PipelineRunTreeNode_QUEUED,
+							Job:   &pb.Ref_Job{Id: "job-for-bye-step"},
+							Children: &pb.UI_PipelineRunTreeNode_Children{
+								Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+								Nodes: []*pb.UI_PipelineRunTreeNode{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"referenced pipeline invocation": {
+			Jobs: []*pb.Job{
+				{
+					Id:          "job-for-prep-step",
+					DependsOn:   []string{"unknown-job"},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "prep",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"preparing"},
+									},
+								},
+							},
+						},
+					},
+					QueueTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:      quickTimestamp("2023-01-01T13:00:10Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:00:20Z"),
+					State:        pb.Job_SUCCESS,
+					Result: &pb.Job_Result{
+						PipelineStep: &pb.Job_PipelineStepResult{
+							Result: &status.Status{},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "prep",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-invoke-step",
+					DependsOn: []string{
+						"job-for-prep-step",
+						"job-for-hi-step",
+						"job-for-bye-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation:   &pb.Job_Noop_{},
+					State:       pb.Job_QUEUED,
+					QueueTime:   quickTimestamp("2023-01-01T13:00:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "invoke-referenced-pipeline",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id:          "job-for-hi-step",
+					DependsOn:   []string{"job-for-prep-step"},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name: "hi",
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hi"},
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_SUCCESS,
+					QueueTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:      quickTimestamp("2023-01-01T13:00:30Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:00:40Z"),
+					Result: &pb.Job_Result{
+						PipelineStep: &pb.Job_PipelineStepResult{
+							Result: &status.Status{},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "referenced-pipeline-id",
+						PipelineName: "referenced-pipeline",
+						Step:         "hi",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-bye-step",
+					DependsOn: []string{
+						"job-for-hi-step",
+						"job-for-prep-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "bye",
+								DependsOn: []string{"hi"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"bye"},
+									},
+								},
+							},
+						},
+					},
+					State:     pb.Job_RUNNING,
+					QueueTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "referenced-pipeline-id",
+						PipelineName: "referenced-pipeline",
+						Step:         "bye",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-done-step",
+					DependsOn: []string{
+						"job-for-hi-step",
+						"job-for-bye-step",
+						"job-for-invoke-step",
+						"job-for-prep-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "done",
+								DependsOn: []string{"invoke-referenced-pipeline"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"done"},
+									},
+								},
+							},
+						},
+					},
+					State:     pb.Job_QUEUED,
+					QueueTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "done",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name:      "prep",
+					DependsOn: []string{},
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"preparing"},
+						},
+					},
+				},
+				Application:  appRef,
+				Job:          &pb.Ref_Job{Id: "job-for-prep-step"},
+				StartTime:    quickTimestamp("2023-01-01T13:00:10Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:00:20Z"),
+				State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+				Result: &pb.Job_Result{
+					PipelineStep: &pb.Job_PipelineStepResult{
+						Result: &status.Status{},
+					},
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode: pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{
+						{
+							Step: &pb.Pipeline_Step{
+								Name: "invoke-referenced-pipeline",
+								Kind: &pb.Pipeline_Step_Pipeline_{
+									Pipeline: &pb.Pipeline_Step_Pipeline{
+										Ref: &pb.Ref_Pipeline{
+											Ref: &pb.Ref_Pipeline_Owner{
+												Owner: &pb.Ref_PipelineOwner{
+													Project: &pb.Ref_Project{
+														Project: "test-project",
+													},
+													PipelineName: "referenced-pipeline",
+												},
+											},
+										},
+									},
+								},
+							},
+							Application: appRef,
+							Job:         &pb.Ref_Job{Id: "job-for-invoke-step"},
+							State:       pb.UI_PipelineRunTreeNode_RUNNING,
+							StartTime:   quickTimestamp("2023-01-01T13:00:30Z"),
+							Children: &pb.UI_PipelineRunTreeNode_Children{
+								Mode: pb.UI_PipelineRunTreeNode_Children_SERIAL,
+								Nodes: []*pb.UI_PipelineRunTreeNode{
+									{
+										Step: &pb.Pipeline_Step{
+											Name: "hi",
+											Kind: &pb.Pipeline_Step_Exec_{
+												Exec: &pb.Pipeline_Step_Exec{
+													Image:   "busybox",
+													Command: "echo",
+													Args:    []string{"hi"},
+												},
+											},
+										},
+										Application:  appRef,
+										Job:          &pb.Ref_Job{Id: "job-for-hi-step"},
+										StartTime:    quickTimestamp("2023-01-01T13:00:30Z"),
+										CompleteTime: quickTimestamp("2023-01-01T13:00:40Z"),
+										State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+										Result: &pb.Job_Result{
+											PipelineStep: &pb.Job_PipelineStepResult{
+												Result: &status.Status{},
+											},
+										},
+										Children: &pb.UI_PipelineRunTreeNode_Children{
+											Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+											Nodes: []*pb.UI_PipelineRunTreeNode{},
+										},
+									},
+									{
+										Step: &pb.Pipeline_Step{
+											Name:      "bye",
+											DependsOn: []string{"hi"},
+											Kind: &pb.Pipeline_Step_Exec_{
+												Exec: &pb.Pipeline_Step_Exec{
+													Image:   "busybox",
+													Command: "echo",
+													Args:    []string{"bye"},
+												},
+											},
+										},
+										Application: appRef,
+										Job:         &pb.Ref_Job{Id: "job-for-bye-step"},
+										StartTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+										State:       pb.UI_PipelineRunTreeNode_RUNNING,
+										Children: &pb.UI_PipelineRunTreeNode_Children{
+											Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+											Nodes: []*pb.UI_PipelineRunTreeNode{},
+										},
+									},
+								},
+							},
+						},
+						{
+							Step: &pb.Pipeline_Step{
+								Name:      "done",
+								DependsOn: []string{"invoke-referenced-pipeline"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"done"},
+									},
+								},
+							},
+							Application: appRef,
+							Job:         &pb.Ref_Job{Id: "job-for-done-step"},
+							State:       pb.UI_PipelineRunTreeNode_QUEUED,
+							Children: &pb.UI_PipelineRunTreeNode_Children{
+								Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+								Nodes: []*pb.UI_PipelineRunTreeNode{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"referenced pipeline invocation AND parallel steps": {
+			Jobs: []*pb.Job{
+				{
+					Id:          "job-for-prep-step",
+					DependsOn:   []string{"unknown-job"},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "prep",
+								DependsOn: []string{},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"preparing"},
+									},
+								},
+							},
+						},
+					},
+					QueueTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:      quickTimestamp("2023-01-01T13:00:10Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:00:20Z"),
+					State:        pb.Job_SUCCESS,
+					Result: &pb.Job_Result{
+						PipelineStep: &pb.Job_PipelineStepResult{
+							Result: &status.Status{},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "prep",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-invoke-step",
+					DependsOn: []string{
+						"job-for-prep-step",
+						"job-for-hi-step",
+						"job-for-bye-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation:   &pb.Job_Noop_{},
+					State:       pb.Job_QUEUED,
+					QueueTime:   quickTimestamp("2023-01-01T13:00:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "invoke-referenced-pipeline",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id:          "job-for-hi-step",
+					DependsOn:   []string{"job-for-prep-step"},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name: "hi",
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"hi"},
+									},
+								},
+							},
+						},
+					},
+					State:        pb.Job_SUCCESS,
+					QueueTime:    quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:      quickTimestamp("2023-01-01T13:00:30Z"),
+					CompleteTime: quickTimestamp("2023-01-01T13:00:40Z"),
+					Result: &pb.Job_Result{
+						PipelineStep: &pb.Job_PipelineStepResult{
+							Result: &status.Status{},
+						},
+					},
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "referenced-pipeline-id",
+						PipelineName: "referenced-pipeline",
+						Step:         "hi",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-bye-step",
+					DependsOn: []string{
+						"job-for-hi-step",
+						"job-for-prep-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "bye",
+								DependsOn: []string{"hi"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"bye"},
+									},
+								},
+							},
+						},
+					},
+					State:     pb.Job_RUNNING,
+					QueueTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "referenced-pipeline-id",
+						PipelineName: "referenced-pipeline",
+						Step:         "bye",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-other-step",
+					DependsOn: []string{
+						"job-for-prep-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "other",
+								DependsOn: []string{"prep"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"other"},
+									},
+								},
+							},
+						},
+					},
+					State:     pb.Job_RUNNING,
+					QueueTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					AckTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "other",
+						RunSequence:  1,
+					},
+				},
+				{
+					Id: "job-for-done-step",
+					DependsOn: []string{
+						"job-for-hi-step",
+						"job-for-bye-step",
+						"job-for-invoke-step",
+						"job-for-prep-step",
+						"job-for-other-step",
+						"unknown-job",
+					},
+					Application: appRef,
+					Operation: &pb.Job_PipelineStep{
+						PipelineStep: &pb.Job_PipelineStepOp{
+							Step: &pb.Pipeline_Step{
+								Name:      "done",
+								DependsOn: []string{"invoke-referenced-pipeline"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"done"},
+									},
+								},
+							},
+						},
+					},
+					State:     pb.Job_QUEUED,
+					QueueTime: quickTimestamp("2023-01-01T13:00:00Z"),
+					Pipeline: &pb.Ref_PipelineStep{
+						PipelineId:   "parent-pipeline-id",
+						PipelineName: "parent-pipeline",
+						Step:         "done",
+						RunSequence:  1,
+					},
+				},
+			},
+			Tree: &pb.UI_PipelineRunTreeNode{
+				Step: &pb.Pipeline_Step{
+					Name:      "prep",
+					DependsOn: []string{},
+					Kind: &pb.Pipeline_Step_Exec_{
+						Exec: &pb.Pipeline_Step_Exec{
+							Image:   "busybox",
+							Command: "echo",
+							Args:    []string{"preparing"},
+						},
+					},
+				},
+				Application:  appRef,
+				Job:          &pb.Ref_Job{Id: "job-for-prep-step"},
+				StartTime:    quickTimestamp("2023-01-01T13:00:10Z"),
+				CompleteTime: quickTimestamp("2023-01-01T13:00:20Z"),
+				State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+				Result: &pb.Job_Result{
+					PipelineStep: &pb.Job_PipelineStepResult{
+						Result: &status.Status{},
+					},
+				},
+				Children: &pb.UI_PipelineRunTreeNode_Children{
+					Mode: pb.UI_PipelineRunTreeNode_Children_SERIAL,
+					Nodes: []*pb.UI_PipelineRunTreeNode{
+						{
+							Job:         &pb.Ref_Job{Id: "job-for-prep-step-virtual"},
+							Application: appRef,
+							StartTime:   quickTimestamp("2023-01-01T13:00:30Z"),
+							State:       pb.UI_PipelineRunTreeNode_RUNNING,
+							Children: &pb.UI_PipelineRunTreeNode_Children{
+								Mode: pb.UI_PipelineRunTreeNode_Children_PARALLEL,
+								Nodes: []*pb.UI_PipelineRunTreeNode{
+									{
+										Step: &pb.Pipeline_Step{
+											Name: "invoke-referenced-pipeline",
+											Kind: &pb.Pipeline_Step_Pipeline_{
+												Pipeline: &pb.Pipeline_Step_Pipeline{
+													Ref: &pb.Ref_Pipeline{
+														Ref: &pb.Ref_Pipeline_Owner{
+															Owner: &pb.Ref_PipelineOwner{
+																Project: &pb.Ref_Project{
+																	Project: "test-project",
+																},
+																PipelineName: "referenced-pipeline",
+															},
+														},
+													},
+												},
+											},
+										},
+										Application: appRef,
+										Job:         &pb.Ref_Job{Id: "job-for-invoke-step"},
+										State:       pb.UI_PipelineRunTreeNode_RUNNING,
+										StartTime:   quickTimestamp("2023-01-01T13:00:30Z"),
+										Children: &pb.UI_PipelineRunTreeNode_Children{
+											Mode: pb.UI_PipelineRunTreeNode_Children_SERIAL,
+											Nodes: []*pb.UI_PipelineRunTreeNode{
+												{
+													Step: &pb.Pipeline_Step{
+														Name: "hi",
+														Kind: &pb.Pipeline_Step_Exec_{
+															Exec: &pb.Pipeline_Step_Exec{
+																Image:   "busybox",
+																Command: "echo",
+																Args:    []string{"hi"},
+															},
+														},
+													},
+													Application:  appRef,
+													Job:          &pb.Ref_Job{Id: "job-for-hi-step"},
+													StartTime:    quickTimestamp("2023-01-01T13:00:30Z"),
+													CompleteTime: quickTimestamp("2023-01-01T13:00:40Z"),
+													State:        pb.UI_PipelineRunTreeNode_SUCCESS,
+													Result: &pb.Job_Result{
+														PipelineStep: &pb.Job_PipelineStepResult{
+															Result: &status.Status{},
+														},
+													},
+													Children: &pb.UI_PipelineRunTreeNode_Children{
+														Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+														Nodes: []*pb.UI_PipelineRunTreeNode{},
+													},
+												},
+												{
+													Step: &pb.Pipeline_Step{
+														Name:      "bye",
+														DependsOn: []string{"hi"},
+														Kind: &pb.Pipeline_Step_Exec_{
+															Exec: &pb.Pipeline_Step_Exec{
+																Image:   "busybox",
+																Command: "echo",
+																Args:    []string{"bye"},
+															},
+														},
+													},
+													Application: appRef,
+													Job:         &pb.Ref_Job{Id: "job-for-bye-step"},
+													StartTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+													State:       pb.UI_PipelineRunTreeNode_RUNNING,
+													Children: &pb.UI_PipelineRunTreeNode_Children{
+														Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+														Nodes: []*pb.UI_PipelineRunTreeNode{},
+													},
+												},
+											},
+										},
+									},
+									{
+										Step: &pb.Pipeline_Step{
+											Name:      "other",
+											DependsOn: []string{"prep"},
+											Kind: &pb.Pipeline_Step_Exec_{
+												Exec: &pb.Pipeline_Step_Exec{
+													Image:   "busybox",
+													Command: "echo",
+													Args:    []string{"other"},
+												},
+											},
+										},
+										Application: appRef,
+										Job:         &pb.Ref_Job{Id: "job-for-other-step"},
+										State:       pb.UI_PipelineRunTreeNode_RUNNING,
+										StartTime:   quickTimestamp("2023-01-01T13:00:50Z"),
+										Children: &pb.UI_PipelineRunTreeNode_Children{
+											Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+											Nodes: []*pb.UI_PipelineRunTreeNode{},
+										},
+									},
+								},
+							},
+						},
+						{
+							Step: &pb.Pipeline_Step{
+								Name:      "done",
+								DependsOn: []string{"invoke-referenced-pipeline"},
+								Kind: &pb.Pipeline_Step_Exec_{
+									Exec: &pb.Pipeline_Step_Exec{
+										Image:   "busybox",
+										Command: "echo",
+										Args:    []string{"done"},
+									},
+								},
+							},
+							Application: appRef,
+							Job:         &pb.Ref_Job{Id: "job-for-done-step"},
+							State:       pb.UI_PipelineRunTreeNode_QUEUED,
+							Children: &pb.UI_PipelineRunTreeNode_Children{
+								Mode:  pb.UI_PipelineRunTreeNode_Children_SERIAL,
+								Nodes: []*pb.UI_PipelineRunTreeNode{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			result, err := UI_PipelineRunTreeFromJobs(tt.Jobs, tt.StatusReports)
+
+			require.NoError(err)
+
+			if diff := cmp.Diff(tt.Tree, result, protocmp.Transform()); diff != "" {
+				t.Errorf("unexpected difference:\n%v", diff)
+			}
+
+		})
+	}
+}
+
+// quickTimestamp parses an RFC3339-formatted string and returns the time it
+// represents as a timestamppb.Timestamp.
+//
+// This is intended purely to make tests more readable and robust to daylight
+// savings time etc.
+func quickTimestamp(s string) *timestamppb.Timestamp {
+	t, _ := time.Parse(time.RFC3339, s)
+	return timestamppb.New(t)
+}

--- a/pkg/server/singleprocess/service_ui_pipeline_run.go
+++ b/pkg/server/singleprocess/service_ui_pipeline_run.go
@@ -5,9 +5,11 @@ package singleprocess
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/waypoint/internal/telemetry/metrics"
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/hcerr"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
@@ -70,5 +72,98 @@ func (s *Service) UI_ListPipelineRuns(
 	return &pb.UI_ListPipelineRunsResponse{
 		PipelineRunBundles: allPipelineRuns,
 		Pagination:         &pb.PaginationResponse{},
+	}, nil
+}
+
+func (s *Service) UI_GetPipelineRun(
+	ctx context.Context,
+	req *pb.UI_GetPipelineRunRequest,
+) (*pb.UI_GetPipelineRunResponse, error) {
+	log := hclog.FromContext(ctx)
+
+	if err := serverptypes.ValidateUIGetPipelineRunRequest(req); err != nil {
+		return nil, err
+	}
+
+	runResp, err := s.GetPipelineRun(ctx, &pb.GetPipelineRunRequest{
+		Pipeline: req.Pipeline,
+		Sequence: req.Sequence,
+	})
+	if err != nil {
+		return nil, err
+	}
+	run := runResp.PipelineRun
+
+	// Fetch full jobs
+	start := time.Now()
+	var jobs []*pb.Job
+	for _, ref := range run.Jobs {
+		job, err := s.GetJob(ctx, &pb.GetJobRequest{JobId: ref.Id})
+		if err != nil {
+			return nil, hcerr.Externalize(
+				log,
+				err,
+				"failed to get jobs for all pipeline steps",
+			)
+		}
+		jobs = append(jobs, job)
+	}
+	metrics.MeasureOperation(ctx, start, "fetch_jobs_for_ui_get_pipeline_run")
+
+	// Fetch latest status report for every deployment and release
+	start = time.Now()
+	var statusReports []*pb.StatusReport
+	for _, job := range jobs {
+		if d := job.Result.GetDeploy().GetDeployment(); d != nil {
+			sr, err := s.GetLatestStatusReport(ctx, &pb.GetLatestStatusReportRequest{
+				Application: d.Application,
+				Workspace:   d.Workspace,
+				Target: &pb.GetLatestStatusReportRequest_DeploymentId{
+					DeploymentId: d.Id,
+				},
+			})
+			if err != nil {
+				return nil, hcerr.Externalize(
+					log,
+					err,
+					"failed to get latest status report for deployment %q",
+					d.Id,
+				)
+			}
+			if sr != nil {
+				statusReports = append(statusReports, sr)
+			}
+		}
+		if r := job.Result.GetRelease().GetRelease(); r != nil {
+			sr, err := s.GetLatestStatusReport(ctx, &pb.GetLatestStatusReportRequest{
+				Application: r.Application,
+				Workspace:   r.Workspace,
+				Target: &pb.GetLatestStatusReportRequest_ReleaseId{
+					ReleaseId: r.Id,
+				},
+			})
+			if err != nil {
+				return nil, hcerr.Externalize(
+					log,
+					err,
+					"failed to get latest status report for release %q",
+					r.Id,
+				)
+			}
+			if sr != nil {
+				statusReports = append(statusReports, sr)
+			}
+		}
+	}
+	metrics.MeasureOperation(ctx, start, "fetch_latest_status_reports_for_ui_get_pipeline_run")
+
+	rootNode, err := serverptypes.UI_PipelineRunTreeFromJobs(jobs, statusReports)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.UI_GetPipelineRunResponse{
+		PipelineRun:  run,
+		RootTreeNode: rootNode,
 	}, nil
 }


### PR DESCRIPTION
## Why the change?

This API will feed the pipeline run detail page.

## What’s the plan?

- [x] Declare rpc and messages
- [x] Implement handlers

### Any deferred tasks?

- [ ] Add more-efficient state functions

## What does it look like?

Given a run of a valid pipeline ([something like this](https://github.com/jgwhite/waypoint-demos/blob/main/pipelines/waypoint.hcl#L30-L44)), running the command below should produce a big ol’ pile of JSON that looks something like [this gist](https://gist.github.com/jgwhite/b2c8d8b22ec10761633c4d8687fdf577).

```sh
./contrib/waypoint-grpc/waypoint-grpc.sh UI_GetPipelineRun '
{
  "pipeline": {
    "id": "01H06BBZH5BK3M7761PD8WP892"
  },
  "sequence": 2
}
'
```

## How do I test it?

1. Run a pipeline
2. From your waypoint source directory, run the following:
   ```sh
   ./contrib/waypoint-grpc/waypoint-grpc.sh UI_GetPipelineRun '
   {
     "pipeline": {
       "id": "<YOUR-PIPELINE-ID>"
     },
     "sequence": <YOUR-RUN-SEQUENCE>
   }
   '
   ```
3. Verify that you see some lovely deeply-nested JSON