### PR TITLE
api: fix duplicate gateway.yml paths

### DIFF
--- a/pkg/server/gen/server.pb.gw.go
+++ b/pkg/server/gen/server.pb.gw.go
@@ -4958,6 +4958,40 @@ func local_request_Waypoint_SetConfig_0(ctx context.Context, marshaler runtime.M
 
 }
 
+func request_Waypoint_DeleteConfig_0(ctx context.Context, marshaler runtime.Marshaler, client WaypointClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ConfigDeleteRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.DeleteConfig(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Waypoint_DeleteConfig_0(ctx context.Context, marshaler runtime.Marshaler, server WaypointServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ConfigDeleteRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.DeleteConfig(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_Waypoint_GetConfig_0 = &utilities.DoubleArray{Encoding: map[string]int{"application": 0, "project": 1}, Base: []int{1, 3, 1, 0, 3, 0}, Check: []int{0, 1, 2, 3, 2, 5}}
 )
@@ -5238,6 +5272,40 @@ func local_request_Waypoint_SetConfigSource_0(ctx context.Context, marshaler run
 	}
 
 	msg, err := server.SetConfigSource(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Waypoint_DeleteConfigSource_0(ctx context.Context, marshaler runtime.Marshaler, client WaypointClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteConfigSourceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.DeleteConfigSource(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Waypoint_DeleteConfigSource_0(ctx context.Context, marshaler runtime.Marshaler, server WaypointServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteConfigSourceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.DeleteConfigSource(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -11812,6 +11880,30 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 
 	})
 
+	mux.Handle("PUT", pattern_Waypoint_DeleteConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteConfig", runtime.WithHTTPPathPattern("/project/config/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Waypoint_DeleteConfig_0(ctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Waypoint_DeleteConfig_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Waypoint_GetConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -11905,6 +11997,30 @@ func RegisterWaypointHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		}
 
 		forward_Waypoint_SetConfigSource_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_Waypoint_DeleteConfigSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		ctx, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteConfigSource", runtime.WithHTTPPathPattern("/config-source/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Waypoint_DeleteConfigSource_0(ctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Waypoint_DeleteConfigSource_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -15169,6 +15285,27 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 
 	})
 
+	mux.Handle("PUT", pattern_Waypoint_DeleteConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteConfig", runtime.WithHTTPPathPattern("/project/config/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Waypoint_DeleteConfig_0(ctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Waypoint_DeleteConfig_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Waypoint_GetConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -15250,6 +15387,27 @@ func RegisterWaypointHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		}
 
 		forward_Waypoint_SetConfigSource_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_Waypoint_DeleteConfigSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		ctx, err = runtime.AnnotateContext(ctx, mux, req, "/hashicorp.waypoint.Waypoint/DeleteConfigSource", runtime.WithHTTPPathPattern("/config-source/delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Waypoint_DeleteConfigSource_0(ctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Waypoint_DeleteConfigSource_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -17025,6 +17183,8 @@ var (
 
 	pattern_Waypoint_SetConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"project", "config"}, ""))
 
+	pattern_Waypoint_DeleteConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"project", "config", "delete"}, ""))
+
 	pattern_Waypoint_GetConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"project", "application.project", "application", "application.application", "config"}, ""))
 
 	pattern_Waypoint_GetConfig_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"project", "project.project", "config"}, ""))
@@ -17032,6 +17192,8 @@ var (
 	pattern_Waypoint_GetConfig_2 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"project", "application.project", "application.application", "config"}, ""))
 
 	pattern_Waypoint_SetConfigSource_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"config-source"}, ""))
+
+	pattern_Waypoint_DeleteConfigSource_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"config-source", "delete"}, ""))
 
 	pattern_Waypoint_GetConfigSource_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"config-source"}, ""))
 
@@ -17321,6 +17483,8 @@ var (
 
 	forward_Waypoint_SetConfig_0 = runtime.ForwardResponseMessage
 
+	forward_Waypoint_DeleteConfig_0 = runtime.ForwardResponseMessage
+
 	forward_Waypoint_GetConfig_0 = runtime.ForwardResponseMessage
 
 	forward_Waypoint_GetConfig_1 = runtime.ForwardResponseMessage
@@ -17328,6 +17492,8 @@ var (
 	forward_Waypoint_GetConfig_2 = runtime.ForwardResponseMessage
 
 	forward_Waypoint_SetConfigSource_0 = runtime.ForwardResponseMessage
+
+	forward_Waypoint_DeleteConfigSource_0 = runtime.ForwardResponseMessage
 
 	forward_Waypoint_GetConfigSource_0 = runtime.ForwardResponseMessage
 

--- a/pkg/server/gen/server.swagger.json
+++ b/pkg/server/gen/server.swagger.json
@@ -314,6 +314,39 @@
         ]
       }
     },
+    "/config-source/delete": {
+      "put": {
+        "summary": "Delete the configuration for a dynamic configuration source",
+        "operationId": "Waypoint_DeleteConfigSource",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.DeleteConfigSourceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      }
+    },
     "/deployment/{deployment.id}/status-report": {
       "put": {
         "summary": "ExpediteStatusReport returns the queued status report job id",
@@ -2216,6 +2249,39 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/hashicorp.waypoint.ConfigSetRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Waypoint"
+        ]
+      }
+    },
+    "/project/config/delete": {
+      "put": {
+        "summary": "Delete one or more configuration variables for applications or runners.",
+        "operationId": "Waypoint_DeleteConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.ConfigDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/hashicorp.waypoint.ConfigDeleteRequest"
             }
           }
         ],
@@ -7683,6 +7749,17 @@
       "default": "UNKNOWN",
       "description": "Supported component types, the values here MUST match the enum values\nin the Go sdk/component package exactly. A test in internal/server\nvalidates this."
     },
+    "hashicorp.waypoint.ConfigDeleteRequest": {
+      "type": "object",
+      "properties": {
+        "variables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/hashicorp.waypoint.ConfigVar"
+          }
+        }
+      }
+    },
     "hashicorp.waypoint.ConfigDeleteResponse": {
       "type": "object"
     },
@@ -7995,6 +8072,14 @@
         "transport": {
           "$ref": "#/definitions/hashicorp.waypoint.TokenTransport",
           "description": "Transport is the wrapper around the token. This may be useful\nto look into the metadata around the token."
+        }
+      }
+    },
+    "hashicorp.waypoint.DeleteConfigSourceRequest": {
+      "type": "object",
+      "properties": {
+        "config_source": {
+          "$ref": "#/definitions/hashicorp.waypoint.ConfigSource"
         }
       }
     },

--- a/pkg/server/proto/gateway.yml
+++ b/pkg/server/proto/gateway.yml
@@ -259,7 +259,7 @@ http:
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.DeleteConfig
-    put: /project/config
+    put: /project/config/delete
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.SetConfigSource
@@ -267,7 +267,7 @@ http:
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.DeleteConfigSource
-    put: /config-source
+    put: /config-source/delete
     body: "*"
 
   - selector: hashicorp.waypoint.Waypoint.GetConfigSource


### PR DESCRIPTION
Turns out this doesn’t work:

```yaml
  - selector: hashicorp.waypoint.Waypoint.SetConfig
    put: /project/config
    body: "*"

  - selector: hashicorp.waypoint.Waypoint.DeleteConfig
    put: /project/config
    body: "*"
```

Because both requests are for `PUT /project/config` and as a result grpc-gateway doesn’t know how to direct the request. protoc-grpc-gateway fails with the following:

```
go generate ./pkg/server
--swagger_out: must not set request body when http method is DELETE except allow_delete_body option is true: DeleteConfig
pkg/server/server.go:6: running "sh": exit status 1
make: *** [gen/server] Error 1
```

This change disambiguates the paths, but at the cost of a rather unintuitive path for the Delete rpcs. We can’t use `delete: /project/config` because grpc-gateway does not permit DELETE request to have a body.