### PR TITLE
Fix nil pointer dereference in auth config

### DIFF
--- a/builtin/docker/platform.go
+++ b/builtin/docker/platform.go
@@ -722,7 +722,7 @@ func (p *Platform) pullImage(cli *client.Client, log hclog.Logger, ui terminal.U
 
 	var authBase64 = ""
 	//Check if auth configuration is not null
-	if (*p.config.Auth != Auth{}) {
+	if p.config.Auth != nil && *p.config.Auth != (Auth{}) {
 		auth := types.AuthConfig{
 			Username:      authConfig.Username,
 			Password:      authConfig.Password,

--- a/builtin/docker/pull/builder.go
+++ b/builtin/docker/pull/builder.go
@@ -329,7 +329,7 @@ func (b *Builder) buildWithDocker(
 			return status.Errorf(codes.Internal, "unable to generate authentication info for registry: %s", err)
 		}
 		encodedAuth = base64.URLEncoding.EncodeToString(buf)
-	} else if *b.config.Auth != (docker.Auth{}) {
+	} else if b.config.Auth != nil && *b.config.Auth != (docker.Auth{}) {
 		//If EncodedAuth is not set, and Auth is, use Auth
 		authBytes, err := json.Marshal(types.AuthConfig{
 			Username:      authConfig.Username,
@@ -394,7 +394,7 @@ func (b *Builder) buildWithImg(
 	env := os.Environ()
 
 	//Check if auth configuration is not null
-	if (*b.config.Auth != docker.Auth{}) {
+	if b.config.Auth != nil && *b.config.Auth != (docker.Auth{}) {
 		auth, err := json.Marshal(types.AuthConfig{
 			Username:      authConfig.Username,
 			Password:      authConfig.Password,

--- a/builtin/docker/registry_docker.go
+++ b/builtin/docker/registry_docker.go
@@ -115,7 +115,7 @@ func (r *Registry) pushWithDocker(
 			return status.Errorf(codes.Internal, "unable to generate authentication info for registry: %s", err)
 		}
 		encodedAuth = base64.URLEncoding.EncodeToString(buf)
-	} else if (*r.config.Auth != Auth{}) {
+	} else if r.config.Auth != nil && *r.config.Auth != (Auth{}) {
 		if authConfig.Hostname != "" {
 			return status.Errorf(codes.InvalidArgument, "hostname not supported for registry")
 		}


### PR DESCRIPTION
Hello!

I noticed some nil pointer dereference in the `deploy` stage using this (basic) configuration:

```hcl
project = "pet-shop"

app "api" {
  build {
    use "docker" {}

    registry {
      use "docker" {
        insecure = true
        image    = "registry.waypoint:5000/pet-shop-api"
        tag      = gitrefpretty()
      }
    }
  }

  deploy {
    use "docker" {
      service_port = 80
    }
  }
}
```

It looks like the `pullImage` function in `builtin/docker/platform.go` checks if the `auth` block is empty or not, but fails to check for `nil`. After taking a quick look around, I found this bug in 3 more cases. I applied the same reasoning as @catsby in e5b5fe97c6bcc181026eb73421f1ff04e8edda0e to fix them.