### PR TITLE
builtin/consul: Properly set datacenter val on request logger

### DIFF
--- a/.changelog/4670.txt
+++ b/.changelog/4670.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+builtin/consul: Fix request logger to properly log configured data center
+```

--- a/builtin/consul/config_sourcer.go
+++ b/builtin/consul/config_sourcer.go
@@ -229,7 +229,7 @@ func (cs *ConfigSourcer) read(ctx context.Context, log hclog.Logger, reqs []*com
 			reqLogger = reqLogger.With("partition", kvReq.Partition)
 		}
 		if kvReq.Datacenter != "" {
-			reqLogger = reqLogger.With("datacenter", kvReq.Partition)
+			reqLogger = reqLogger.With("datacenter", kvReq.Datacenter)
 		}
 
 		cacheVal, ok := cs.cache[kvReq.cacheKey()]


### PR DESCRIPTION
Fixes WAYP-1175