### PR TITLE
Add guards against nil derefernce panics in job/task CLI commands

### DIFF
--- a/.changelog/4867.txt
+++ b/.changelog/4867.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix possible issues with deleted applications or projects failing to render in output
+```

--- a/internal/cli/job_get_stream.go
+++ b/internal/cli/job_get_stream.go
@@ -57,7 +57,6 @@ func (c *JobGetStreamCommand) Run(args []string) int {
 
 func (c *JobGetStreamCommand) Flags() *flag.Sets {
 	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
-		//f := set.NewSet("Command Options")
 	})
 }
 

--- a/internal/cli/job_inspect.go
+++ b/internal/cli/job_inspect.go
@@ -169,6 +169,18 @@ func (c *JobInspectCommand) Run(args []string) int {
 	}
 
 	c.ui.Output("Job Configuration", terminal.WithHeaderStyle())
+	appProjectName := resp.GetApplication().GetProject()
+	if appProjectName == "" {
+		appProjectName = "deleted"
+	}
+	appName := resp.GetApplication().GetApplication()
+	if appName == "" {
+		appName = "deleted"
+	}
+	workspaceName := resp.GetWorkspace().GetWorkspace()
+	if workspaceName == "" {
+		workspaceName = "deleted"
+	}
 	c.ui.NamedValues([]terminal.NamedValue{
 		{
 			Name: "ID", Value: resp.Id,
@@ -183,13 +195,13 @@ func (c *JobInspectCommand) Run(args []string) int {
 			Name: "Target Runner", Value: targetRunner,
 		},
 		{
-			Name: "Workspace", Value: resp.Workspace.Workspace,
+			Name: "Workspace", Value: workspaceName,
 		},
 		{
-			Name: "Project", Value: resp.Application.Project,
+			Name: "Project", Value: appProjectName,
 		},
 		{
-			Name: "Application", Value: resp.Application.Application,
+			Name: "Application", Value: appName,
 		},
 	}, terminal.WithInfoStyle())
 

--- a/internal/cli/job_list.go
+++ b/internal/cli/job_list.go
@@ -311,6 +311,12 @@ func (c *JobListCommand) Run(args []string) int {
 			pipeline = "name: " + j.Pipeline.PipelineName + ", run: " + strconv.FormatUint(j.Pipeline.RunSequence, 10) + ", step: " + j.Pipeline.Step
 		}
 
+		appProject := j.GetApplication().GetProject()
+		if appProject == "" {
+			appProject = "deleted"
+		}
+		appWorkspace := j.GetWorkspace().GetWorkspace()
+
 		tblColumn := []string{
 			j.Id,
 			op,
@@ -318,13 +324,13 @@ func (c *JobListCommand) Run(args []string) int {
 			queueTime,
 			completeTime,
 			targetRunner,
-			j.Application.Project,
-			j.Workspace.Workspace,
+			appProject,
+			appWorkspace,
 		}
 
 		if c.flagVerbose {
 			tblColumn = append(tblColumn, []string{
-				j.Application.Application,
+				appProject,
 				pipeline,
 			}...)
 		}

--- a/internal/cli/task_inspect.go
+++ b/internal/cli/task_inspect.go
@@ -103,7 +103,9 @@ func (c *TaskInspectCommand) Run(args []string) int {
 		return 1
 	}
 
-	var workspace, project, application string
+	var workspace string
+	project := "deleted"
+	application := "deleted"
 	if taskResp.TaskJob.Workspace != nil {
 		workspace = taskResp.TaskJob.Workspace.Workspace
 	}
@@ -259,6 +261,16 @@ func (c *TaskInspectCommand) FormatJob(job *pb.Job) error {
 		errMsg = job.Error.Message
 	}
 
+	var workspace string
+	project := "deleted"
+	application := "deleted"
+	if job.Workspace != nil {
+		workspace = job.Workspace.Workspace
+	}
+	if job.Application != nil {
+		project = job.Application.Project
+		application = job.Application.Application
+	}
 	c.ui.Output("Job Configuration:", terminal.WithInfoStyle())
 	c.ui.NamedValues([]terminal.NamedValue{
 		{
@@ -274,13 +286,13 @@ func (c *TaskInspectCommand) FormatJob(job *pb.Job) error {
 			Name: "Target Runner", Value: targetRunner,
 		},
 		{
-			Name: "Workspace", Value: job.Workspace.Workspace,
+			Name: "Workspace", Value: workspace,
 		},
 		{
-			Name: "Project", Value: job.Application.Project,
+			Name: "Project", Value: project,
 		},
 		{
-			Name: "Application", Value: job.Application.Application,
+			Name: "Application", Value: application,
 		},
 	}, terminal.WithInfoStyle())
 


### PR DESCRIPTION
If a project has been destroyed, both the project and app are removed from the state. Jobs and Tasks still reference things by application ID and if null in the state are being set to nil in the gRPC response. 

In this PR we simply guard against nil values when outputting to the CLI. We assume a nil Project/Application means the project/application was deleted. If we use `""` instead then these columns will simply not show in the output, so we felt it should be explicit that those projects/applications have been deleted. 