### PR TITLE
Remove race condition in job test

### DIFF
--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -2681,9 +2681,11 @@ func TestJobHeartbeatOnRestart(t *testing.T, factory Factory, rf RestartFactory)
 		defer s.Close()
 
 		// Verify it exists
-		job, err = s.JobById(ctx, "A", nil)
-		require.NoError(err)
-		require.Equal(pb.Job_RUNNING, job.Job.State)
+		{
+			job, err := s.JobById(ctx, "A", nil)
+			require.NoError(err)
+			require.Equal(pb.Job_RUNNING, job.Job.State)
+		}
 
 		// Should time out
 		require.Eventually(func() bool {

--- a/pkg/serverstate/statetest/test_job.go
+++ b/pkg/serverstate/statetest/test_job.go
@@ -2680,7 +2680,7 @@ func TestJobHeartbeatOnRestart(t *testing.T, factory Factory, rf RestartFactory)
 		s = rf(t, s)
 		defer s.Close()
 
-		// Verify it exists
+		// Verify it exists. We use a closure here to avoid a possible race condition with the job object
 		{
 			job, err := s.JobById(ctx, "A", nil)
 			require.NoError(err)


### PR DESCRIPTION
This removes a race condition where we're writing to `job` in one goroutine and reading in another during a test.

Race report: https://github.com/hashicorp/waypoint/actions/runs/4962203124/jobs/8879981994?pr=4708#step:8:387