### PR TITLE
Standardizing templating routes

### DIFF
--- a/pkg/server/gen/server.pb.gw.go
+++ b/pkg/server/gen/server.pb.gw.go
@@ -13196,7 +13196,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectTemplate", runtime.WithHTTPPathPattern("/project-template"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13220,7 +13220,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/UpdateProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/UpdateProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13244,7 +13244,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13268,7 +13268,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13292,7 +13292,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/ListProjectTemplates", runtime.WithHTTPPathPattern("/projecttemplates"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/ListProjectTemplates", runtime.WithHTTPPathPattern("/project-templates"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13316,7 +13316,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectFromTemplate", runtime.WithHTTPPathPattern("/project/fromtemplate"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectFromTemplate", runtime.WithHTTPPathPattern("/project/from-template"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -13340,7 +13340,7 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetTFCRunStatus", runtime.WithHTTPPathPattern("/project/{project.project}/tfcrunstatus"))
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetTFCRunStatus", runtime.WithHTTPPathPattern("/project/{project.project}/tfc-run-status"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16361,7 +16361,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectTemplate", runtime.WithHTTPPathPattern("/project-template"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16382,7 +16382,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/UpdateProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/UpdateProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16403,7 +16403,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16424,7 +16424,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteProjectTemplate", runtime.WithHTTPPathPattern("/projecttemplate/{project_template.id}"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteProjectTemplate", runtime.WithHTTPPathPattern("/project-template/{project_template.id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16445,7 +16445,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/ListProjectTemplates", runtime.WithHTTPPathPattern("/projecttemplates"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/ListProjectTemplates", runtime.WithHTTPPathPattern("/project-templates"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16466,7 +16466,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectFromTemplate", runtime.WithHTTPPathPattern("/project/fromtemplate"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/CreateProjectFromTemplate", runtime.WithHTTPPathPattern("/project/from-template"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -16487,7 +16487,7 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
-		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetTFCRunStatus", runtime.WithHTTPPathPattern("/project/{project.project}/tfcrunstatus"))
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/GetTFCRunStatus", runtime.WithHTTPPathPattern("/project/{project.project}/tfc-run-status"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -17032,19 +17032,19 @@ var (
 
 	pattern_Waypoint_ConfigSyncPipeline_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"project", "project.project", "config-sync-pipeline"}, ""))
 
-	pattern_Waypoint_CreateProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"projecttemplate"}, ""))
+	pattern_Waypoint_CreateProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"project-template"}, ""))
 
-	pattern_Waypoint_UpdateProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"projecttemplate", "project_template.id"}, ""))
+	pattern_Waypoint_UpdateProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"project-template", "project_template.id"}, ""))
 
-	pattern_Waypoint_GetProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"projecttemplate", "project_template.id"}, ""))
+	pattern_Waypoint_GetProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"project-template", "project_template.id"}, ""))
 
-	pattern_Waypoint_DeleteProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"projecttemplate", "project_template.id"}, ""))
+	pattern_Waypoint_DeleteProjectTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"project-template", "project_template.id"}, ""))
 
-	pattern_Waypoint_ListProjectTemplates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"projecttemplates"}, ""))
+	pattern_Waypoint_ListProjectTemplates_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"project-templates"}, ""))
 
-	pattern_Waypoint_CreateProjectFromTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"project", "fromtemplate"}, ""))
+	pattern_Waypoint_CreateProjectFromTemplate_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"project", "from-template"}, ""))
 
-	pattern_Waypoint_GetTFCRunStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"project", "project.project", "tfcrunstatus"}, ""))
+	pattern_Waypoint_GetTFCRunStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"project", "project.project", "tfc-run-status"}, ""))
 
 	pattern_Waypoint_UI_ListProjects_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"ui", "projects"}, ""))
 

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -1888,6 +1888,200 @@
         ]
       }
     },
+    "/project-template": {
+      "post": {
+        "summary": "CreateProjectTemplate creates a new projecttemplate.",
+        "operationId": "Waypoint_CreateProjectTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.CreateProjectTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.CreateProjectTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      }
+    },
+    "/project-template/{project_template.id}": {
+      "get": {
+        "summary": "GetProjectTemplate returns a projecttemplate by the projecttemplate name or id",
+        "operationId": "Waypoint_GetProjectTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.GetProjectTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "project_template.id",
+            "description": "ID of the ProjectTemplate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "project_template.name",
+            "description": "Name of the ProjectTemplate.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      },
+      "delete": {
+        "summary": "DeleteProjectTemplate deletes a projecttemplate by the projecttemplate name or id",
+        "operationId": "Waypoint_DeleteProjectTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "project_template.id",
+            "description": "ID of the ProjectTemplate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "project_template.name",
+            "description": "Name of the ProjectTemplate.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      },
+      "put": {
+        "summary": "UpdateProjectTemplate updates an existing projecttemplate.",
+        "operationId": "Waypoint_UpdateProjectTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.UpdateProjectTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "project_template.id",
+            "description": "Unique ID of the ProjectTemplate",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.UpdateProjectTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      }
+    },
+    "/project-templates": {
+      "get": {
+        "summary": "ListProjectTemplates returns a list of all projecttemplates known.\n(Pagination is currently ignored on this request)",
+        "operationId": "Waypoint_ListProjectTemplates",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.ListProjectTemplatesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pagination.page_size",
+            "description": "The max number of results per page that should be returned. If the number\nof available results is larger than `page_size`, a `next_page_token` is\nreturned which can be used to get the next page of results in subsequent\nrequests. A value of zero will cause `page_size` to be defaulted.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "pagination.next_page_token",
+            "description": "Specifies a page token to use to retrieve the next page. Set this to the\n`next_page_token` returned by previous list requests to get the next page of\nresults. If set, `previous_page_token` must not be set.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pagination.previous_page_token",
+            "description": "Specifies a page token to use to retrieve the previous page. Set this to\nthe `previous_page_token` returned by previous list requests to get the\nprevious page of results. If set, `next_page_token` must not be set.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      }
+    },
     "/project/config": {
       "put": {
         "summary": "Set one or more configuration variables for applications or runners.",
@@ -1921,7 +2115,7 @@
         ]
       }
     },
-    "/project/fromtemplate": {
+    "/project/from-template": {
       "post": {
         "summary": "CreateProjectFromTemplate is in BETA. It creates a new Waypoint project\nfrom a Project Template, provisioning infrastructure before upserting the\nWaypoint project to the database",
         "operationId": "Waypoint_CreateProjectFromTemplate",
@@ -4295,7 +4489,7 @@
         ]
       }
     },
-    "/project/{project.project}/tfcrunstatus": {
+    "/project/{project.project}/tfc-run-status": {
       "get": {
         "summary": "GetTFCRunStatus is in BETA. It returns the status of a TFC run, which was\nrun to render a project template.",
         "operationId": "Waypoint_GetTFCRunStatus",
@@ -4900,200 +5094,6 @@
             "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/hashicorp.waypoint.ListProjectsResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "pagination.page_size",
-            "description": "The max number of results per page that should be returned. If the number\nof available results is larger than `page_size`, a `next_page_token` is\nreturned which can be used to get the next page of results in subsequent\nrequests. A value of zero will cause `page_size` to be defaulted.",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "pagination.next_page_token",
-            "description": "Specifies a page token to use to retrieve the next page. Set this to the\n`next_page_token` returned by previous list requests to get the next page of\nresults. If set, `previous_page_token` must not be set.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "pagination.previous_page_token",
-            "description": "Specifies a page token to use to retrieve the previous page. Set this to\nthe `previous_page_token` returned by previous list requests to get the\nprevious page of results. If set, `next_page_token` must not be set.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Waypoint"
-        ]
-      }
-    },
-    "/projecttemplate": {
-      "post": {
-        "summary": "CreateProjectTemplate creates a new projecttemplate.",
-        "operationId": "Waypoint_CreateProjectTemplate",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.CreateProjectTemplateResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.CreateProjectTemplateRequest"
-            }
-          }
-        ],
-        "tags": [
-          "Waypoint"
-        ]
-      }
-    },
-    "/projecttemplate/{project_template.id}": {
-      "get": {
-        "summary": "GetProjectTemplate returns a projecttemplate by the projecttemplate name or id",
-        "operationId": "Waypoint_GetProjectTemplate",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.GetProjectTemplateResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "project_template.id",
-            "description": "ID of the ProjectTemplate",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "project_template.name",
-            "description": "Name of the ProjectTemplate.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Waypoint"
-        ]
-      },
-      "delete": {
-        "summary": "DeleteProjectTemplate deletes a projecttemplate by the projecttemplate name or id",
-        "operationId": "Waypoint_DeleteProjectTemplate",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "properties": {}
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "project_template.id",
-            "description": "ID of the ProjectTemplate",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "project_template.name",
-            "description": "Name of the ProjectTemplate.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "Waypoint"
-        ]
-      },
-      "put": {
-        "summary": "UpdateProjectTemplate updates an existing projecttemplate.",
-        "operationId": "Waypoint_UpdateProjectTemplate",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.UpdateProjectTemplateResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "project_template.id",
-            "description": "Unique ID of the ProjectTemplate",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.UpdateProjectTemplateRequest"
-            }
-          }
-        ],
-        "tags": [
-          "Waypoint"
-        ]
-      }
-    },
-    "/projecttemplates": {
-      "get": {
-        "summary": "ListProjectTemplates returns a list of all projecttemplates known.\n(Pagination is currently ignored on this request)",
-        "operationId": "Waypoint_ListProjectTemplates",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/hashicorp.waypoint.ListProjectTemplatesResponse"
             }
           },
           "default": {

--- a/pkg/server/proto/gateway.yml
+++ b/pkg/server/proto/gateway.yml
@@ -514,28 +514,28 @@ http:
 
     # Project Templates
   - selector: hashicorp.waypoint.Waypoint.CreateProjectTemplate
-    post: /projecttemplate
+    post: /project-template
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.UpdateProjectTemplate
-    put: /projecttemplate/{project_template.id}
+    put: /project-template/{project_template.id}
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.GetProjectTemplate
-    get: /projecttemplate/{project_template.id}
+    get: /project-template/{project_template.id}
 
   - selector: hashicorp.waypoint.Waypoint.DeleteProjectTemplate
-    delete: /projecttemplate/{project_template.id}
+    delete: /project-template/{project_template.id}
 
   - selector: hashicorp.waypoint.Waypoint.ListProjectTemplates
-    get: /projecttemplates
+    get: /project-templates
 
   - selector: hashicorp.waypoint.Waypoint.CreateProjectFromTemplate
-    post: /project/fromtemplate
+    post: /project/from-template
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.GetTFCRunStatus
-    get: /project/{project.project}/tfcrunstatus
+    get: /project/{project.project}/tfc-run-status
 
     # Events
   - selector: hashicorp.waypoint.Waypoint.UI_ListEvents


### PR DESCRIPTION
Using dashes, like our other endpoints do!

Precedent:
```
/waypoint/2022-02-03/namespace/*/config-source
/waypoint/2022-02-03/namespace/*/runner/on-demand
```

NOTE: while this is a breaking api change, the templating feature is currently unreleased, so we don't need to worry about maintaining backwards compat.