### PR TITLE
Nomad runner install CPU and memory flags

### DIFF
--- a/.changelog/4798.txt
+++ b/.changelog/4798.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runnerinstall/nomad: Add CLI flags for setting custom CPU and memory resources.
+```

--- a/internal/runnerinstall/nomad.go
+++ b/internal/runnerinstall/nomad.go
@@ -250,6 +250,18 @@ func (i *NomadRunnerInstaller) InstallFlags(set *flag.Set) {
 	})
 
 	set.StringVar(&flag.StringVar{
+		Name:   "nomad-runner-cpu",
+		Target: &i.Config.RunnerResourcesCPU,
+		Usage:  "CPU required to run the runner task in MHz.",
+	})
+
+	set.StringVar(&flag.StringVar{
+		Name:   "nomad-runner-memory",
+		Target: &i.Config.RunnerResourcesMemory,
+		Usage:  "MB of Memory to allocate to the runner job task.",
+	})
+
+	set.StringVar(&flag.StringVar{
 		Name:   "nomad-host-volume",
 		Target: &i.Config.HostVolume,
 		Usage:  "Nomad host volume name.",

--- a/website/content/commands/runner-install.mdx
+++ b/website/content/commands/runner-install.mdx
@@ -84,6 +84,8 @@ the install, the command would be:
 
 - `-nomad-dc=<string>` - Datacenters to install to for Nomad. The default is dc1.
 - `-nomad-runner-image=<string>` - Docker image for the Waypoint runner. The default is hashicorp/waypoint.
+- `-nomad-runner-cpu=<string>` - CPU required to run the runner task in MHz.
+- `-nomad-runner-memory=<string>` - MB of Memory to allocate to the runner job task.
 - `-nomad-host-volume=<string>` - Nomad host volume name.
 - `-nomad-csi-volume-plugin-id=<string>` - The ID of the CSI plugin that manages the volume, required for volume type 'csi'.
 - `-nomad-csi-volume-provider=<string>` - Nomad CSI volume provider, required for volume type 'csi'.


### PR DESCRIPTION
The Nomad runner install configuration has fields for CPU and memory, but no flags for the user to set them - this PR adds those flags. This fix stems from a [discussion on HashiCorp Discuss](https://discuss.hashicorp.com/t/hcp-waypoint-unable-to-install-runner-on-nomad-client/54759/8), where a user installing a runner had insufficient resources on their Nomad client to run the runner, and I realized I could not suggest setting lower memory or CPU on the runner because there were no CLI flags to support it.