### PR TITLE
Jira sync fix

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -76,8 +76,7 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },            
-                          "components": [{ "name": "${{ github.event.repository.name }}" }],
+                          "customfield_10371": { "value": "GitHub Issue" },            
                           "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
 
       - name: Sync comment


### PR DESCRIPTION
Remove no-longer-needed field from the Jira workflow.