### PR TITLE
cli/runner_install: Do not use cli slice for runner platform

### DIFF
--- a/.changelog/4672.txt
+++ b/.changelog/4672.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Avoid panic in empty slice for runner installs platform var.
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -167,16 +167,16 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 	}
 
 	// If the user doesn't set a platform, set platform to the platform of the user's context
-	platform := c.platform
-	if len(platform) == 0 {
-		platform = append(platform, serverConfig.Config.Platform)
+	var runnerPlatform string
+	if len(c.platform) == 0 {
+		runnerPlatform = serverConfig.Config.Platform
 	}
 
-	p, ok := runnerinstall.Platforms[strings.ToLower(platform[0])]
+	p, ok := runnerinstall.Platforms[strings.ToLower(runnerPlatform)]
 	if !ok {
 		c.ui.Output(
 			"Error installing runner into %q: unsupported platform",
-			platform[0],
+			runnerPlatform,
 			terminal.WithErrorStyle(),
 		)
 		return 1
@@ -271,10 +271,10 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 		c.ui.Output("Error installing runner: %s", clierrors.Humanize(err),
 			terminal.WithErrorStyle(),
 		)
-		c.ui.Output(runnerInstallFailed, c.platform[0], id, terminal.WithWarningStyle())
+		c.ui.Output(runnerInstallFailed, runnerPlatform, id, terminal.WithWarningStyle())
 		return 1
 	}
-	s.Update("Runner %q installed successfully to %s", id, platform[0])
+	s.Update("Runner %q installed successfully to %s", id, runnerPlatform)
 	s.Status(terminal.StatusOK)
 	s.Done()
 
@@ -296,9 +296,9 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 			odrConfig.OciUrl = c.runnerProfileOdrImage // Use what we got from flags (or the default)
 		} else {
 			odrConfig = &pb.OnDemandRunnerConfig{
-				Name:       platform[0] + "-" + id,
+				Name:       runnerPlatform + "-" + id,
 				OciUrl:     c.runnerProfileOdrImage,
-				PluginType: platform[0],
+				PluginType: runnerPlatform,
 			}
 		}
 		if len(targetLabels) != 0 {


### PR DESCRIPTION
Prior to this commit, the runner install cli attempted to use the target var for the EnumVar platform. We make this an EnumVar because the flag package gives good validation when you pass a string that isn't one of the supported values. In practice however, the CLI only uses a single value, the first one in the slice. To avoid any panics, we simply use a string var once the flag package has parsed and actualized its values.

Fixes WAYP-1166