### PR TITLE
Backport #4636 to release/0.11.x

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Make waypoint binary
         run: |-
           make bin
-          pushd dist
-          tar -cvf ../waypoint.tar ./waypoint
+          tar -cvf waypoint.tar ./waypoint
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           path: waypoint.tar

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bin: # Creates the binaries for Waypoint for the current platform
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(GOLDFLAGS) -o ./internal/assets/ceb/ceb ./cmd/waypoint-entrypoint
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(GOLDFLAGS) -o ./internal/assets/ceb/ceb-arm64 ./cmd/waypoint-entrypoint
 	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
-	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o dist/waypoint ./cmd/waypoint
+	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./waypoint ./cmd/waypoint
 
 .PHONY: bin/crt-waypoint
 bin/crt-waypoint: # Creates the binaries for Waypoint for the current platform


### PR DESCRIPTION
This PR backports https://github.com/hashicorp/waypoint/pull/4636 which failed to auto-backport when I added the label. It's a fix for the `dev-build` integration step that was busted on main due to an accidental inclusion of a `dist/` directory in the process. 

Note that this PR is opened against the `release/0.11.x` branch, not `main`