### PR TITLE
docs: Fix user-facing typos

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -318,7 +318,7 @@ CLI:
 Server:
 
 4. `internal/server/singleprocess`: Server-side API request logic
-5. `internal/server/singleprocess/state`: Server-side persistant storage logic
+5. `internal/server/singleprocess/state`: Server-side persistent storage logic
 
 Runner: 
 
@@ -374,7 +374,7 @@ This makes it easy to use in different contexts (runners, entrypoints, locally).
 ### `internal/auth`
 
 Package auth contains helpers for both the server and client-side for
-autenticating with the Waypoint server. 
+authenticating with the Waypoint server. 
 
 ### `internal/ceb`
 
@@ -499,7 +499,7 @@ anyone trying to implement a Waypoint server.
 
 This is the main current implementation of the Waypoint server. This is
 a Waypoint server designed to be single process only; this server implementation
-is never intended to become multi-process (i.e. horizonally scalable). 
+is never intended to become multi-process (i.e. horizontally scalable). 
 
 #### `internal/server/singleprocess/state`
 

--- a/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
@@ -118,7 +118,7 @@ parameter {
   description   = "the name of the IAM role to use for ECS execution"
   type          = "string"
   required      = false
-  default_value = "create a new exeuction IAM role based on the application name"
+  default_value = "create a new execution IAM role based on the application name"
 }
 
 parameter {

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -2971,7 +2971,7 @@ deploy {
 	doc.SetField(
 		"execution_role_name",
 		"the name of the IAM role to use for ECS execution",
-		docs.Default("create a new exeuction IAM role based on the application name"),
+		docs.Default("create a new execution IAM role based on the application name"),
 	)
 
 	doc.SetField(

--- a/docs/gen/platform-aws-ecs.json
+++ b/docs/gen/platform-aws-ecs.json
@@ -177,7 +177,7 @@
          "Synopsis": "the name of the IAM role to use for ECS execution",
          "Summary": "",
          "Optional": true,
-         "Default": "create a new exeuction IAM role based on the application name",
+         "Default": "create a new execution IAM role based on the application name",
          "EnvVar": "",
          "Category": false,
          "SubFields": null

--- a/embedJson/gen/platform-aws-ecs.json
+++ b/embedJson/gen/platform-aws-ecs.json
@@ -95,7 +95,7 @@
          "Synopsis": "the name of the IAM role to use for ECS execution",
          "Summary": "",
          "Optional": true,
-         "Default": "create a new exeuction IAM role based on the application name",
+         "Default": "create a new execution IAM role based on the application name",
          "EnvVar": "",
          "Category": false,
          "Example": "",

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -188,7 +188,7 @@ func (c *ConfigSetCommand) Flags() *flag.Sets {
 			Target: &c.flagWorkspaceScope,
 			Usage: "Specify that the configuration is only available within a " +
 				"specific workspace. This configuration will only be set for " +
-				"deployments or operations (if -runner if set) when the workspace " +
+				"deployments or operations (if -runner is set) when the workspace " +
 				"matches this.",
 			Default: "",
 		})

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -247,7 +247,7 @@ func (i *ECSRunnerInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
-		Name:    "ecs-exeuction-role-name",
+		Name:    "ecs-execution-role-name",
 		Target:  &i.Config.ExecutionRoleName,
 		Usage:   "The name of the execution task IAM Role to associate with the ECS Service.",
 		Default: "waypoint-runner-execution-role",

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -79,7 +79,7 @@ func UserWithContext(ctx context.Context, u *pb.User) context.Context {
 // UserFromContext returns the authenticated user in the request context.
 // This will return nil if the user is not authenticated. Note that a user
 // may not be authenticated but the request can still be authenticated
-// using a non-user token type. The safeste way to check is decodedTokenFromContext.
+// using a non-user token type. The safest way to check is decodedTokenFromContext.
 func (s *Service) UserFromContext(ctx context.Context) *pb.User {
 	value, ok := ctx.Value(userKey{}).(*pb.User)
 	if !ok && s.superuser {

--- a/website/content/commands/config-set.mdx
+++ b/website/content/commands/config-set.mdx
@@ -37,7 +37,7 @@ Specify the "-app" flag to set a config variable for a specific app.
 #### Command Options
 
 - `-scope=<string>` - The scope for this configuration. The configuration will only appear within this scope. This can be one of 'global', 'project', or 'app'. The default is project.
-- `-workspace-scope=<string>` - Specify that the configuration is only available within a specific workspace. This configuration will only be set for deployments or operations (if -runner if set) when the workspace matches this.
+- `-workspace-scope=<string>` - Specify that the configuration is only available within a specific workspace. This configuration will only be set for deployments or operations (if -runner is set) when the workspace matches this.
 - `-label-scope=<string>` - If set, configuration will only be set if the deployment or operation (if -runner is set) has a matching label set.
 - `-runner` - Expose this configuration on runners. This can be used to set things such as credentials to cloud platforms for remote runners. This configuration will not be exposed to deployed applications. If this is specified in the context of a project, this will apply only to runners operating on jobs for the specific project or application. The default is false.
 

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -60,7 +60,7 @@ the install, the command would be:
 #### ecs Options
 
 - `-ecs-region=<string>` - AWS region in which to install the Waypoint runner.
-- `-ecs-exeuction-role-name=<string>` - The name of the execution task IAM Role to associate with the ECS Service. The default is waypoint-runner-execution-role.
+- `-ecs-execution-role-name=<string>` - The name of the execution task IAM Role to associate with the ECS Service. The default is waypoint-runner-execution-role.
 - `-ecs-task-role-name=<string>` - IAM Execution Role to assign to the on-demand runner. The default is waypoint-runner.
 - `-ecs-cpu=<string>` - The amount of CPU to allocate for the Waypoint runner task. The default is 512.
 - `-ecs-memory=<string>` - The amount of memory to allocate for the Waypoint runner task. The default is 2048.

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -371,7 +371,7 @@ The name of the IAM role to use for ECS execution.
 
 - Type: **string**
 - **Optional**
-- Default: create a new exeuction IAM role based on the application name
+- Default: create a new execution IAM role based on the application name
 
 #### log_group
 


### PR DESCRIPTION
This PR fixes a few minor typos found in documentation, Go doc comments and flags. Most notably, it fixes the "exeuction" typo in the `ecs-execution-role-name` flag found under the `runner install` command, which could have a user impact.