### PR TITLE
server: Check that UserFromContext gets user before generating token

### DIFF
--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -452,6 +452,10 @@ func (s *Service) GenerateLoginToken(
 
 	// Get our user, that's what we log in as
 	currentUser := s.UserFromContext(ctx)
+	if currentUser == nil {
+		return nil,
+			status.Error(codes.Unauthenticated, "no user found from current context")
+	}
 
 	// If we have a duration set, set the expiry
 	var dur time.Duration


### PR DESCRIPTION
Prior to this commit, the servers auth would not validate that a proper user was found for the given context prior to generating a token. We should not generate a token if no user was found, so this commit updates the login token func to return an unathenticated error if no user was found in the given context.

Fixes WAYP-1155