### PR TITLE
waypoint/builtin/docker/pull: Update `Builder` link in README.md

### DIFF
--- a/builtin/docker/pull/README.md
+++ b/builtin/docker/pull/README.md
@@ -3,7 +3,7 @@ and wraps the existing image entrypoint with the Waypoint entrypoint.
 
 ### Components
 
-1. [Builder](/waypoint/integrations/hashicorp/docker/latest/components/builder/docker-pull-builder)
+1. [Builder](/waypoint/integrations/hashicorp/docker-pull/latest/components/builder/docker-pull-builder)
 
 ### Related Plugins
 


### PR DESCRIPTION
The current link https://developer.hashicorp.com/waypoint/integrations/hashicorp/docker/latest/components/builder/docker-pull-builder returns `We couldn't find the page you're looking for.` 