### PR TITLE
install/nomad: Add host network config option.

### DIFF
--- a/.changelog/4804.txt
+++ b/.changelog/4804.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+serverinstall/nomad: Add config flag `-nomad-host-network` for specifying the
+host network of the Waypoint server Nomad job's gRPC and HTTP (UI) ports.
+```

--- a/website/content/commands/install.mdx
+++ b/website/content/commands/install.mdx
@@ -108,6 +108,7 @@ and disable the UI, the command would be:
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-network-mode=<string>` - Nomad task group network mode. The default is host.
+- `-nomad-host-network=<string>` - Designates the host network name to use when allocating the ports of the Waypoint server. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.

--- a/website/content/commands/server-install.mdx
+++ b/website/content/commands/server-install.mdx
@@ -108,6 +108,7 @@ and disable the UI, the command would be:
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-network-mode=<string>` - Nomad task group network mode. The default is host.
+- `-nomad-host-network=<string>` - Designates the host network name to use when allocating the ports of the Waypoint server. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.

--- a/website/content/commands/server-upgrade.mdx
+++ b/website/content/commands/server-upgrade.mdx
@@ -78,6 +78,7 @@ manually installed runners will not be automatically upgraded.
 - `-nomad-host=<string>` - Hostname of the Nomad server to use, like for launching on-demand tasks. The default is http://localhost:4646.
 - `-nomad-namespace=<string>` - Namespace to install the Waypoint server into for Nomad. The default is default.
 - `-nomad-network-mode=<string>` - Nomad task group network mode. The default is host.
+- `-nomad-host-network=<string>` - Designates the host network name to use when allocating the ports of the Waypoint server. The default is default.
 - `-nomad-odr-image=<string>` - Docker image for the on-demand runners. If not specified, it defaults to the server image name + '-odr' (i.e. 'hashicorp/waypoint-odr:latest').
 - `-nomad-policy-override` - Override the Nomad sentinel policy for enterprise Nomad. The default is false.
 - `-nomad-region=<string>` - Region to install to for Nomad. The default is global.


### PR DESCRIPTION
This enables users to configure the networking of the Waypoint server Nomad job to use a host network other than one named "default", for the gRPC and HTTP (UI) server ports. Closes #4751. 