### PR TITLE
Fix bug caused by trying to fix bug related to job "loss"

### DIFF
--- a/.changelog/4596.txt
+++ b/.changelog/4596.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-server: Fix intermident issue with finished jobs reporting they errored
+server: Fix intermittent issue with finished jobs reporting they errored
 ```

--- a/.changelog/4596.txt
+++ b/.changelog/4596.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fix intermident issue with finished jobs reporting they errored
+```


### PR DESCRIPTION
TLDR: calling all the job values 'job' introduced a goroutine-using-outer-scope-variable bug.

The source of all of this is ultimate a 3 year old bug:

https://github.com/hashicorp/waypoint/blob/9d34ba23599142a5b2efbdc7a79c7a4ce163f060/internal/server/singleprocess/service_runner.go#L586

That code used `=` instead of `:=`, which caused the goroutine to update the 'primary' job local variable used by everything else in the function. So WHEN (not if, as we'll see in a moment) ctx is canceled, job becomes nil, and any code further down in the function will see than nil DEPENDING on the goroutine scheduling order.

So, why would the context be canceled? The goroutine defined right after this does `defer cancel()` when the client disconnects. So due to the magic of goroutine scheduling, it's possible for the `server.Recv()` goroutine to exit, canceling the context, then the WatchSet goroutine wakes up, because there is a job change (as we just updated it), causing the loop to start and JobById uses a canceled context.

We attempted to figure out WHY the job was nil in the past by adding code into the primary select statement at the bottom of the function, which introduced a second pathology: the WatchSet routine pushed a value onto errCh when it used the canceled context, and the 'job is nil' detection code did a non-blocking read on 'errCh' AFTER it read an event (almostly certainly a Complete event btw). We then saw the error and figured "oh something is weird and wrong", so we logged and basically orphaned the Complete event because we had no job record to record things with!

TLDidR: calling all the job values 'job' introduced a goroutine-using-outer-scope-variable bug.

I've renamed various other job-related variables that held jobs from 'job' to something else to prevent a similar condition in the future.