### PR TITLE
Automatically register apps when project has server-stored waypoint.hcl

### DIFF
--- a/.changelog/4819.txt
+++ b/.changelog/4819.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: Perform project init without requiring a runner if waypoint.hcl is stored serverside
+```

--- a/pkg/server/singleprocess/service_project.go
+++ b/pkg/server/singleprocess/service_project.go
@@ -301,7 +301,7 @@ func (s *Service) serverSideProjectInit(ctx context.Context, project *pb.Project
 
 	for _, b := range content.Blocks.ByType()["app"] {
 		name := b.Labels[0]
-		_, err := s.UpsertApplication(ctx, &pb.UpsertApplicationRequest{
+		_, err := s.state(ctx).AppPut(ctx, &pb.Application{
 			Project: projRef,
 			Name:    name,
 		})
@@ -316,9 +316,7 @@ func (s *Service) serverSideProjectInit(ctx context.Context, project *pb.Project
 	}
 
 	// Reload the project to populate the newly-added apps
-	resp, err := s.GetProject(ctx, &pb.GetProjectRequest{
-		Project: projRef,
-	})
+	result, err := s.state(ctx).ProjectGet(ctx, projRef)
 	if err != nil {
 		return nil, hcerr.Externalize(
 			hclog.FromContext(ctx),
@@ -327,7 +325,6 @@ func (s *Service) serverSideProjectInit(ctx context.Context, project *pb.Project
 			project.GetName(),
 		)
 	}
-	project = resp.Project
 
-	return project, nil
+	return result, nil
 }


### PR DESCRIPTION
## Why the change?

We have found it testing that it’s not _that_ easy to get remote-init working, and it’s not strictly necessary when all we want to do is register the applications for the project. This patch allows the server to perform the app-registration when a server-stored waypoint.hcl is present.

## How do I test this?

- Start and bootstrap a new waypoint server
- Write some HCL to disk (for example: https://github.com/hashicorp/waypoint-examples/blob/main/docker/static/waypoint.hcl)
- Run `waypoint project apply`, creating a new project with that waypoint.hcl stored server-side:
```
$ waypoint project apply -waypoint-hcl=`pwd`/waypoint.hcl foo
✓ Project "foo" updated
```
- Inspect the project, and notice that the app is registered! The server read them from the hcl.
```
$ waypoint project inspect -json foo
{
	"name": "foo",
	"applications": [
		{
			"project": {
				"project": "foo"
			},
			"name": "web".                                    <-- App is registered!
		}
	],
...
}

```