### PR TITLE
runnerinstall/aws-ecs: Add AddTags permission to ODR IAM policy.

### DIFF
--- a/.changelog/4818.txt
+++ b/.changelog/4818.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+runnerinstall/aws-ecs: Fix ODR policy for AWS ECS runners to enable adding tags
+to an ALB.
+```

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -84,6 +84,7 @@ const odrRolePolicy = `{
         "ecs:DeregisterTaskDefinition",
         "ecs:RunTask",
         "ecs:StopTask",
+	"elasticloadbalancing:AddTags",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
         "elasticloadbalancing:CreateRule",


### PR DESCRIPTION
The `AddTags` permission is required when Waypoint manages the ALB resource for the AWS ECS plugin. If the user supplies their own ALB, this permission is not needed, because the plugin won't add a tag to indicate that it's managed by Waypoint.