### PR TITLE
Azure Plugin auth fix

### DIFF
--- a/.changelog/4763.txt
+++ b/.changelog/4763.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/azure-aci: Update plugin to attempt CLI auth if environment auth fails.
+```

--- a/builtin/azure/aci/platform.go
+++ b/builtin/azure/aci/platform.go
@@ -83,7 +83,7 @@ func (p *Platform) Deploy(
 		},
 	}
 
-	auth, err := deployment.authenticate(ctx)
+	auth, err := deployment.authenticate(ctx, log)
 	if err != nil {
 		return nil, status.Error(
 			codes.Unauthenticated,


### PR DESCRIPTION
Update the Azure ACI plugin to attempt CLI auth before erroring, rather than erroring if environment auth failed. Closes #2589.