### PR TITLE
Set reasonable defaults for ECS plugin health check timeout

### DIFF
--- a/.changelog/4767.txt
+++ b/.changelog/4767.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+plugin/ecs: Set health check timeout and interval values to compatible default
+values.
+```

--- a/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
@@ -123,7 +123,7 @@ parameter {
 
 parameter {
   key         = "health_check"
-  description = "Health check settings for the app."
+  description = "Health check settings for the app.\nThese settings configure a health check for the applicationtarget group."
   type        = "category"
   required    = false
 }
@@ -151,10 +151,11 @@ parameter {
 }
 
 parameter {
-  key         = "health_check.interval"
-  description = "The amount of time, in seconds, between health checks."
-  type        = "int64"
-  required    = false
+  key           = "health_check.interval"
+  description   = "The amount of time, in seconds, between health checks."
+  type          = "int64"
+  required      = false
+  default_value = "30"
 }
 
 parameter {
@@ -180,10 +181,11 @@ parameter {
 }
 
 parameter {
-  key         = "health_check.timeout"
-  description = "The amount of time, in seconds, for which no target response means a failure."
-  type        = "int64"
-  required    = false
+  key           = "health_check.timeout"
+  description   = "The amount of time, in seconds, for which no target response means a failure. Must be lower than the interval."
+  type          = "int64"
+  required      = false
+  default_value = "5"
 }
 
 parameter {

--- a/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/aws-ecs-platform/parameters.hcl
@@ -123,7 +123,7 @@ parameter {
 
 parameter {
   key         = "health_check"
-  description = "Health check settings for the app.\nThese settings configure a health check for the applicationtarget group."
+  description = "Health check settings for the app.\nThese settings configure a health check for the application target group."
   type        = "category"
   required    = false
 }

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1349,6 +1349,10 @@ func (p *Platform) resourceTargetGroupCreate(
 			createTargetGroupInput.HealthCheckIntervalSeconds = aws.Int64(p.config.HealthCheck.Interval)
 		}
 
+		if *createTargetGroupInput.HealthCheckIntervalSeconds < *createTargetGroupInput.HealthCheckTimeoutSeconds {
+			return status.Errorf(codes.InvalidArgument, fmt.Sprintf("Health check interval cannot be shorter than the timeout"))
+		}
+
 		if p.config.HealthCheck.HealthyThresholdCount != 0 {
 			createTargetGroupInput.HealthyThresholdCount = aws.Int64(p.config.HealthCheck.HealthyThresholdCount)
 		} else {
@@ -3217,7 +3221,7 @@ deploy {
 
 	doc.SetField("health_check",
 		"Health check settings for the app.",
-		docs.Summary("These settings configure a health check for the application"+
+		docs.Summary("These settings configure a health check for the application "+
 			"target group."),
 
 		docs.SubFields(func(doc *docs.SubFieldDoc) {

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1339,10 +1339,12 @@ func (p *Platform) resourceTargetGroupCreate(
 			createTargetGroupInput.HealthCheckPath = aws.String(p.config.HealthCheck.Path)
 		}
 
+		createTargetGroupInput.HealthCheckTimeoutSeconds = aws.Int64(5)
 		if p.config.HealthCheck.Timeout != 0 {
 			createTargetGroupInput.HealthCheckTimeoutSeconds = aws.Int64(p.config.HealthCheck.Timeout)
 		}
 
+		createTargetGroupInput.HealthCheckIntervalSeconds = aws.Int64(30)
 		if p.config.HealthCheck.Interval != 0 {
 			createTargetGroupInput.HealthCheckIntervalSeconds = aws.Int64(p.config.HealthCheck.Interval)
 		}
@@ -3215,6 +3217,9 @@ deploy {
 
 	doc.SetField("health_check",
 		"Health check settings for the app.",
+		docs.Summary("These settings configure a health check for the application"+
+			"target group."),
+
 		docs.SubFields(func(doc *docs.SubFieldDoc) {
 			doc.SetField("protocol",
 				"The protocol for the health check to use.",
@@ -3225,10 +3230,12 @@ deploy {
 
 			doc.SetField("timeout",
 				"The amount of time, in seconds, for which no target response "+
-					"means a failure.")
+					"means a failure. Must be lower than the interval.",
+				docs.Default("5"))
 
 			doc.SetField("interval",
-				"The amount of time, in seconds, between health checks.")
+				"The amount of time, in seconds, between health checks.",
+				docs.Default("30"))
 
 			doc.SetField("healthy_threshold_count",
 				"The number of consecutive successful health checks required to"+


### PR DESCRIPTION
Prior to this PR, depending on the type of health check configured, the default timeout could have been set to be longer than the default interval (the defaults are set differently by AWS depending on how you configure the health check protocol), which is not a valid setting in AWS. This PR sets the default timeout to be lower than the interval - 5 second timeout and 30 second interval.