### PR TITLE
Add sorting to `serverstate.PipelineRunList`

### DIFF
--- a/pkg/server/singleprocess/service_pipeline_run.go
+++ b/pkg/server/singleprocess/service_pipeline_run.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
+
 	pb "github.com/hashicorp/waypoint/pkg/server/gen"
 	"github.com/hashicorp/waypoint/pkg/server/hcerr"
 	serverptypes "github.com/hashicorp/waypoint/pkg/server/ptypes"
@@ -20,7 +21,7 @@ func (s *Service) ListPipelineRuns(
 		return nil, err
 	}
 
-	result, err := s.state(ctx).PipelineRunList(ctx, req.Pipeline)
+	result, err := s.state(ctx).PipelineRunList(ctx, req.Pipeline, nil)
 	if err != nil {
 		return nil, hcerr.Externalize(
 			hclog.FromContext(ctx),

--- a/pkg/server/singleprocess/service_pipeline_run.go
+++ b/pkg/server/singleprocess/service_pipeline_run.go
@@ -21,7 +21,7 @@ func (s *Service) ListPipelineRuns(
 		return nil, err
 	}
 
-	result, err := s.state(ctx).PipelineRunList(ctx, req.Pipeline, nil)
+	result, err := s.state(ctx).PipelineRunList(ctx, req.Pipeline, &pb.SortingRequest{})
 	if err != nil {
 		return nil, hcerr.Externalize(
 			hclog.FromContext(ctx),

--- a/pkg/server/singleprocess/service_ui_pipeline_run.go
+++ b/pkg/server/singleprocess/service_ui_pipeline_run.go
@@ -32,7 +32,11 @@ func (s *Service) UI_ListPipelineRuns(
 	var allPipelineRuns []*pb.UI_PipelineRunBundle
 
 	// Get list of all pipeline runs
-	pipelineRunListResponse, err := s.state(ctx).PipelineRunList(ctx, req.Pipeline)
+	pipelineRunListResponse, err := s.state(ctx).PipelineRunList(
+		ctx,
+		req.Pipeline,
+		&pb.SortingRequest{OrderBy: []string{"sequence desc"}},
+	)
 	if err != nil {
 		return nil, hcerr.Externalize(
 			log,

--- a/pkg/serverstate/serverstate.go
+++ b/pkg/serverstate/serverstate.go
@@ -210,7 +210,8 @@ type Interface interface {
 	PipelineRunGet(context.Context, *pb.Ref_Pipeline, uint64) (*pb.PipelineRun, error)
 	PipelineRunGetLatest(context.Context, string) (*pb.PipelineRun, error)
 	PipelineRunGetById(context.Context, string) (*pb.PipelineRun, error)
-	PipelineRunList(context.Context, *pb.Ref_Pipeline) ([]*pb.PipelineRun, error)
+	// Runs are returned in insertion order by default. Pass `sequence desc` for reverse order.
+	PipelineRunList(context.Context, *pb.Ref_Pipeline, *pb.SortingRequest) ([]*pb.PipelineRun, error)
 
 	//---------------------------------------------------------------
 	// Templates


### PR DESCRIPTION
## Why the change?

We’d like to be able to show runs newest-first in the UI.

Note that this PR only addresses sorting at the state layer. Longer term, we hope to [allow sorting options](https://github.com/hashicorp/waypoint/blob/WAYP-1541/pkg/server/proto/server.proto#L581) to be passed to `UI_ListPipelineRuns`, but that’s for another PR.

## What does it look like?

```sh
$ ./contrib/waypoint-grpc/waypoint-grpc.sh ListPipelineRuns '{ "pipeline": { "id": "01H2QGNVQ77KB4H67VJDESEATA" } }'
{
  "pipelineRuns": [
    {
      "sequence": "1",
      // ...
    },
    {
      "sequence": "2",
      // ...
    },
    {
      "sequence": "3",
      // ...
    }
  ]
}

$ ./contrib/waypoint-grpc/waypoint-grpc.sh UI_ListPipelineRuns '{ "pipeline": { "id": "01H2QGNVQ77KB4H67VJDESEATA" } }'
{
  "pipelineRunBundles": [
    {
      "pipelineRun": {
        "sequence": "3",
        // ... 
      },
    },
    {
      "pipelineRun": {
        "sequence": "2",
        // ...
      },
    },
    {
      "pipelineRun": {
        "sequence": "1",
        // ...
      },
    }
  ],
}
```

## How do I test it?

1. Boot the server
2. Run a pipeline a few times
3. List runs using `ListPipelineRuns`
4. Verify they are in insertion-order
5. List runs using `UI_ListPipelineRuns`
6. Verify they are in newest-first order