### PR TITLE
Dockerfile: Include binutils for including `ld` for gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM docker.mirror.hashicorp.services/golang:1.19-alpine3.17 AS builder
 
-RUN apk add --no-cache git gcc libc-dev make
+RUN apk add --no-cache git gcc libc-dev make binutils-gold
 
 RUN mkdir -p /tmp/wp-prime
 COPY go.sum /tmp/wp-prime


### PR DESCRIPTION
Without this fix, docker fails to build the waypoint container image with:

```
...
#0 15.39 # github.com/hashicorp/waypoint/cmd/waypoint
#0 15.39 /usr/local/go/pkg/tool/linux_arm64/link: running gcc failed: exit status 1
#0 15.39 collect2: fatal error: cannot find 'ld'
#0 15.39 compilation terminated.
#0 15.39
#0 15.40 make: *** [Makefile:23: bin] Error 2
------
Dockerfile:26
--------------------
  24 |     WORKDIR /tmp/wp-src
  25 |
  26 | >>> RUN --mount=type=cache,target=/root/.cache/go-build make bin
  27 |     RUN --mount=type=cache,target=/root/.cache/go-build make bin/entrypoint
  28 |
--------------------
ERROR: failed to solve: process "/bin/sh -c make bin" did not complete successfully: exit code: 2
make: *** [Makefile:81: docker/server-only] Error 1
```