### PR TITLE
Additional install flags for Nomad service address and network mode

### DIFF
--- a/.changelog/4619.txt
+++ b/.changelog/4619.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli: new flags for `waypoint install` on Nomad:
+-nomad-service-address and -nomad-network-mode
+```

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -107,11 +107,13 @@ and disable the UI, the command would be:
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
+- `-nomad-network-mode=<string>` - Nomad task group network mode. The default is host.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
 - `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
 - `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task. The default is 600.
+- `-nomad-service-address=<string>` - Address for the Nomad services.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -107,11 +107,13 @@ and disable the UI, the command would be:
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
+- `-nomad-network-mode=<string>` - Nomad task group network mode. The default is host.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.
 - `-nomad-server-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
 - `-nomad-server-memory=<string>` - MB of Memory to allocate to the Server job task. The default is 600.
+- `-nomad-service-address=<string>` - Address for the Nomad services.
 - `-nomad-runner-cpu=<string>` - CPU required to run this task in MHz. The default is 200.
 - `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task. The default is 600.
 - `-nomad-runner-host-volume=<string>` - Name of the host volume to use for the Waypoint runner.


### PR DESCRIPTION
The overall goal here is to `waypoint install` into a Nomad node from the outside.  In my case, a Vagrant machine from my laptop, but also should work with other cases like cloud vendors where the `waypoint-server` service needs to be given a public IP, to which the install procedure connects after job submission.

For example, using a `meta.public_ip` that I set manually in my Nomad client config:

```
$ ./waypoint install -accept-tos \
  -platform=nomad \
  -nomad-host-volume=waypoint \
  -nomad-runner-host-volume=waypoint \
  -nomad-service-provider=nomad \             
  -nomad-service-address='${meta.public_ip}' \
  -nomad-network-mode=bridge

✓ Waypoint server ready
...
✓ Runner "static" adopted successfully.
Waypoint server successfully installed and configured!
...
Advertise Address: 192.168.56.200:9701
Web UI Address: https://192.168.56.200:9702/
```

Of course `-nomad-service-address=192.168.56.200` would have worked just as well, but the meta is for demonstration, as I imagine that on AWS one might use `'${attr.unique.platform.aws.public-ipv4}'` to set the service address dynamically.

The ~publicly-routable IP at the bottom of the install output (and used during install) comes from the Nomad services:

```
$ nomad service info waypoint-server
Job ID           Address              Tags        Node ID   Alloc ID
waypoint-server  192.168.56.200:9701  [waypoint]  f8ffd891  57e5dcfd
$ nomad service info waypoint-ui
Job ID           Address              Tags        Node ID   Alloc ID
waypoint-server  192.168.56.200:9702  [waypoint]  f8ffd891  57e5dcfd
```

I do wonder though if perhaps separate service(s) could/should be made for this connection during install, vs internal waypoint->waypoint communication?  Do the runner(s) connect to waypoint-server using this service?  I didn't look that far into this part.