### PR TITLE
Fix syntax error in ECS policy doc

### DIFF
--- a/.changelog/4873.txt
+++ b/.changelog/4873.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+runneruninstall/aws-ecs: Fix installing runners in new AWS accounts by fixing an inline policy syntax error.
+```

--- a/internal/runnerinstall/ecs.go
+++ b/internal/runnerinstall/ecs.go
@@ -96,7 +96,7 @@ const odrRolePolicy = `{
         "elasticloadbalancing:DescribeListeners",
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeRules",
-		"elasticloadbalancing:DescribeTags,
+		"elasticloadbalancing:DescribeTags",
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:ModifyListener",
 		"elasticloadbalancing:DescribeTargetHealth",


### PR DESCRIPTION
Closes https://github.com/hashicorp/waypoint/issues/4872

Fixes a json syntax error in the ecs inline policy introduced in https://github.com/hashicorp/waypoint/pull/4840 by adding a close quote

### How can I verify this fix?

Run a `waypoint install` against an AWS account without a role named `waypoint-runner`, and verify success:

```
$ ./waypoint runner install   -platform=ecs   -server-addr=api.hashicorp.cloud:443   -ecs-runner-image=hashicorp/waypoint -ecs-region=us-east-1 -ecs-cluster=waypoint
✓ Finished connecting to: api.hashicorp.cloud:443
✓ Runner "01H7BA4XNXE0Y4CEMEHKFQAK3R" installed successfully to ecs
✓ Runner profile "ecs-01H7BA4XNXE0Y4CEMEHKFQAK3R" created successfully.
✓ Networking setup
✓ EFS ready
✓ Found existing IAM role to use: waypoint-runner-execution-role
✓ Created IAM task role: waypoint-runner
✓ Using existing log group
✓ Runner service created
✓ Runner "01H7BA4XNXE0Y4CEMEHKFQAK3R" adopted successfully.
```