### PR TITLE
Revert output path for bin make target

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Make waypoint binary
         run: |-
           make bin
-          pushd dist
-          tar -cvf ../waypoint.tar ./waypoint
+          tar -cvf waypoint.tar ./waypoint
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           path: waypoint.tar

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bin: # Creates the binaries for Waypoint for the current platform
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(GOLDFLAGS) -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(GOLDFLAGS) -o ./internal/assets/ceb/ceb-arm64 ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
-	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o dist/waypoint ./cmd/waypoint
+	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
 
 .PHONY: bin/crt-waypoint
 bin/crt-waypoint: # Creates the binaries for Waypoint for the current platform


### PR DESCRIPTION
Output bath for `bin` make target was unnecessarily changed during migration to CRT.