### PR TITLE
Fixing a race condition in GetJobStream

### DIFF
--- a/.changelog/4705.txt
+++ b/.changelog/4705.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fix theoretical race condition in job stream handling
+```

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -738,13 +738,13 @@ func (s *Service) GetJobStream(
 			// Updated job, requery it
 			ws = memdb.NewWatchSet()
 
-			updatedJobjob, err := s.state(ctx).JobById(ctx, job.Id, ws)
+			updatedJob, err := s.state(ctx).JobById(ctx, job.Id, ws)
 			if err != nil {
 				log.Error("error acquiring job by id", "error", err, "id", req.JobId)
 				errCh <- err
 				return
 			}
-			job = updatedJobjob
+			job = updatedJob
 			if job == nil {
 				errCh <- status.Errorf(codes.Internal, "job disappeared for ID: %s", req.JobId)
 				return

--- a/pkg/server/singleprocess/service_job.go
+++ b/pkg/server/singleprocess/service_job.go
@@ -737,12 +737,14 @@ func (s *Service) GetJobStream(
 
 			// Updated job, requery it
 			ws = memdb.NewWatchSet()
-			job, err = s.state(ctx).JobById(ctx, job.Id, ws)
+
+			updatedJobjob, err := s.state(ctx).JobById(ctx, job.Id, ws)
 			if err != nil {
 				log.Error("error acquiring job by id", "error", err, "id", req.JobId)
 				errCh <- err
 				return
 			}
+			job = updatedJobjob
 			if job == nil {
 				errCh <- status.Errorf(codes.Internal, "job disappeared for ID: %s", req.JobId)
 				return


### PR DESCRIPTION
## What problem does this solve?

Previously, it was theoretically possible for multiple goroutines to write to `err` at the same time in GetJobStream, which would have caused a panic. 

Failing test output: https://gist.github.com/izaaklauer/ff8b42abc38db7785bf49bc3c9b45731

## How does this solve it?

This PR modifies one of the goroutines in job stream handling to reassign the `err` variable when it uses it, avoiding a concurrent write

## How do I verify the fix?

Run the `TestStream_single` test with the `-race` flag, and verify passing!