### PR TITLE
Fix flakey ceb/ssh test

### DIFF
--- a/internal/ceb/ssh/server_test.go
+++ b/internal/ceb/ssh/server_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gliderlabs/ssh"
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -93,6 +92,10 @@ func TestServer(t *testing.T) {
 
 	err = sess.Run("sh -c 'echo hello'")
 	require.NoError(t, err)
-
-	assert.Equal(t, "hello\n", buf.String())
+	require.Eventually(
+		t,
+		func() bool { return buf.String() == "hello\n" },
+		time.Second,
+		10*time.Millisecond,
+	)
 }


### PR DESCRIPTION
Using require.Eventually rather than an immediate assertion.