### PR TITLE
Fixed typo: task-inspect.go

### DIFF
--- a/internal/cli/task_inspect.go
+++ b/internal/cli/task_inspect.go
@@ -297,7 +297,7 @@ func (c *TaskInspectCommand) FormatJob(job *pb.Job) error {
 			Name: "Cancel Time", Value: cancelTime,
 		},
 		{
-			Name: "Error Messsage", Value: errMsg,
+			Name: "Error Message", Value: errMsg,
 		},
 	}, terminal.WithInfoStyle())
 

--- a/internal/cli/task_inspect.go
+++ b/internal/cli/task_inspect.go
@@ -46,7 +46,7 @@ func (c *TaskInspectCommand) Run(args []string) int {
 	if c.flagRunJobId != "" && taskId != "" {
 		c.ui.Output("Both Run Job Id and Task Id was supplied, will look up by Task Id", terminal.WithWarningStyle())
 	}
-
+	
 	var (
 		taskReq *pb.GetTaskRequest
 	)

--- a/internal/cli/task_inspect.go
+++ b/internal/cli/task_inspect.go
@@ -46,7 +46,6 @@ func (c *TaskInspectCommand) Run(args []string) int {
 	if c.flagRunJobId != "" && taskId != "" {
 		c.ui.Output("Both Run Job Id and Task Id was supplied, will look up by Task Id", terminal.WithWarningStyle())
 	}
-	
 	var (
 		taskReq *pb.GetTaskRequest
 	)


### PR DESCRIPTION
Removed typo in line 300 of [task-inspect.go](https://github.com/hashicorp/waypoint/blob/main/internal/cli/task_inspect.go)
