### PR TITLE
Update reference to GCP Builder build.mdx

### DIFF
--- a/website/content/docs/lifecycle/build.mdx
+++ b/website/content/docs/lifecycle/build.mdx
@@ -133,11 +133,11 @@ provider's documentation for further details around this capability.
 
 #### Configuring an Alternative Buildpack Provider
 
-| Provider              | Builder Image                 |
-| --------------------- | ----------------------------- |
-| Heroku                | heroku/buildpacks:18          |
-| Paketo                | paketobuildpacks/builder:base |
-| Google Cloud Platform | gcr.io/buildpacks/builder:v1  |
+| Provider              | Builder Image                     |
+| --------------------- | --------------------------------- |
+| Heroku                | heroku/buildpacks:18              |
+| Paketo                | paketobuildpacks/builder:base     |
+| Google Cloud Platform | gcr.io/buildpacks/builder:latest  |
 
 Several `waypoint.hcl` adjustments may be required to enable alternative builders.
 


### PR DESCRIPTION
Update reference to the GCP builder in order to use latest and greatest https://cloud.google.com/docs/buildpacks/builders