### PR TITLE
Remove plugin titles from top-level README

### DIFF
--- a/builtin/aws/alb/README.md
+++ b/builtin/aws/alb/README.md
@@ -1,5 +1,3 @@
-## AWS ALB
-
 The AWS ALB plugin releases applications deployed to AWS by attaching [target
 groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
 to an [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html).

--- a/builtin/aws/ami/README.md
+++ b/builtin/aws/ami/README.md
@@ -1,5 +1,3 @@
-## AWS AMI
-
 The AWS AMI plugin searches for an returns an existing [AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html),
 to be deployed as an [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html).
 

--- a/builtin/aws/ec2/README.md
+++ b/builtin/aws/ec2/README.md
@@ -1,5 +1,3 @@
-## AWS EC2
-
 The AWS EC2 plugin deploys an AWS AMI as a virtual machine, running on AWS EC2.
 
 ### Components

--- a/builtin/aws/ecr/README.md
+++ b/builtin/aws/ecr/README.md
@@ -1,5 +1,3 @@
-## AWS ECR
-
 The AWS ECR plugin pushes a Docker image to an [Elastic Container Registry](https://aws.amazon.com/ecr/getting-started/)
 on AWS.
 

--- a/builtin/aws/ecr/pull/README.md
+++ b/builtin/aws/ecr/pull/README.md
@@ -1,5 +1,3 @@
-## AWS ECR Pull
-
 The AWS ECR Pull plugin references an existing image, if found, in an AWS
 [Elastic Container Registry](https://aws.amazon.com/ecr/getting-started/).
 The image information can be used to push an image to a new registry, or be

--- a/builtin/aws/ecs/README.md
+++ b/builtin/aws/ecs/README.md
@@ -1,5 +1,3 @@
-## AWS ECS
-
 The AWS ECS plugin deploys an application image to an AWS [ECS cluster](https://aws.amazon.com/ecs/getting-started/).
 It also launches on-demand runners to do operations remotely.
 

--- a/builtin/aws/lambda/README.md
+++ b/builtin/aws/lambda/README.md
@@ -1,5 +1,3 @@
-## AWS Lambda
-
 The AWS Lambda plugin deploys OCI images as functions to [AWS Lambda](https://aws.amazon.com/lambda/getting-started/).
 
 ### Components

--- a/builtin/aws/lambda/function_url/README.md
+++ b/builtin/aws/lambda/function_url/README.md
@@ -1,5 +1,3 @@
-## AWS Lambda Function URL
-
 The AWS Lambda Function URL plugin releases a function deployed with the AWS
 Lambda plugin by creating a [Lambda function URL](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html).
 

--- a/builtin/aws/ssm/README.md
+++ b/builtin/aws/ssm/README.md
@@ -1,5 +1,3 @@
-## AWS SSM
-
 The AWS SSM plugin reads configuration values from the [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
 
 ### Components

--- a/builtin/azure/aci/README.md
+++ b/builtin/azure/aci/README.md
@@ -1,5 +1,3 @@
-## Azure ACI
-
 The Azure ACI plugin deploys a container to [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances#layout-container-uid0a01).
 
 ### Components

--- a/builtin/consul/README.md
+++ b/builtin/consul/README.md
@@ -1,5 +1,3 @@
-## Consul
-
 The Consul plugin reads configuration values from the [Consul KV store](https://developer.hashicorp.com/consul/docs/dynamic-app-config/kv).
 
 ### Components

--- a/builtin/docker/README.md
+++ b/builtin/docker/README.md
@@ -1,5 +1,3 @@
-## Docker
-
 The Docker plugin can build a Docker image of an application, push a Docker
 image to a remote registry, and/or deploy the Docker image to a Docker daemon.
 It also launches on-demand runners to do operations remotely.

--- a/builtin/docker/pull/README.md
+++ b/builtin/docker/pull/README.md
@@ -1,5 +1,3 @@
-## Docker Pull
-
 The Docker Pull plugin pulls a Docker image from an existing Docker repository,
 and wraps the existing image entrypoint with the Waypoint entrypoint.
 

--- a/builtin/docker/ref/README.md
+++ b/builtin/docker/ref/README.md
@@ -1,5 +1,3 @@
-## Docker Ref
-
 The Docker Ref plugin refers to an existing Docker image, passing its image
 information, the image name and tag, to the Waypoint lifecycle.
 

--- a/builtin/exec/README.md
+++ b/builtin/exec/README.md
@@ -1,5 +1,3 @@
-## Exec
-
 The Exec plugin executes any command to perform a deploy. This enables the use
 of pre-existing deployment tools.
 

--- a/builtin/files/README.md
+++ b/builtin/files/README.md
@@ -1,5 +1,3 @@
-## Files
-
 The Files plugin generates a value representing a path on disk, and can copy
 them to a specific directory.
 

--- a/builtin/google/cloudrun/README.md
+++ b/builtin/google/cloudrun/README.md
@@ -1,5 +1,3 @@
-## Google Cloud Run
-
 The Google Cloud Run plugin deploys a container to [Google Cloud Run](https://cloud.google.com/run).
 
 ### Components

--- a/builtin/k8s/README.md
+++ b/builtin/k8s/README.md
@@ -1,5 +1,3 @@
-## Getting Started
-
 The Kubernetes plugin can deploy a Docker image of an application to Kubernetes,
 expose the Deployment with a Kubernetes Service, and source configuration from
 a Kubernetes Secret or ConfigMap. It also launches on-demand runners to do

--- a/builtin/k8s/apply/README.md
+++ b/builtin/k8s/apply/README.md
@@ -1,5 +1,3 @@
-## kubernetes-apply (platform)
-
 The Kubernetes Apply plugin deploys Kubernetes resources directly from a single
 file or a directory of YAML or JSON files.
 

--- a/builtin/k8s/helm/README.md
+++ b/builtin/k8s/helm/README.md
@@ -1,5 +1,3 @@
-## Helm
-
 The Helm plugin deploys to Kubernetes from a Helm chart. The Helm chart can be
 a local path or a chart in a repository.
 

--- a/builtin/nomad/README.md
+++ b/builtin/nomad/README.md
@@ -1,5 +1,3 @@
-## Nomad
-
 The Nomad plugin deploys a Docker container to a [Nomad](https://www.nomadproject.io/)
 cluster. It also launches on-demand runners to do operations remotely.
 

--- a/builtin/nomad/canary/README.md
+++ b/builtin/nomad/canary/README.md
@@ -1,5 +1,3 @@
-## Nomad Jobspec Canary
-
 The Nomad Jobspec Canary plugin promotes a [Nomad](https://www.nomadproject.io/)
 canary deployment initiated by a Nomad jobspec deployment.
 

--- a/builtin/nomad/jobspec/README.md
+++ b/builtin/nomad/jobspec/README.md
@@ -1,5 +1,3 @@
-## Nomad Jobspec
-
 The Nomad Jobspec plugin deploys to a Nomad cluster from a pre-existing [Nomad](https://www.nomadproject.io/)
 job specification file.
 

--- a/builtin/pack/README.md
+++ b/builtin/pack/README.md
@@ -1,5 +1,3 @@
-## Pack
-
 The Pack plugin creates a Docker image using [CloudNative Buildpacks](https://buildpacks.io/).
 
 ### Components

--- a/builtin/packer/README.md
+++ b/builtin/packer/README.md
@@ -1,5 +1,3 @@
-## Packer
-
 The Packer plugin retrieves the image ID of an image whose metadata is pushed
 to an [HCP Packer](https://cloud.hashicorp.com/products/packer) registry. The
 image ID is that of the HCP Packer bucket iteration assigned to the configured

--- a/builtin/tfc/README.md
+++ b/builtin/tfc/README.md
@@ -1,5 +1,3 @@
-## Terraform Cloud
-
 The Terraform Cloud plugin reads Terraform state outputs from [Terraform Cloud](https://cloud.hashicorp.com/products/terraform).
 
 ### Components

--- a/builtin/vault/README.md
+++ b/builtin/vault/README.md
@@ -1,5 +1,3 @@
-## Vault
-
 The Vault plugin reads configuration values from [Vault](https://www.vaultproject.io/).
 
 ### Components


### PR DESCRIPTION
We're going to incorporate these titles differently on the integrations library in HashiCorp Developer, which will not require authors to incorporate the title at the top of the README, which will ensure better consistency.

We'll need to deploy this in a semi-coordinated manner with a subsequent PR on HashiCorp Developer (to come).