### PR TITLE
fix: plugin discover path

### DIFF
--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -103,7 +103,7 @@ func DefaultPaths(pwd string) ([]string, error) {
 		pwd,
 		filepath.Join(pwd, ".waypoint", "plugins"),
 		filepath.Dir(xdgPath),
-		filepath.Join(hd, ".config", ".waypoint", "plugins"),
+		filepath.Join(hd, ".config", "waypoint", "plugins"),
 	}, nil
 }
 


### PR DESCRIPTION
As stated in the above comment:
```
We also allow plugins in $HOME/.config/waypoint/plugins
```
But the path used is `filepath.Join(hd, ".config", ".waypoint", "plugins")`