### PR TITLE
internal: Cleanup remote URL trimming for git

### DIFF
--- a/.changelog/4675.txt
+++ b/.changelog/4675.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+internal: Improve git URL string trimming when determining remote URLs
+```

--- a/internal/pkg/gitdirty/gitdirty.go
+++ b/internal/pkg/gitdirty/gitdirty.go
@@ -244,8 +244,8 @@ func remoteConvertSSHtoHTTPS(sshRemote string) (string, error) {
 // Remote urls of type ssh may not start with git@, so this is trimmed.
 func normalizeRemote(remoteUrl string) string {
 	// Trim the git@ bc you can still have a remote url of type ssh w/o the git@
-	trimmedRemoteUrl := strings.TrimLeft(remoteUrl, "git@")
-	return strings.TrimRight(trimmedRemoteUrl, ".git")
+	trimmedRemoteUrl := strings.TrimPrefix(remoteUrl, "git@")
+	return strings.TrimSuffix(trimmedRemoteUrl, ".git")
 }
 
 // getRemoteName queries the repo at GitDirty.path for all remotes, and then


### PR DESCRIPTION
Prior to this commit, it was possible to craft a bad git remote and bypass our normalize func for remote git URLs. TrimLeft and TrimRight remote all occurances of the given pattern. The intention however is to only remove the first instance of `git@` and the last instance of `.git` from the given url. This commit fixes that by updating the string trimmers to use TrimPrefix and TrimSuffix, which will only remove the single instance of the pattern.

Fixes WAYP-1173