### PR TITLE
cli: Ensure that img string passed is proper length

### DIFF
--- a/internal/cli/deployment_list.go
+++ b/internal/cli/deployment_list.go
@@ -37,12 +37,16 @@ type DeploymentListCommand struct {
 	filterFlags      filterFlags
 }
 
-func shortImg(img string) string {
-	if strings.HasPrefix(img, "sha256:") {
-		return img[7:14]
+func shortImg(img string) (string, error) {
+	if len(img) < 7 {
+		return "", fmt.Errorf("string not long enough to obtain short img: %s", img)
 	}
 
-	return img[:7]
+	if strings.HasPrefix(img, "sha256:") {
+		return img[7:14], nil
+	}
+
+	return img[:7], nil
 }
 
 // Add either language: or languages: based on how many values are specified
@@ -247,7 +251,11 @@ func (c *DeploymentListCommand) Run(args []string) int {
 				}
 
 				if img, ok := build.Labels["common/image-id"]; ok {
-					img = shortImg(img)
+					img, err = shortImg(img)
+					if err != nil {
+						app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+						return err
+					}
 
 					details = append(details, "image:"+img)
 				}

--- a/internal/cli/release_list.go
+++ b/internal/cli/release_list.go
@@ -194,7 +194,11 @@ func (c *ReleaseListCommand) Run(args []string) int {
 				}
 
 				if img, ok := build.Labels["common/image-id"]; ok {
-					img = shortImg(img)
+					img, err = shortImg(img)
+					if err != nil {
+						app.UI.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+						return err
+					}
 
 					details = append(details, "image:"+img)
 				}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -607,7 +607,11 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 				details = artDetails
 			}
 			if img, ok := deployBundle.Build.Labels["common/image-id"]; ok {
-				img = shortImg(img)
+				img, err = shortImg(img)
+				if err != nil {
+					c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+					return err
+				}
 
 				details = details + " image:" + img
 			}
@@ -705,7 +709,11 @@ func (c *StatusCommand) FormatAppStatus(projectTarget string, appTarget string) 
 				details = artDetails
 			}
 			if img, ok := release.Preload.Build.Labels["common/image-id"]; ok {
-				img = shortImg(img)
+				img, err = shortImg(img)
+				if err != nil {
+					c.ui.Output(clierrors.Humanize(err), terminal.WithErrorStyle())
+					return err
+				}
 
 				details = details + " image:" + img
 			}


### PR DESCRIPTION
Prior to this commit, if a func calls shortImg with an improper string length, the whole CLI could panic given the shortImg func has a hardcoded expectation for the length of the passed in string. This commit fixes that by first validating the string length and then returning an error if the passed in string is not long enough to trim as expected.

Fixes WAYP-1151 (part 1)