### PR TITLE
update error handling for unhandled errors

### DIFF
--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -207,7 +207,10 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 		}
 
 		err = clisnapshot.WriteSnapshot(c.Ctx, c.project.Client(), writer)
-		writer.Close()
+		closeErr := writer.Close()
+		if err == nil && closeErr != nil {
+			err = closeErr
+		}
 
 		if err != nil {
 			s.Update("Failed to take server snapshot\n")

--- a/internal/pkg/httpfs/copy.go
+++ b/internal/pkg/httpfs/copy.go
@@ -32,10 +32,13 @@ func Copy(fs http.FileSystem, dst, src string) error {
 		if err != nil {
 			return err
 		}
-		defer dstF.Close()
+		defer dstF.Close() // 2nd call to make sure the file is closed
 
 		_, err = io.Copy(dstF, f)
-		return err
+		if err != nil {
+			return err
+		}
+		return dstF.Close() // 1st call to surface any errors from close
 	}
 
 	// Create this directory
@@ -69,7 +72,7 @@ func Copy(fs http.FileSystem, dst, src string) error {
 		}
 	}
 
-	return nil
+	return f.Close()
 }
 
 // mode returns the proper mode to use for creating files


### PR DESCRIPTION
This PR adds establishes a pattern for error handling on `Close()` and `defer Close()`.

This allows the application to surface possible errors that occur after a write function instead of ignoring them.