### PR TITLE
internal/config: Remove redundant context append for parsing

### DIFF
--- a/internal/config/pipeline.go
+++ b/internal/config/pipeline.go
@@ -86,8 +86,6 @@ func (c *Config) Pipelines() []string {
 // Note that currently this parsing function does not attempt to detect cycles
 // between embedded pipelines.
 func (c *Config) Pipeline(id string, ctx *hcl.EvalContext) (*Pipeline, error) {
-	ctx = appendContext(c.ctx, ctx)
-
 	// Find the pipeline by progressively decoding
 	var rawPipeline *hclPipeline
 	for _, p := range c.hclConfig.Pipelines {

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -309,6 +309,20 @@ func TestPipelineProtos(t *testing.T) {
 		},
 
 		{
+			"pipelines_many_many_many.hcl",
+			func(t *testing.T, c *Config) {
+				require := require.New(t)
+
+				pipelines, err := c.PipelineProtos()
+				require.NoError(err)
+				require.Len(pipelines, 7)
+
+				require.Equal(pipelines[0].Name, "foo")
+				require.Equal(pipelines[1].Name, "bar")
+			},
+		},
+
+		{
 			"pipeline_nested_pipes.hcl",
 			func(t *testing.T, c *Config) {
 				require := require.New(t)

--- a/internal/config/testdata/pipelines/pipelines_many_many_many.hcl
+++ b/internal/config/testdata/pipelines/pipelines_many_many_many.hcl
@@ -1,0 +1,84 @@
+project = "foo"
+
+pipeline "foo" {
+  step "test" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+
+pipeline "bar" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+pipeline "foofoo" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+pipeline "barbar" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+pipeline "foobar" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+pipeline "naming-is-hard" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+pipeline "hey-we-made-it" {
+  step "test2" {
+    image_url = "example.com/test"
+
+    use "test" {
+      foo = "bar"
+    }
+  }
+}
+
+app "web" {
+    config {
+        env = {
+            static = "hello"
+        }
+    }
+
+    build {}
+
+    deploy {}
+}


### PR DESCRIPTION
Prior to this commit, if a config had many pipeline stanzas, say more than 6, each time we would parse a pipeline via the hcl EvalContext we would append that context to the current one to capture any additional parts of the config. Given that we are evaluating the entire config file and not parts of it, this action was redundant. Additionally, it made parsing many pipeline configs slow for each appended context.

This fixes it by removing the append. We don't need to append this, given we have the full config context each time we parse pipelines.

Thank you @jgwhite and @sdav9375 for identifying this!