### PR TITLE
Update linux package license to BUSL-1.1

### DIFF
--- a/.github/workflows/build-waypoint-oss.yml
+++ b/.github/workflows/build-waypoint-oss.yml
@@ -98,7 +98,7 @@ jobs:
           version: ${{ inputs.waypoint-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/waypoint"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/${{ inputs.package-name }}"
           deb_depends: "git"
           rpm_depends: "git"


### PR DESCRIPTION
This updates the linux package license to BUSL-1.1.
This PR should be merged to main so that the change is included in the next minor release that is cut from main.
License changes are not required on release branches (ongoing patch releases of current minor releases).
