### PR TITLE
Tests for template-related fields Projects

### DIFF
--- a/internal/server/boltdbstate/state_test.go
+++ b/internal/server/boltdbstate/state_test.go
@@ -29,11 +29,16 @@ func TestImpl(t *testing.T) {
 		"TestEvent",             //Failing b/c events aren't implemented in boltdb
 	}
 
+	// Tests for features that have not been implemented in OSS
+	unimplementedTests := []string{
+		"TestProjectTemplateFeatures",
+	}
+
 	statetest.Test(t, func(t *testing.T) serverstate.Interface {
 		return TestState(t)
 	}, func(t *testing.T, impl serverstate.Interface) serverstate.Interface {
 		v, err := TestStateRestart(t, impl.(*State))
 		require.NoError(t, err)
 		return v
-	}, knownFailingStateTests)
+	}, append(knownFailingStateTests, unimplementedTests...))
 }

--- a/pkg/server/gen/server.pb.go
+++ b/pkg/server/gen/server.pb.go
@@ -2181,8 +2181,9 @@ type Project struct {
 	// poll operations and their success/failure by using the ListJobs API.
 	StatusReportPoll *Project_AppStatusPoll `protobuf:"bytes,10,opt,name=status_report_poll,json=statusReportPoll,proto3" json:"status_report_poll,omitempty"`
 	State            Project_ProjectState   `protobuf:"varint,11,opt,name=state,proto3,enum=hashicorp.waypoint.Project_ProjectState" json:"state,omitempty"`
-	// readme_markdown is markdown formatted instructions on how to operate the project. This may be populated from a project template.
-	ReadmeMarkdown string `protobuf:"bytes,13,opt,name=readme_markdown,json=readmeMarkdown,proto3" json:"readme_markdown,omitempty"`
+	// readme_markdown is markdown formatted instructions on how to operate the project.
+	// This may be populated from a project template.
+	ReadmeMarkdown []byte `protobuf:"bytes,13,opt,name=readme_markdown,json=readmeMarkdown,proto3" json:"readme_markdown,omitempty"`
 	// project_template is a reference to the template that this project was
 	// created from, if any.
 	ProjectTemplate *Ref_ProjectTemplate `protobuf:"bytes,12,opt,name=project_template,json=projectTemplate,proto3" json:"project_template,omitempty"`
@@ -2297,11 +2298,11 @@ func (x *Project) GetState() Project_ProjectState {
 	return Project_ACTIVE
 }
 
-func (x *Project) GetReadmeMarkdown() string {
+func (x *Project) GetReadmeMarkdown() []byte {
 	if x != nil {
 		return x.ReadmeMarkdown
 	}
-	return ""
+	return nil
 }
 
 func (x *Project) GetProjectTemplate() *Ref_ProjectTemplate {
@@ -16571,9 +16572,14 @@ type ProjectTemplate struct {
 	// A long summary of what the ProjectTemplate is to be used for. This summary
 	// is shared between platform engineers and application developers.
 	ExpandedSummary string `protobuf:"bytes,4,opt,name=expanded_summary,json=expandedSummary,proto3" json:"expanded_summary,omitempty"`
-	// A markdown template which is rendered when a Project is created from a
+	// A markdown text template which is rendered when a Project is created from a
 	// ProjectTemplate to be shown to application developers.
-	ReadmeMarkdownTemplate string `protobuf:"bytes,5,opt,name=readme_markdown_template,json=readmeMarkdownTemplate,proto3" json:"readme_markdown_template,omitempty"`
+	// Accepted tokens:
+	// "{{ .ProjectName }}", representing the application developer chosen project name
+	// "{{ .TfcOrgName }}", representing the Terraform Cloud organization name in which
+	//
+	//	the no-code module was reified
+	ReadmeMarkdownTemplate []byte `protobuf:"bytes,5,opt,name=readme_markdown_template,json=readmeMarkdownTemplate,proto3" json:"readme_markdown_template,omitempty"`
 	// Settings for the Waypoint project that should be set when a project is
 	// created from a ProjectTemplate.
 	WaypointProject *ProjectTemplate_WaypointProject `protobuf:"bytes,6,opt,name=waypoint_project,json=waypointProject,proto3" json:"waypoint_project,omitempty"`
@@ -16644,11 +16650,11 @@ func (x *ProjectTemplate) GetExpandedSummary() string {
 	return ""
 }
 
-func (x *ProjectTemplate) GetReadmeMarkdownTemplate() string {
+func (x *ProjectTemplate) GetReadmeMarkdownTemplate() []byte {
 	if x != nil {
 		return x.ReadmeMarkdownTemplate
 	}
-	return ""
+	return nil
 }
 
 func (x *ProjectTemplate) GetWaypointProject() *ProjectTemplate_WaypointProject {
@@ -30676,7 +30682,12 @@ type ProjectTemplate_WaypointProject struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The templated waypoint.hcl file stored as HCL.
+	// waypoint.hcl text template file stored as HCL.
+	// Accepted tokens:
+	// "{{ .ProjectName }}", representing the application developer chosen project name
+	// "{{ .TfcOrgName }}", representing the Terraform Cloud organization name in which
+	//
+	//	the no-code module was reified
 	WaypointHclTemplate []byte `protobuf:"bytes,1,opt,name=waypoint_hcl_template,json=waypointHclTemplate,proto3" json:"waypoint_hcl_template,omitempty"`
 }
 
@@ -32079,7 +32090,7 @@ var file_pkg_server_proto_server_proto_rawDesc = []byte{
 	0x70, 0x6f, 0x69, 0x6e, 0x74, 0x2e, 0x50, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x2e, 0x50, 0x72,
 	0x6f, 0x6a, 0x65, 0x63, 0x74, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x05, 0x73, 0x74, 0x61, 0x74,
 	0x65, 0x12, 0x27, 0x0a, 0x0f, 0x72, 0x65, 0x61, 0x64, 0x6d, 0x65, 0x5f, 0x6d, 0x61, 0x72, 0x6b,
-	0x64, 0x6f, 0x77, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x72, 0x65, 0x61, 0x64,
+	0x64, 0x6f, 0x77, 0x6e, 0x18, 0x0d, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x0e, 0x72, 0x65, 0x61, 0x64,
 	0x6d, 0x65, 0x4d, 0x61, 0x72, 0x6b, 0x64, 0x6f, 0x77, 0x6e, 0x12, 0x52, 0x0a, 0x10, 0x70, 0x72,
 	0x6f, 0x6a, 0x65, 0x63, 0x74, 0x5f, 0x74, 0x65, 0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x18, 0x0c,
 	0x20, 0x01, 0x28, 0x0b, 0x32, 0x27, 0x2e, 0x68, 0x61, 0x73, 0x68, 0x69, 0x63, 0x6f, 0x72, 0x70,
@@ -35637,7 +35648,7 @@ var file_pkg_server_proto_server_proto_rawDesc = []byte{
 	0x61, 0x72, 0x79, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x65, 0x78, 0x70, 0x61, 0x6e,
 	0x64, 0x65, 0x64, 0x53, 0x75, 0x6d, 0x6d, 0x61, 0x72, 0x79, 0x12, 0x38, 0x0a, 0x18, 0x72, 0x65,
 	0x61, 0x64, 0x6d, 0x65, 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x64, 0x6f, 0x77, 0x6e, 0x5f, 0x74, 0x65,
-	0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x16, 0x72, 0x65,
+	0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x16, 0x72, 0x65,
 	0x61, 0x64, 0x6d, 0x65, 0x4d, 0x61, 0x72, 0x6b, 0x64, 0x6f, 0x77, 0x6e, 0x54, 0x65, 0x6d, 0x70,
 	0x6c, 0x61, 0x74, 0x65, 0x12, 0x5e, 0x0a, 0x10, 0x77, 0x61, 0x79, 0x70, 0x6f, 0x69, 0x6e, 0x74,
 	0x5f, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x33,

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -10759,7 +10759,8 @@
         },
         "readme_markdown": {
           "type": "string",
-          "description": "readme_markdown is markdown formatted instructions on how to operate the project. This may be populated from a project template."
+          "format": "byte",
+          "description": "readme_markdown is markdown formatted instructions on how to operate the project.\nThis may be populated from a project template."
         },
         "project_template": {
           "$ref": "#/definitions/hashicorp.waypoint.Ref.ProjectTemplate",
@@ -10823,7 +10824,8 @@
         },
         "readme_markdown_template": {
           "type": "string",
-          "description": "A markdown template which is rendered when a Project is created from a\nProjectTemplate to be shown to application developers."
+          "format": "byte",
+          "title": "A markdown text template which is rendered when a Project is created from a\nProjectTemplate to be shown to application developers.\nAccepted tokens:\n\"{{ .ProjectName }}\", representing the application developer chosen project name\n\"{{ .TfcOrgName }}\", representing the Terraform Cloud organization name in which\n the no-code module was reified"
         },
         "waypoint_project": {
           "$ref": "#/definitions/hashicorp.waypoint.ProjectTemplate.WaypointProject",
@@ -10861,7 +10863,7 @@
         "waypoint_hcl_template": {
           "type": "string",
           "format": "byte",
-          "description": "The templated waypoint.hcl file stored as HCL."
+          "title": "waypoint.hcl text template file stored as HCL.\nAccepted tokens:\n\"{{ .ProjectName }}\", representing the application developer chosen project name\n\"{{ .TfcOrgName }}\", representing the Terraform Cloud organization name in which\n the no-code module was reified"
         }
       },
       "description": "WaypointProject governs the properties that will be set on the final\nwaypoint Project that we create. Future fields will likely include status\nreport and datasource polling settings."

--- a/pkg/server/proto/server.proto
+++ b/pkg/server/proto/server.proto
@@ -1050,8 +1050,9 @@ message Project {
 
   ProjectState state = 11;
 
-  // readme_markdown is markdown formatted instructions on how to operate the project. This may be populated from a project template.
-  string readme_markdown = 13;
+  // readme_markdown is markdown formatted instructions on how to operate the project.
+  // This may be populated from a project template.
+  bytes readme_markdown = 13;
 
   // project_template is a reference to the template that this project was
   // created from, if any.
@@ -5334,9 +5335,13 @@ message ProjectTemplate {
   // is shared between platform engineers and application developers.
   string expanded_summary = 4;
 
-  // A markdown template which is rendered when a Project is created from a
+  // A markdown text template which is rendered when a Project is created from a
   // ProjectTemplate to be shown to application developers.
-  string readme_markdown_template = 5;
+  // Accepted tokens:
+  // "{{ .ProjectName }}", representing the application developer chosen project name
+  // "{{ .TfcOrgName }}", representing the Terraform Cloud organization name in which
+  //  the no-code module was reified
+  bytes readme_markdown_template = 5;
 
   // Settings for the Waypoint project that should be set when a project is
   // created from a ProjectTemplate.
@@ -5353,7 +5358,11 @@ message ProjectTemplate {
   // waypoint Project that we create. Future fields will likely include status
   // report and datasource polling settings.
   message WaypointProject {
-    // The templated waypoint.hcl file stored as HCL.
+    // waypoint.hcl text template file stored as HCL.
+    // Accepted tokens:
+    // "{{ .ProjectName }}", representing the application developer chosen project name
+    // "{{ .TfcOrgName }}", representing the Terraform Cloud organization name in which
+    //  the no-code module was reified
     bytes waypoint_hcl_template = 1;
   }
 

--- a/pkg/serverstate/statetest/test_project.go
+++ b/pkg/serverstate/statetest/test_project.go
@@ -1164,19 +1164,17 @@ func TestProjectTemplateFeatures(t *testing.T, factory Factory, restartF Restart
 		}
 	}
 
-	// Deleting the project template doesn't cause an error when getting projects
+	// Deleting the project template
 	{
-		//require.NoError(
-		err := s.DeleteProjectTemplate(ctx, &pb.Ref_ProjectTemplate{
-			Ref: &pb.Ref_ProjectTemplate_Id{
-				Id: projectTemplate2.Id,
-			},
-		})
-		//)
+		require.NoError(
+			s.DeleteProjectTemplate(ctx, &pb.Ref_ProjectTemplate{
+				Ref: &pb.Ref_ProjectTemplate_Id{
+					Id: projectTemplate2.Id,
+				},
+			}),
+		)
 
-		resp, err := s.ProjectGet(ctx, &pb.Ref_Project{Project: name})
+		_, err := s.ProjectGet(ctx, &pb.Ref_Project{Project: name})
 		require.NoError(err)
-
-		require.Empty(resp.ProjectTemplate)
 	}
 }


### PR DESCRIPTION
## What changed?

This adds state-layer tests for CRUD operations on the new template-related protobuf fields.

Note that the tests are added to a new "unimplemented" stanza in the state tests. Open-source waypoint does not implement templating. 

## What else changed?

This also sneaks in a related protobuf change, updating the readme fields from `string` type to `bytes` on the `Project` and `ProjectTemplate`, as they represent the contents of whole files.