### PR TITLE
builtin/exec: Properly return a closer for template rendering

### DIFF
--- a/.changelog/4674.txt
+++ b/.changelog/4674.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/exec: Cleanup all values stored in /tmp while rendering exec templates
+```

--- a/builtin/exec/platform.go
+++ b/builtin/exec/platform.go
@@ -152,7 +152,7 @@ func (p *Platform) renderTemplate(tpl *ConfigTemplate, data *tplData) (string, f
 	if err != nil {
 		return "", nil, err
 	}
-	closer := func() {} //os.RemoveAll(td) }
+	closer := func() { os.RemoveAll(td) }
 
 	// Render
 	var path string


### PR DESCRIPTION
Prior to this commit, the closer function for rendering a template was commented out, meaning that the exec plugin wouldn't properly cleanup its mess in `/tmp` while rendering commands. This commit updates that behaviort to return the proper closer func to be called by the caller once they're finished rendering templates.

Fixes WAYP-1164