### PR TITLE
Validating tokens

### DIFF
--- a/pkg/server/ptypes/auth.go
+++ b/pkg/server/ptypes/auth.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ptypes
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/waypoint/internal/pkg/validationext"
+	pb "github.com/hashicorp/waypoint/pkg/server/gen"
+)
+
+// TestToken returns a valid token for tests
+func TestToken(t testing.T, src *pb.Token) *pb.Token {
+	t.Helper()
+
+	if src == nil {
+		src = &pb.Token{}
+	}
+
+	require.NoError(t, mergo.Merge(src, &pb.Token{
+		Kind: &pb.Token_Login_{
+			Login: &pb.Token_Login{
+				UserId: "test",
+			},
+		},
+	}))
+
+	return src
+}
+
+func ValidateToken(v *pb.Token) error {
+	if v == nil {
+		return status.Error(codes.InvalidArgument, "token must not be nil")
+	}
+	return validationext.Error(validation.ValidateStruct(v,
+		validation.Field(&v.Kind, validation.Required),
+	))
+}

--- a/pkg/server/ptypes/deployment.go
+++ b/pkg/server/ptypes/deployment.go
@@ -15,7 +15,7 @@ import (
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 )
 
-// TestDeployment returns a valid project for tests.
+// TestDeployment returns a valid deployment for tests.
 func TestDeployment(t testing.T, src *pb.Deployment) *pb.Deployment {
 	t.Helper()
 

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -170,11 +170,6 @@ func (s *Service) Authenticate(
 		}
 	}
 
-	// Ensure the token message is well-formed (e.g. has required fields)
-	if err := serverptypes.ValidateToken(body); err != nil {
-		return nil, err
-	}
-
 	// Store the token in the context
 	ctx = DecodedTokenWithContext(ctx, body)
 

--- a/pkg/server/singleprocess/auth.go
+++ b/pkg/server/singleprocess/auth.go
@@ -170,6 +170,11 @@ func (s *Service) Authenticate(
 		}
 	}
 
+	// Ensure the token message is well-formed (e.g. has required fields)
+	if err := serverptypes.ValidateToken(body); err != nil {
+		return nil, err
+	}
+
 	// Store the token in the context
 	ctx = DecodedTokenWithContext(ctx, body)
 
@@ -534,6 +539,9 @@ func (s *Service) GenerateRunnerToken(
 	}
 
 	decodedToken := s.decodedTokenFromContext(ctx)
+	if err := serverptypes.ValidateToken(decodedToken); err != nil {
+		return nil, errors.Wrapf(err, "invalid request token")
+	}
 
 	switch k := decodedToken.Kind.(type) {
 	case *pb.Token_Runner_:


### PR DESCRIPTION
## What problem does this solve?

Currently, we aren't validating that tokens that have passed the hmac test and proto unmarshalling are otherwise valid! 

This is mostly only relevant for testing - the server shouldn't ever generate a token that it doesn't think is valid - but this at least turns a category of bug from a panic to an appropriate server error.

## What changed?

This implements a basic ptypes validator for our protobuf tokens and calls it in appropriate spots.