### PR TITLE
cli: Fixup snapshot CLI when creating a file that might exist

### DIFF
--- a/internal/cli/snapshot_backup.go
+++ b/internal/cli/snapshot_backup.go
@@ -27,7 +27,7 @@ func (c *SnapshotBackupCommand) initWriter(args []string) (io.Writer, io.Closer,
 			return os.Stdout, nil, nil
 		}
 
-		f, err := os.Create(args[0])
+		f, err := os.OpenFile(args[0], os.O_CREATE|os.O_EXCL, 0600)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Prior to this commit, the init writer for snapshot backups wouldn't validate the existence of the file its creating prior to creating it. This fixes that up by instead calling the OpenFile func with CREATE flags enabled.

Fixes WAYP-1150