### PR TITLE
server: Ensure trigger names are valid paths

### DIFF
--- a/.changelog/4660.txt
+++ b/.changelog/4660.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+trigger: Ensure trigger Name is only alpha-numeric
+```

--- a/pkg/server/ptypes/trigger.go
+++ b/pkg/server/ptypes/trigger.go
@@ -62,6 +62,9 @@ func ValidateUpsertTriggerRequest(v *pb.UpsertTriggerRequest) error {
 		validationext.StructField(&v.Trigger, func() []*validation.FieldRules {
 			return []*validation.FieldRules{
 				validation.Field(&v.Trigger.Project, validation.Required),
+				// Trigger Name is also the "path" in the HTTP request, so we will
+				// validate the name against our valid path token check
+				validation.Field(&v.Trigger.Name, validation.Required, validation.By(validatePathToken)),
 			}
 		}),
 	))

--- a/pkg/server/ptypes/trigger.go
+++ b/pkg/server/ptypes/trigger.go
@@ -64,7 +64,7 @@ func ValidateUpsertTriggerRequest(v *pb.UpsertTriggerRequest) error {
 				validation.Field(&v.Trigger.Project, validation.Required),
 				// Trigger Name is also the "path" in the HTTP request, so we will
 				// validate the name against our valid path token check
-				validation.Field(&v.Trigger.Name, validation.Required, validation.By(validatePathToken)),
+				validation.Field(&v.Trigger.Name, validation.By(validatePathToken)),
 			}
 		}),
 	))

--- a/pkg/serverhandler/handlertest/test_service_trigger.go
+++ b/pkg/serverhandler/handlertest/test_service_trigger.go
@@ -58,6 +58,28 @@ func TestServiceTrigger(t *testing.T, factory Factory) {
 		require.Equal(result.Name, testName)
 	})
 
+	t.Run("upsert fails if invalid Name for path given", func(t *testing.T) {
+		require := require.New(t)
+
+		// Create, should get an ID back
+		resp, err := client.UpsertTrigger(ctx, &pb.UpsertTriggerRequest{
+			Trigger: serverptypes.TestValidTrigger(t, nil),
+		})
+		require.NoError(err)
+		require.NotNil(resp)
+		result := resp.Trigger
+		require.NotEmpty(result.Id)
+
+		// Let's write some bad data
+		testName := "../TestyTest" // this is an invalid path
+		result.Name = testName
+		resp, err = client.UpsertTrigger(ctx, &pb.UpsertTriggerRequest{
+			Trigger: result,
+		})
+		require.Error(err)
+		require.Nil(resp)
+	})
+
 	t.Run("create uses default workspace if unset", func(t *testing.T) {
 		require := require.New(t)
 


### PR DESCRIPTION
Prior to this commit, a user could create a bad HTTP path with a trigger name like `../bad`. This commit fixes that behavior by validating the given trigger name matches our expected valid path tokens.

With this fix:

```
brian@ubuntu:waypoint-tetris λ waypoint trigger create -name=../hello -op=build                                                                        ±[main]
! trigger: (name: name cannot contain '../'.).
```