### PR TITLE
Make ecs platform alb.load_balancer_arn optional

### DIFF
--- a/.changelog/4729.txt
+++ b/.changelog/4729.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/ecs: Make `alb.load_balancer_arn` optional
+```

--- a/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "alb"
   description = "Provides additional configuration for using an ALB with ECS"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -38,7 +38,7 @@ parameter {
   key         = "alb.load_balancer_arn"
   description = "the ARN on an existing ALB to configure\nwhen this is set, Waypoint will use this ALB instead of creating its own. A target group will still be created for each deployment, and will be added to a listener on the configured ALB port (Waypoint will the listener if it doesn't exist). This allows users to configure their ALB outside Waypoint but still have Waypoint hook the application to that ALB"
   type        = "string"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -2787,7 +2787,7 @@ type ALBConfig struct {
 
 	// When set, waypoint will configure the target group into the load balancer.
 	// This allows for usage of existing ALBs.
-	LoadBalancerArn string `hcl:"load_balancer_arn"`
+	LoadBalancerArn string `hcl:"load_balancer_arn,optional"`
 
 	// Indicates, when creating an ALB, that it should be internal rather than
 	// internet facing.

--- a/embedJson/gen/platform-aws-ecs.json
+++ b/embedJson/gen/platform-aws-ecs.json
@@ -6,6 +6,115 @@
    "name": "aws-ecs",
    "optionalFields": [
       {
+         "Field": "alb",
+         "Type": "ecs.ALBConfig",
+         "Synopsis": "Provides additional configuration for using an ALB with ECS",
+         "Summary": "",
+         "Optional": true,
+         "Default": "",
+         "EnvVar": "",
+         "Category": true,
+         "Example": "",
+         "SubFields": [
+            {
+               "Field": "certificate",
+               "Type": "string",
+               "Synopsis": "the ARN of an AWS Certificate Manager cert to associate with the ALB",
+               "Summary": "",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "domain_name",
+               "Type": "string",
+               "Synopsis": "Fully qualified domain name to set for the ALB",
+               "Summary": "set along with zone_id to have DNS automatically setup for the ALB. this value should include the full hostname and domain name, for instance app.example.com",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "ingress_port",
+               "Type": "int64",
+               "Synopsis": "Internet-facing traffic port. Defaults to 80 if 'certificate' is unset, 443 if set.",
+               "Summary": "used to set the ALB listener port, and the ALB security group ingress port",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "internal",
+               "Type": "bool",
+               "Synopsis": "Whether or not the created ALB should be internal",
+               "Summary": "used when listener_arn is not set. If set, the created ALB will have a scheme of `internal`, otherwise by default it has a scheme of `internet-facing`.",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "load_balancer_arn",
+               "Type": "string",
+               "Synopsis": "the ARN on an existing ALB to configure",
+               "Summary": "when this is set, Waypoint will use this ALB instead of creating its own. A target group will still be created for each deployment, and will be added to a listener on the configured ALB port (Waypoint will the listener if it doesn't exist). This allows users to configure their ALB outside Waypoint but still have Waypoint hook the application to that ALB",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "security_group_ids",
+               "Type": "list of string",
+               "Synopsis": "",
+               "Summary": "",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "subnets",
+               "Type": "list of string",
+               "Synopsis": "the VPC subnets to use for the ALB",
+               "Summary": "",
+               "Optional": true,
+               "Default": "public subnets in the default VPC",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            },
+            {
+               "Field": "zone_id",
+               "Type": "string",
+               "Synopsis": "Route53 ZoneID to create a DNS record into",
+               "Summary": "set along with alb.domain_name to have DNS automatically setup for the ALB",
+               "Optional": true,
+               "Default": "",
+               "EnvVar": "",
+               "Category": false,
+               "Example": "",
+               "SubFields": null
+            }
+         ]
+      },
+      {
          "Field": "architecture",
          "Type": "string",
          "Synopsis": "the instruction set CPU architecture that the Amazon ECS supports. Valid values are: \"x86_64\", \"arm64\"",
@@ -311,115 +420,6 @@
    ],
    "outputAttrsHelp": "Output attributes can be used in your `waypoint.hcl` as [variables](/waypoint/docs/waypoint-hcl/variables) via [`artifact`](/waypoint/docs/waypoint-hcl/variables/artifact) or [`deploy`](/waypoint/docs/waypoint-hcl/variables/deploy).",
    "requiredFields": [
-      {
-         "Field": "alb",
-         "Type": "ecs.ALBConfig",
-         "Synopsis": "Provides additional configuration for using an ALB with ECS",
-         "Summary": "",
-         "Optional": false,
-         "Default": "",
-         "EnvVar": "",
-         "Category": true,
-         "Example": "",
-         "SubFields": [
-            {
-               "Field": "certificate",
-               "Type": "string",
-               "Synopsis": "the ARN of an AWS Certificate Manager cert to associate with the ALB",
-               "Summary": "",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "domain_name",
-               "Type": "string",
-               "Synopsis": "Fully qualified domain name to set for the ALB",
-               "Summary": "set along with zone_id to have DNS automatically setup for the ALB. this value should include the full hostname and domain name, for instance app.example.com",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "ingress_port",
-               "Type": "int64",
-               "Synopsis": "Internet-facing traffic port. Defaults to 80 if 'certificate' is unset, 443 if set.",
-               "Summary": "used to set the ALB listener port, and the ALB security group ingress port",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "internal",
-               "Type": "bool",
-               "Synopsis": "Whether or not the created ALB should be internal",
-               "Summary": "used when listener_arn is not set. If set, the created ALB will have a scheme of `internal`, otherwise by default it has a scheme of `internet-facing`.",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "load_balancer_arn",
-               "Type": "string",
-               "Synopsis": "the ARN on an existing ALB to configure",
-               "Summary": "when this is set, Waypoint will use this ALB instead of creating its own. A target group will still be created for each deployment, and will be added to a listener on the configured ALB port (Waypoint will the listener if it doesn't exist). This allows users to configure their ALB outside Waypoint but still have Waypoint hook the application to that ALB",
-               "Optional": false,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "security_group_ids",
-               "Type": "list of string",
-               "Synopsis": "",
-               "Summary": "",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "subnets",
-               "Type": "list of string",
-               "Synopsis": "the VPC subnets to use for the ALB",
-               "Summary": "",
-               "Optional": true,
-               "Default": "public subnets in the default VPC",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            },
-            {
-               "Field": "zone_id",
-               "Type": "string",
-               "Synopsis": "Route53 ZoneID to create a DNS record into",
-               "Summary": "set along with alb.domain_name to have DNS automatically setup for the ALB",
-               "Optional": true,
-               "Default": "",
-               "EnvVar": "",
-               "Category": false,
-               "Example": "",
-               "SubFields": null
-            }
-         ]
-      },
       {
          "Field": "health_check",
          "Type": "ecs.AppHealthCheck",

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -22,74 +22,6 @@ deploy {
 
 These parameters are used in the [`use` stanza](/waypoint/docs/waypoint-hcl/use) for this plugin.
 
-#### alb (category)
-
-Provides additional configuration for using an ALB with ECS.
-
-##### alb.certificate
-
-The ARN of an AWS Certificate Manager cert to associate with the ALB.
-
-- Type: **string**
-- **Optional**
-
-##### alb.domain_name
-
-Fully qualified domain name to set for the ALB.
-
-Set along with zone_id to have DNS automatically setup for the ALB. this value should include the full hostname and domain name, for instance app.example.com.
-
-- Type: **string**
-- **Optional**
-
-##### alb.ingress_port
-
-Internet-facing traffic port. Defaults to 80 if 'certificate' is unset, 443 if set.
-
-Used to set the ALB listener port, and the ALB security group ingress port.
-
-- Type: **int64**
-- **Optional**
-
-##### alb.internal
-
-Whether or not the created ALB should be internal.
-
-Used when listener_arn is not set. If set, the created ALB will have a scheme of `internal`, otherwise by default it has a scheme of `internet-facing`.
-
-- Type: **bool**
-- **Optional**
-
-##### alb.load_balancer_arn
-
-The ARN on an existing ALB to configure.
-
-When this is set, Waypoint will use this ALB instead of creating its own. A target group will still be created for each deployment, and will be added to a listener on the configured ALB port (Waypoint will the listener if it doesn't exist). This allows users to configure their ALB outside Waypoint but still have Waypoint hook the application to that ALB.
-
-- Type: **string**
-
-##### alb.security_group_ids
-
-- Type: **list of string**
-- **Optional**
-
-##### alb.subnets
-
-The VPC subnets to use for the ALB.
-
-- Type: **list of string**
-- **Optional**
-- Default: public subnets in the default VPC
-
-##### alb.zone_id
-
-Route53 ZoneID to create a DNS record into.
-
-Set along with alb.domain_name to have DNS automatically setup for the ALB.
-
-- Type: **string**
-- **Optional**
-
 #### health_check (category)
 
 Health check settings for the app.
@@ -298,6 +230,78 @@ Environment variables to expose to this container.
 ### Optional Parameters
 
 These parameters are used in the [`use` stanza](/waypoint/docs/waypoint-hcl/use) for this plugin.
+
+#### alb (category)
+
+Provides additional configuration for using an ALB with ECS.
+
+
+- **Optional**
+
+##### alb.certificate
+
+The ARN of an AWS Certificate Manager cert to associate with the ALB.
+
+- Type: **string**
+- **Optional**
+
+##### alb.domain_name
+
+Fully qualified domain name to set for the ALB.
+
+Set along with zone_id to have DNS automatically setup for the ALB. this value should include the full hostname and domain name, for instance app.example.com.
+
+- Type: **string**
+- **Optional**
+
+##### alb.ingress_port
+
+Internet-facing traffic port. Defaults to 80 if 'certificate' is unset, 443 if set.
+
+Used to set the ALB listener port, and the ALB security group ingress port.
+
+- Type: **int64**
+- **Optional**
+
+##### alb.internal
+
+Whether or not the created ALB should be internal.
+
+Used when listener_arn is not set. If set, the created ALB will have a scheme of `internal`, otherwise by default it has a scheme of `internet-facing`.
+
+- Type: **bool**
+- **Optional**
+
+##### alb.load_balancer_arn
+
+The ARN on an existing ALB to configure.
+
+When this is set, Waypoint will use this ALB instead of creating its own. A target group will still be created for each deployment, and will be added to a listener on the configured ALB port (Waypoint will the listener if it doesn't exist). This allows users to configure their ALB outside Waypoint but still have Waypoint hook the application to that ALB.
+
+- Type: **string**
+- **Optional**
+
+##### alb.security_group_ids
+
+- Type: **list of string**
+- **Optional**
+
+##### alb.subnets
+
+The VPC subnets to use for the ALB.
+
+- Type: **list of string**
+- **Optional**
+- Default: public subnets in the default VPC
+
+##### alb.zone_id
+
+Route53 ZoneID to create a DNS record into.
+
+Set along with alb.domain_name to have DNS automatically setup for the ALB.
+
+- Type: **string**
+- **Optional**
 
 #### architecture
 


### PR DESCRIPTION
Updates the ecs platform plugin to make `alb.load_balancer_arn` optional as per comment here: https://github.com/hashicorp/waypoint/issues/4680#issuecomment-1551731412

Fixes: https://github.com/hashicorp/waypoint/issues/4680