### PR TITLE
Do not allow forwarded IP to overwrite request source IP in logs

### DIFF
--- a/.changelog/4712.txt
+++ b/.changelog/4712.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server/http-response: Forwarded IP address in request header no longer overwrites Client IP address in request response
+```

--- a/.changelog/4712.txt
+++ b/.changelog/4712.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-server/http-response: Forwarded IP address in request header no longer overwrites Client IP address in request response
+server/http: Forwarded IP address in request header no longer overwrites Client IP address in request response
 ```


### PR DESCRIPTION
Add `forwardedIP` section to response so that `X-Forwarded-For` request header does not overwrite actual client IP, and validate it is a proper IP address.