### PR TITLE
Runner token ID check

### DIFF
--- a/.changelog/4707.txt
+++ b/.changelog/4707.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth: Prevent a runner token from generating a new token for a different runner
+```

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -533,6 +533,20 @@ func (s *Service) GenerateRunnerToken(
 		}
 	}
 
+	decodedToken := s.decodedTokenFromContext(ctx)
+
+	switch k := decodedToken.Kind.(type) {
+	case *pb.Token_Runner_:
+		// Prevent a runner token from generating a token for a runner with an
+		// ID different from the ID encoded in the runner token
+		if k.Runner.Id != req.Id {
+			msg := "cannot generate a token for runner " + req.Id + " using a runner token for runner " + k.Runner.Id
+			log.Error(msg)
+			return nil, status.Errorf(codes.InvalidArgument, msg)
+		}
+	default:
+	}
+
 	encodedId, err := s.encodeId(ctx, req.Id)
 	if err != nil {
 		msg := "failed to encode id when generating a runner token"

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -539,10 +539,12 @@ func (s *Service) GenerateRunnerToken(
 	case *pb.Token_Runner_:
 		// Prevent a runner token from generating a token for a runner with an
 		// ID different from the ID encoded in the runner token
-		if k.Runner.Id != req.Id {
-			msg := "cannot generate a token for runner " + req.Id + " using a runner token for runner " + k.Runner.Id
-			log.Error(msg)
-			return nil, status.Errorf(codes.InvalidArgument, msg)
+		if k.Runner != nil {
+			if k.Runner.Id != req.Id {
+				msg := "cannot generate a token for runner " + req.Id + " using a runner token for runner " + k.Runner.Id
+				log.Error(msg)
+				return nil, status.Errorf(codes.InvalidArgument, msg)
+			}
 		}
 	default:
 	}


### PR DESCRIPTION
This change in this PR prevents a runner token from being used to generate a new token for a runner other than the runner ID which is encoded in the runner token.