### PR TITLE
Update hardcoded version to 0.12.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,7 +10,7 @@ var (
 	GitCommit   string
 	GitDescribe string
 
-	Version           = "0.11.0"
+	Version           = "0.12.0" // Note: This value should match /version/VERSION!
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
After the CRT integration, the load-bearing version is kept in `version/VERSION`. However, this hard-coded value wasn't update to match at the time. Since it's the value used by local development builds (or builds off of main), we should keep it in-sync.

Since we don't have the runway to properly refactor. For the next release, we will update this value to match by hand.

A future patch will address this gap and use automation to maintain the value.

See also: hashicorp/waypoint#4583