### PR TITLE
internal/runnerinstall: fix dropped error

### DIFF
--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -407,6 +407,9 @@ DeleteFileSystem:
 	describeMountTargetsResp, err := efsSvc.DescribeMountTargets(&efs.DescribeMountTargetsInput{
 		FileSystemId: fileSystemId,
 	})
+	if err != nil {
+		return err
+	}
 	for _, mountTarget := range describeMountTargetsResp.MountTargets {
 		_, err = efsSvc.DeleteMountTarget(&efs.DeleteMountTargetInput{MountTargetId: mountTarget.MountTargetId})
 		if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in `internal/runnerinstall`. No changelog entry is required.