### PR TITLE
fix(cli): honor runner install -platform arg

### DIFF
--- a/.changelog/4699.txt
+++ b/.changelog/4699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Honor runner install -platform arg
+```

--- a/internal/cli/runner_install.go
+++ b/internal/cli/runner_install.go
@@ -170,6 +170,8 @@ func (c *RunnerInstallCommand) Run(args []string) int {
 	var runnerPlatform string
 	if len(c.platform) == 0 {
 		runnerPlatform = serverConfig.Config.Platform
+	} else {
+		runnerPlatform = c.platform[0]
 	}
 
 	p, ok := runnerinstall.Platforms[strings.ToLower(runnerPlatform)]


### PR DESCRIPTION
Currently we’re only assigning a value to `runnerPlatform` if `c.platform` is empty, leading to the following bug:

```
$ waypoint runner install -platform=docker
! Error installing runner into "": unsupported platform
```

This patch ensures we use the given value for `c.platform`.

```
$ waypoint runner install -platform=docker
✓ Finished connecting to: host.docker.internal:9701
```