### PR TITLE
Respecting context when installing the ECS server

### DIFF
--- a/.changelog/4811.txt
+++ b/.changelog/4811.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugin/aws-ecs: Allow cancelling server install command when waiting on health.
+```

--- a/internal/serverinstall/ecs.go
+++ b/internal/serverinstall/ecs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/resourcegroups"
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/waypoint-plugin-sdk/terminal"
 	"github.com/hashicorp/waypoint/builtin/aws/utils"
 	"github.com/hashicorp/waypoint/internal/clicontext"
@@ -429,7 +430,12 @@ func (i *ECSInstaller) Launch(
 				break
 			}
 		}
-		time.Sleep(5 * time.Second)
+
+		select {
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	if !healthy {


### PR DESCRIPTION
Without this change, if the server isn't becoming healthy and the user wants to ctrl-c the install process, nothing will happen!