### PR TITLE
Validate CEB token context DeploymentID

### DIFF
--- a/internal/cli/server_upgrade.go
+++ b/internal/cli/server_upgrade.go
@@ -207,8 +207,9 @@ func (c *ServerUpgradeCommand) Run(args []string) int {
 		}
 
 		err = clisnapshot.WriteSnapshot(c.Ctx, c.project.Client(), writer)
-		writer.Close()
-
+		if err == nil {
+			err = writer.Close()
+		}
 		if err != nil {
 			s.Update("Failed to take server snapshot\n")
 			s.Status(terminal.StatusError)

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -51,6 +51,17 @@ func (s *Service) EntrypointConfig(
 		)
 	}
 
+	if tok := s.decodedTokenFromContext(ctx); tok != nil {
+		if tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
+			return hcerr.Externalize(
+				log,
+				err,
+				"entrypoint token invalid for this deployment ID", "deployment_id",
+				req.DeploymentId,
+			)
+		}
+	}
+
 	// Create our record
 	log = log.With("deployment_id", req.DeploymentId, "instance_id", req.InstanceId)
 	log.Trace("registering entrypoint")

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -36,7 +36,7 @@ func (s *Service) EntrypointConfig(
 	// Validate CEB token is valid for this deployment
 	if tok := s.decodedTokenFromContext(ctx); tok != nil {
 		if tok.UnusedEntrypoint != nil && tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
-			log.Error("entrypoint token invalid for this deployment ID", "deployment_id")
+			return status.Errorf(codes.PermissionDenied, "entrypoint token invalid for this deployment ID: %s", req.DeploymentId)
 		}
 	}
 

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -33,6 +33,13 @@ func (s *Service) EntrypointConfig(
 	log := hclog.FromContext(srv.Context())
 	ctx := srv.Context()
 
+	// Validate CEB token is valid for this deployment
+	if tok := s.decodedTokenFromContext(ctx); tok != nil {
+		if tok.UnusedEntrypoint != nil && tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
+			log.Error("entrypoint token invalid for this deployment ID", "deployment_id")
+		}
+	}
+
 	// Fetch the deployment info so we can calculate the config variables to send.
 	// This also verifies this deployment exists.
 	deployment, err := s.GetDeployment(srv.Context(), &pb.GetDeploymentRequest{
@@ -48,17 +55,6 @@ func (s *Service) EntrypointConfig(
 			"deployment_id",
 			req.DeploymentId,
 		)
-	}
-
-	if tok := s.decodedTokenFromContext(ctx); tok != nil {
-		if tok.UnusedEntrypoint != nil && tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
-			return hcerr.Externalize(
-				log,
-				err,
-				"entrypoint token invalid for this deployment ID", "deployment_id",
-				req.DeploymentId,
-			)
-		}
 	}
 
 	// Create our record

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -51,7 +51,7 @@ func (s *Service) EntrypointConfig(
 	}
 
 	if tok := s.decodedTokenFromContext(ctx); tok != nil {
-		if tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
+		if tok.UnusedEntrypoint != nil && tok.UnusedEntrypoint.DeploymentId != req.DeploymentId {
 			return hcerr.Externalize(
 				log,
 				err,

--- a/pkg/server/singleprocess/service_entrypoint.go
+++ b/pkg/server/singleprocess/service_entrypoint.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/waypoint/pkg/serverstate"
 )
 
-// TODO: test
 func (s *Service) EntrypointConfig(
 	req *pb.EntrypointConfigRequest,
 	srv pb.Waypoint_EntrypointConfigServer,

--- a/pkg/server/singleprocess/service_entrypoint_test.go
+++ b/pkg/server/singleprocess/service_entrypoint_test.go
@@ -60,6 +60,43 @@ func TestServiceEntrypointConfig(t *testing.T) {
 		require.Equal("testapp", cfgResp.Config.Deployment.Component.Name)
 	})
 
+	t.Run("deployment info mismatch", func(t *testing.T) {
+		require := require.New(t)
+
+		// Create our server
+		impl, err := New(WithDB(testDB(t)))
+		require.NoError(err)
+		client := server.TestServer(t, impl)
+
+		// Create a deployment
+		resp, err := client.UpsertDeployment(ctx, &pb.UpsertDeploymentRequest{
+			Deployment: serverptypes.TestValidDeployment(t, &pb.Deployment{
+				Component: &pb.Component{
+					Name: "testapp",
+				},
+			}),
+		})
+		require.NoError(err)
+		dep := resp.Deployment
+
+		// Create the config
+		instanceId, err := server.Id()
+		require.NoError(err)
+		stream, err := client.EntrypointConfig(ctx, &pb.EntrypointConfigRequest{
+			InstanceId:   instanceId,
+			DeploymentId: dep.Id,
+		})
+		require.NoError(err)
+
+		// Wait for the first config so that we know we're registered
+		cfgResp, err := stream.Recv()
+		require.NoError(err)
+
+		// Validate config
+		require.NotNil(cfgResp.Config.Deployment)
+		require.Equal("testapp", cfgResp.Config.Deployment.Component.Name)
+	})
+
 	t.Run("no URL service", func(t *testing.T) {
 		require := require.New(t)
 

--- a/pkg/server/singleprocess/service_entrypoint_test.go
+++ b/pkg/server/singleprocess/service_entrypoint_test.go
@@ -60,43 +60,6 @@ func TestServiceEntrypointConfig(t *testing.T) {
 		require.Equal("testapp", cfgResp.Config.Deployment.Component.Name)
 	})
 
-	t.Run("deployment info mismatch", func(t *testing.T) {
-		require := require.New(t)
-
-		// Create our server
-		impl, err := New(WithDB(testDB(t)))
-		require.NoError(err)
-		client := server.TestServer(t, impl)
-
-		// Create a deployment
-		resp, err := client.UpsertDeployment(ctx, &pb.UpsertDeploymentRequest{
-			Deployment: serverptypes.TestValidDeployment(t, &pb.Deployment{
-				Component: &pb.Component{
-					Name: "testapp",
-				},
-			}),
-		})
-		require.NoError(err)
-		dep := resp.Deployment
-
-		// Create the config
-		instanceId, err := server.Id()
-		require.NoError(err)
-		stream, err := client.EntrypointConfig(ctx, &pb.EntrypointConfigRequest{
-			InstanceId:   instanceId,
-			DeploymentId: dep.Id,
-		})
-		require.NoError(err)
-
-		// Wait for the first config so that we know we're registered
-		cfgResp, err := stream.Recv()
-		require.NoError(err)
-
-		// Validate config
-		require.NotNil(cfgResp.Config.Deployment)
-		require.Equal("testapp", cfgResp.Config.Deployment.Component.Name)
-	})
-
 	t.Run("no URL service", func(t *testing.T) {
 		require := require.New(t)
 


### PR DESCRIPTION
Validate the deployment ID associated with the context of the CEB token to ensure that the token is authorized to take actions on the current deployment.