### PR TITLE
Core: Ensure Project and Workspace names are valid

### DIFF
--- a/.changelog/4588.txt
+++ b/.changelog/4588.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Ensure project and workspaces cannot be created with malformed names
+```

--- a/internal/client/runner_test.go
+++ b/internal/client/runner_test.go
@@ -27,7 +27,7 @@ func Test_remoteOpPreferred(t *testing.T) {
 	}
 
 	_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-	require.Nil(err)
+	require.NoError(err)
 
 	t.Run("Choose local if remote enabled is false for the project.", func(t *testing.T) {
 		project = &pb.Project{
@@ -35,10 +35,10 @@ func Test_remoteOpPreferred(t *testing.T) {
 			RemoteEnabled: false,
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		remote, err := remoteOpPreferred(ctx, client, project, nil, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.False(remote)
 	})
 
@@ -51,10 +51,10 @@ func Test_remoteOpPreferred(t *testing.T) {
 			},
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		remote, err := remoteOpPreferred(ctx, client, project, nil, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.False(remote)
 	})
 
@@ -74,7 +74,7 @@ func Test_remoteOpPreferred(t *testing.T) {
 	defer remoteRunnerClose()
 
 	// Register a non-default runner profile
-	odrProfileName := "project-specific ODR profile"
+	odrProfileName := "project-specific-ODR-profile"
 	_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
 		Config: &pb.OnDemandRunnerConfig{
 			Name:       odrProfileName,
@@ -82,7 +82,7 @@ func Test_remoteOpPreferred(t *testing.T) {
 			Default:    false,
 		},
 	})
-	require.Nil(err)
+	require.NoError(err)
 
 	t.Run("Choose remote if the datasource is good, a remote runner exists, and a runner profile is set for the project", func(t *testing.T) {
 		project = &pb.Project{
@@ -91,12 +91,12 @@ func Test_remoteOpPreferred(t *testing.T) {
 			DataSource:    remoteCapableDataSource,
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		runnerCfgs := []*configpkg.Runner{{Profile: "test"}}
 
 		remote, err := remoteOpPreferred(ctx, client, project, runnerCfgs, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.True(remote)
 	})
 
@@ -110,12 +110,12 @@ func Test_remoteOpPreferred(t *testing.T) {
 			}},
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		runnerCfgs := []*configpkg.Runner{{Profile: "test"}}
 
 		remote, err := remoteOpPreferred(ctx, client, project, runnerCfgs, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.True(remote)
 	})
 
@@ -126,10 +126,10 @@ func Test_remoteOpPreferred(t *testing.T) {
 			DataSource:    remoteCapableDataSource,
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		remote, err := remoteOpPreferred(ctx, client, project, nil, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.False(remote)
 	})
 
@@ -137,12 +137,12 @@ func Test_remoteOpPreferred(t *testing.T) {
 		// Register a default runner profile
 		_, err = client.UpsertOnDemandRunnerConfig(ctx, &pb.UpsertOnDemandRunnerConfigRequest{
 			Config: &pb.OnDemandRunnerConfig{
-				Name:       "the default",
+				Name:       "the-default",
 				PluginType: "docker",
 				Default:    true,
 			},
 		})
-		require.Nil(err)
+		require.NoError(err)
 
 		project = &pb.Project{
 			Name:          "test",
@@ -150,10 +150,10 @@ func Test_remoteOpPreferred(t *testing.T) {
 			DataSource:    remoteCapableDataSource,
 		}
 		_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{Project: project})
-		require.Nil(err)
+		require.NoError(err)
 
 		remote, err := remoteOpPreferred(ctx, client, project, nil, log)
-		require.Nil(err)
+		require.NoError(err)
 		require.True(remote)
 	})
 }

--- a/pkg/server/ptypes/ref.go
+++ b/pkg/server/ptypes/ref.go
@@ -2,6 +2,8 @@ package ptypes
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -32,6 +34,8 @@ func validatePathToken(pathToken interface{}) error {
 	// as a path traversal.
 	if strings.Contains(s, "../") {
 		return errors.New("name cannot contain '../'")
+	} else if !regexp.MustCompile(`^[a-zA-Z0-9_-]*$`).MatchString(s) {
+		return fmt.Errorf("name %q must be alpha numeric", s)
 	}
 	return nil
 }

--- a/pkg/server/ptypes/ref.go
+++ b/pkg/server/ptypes/ref.go
@@ -14,7 +14,7 @@ import (
 // ValidateRefWorkspaceRules
 func ValidateRefWorkspaceRules(v *pb.Ref_Workspace) []*validation.FieldRules {
 	return []*validation.FieldRules{
-		validation.Field(&v.Workspace, validation.Required),
+		validation.Field(&v.Workspace, validation.Required, validation.By(validatePathToken)),
 	}
 }
 

--- a/pkg/serverhandler/handlertest/test_service_project.go
+++ b/pkg/serverhandler/handlertest/test_service_project.go
@@ -55,6 +55,23 @@ func TestServiceProject(t *testing.T, factory Factory) {
 		}
 	})
 
+	t.Run("create with invalid name", func(t *testing.T) {
+		require := require.New(t)
+
+		project := ptypes.TestProject(t, &pb.Project{
+			Name: ".",
+		})
+
+		// Fails to create a project with a bad name
+		{
+			_, err := client.UpsertProject(ctx, &pb.UpsertProjectRequest{
+				Project: project,
+			})
+
+			require.Error(err)
+		}
+	})
+
 	t.Run("get", func(t *testing.T) {
 		require := require.New(t)
 


### PR DESCRIPTION
Prior to this commit, users could create project names like "." or even
"   ". This commit tightens up those rules to only allow for
alpha-numberic characters, as well as underscore and hyphens. All other
characters are not valid for projects.

Fixes #4572
Fixes https://github.com/hashicorp/waypoint/issues/4571