### PR TITLE
builtin/ecr: Return err if token length is less than expected

### DIFF
--- a/builtin/aws/ecr/registry.go
+++ b/builtin/aws/ecr/registry.go
@@ -141,6 +141,11 @@ func (r *Registry) setupRepo(
 	data, err := base64.StdEncoding.DecodeString(uptoken)
 	if err != nil {
 		return nil, err
+	} else if len(data) < 5 {
+		// We trim the token string to remove the fist 4 characters. If a token
+		// is smaller than this, we would panic, so warn against it before it happens.
+		return nil, status.Error(
+			codes.FailedPrecondition, "authorization token length is invalid")
 	}
 
 	info := &ecrInfo{


### PR DESCRIPTION
Prior to this commit, we would accept the given decoded token string no matter what length it might be. Given that we expect to trim the first four characters from that token, we should validate its length prior, otherwise the plugin will panic.

Fixes WAYP-1151 (part 2)